### PR TITLE
feat: Consolidate config dir + saved commands & persistent history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ coverage.xml
 
 # Projectile marker file
 .projectile
+/local/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ ConfigManager → config
   ├── ScanService(config_manager)
   ├── KeywordStore(config.keyword_store_path)
   ├── TerminalService(preferred=config.terminal_emulator)
-  └── SCPService()
+  ├── SCPService()
+  └── CommandHistoryService(config.command_history_path)
 ```
 
 ### Screen Navigation
@@ -78,13 +79,13 @@ All CSS is in a single `app.css` file using Textual's CSS-like syntax with desig
 - External SSH sessions launch in new terminal window via wrapper script that keeps terminal open on failure
 
 **Instance Caching (stale-while-revalidate):**
-- Cache at `~/.ec2_ssh_cache.json` with configurable TTL (default 3600s)
+- Cache at `~/.ec2-ssh/cache.json` with configurable TTL (default 3600s)
 - Startup: show stale data immediately, refresh in background if expired
 - `CacheService.load()` respects TTL; `load_any()` ignores TTL; `is_fresh()` checks TTL
 - Force refresh via `R` key in instance list
 
 **Configuration:**
-- JSON at `~/.ec2_ssh_config.json`, dataclass-based schema (`AppConfig`, `ScanRule`, `ConnectionProfile`, `ConnectionRule`)
+- JSON at `~/.ec2-ssh/config.json`, dataclass-based schema (`AppConfig`, `ScanRule`, `ConnectionProfile`, `ConnectionRule`)
 - Schema versioning (`CONFIG_VERSION = 2`) with automatic v1→v2 migration
 - Connection rules evaluated in order — first match wins
 
@@ -95,11 +96,14 @@ All CSS is in a single `app.css` file using Textual's CSS-like syntax with desig
 
 ## Runtime Files
 
-- `~/.ec2_ssh_config.json` — Main configuration
-- `~/.ec2_ssh_cache.json` — Cached instance list
-- `~/.ec2_ssh_keywords.json` — Scan results store
-- `~/.ec2_ssh_logs/ec2_ssh.log` — Application log
-- `~/.ec2_ssh_logs/ec2ssh_*.sh` — Temporary SSH wrapper scripts
+All runtime files are under `~/.ec2-ssh/`:
+
+- `~/.ec2-ssh/config.json` — Main configuration
+- `~/.ec2-ssh/cache.json` — Cached instance list
+- `~/.ec2-ssh/keywords.json` — Scan results store
+- `~/.ec2-ssh/command_history.json` — Saved commands and command history
+- `~/.ec2-ssh/logs/ec2_ssh.log` — Application log
+- `~/.ec2-ssh/logs/ec2ssh_*.sh` — Temporary SSH wrapper scripts
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ pipx install .
 - **Interactive TUI** with mouse and keyboard support powered by [Textual](https://textual.textualize.io/)
 - **List and search** EC2 instances across all AWS regions
 - **SSH into instances** — launches in new terminal window with auto-detected emulator
-- **Run remote commands** via overlay panel with real-time streaming output
+- **Run remote commands** via overlay panel with real-time streaming output, persistent history, and saved command favorites
 - **Browse remote file systems** — interactive file tree navigation
 - **SCP file transfer** — upload/download files and directories
 - **Keyword-based server scanning** — search file contents across instances
 - **Bastion host / jump server support** via ProxyJump or ProxyCommand
 - **SSH key management** with auto-discovery and per-instance configuration
 - **Instance caching** with stale-while-revalidate for fast startup
-- **Fully configurable** — all settings in `~/.ec2_ssh_config.json`
+- **Fully configurable** — all settings in `~/.ec2-ssh/config.json`
 
 ## Prerequisites
 
@@ -74,6 +74,8 @@ ec2-ssh --debug   # Launch with debug logging to stderr
 | Instance List | `C` | Run command overlay |
 | Instance List | `T` | SCP transfer |
 | Command Overlay | `Ctrl+C` | Stop running command |
+| Command Overlay | `Ctrl+R` | Command picker (saved + recent) |
+| Command Overlay | `Ctrl+S` | Save command to favorites |
 | Command Overlay | `Up/Down` | Command history |
 
 ### What You Can Do
@@ -84,7 +86,7 @@ ec2-ssh --debug   # Launch with debug logging to stderr
 4. **Scan Servers** — Run keyword scans across running instances
 5. **Settings** — Configure connection profiles, scan rules, preferences
 
-When you select a server: browse files, run commands, SSH connect, SCP transfer, or view scan results.
+When you select a server: browse files, run commands, SSH connect, SCP transfer, or view scan results. Command history persists across sessions — use `Ctrl+R` to search history and saved commands, `Ctrl+S` to save favorites.
 
 ### Instance Caching
 
@@ -97,7 +99,7 @@ When you select a server: browse files, run commands, SSH connect, SCP transfer,
 
 ### Configuration
 
-All configuration lives in `~/.ec2_ssh_config.json`, created automatically on first run.
+All configuration lives in `~/.ec2-ssh/config.json`, created automatically on first run.
 
 See [Configuration Guide](docs/configuration.md) for the full reference including connection profiles, scan rules, and match conditions.
 
@@ -131,7 +133,7 @@ See [Troubleshooting Guide](docs/troubleshooting.md) for help with SSH connectio
 
 ## Logging
 
-Logs are always written to `~/.ec2_ssh_logs/ec2_ssh.log`. Use `--debug` for verbose stderr output.
+Logs are always written to `~/.ec2-ssh/logs/ec2_ssh.log`. Use `--debug` for verbose stderr output.
 
 When SSH fails, the terminal window stays open showing the error and exit code.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ src/ec2_ssh/
 ### config/
 
 - **`schema.py`** — Dataclass definitions: `AppConfig`, `ScanRule`, `ConnectionProfile`, `ConnectionRule`. Schema version constant (`CONFIG_VERSION = 2`).
-- **`manager.py`** — `ConfigManager` handles JSON load/save/validate at `~/.ec2_ssh_config.json`.
+- **`manager.py`** — `ConfigManager` handles JSON load/save/validate at `~/.ec2-ssh/config.json`.
 - **`migration.py`** — Automatic v1 → v2 migration (flat bastion settings → nested profiles/rules).
 
 ### services/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Guide
 
-All configuration is stored in `~/.ec2_ssh_config.json`. The file is created automatically on first run with sensible defaults.
+All configuration is stored in `~/.ec2-ssh/config.json`. The file is created automatically on first run with sensible defaults.
 
 ## Configuration Reference
 
@@ -15,7 +15,7 @@ All configuration is stored in `~/.ec2_ssh_config.json`. The file is created aut
   "cache_ttl_seconds": 3600,
   "terminal_emulator": "auto",
   "theme": "dark",
-  "keyword_store_path": "~/.ec2_ssh_keywords.json",
+  "keyword_store_path": "~/.ec2-ssh/keywords.json",
   "default_scan_paths": ["~/shared/", "/var/log/app.log"],
   "scan_rules": [],
   "connection_profiles": [],
@@ -32,7 +32,7 @@ All configuration is stored in `~/.ec2_ssh_config.json`. The file is created aut
 | `cache_ttl_seconds` | int | `3600` | Instance cache TTL in seconds (1 hour) |
 | `terminal_emulator` | string | `"auto"` | Terminal preference (see [Supported Terminals](#supported-terminals)) |
 | `theme` | string | `"dark"` | UI theme: `dark` or `light` |
-| `keyword_store_path` | string | `"~/.ec2_ssh_keywords.json"` | Path to keyword scan results file |
+| `keyword_store_path` | string | `"~/.ec2-ssh/keywords.json"` | Path to keyword scan results file |
 | `default_scan_paths` | array | `["~/"]` | Default paths to scan on all instances |
 | `scan_rules` | array | `[]` | Conditional scan rules (see [Scan Rules](#scan-rules)) |
 | `connection_profiles` | array | `[]` | SSH connection profiles (see [Connection Profiles](#connection-profiles)) |
@@ -173,10 +173,13 @@ If you're upgrading from v1 (flat configuration structure), the app automaticall
 
 ## Runtime Files
 
+All runtime files are stored under `~/.ec2-ssh/`:
+
 | File | Purpose |
 |------|---------|
-| `~/.ec2_ssh_config.json` | Main configuration |
-| `~/.ec2_ssh_cache.json` | Cached instance list with timestamp |
-| `~/.ec2_ssh_keywords.json` | Keyword scan results |
-| `~/.ec2_ssh_logs/ec2_ssh.log` | Application log |
-| `~/.ec2_ssh_logs/ec2ssh_*.sh` | Temporary SSH wrapper scripts |
+| `~/.ec2-ssh/config.json` | Main configuration |
+| `~/.ec2-ssh/cache.json` | Cached instance list with timestamp |
+| `~/.ec2-ssh/keywords.json` | Keyword scan results |
+| `~/.ec2-ssh/command_history.json` | Saved commands and command history |
+| `~/.ec2-ssh/logs/ec2_ssh.log` | Application log |
+| `~/.ec2-ssh/logs/ec2ssh_*.sh` | Temporary SSH wrapper scripts |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,14 +23,14 @@ When SSH fails, the terminal window **stays open** showing the error and exit co
 Check the log for the exact SSH command:
 
 ```bash
-grep "SSH command" ~/.ec2_ssh_logs/ec2_ssh.log
+grep "SSH command" ~/.ec2-ssh/logs/ec2_ssh.log
 ```
 
 ## Bastion Connection Hangs
 
 If the terminal opens but SSH hangs:
 
-1. **No connection profile** — Check that `connection_profiles` and `connection_rules` are set in `~/.ec2_ssh_config.json`
+1. **No connection profile** — Check that `connection_profiles` and `connection_rules` are set in `~/.ec2-ssh/config.json`
 2. **Wrong bastion host** — Verify reachability: `ssh -i key.pem user@bastion-host`
 3. **Wrong bastion key** — If the bastion uses a different key, set `bastion_key` in the profile
 4. **Private IP unreachable** — The bastion must be able to reach the target's private IP
@@ -91,7 +91,7 @@ The file browser connects via SSH to list directory contents. If it fails:
 
 ## Logging
 
-Logs are always written to `~/.ec2_ssh_logs/ec2_ssh.log` and include:
+Logs are always written to `~/.ec2-ssh/logs/ec2_ssh.log` and include:
 
 - SSH commands executed
 - Terminal emulator detection

--- a/install.ps1
+++ b/install.ps1
@@ -237,7 +237,7 @@ function Write-FinalMessage {
     Write-Host "  https://github.com/zb-ss/ec2-ssh"
     Write-Host ""
     Write-Host "Configuration:" -ForegroundColor White
-    Write-Host "  Config: $env:USERPROFILE\.ec2_ssh_config.json"
+    Write-Host "  Config: $env:USERPROFILE\.ec2-ssh\config.json"
     Write-Host ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -302,7 +302,7 @@ setup_wizard() {
 
 # Create starter config file
 create_starter_config() {
-    CONFIG_FILE="$HOME/.ec2_ssh_config.json"
+    CONFIG_FILE="$HOME/.ec2-ssh/config.json"
 
     if [ -f "$CONFIG_FILE" ]; then
         print_warning "Configuration file already exists at: $CONFIG_FILE"
@@ -318,6 +318,7 @@ create_starter_config() {
 
     print_info "Creating starter configuration at: $CONFIG_FILE"
 
+    mkdir -p "$(dirname "$CONFIG_FILE")"
     cat > "$CONFIG_FILE" << 'EOF'
 {
   "version": 2,
@@ -330,7 +331,7 @@ create_starter_config() {
   "connection_profiles": [],
   "connection_rules": [],
   "terminal_emulator": "auto",
-  "keyword_store_path": "~/.ec2_ssh_keywords.json",
+  "keyword_store_path": "~/.ec2-ssh/keywords.json",
   "theme": "dark"
 }
 EOF
@@ -371,8 +372,8 @@ print_final_message() {
     echo "  https://github.com/zb-ss/ec2-ssh"
     echo ""
     echo "${BOLD}Configuration:${RESET}"
-    echo "  Config file: ~/.ec2_ssh_config.json"
-    echo "  Cache file:  ~/.ec2_ssh_cache.json"
+    echo "  Config dir:  ~/.ec2-ssh/"
+    echo "  Config file: ~/.ec2-ssh/config.json"
     echo ""
 }
 

--- a/src/ec2_ssh/app.css
+++ b/src/ec2_ssh/app.css
@@ -340,10 +340,16 @@ CommandOverlay {
     overflow-y: auto;
 }
 
+#command_hints {
+    height: 1;
+    padding: 0 2;
+    margin: 0 1;
+    color: $text-muted;
+    background: $boost;
+}
+
 #command_input {
-    dock: bottom;
-    margin: 1;
-    width: 1fr;
+    margin: 0 1 0 1;
 }
 
 RichLog {
@@ -631,6 +637,73 @@ RadioButton:focus {
 #results_table {
     height: 1fr;
     margin-top: 1;
+}
+
+/* ===================================================================
+   COMMAND PICKER MODAL
+   =================================================================== */
+
+CommandPickerModal {
+    align: center middle;
+}
+
+#picker_container {
+    width: 70%;
+    max-width: 80;
+    height: 60%;
+    background: $surface;
+    border: thick $accent;
+    layout: vertical;
+}
+
+#picker_header {
+    dock: top;
+    padding: 1 2;
+    background: $primary;
+    color: $text;
+    border-bottom: thick $accent;
+    text-style: bold;
+}
+
+#picker_search {
+    margin: 1 1 0 1;
+    width: 1fr;
+}
+
+#picker_list {
+    height: 1fr;
+    background: $panel;
+    margin: 0 1 1 1;
+    border: solid $primary-background;
+}
+
+/* Save Command Modal */
+
+SaveCommandModal {
+    align: center middle;
+}
+
+#save_container {
+    width: 60%;
+    max-width: 60;
+    height: auto;
+    background: $surface;
+    border: thick $accent;
+    padding: 1 2;
+}
+
+#save_header {
+    padding: 1;
+    text-style: bold;
+}
+
+#save_command_preview {
+    padding: 0 1 1 1;
+}
+
+#save_name_input {
+    margin: 0 1 1 1;
+    width: 1fr;
 }
 
 /* ===================================================================

--- a/src/ec2_ssh/app.py
+++ b/src/ec2_ssh/app.py
@@ -27,6 +27,7 @@ class EC2ConnectApp(App):
     keyword_store = None
     terminal_service = None
     scp_service = None
+    command_history = None
 
     # Shared state
     instances: List[dict] = []  # all fetched instances
@@ -53,6 +54,7 @@ class EC2ConnectApp(App):
         from ec2_ssh.services.keyword_store import KeywordStore
         from ec2_ssh.services.terminal_service import TerminalService
         from ec2_ssh.services.scp_service import SCPService
+        from ec2_ssh.services.command_history import CommandHistoryService
 
         self.config_manager = ConfigManager()
         config = self.config_manager.get()
@@ -64,6 +66,7 @@ class EC2ConnectApp(App):
         self.keyword_store = KeywordStore(config.keyword_store_path)
         self.terminal_service = TerminalService(preferred=config.terminal_emulator)
         self.scp_service = SCPService()
+        self.command_history = CommandHistoryService(config.command_history_path)
 
     def action_show_help(self) -> None:
         """Show help screen from any context."""

--- a/src/ec2_ssh/config/migration.py
+++ b/src/ec2_ssh/config/migration.py
@@ -41,7 +41,7 @@ def migrate_v1_to_v2(v1_data: Dict[str, Any]) -> Dict[str, Any]:
             "connection_profiles": [],
             "connection_rules": [],
             "terminal_emulator": "auto",
-            "keyword_store_path": "~/.ec2_ssh_keywords.json",
+            "keyword_store_path": "~/.ec2-ssh/keywords.json",
             "theme": "dark"
         }
     """
@@ -61,7 +61,7 @@ def migrate_v1_to_v2(v1_data: Dict[str, Any]) -> Dict[str, Any]:
         'connection_profiles': [],
         'connection_rules': [],
         'terminal_emulator': 'auto',
-        'keyword_store_path': '~/.ec2_ssh_keywords.json',
+        'keyword_store_path': '~/.ec2-ssh/keywords.json',
         'theme': 'dark',
     })
 

--- a/src/ec2_ssh/config/schema.py
+++ b/src/ec2_ssh/config/schema.py
@@ -88,5 +88,7 @@ class AppConfig:
     connection_profiles: List[ConnectionProfile] = field(default_factory=list)
     connection_rules: List[ConnectionRule] = field(default_factory=list)
     terminal_emulator: str = "auto"
-    keyword_store_path: str = "~/.ec2_ssh_keywords.json"
+    keyword_store_path: str = "~/.ec2-ssh/keywords.json"
+    command_history_path: str = "~/.ec2-ssh/command_history.json"
+    max_command_history: int = 50
     theme: str = "dark"

--- a/src/ec2_ssh/main.py
+++ b/src/ec2_ssh/main.py
@@ -16,7 +16,7 @@ def _setup_logging(debug: bool = False) -> Path:
     Returns:
         Path to the log file.
     """
-    log_dir = Path.home() / '.ec2_ssh_logs'
+    log_dir = Path.home() / '.ec2-ssh' / 'logs'
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / 'ec2_ssh.log'
 
@@ -50,7 +50,7 @@ def main() -> None:
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging (also prints to stderr)')
     parser.add_argument('--config', type=str, default=None,
-                        help='Path to config file (default: ~/.ec2_ssh_config.json)')
+                        help='Path to config file (default: ~/.ec2-ssh/config.json)')
     args = parser.parse_args()
 
     log_file = _setup_logging(debug=args.debug)

--- a/src/ec2_ssh/screens/command_picker.py
+++ b/src/ec2_ssh/screens/command_picker.py
@@ -1,0 +1,195 @@
+"""Command picker modal for selecting saved and recent commands."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList, Static
+from textual.widgets.option_list import Option
+
+
+class CommandPickerModal(ModalScreen[str]):
+    """Modal for picking saved commands or recent history with search.
+
+    Dismisses with the selected command string, or None on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+    ]
+
+    def __init__(
+        self,
+        saved_commands: List[Dict[str, str]],
+        recent_commands: List[str],
+    ) -> None:
+        """Initialize command picker.
+
+        Args:
+            saved_commands: List of dicts with 'name' and 'command' keys.
+            recent_commands: List of recent command strings (newest first).
+        """
+        super().__init__()
+        self._saved_commands = saved_commands
+        self._recent_commands = recent_commands
+        self._option_map: Dict[str, str] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Static(
+                "[bold cyan]Command Picker[/bold cyan]  "
+                "[dim]Type to filter, Enter to select, Escape to cancel[/dim]",
+                id="picker_header",
+            ),
+            Input(
+                placeholder="Search commands...",
+                id="picker_search",
+            ),
+            OptionList(id="picker_list"),
+            id="picker_container",
+        )
+
+    def on_mount(self) -> None:
+        """Populate the option list and focus search."""
+        self._rebuild_options("")
+        self.query_one("#picker_search", Input).focus()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter options as the user types."""
+        if event.input.id == "picker_search":
+            self._rebuild_options(event.value.strip().lower())
+
+    def _rebuild_options(self, query: str) -> None:
+        """Rebuild the option list filtered by query.
+
+        Args:
+            query: Lowercase search string to filter by.
+        """
+        option_list = self.query_one("#picker_list", OptionList)
+        option_list.clear_options()
+        self._option_map.clear()
+
+        # Filter saved commands
+        filtered_saved = [
+            entry for entry in self._saved_commands
+            if not query
+            or query in entry['name'].lower()
+            or query in entry['command'].lower()
+        ]
+
+        # Filter recent commands (deduplicated against saved)
+        saved_cmds = {e['command'] for e in self._saved_commands}
+        filtered_recent = [
+            cmd for cmd in self._recent_commands
+            if cmd not in saved_cmds
+            and (not query or query in cmd.lower())
+        ]
+
+        # Saved commands section
+        if filtered_saved:
+            option_list.add_option(Option("── Saved Commands ──", disabled=True))
+            for entry in filtered_saved:
+                option_id = f"saved:{entry['name']}"
+                self._option_map[option_id] = entry['command']
+                option_list.add_option(
+                    Option(
+                        f"  [bold]★[/bold] {entry['name']}  [dim]{entry['command']}[/dim]",
+                        id=option_id,
+                    )
+                )
+
+        # Separator between sections
+        if filtered_saved and filtered_recent:
+            option_list.add_option(Option("", disabled=True))
+
+        # Recent commands section
+        if filtered_recent:
+            option_list.add_option(Option("── Recent Commands ──", disabled=True))
+            for i, cmd in enumerate(filtered_recent):
+                option_id = f"recent:{i}"
+                self._option_map[option_id] = cmd
+                option_list.add_option(Option(f"  {cmd}", id=option_id))
+
+        if not filtered_saved and not filtered_recent:
+            if query:
+                option_list.add_option(Option("  (no matches)", disabled=True))
+            else:
+                option_list.add_option(Option("  (no commands yet)", disabled=True))
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Select first visible option on Enter in search field."""
+        if event.input.id != "picker_search":
+            return
+        option_list = self.query_one("#picker_list", OptionList)
+        # Find first selectable option
+        for i in range(option_list.option_count):
+            option = option_list.get_option_at_index(i)
+            if not option.disabled and option.id and option.id in self._option_map:
+                self.dismiss(self._option_map[option.id])
+                return
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Handle option selection."""
+        option_id = event.option.id
+        if option_id and option_id in self._option_map:
+            self.dismiss(self._option_map[option_id])
+
+    def action_cancel(self) -> None:
+        """Close without selecting."""
+        self.dismiss(None)
+
+
+class SaveCommandModal(ModalScreen[str]):
+    """Small modal prompting for a name to save a command under.
+
+    Dismisses with the name string, or None on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+    ]
+
+    def __init__(self, command: str) -> None:
+        """Initialize save modal.
+
+        Args:
+            command: The command being saved (shown for reference).
+        """
+        super().__init__()
+        self._command = command
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Static(
+                "[bold cyan]Save Command[/bold cyan]",
+                id="save_header",
+            ),
+            Static(f"[dim]Command:[/dim] {self._command}", id="save_command_preview"),
+            Input(
+                placeholder="Enter a name for this command...",
+                id="save_name_input",
+            ),
+            id="save_container",
+        )
+
+    def on_mount(self) -> None:
+        """Focus the name input."""
+        self.query_one("#save_name_input", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Save on Enter."""
+        if event.input.id != "save_name_input":
+            return
+        name = event.value.strip()
+        if name:
+            self.dismiss(name)
+        else:
+            self.notify("Name cannot be empty", severity="warning")
+
+    def action_cancel(self) -> None:
+        """Close without saving."""
+        self.dismiss(None)

--- a/src/ec2_ssh/screens/help.py
+++ b/src/ec2_ssh/screens/help.py
@@ -41,14 +41,14 @@ HELP_TEXT = """
 | Action | What it does |
 |--------|-------------|
 | **Browse Files** | Interactive remote filesystem tree via SSH |
-| **Run Command** | Execute commands on the server (overlay panel, `Up`/`Down` for history) |
+| **Run Command** | Execute commands on the server (overlay panel, `Up`/`Down` for history, `Ctrl+R` picker, `Ctrl+S` save) |
 | **SSH Connect** | Opens a **new terminal window** with SSH session |
 | **SCP Transfer** | Upload/download files via SCP |
 | **View Scan Results** | Show keyword scan data for this server |
 
 ## Instance Caching
 
-Instances are cached to `~/.ec2_ssh_cache.json` for fast startup.
+Instances are cached to `~/.ec2-ssh/cache.json` for fast startup.
 
 | Scenario | Behavior |
 |----------|----------|
@@ -62,7 +62,7 @@ Background refresh shows a notification when complete (e.g., "2 more instances f
 
 ## Connection Profiles (Bastion Support)
 
-For instances behind a bastion host, add to `~/.ec2_ssh_config.json`:
+For instances behind a bastion host, add to `~/.ec2-ssh/config.json`:
 
 ```json
 {
@@ -99,7 +99,7 @@ You can also set keys per-instance or set a default key in Settings.
 
 ## Configuration Reference
 
-Config file: `~/.ec2_ssh_config.json`
+Config file: `~/.ec2-ssh/config.json`
 
 | Field | Default | Description |
 |-------|---------|-------------|
@@ -112,10 +112,20 @@ Config file: `~/.ec2_ssh_config.json`
 
 ## Logging & Debugging
 
-Logs: `~/.ec2_ssh_logs/ec2_ssh.log`
+Logs: `~/.ec2-ssh/logs/ec2_ssh.log`
 Debug mode: `ec2-ssh --debug`
 
 SSH failures keep the terminal window **open** so you can read the error message.
+
+## Command Overlay Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Up` / `Down` | Navigate command history |
+| `Ctrl+R` | Open command picker (saved + recent) |
+| `Ctrl+S` | Save current command to favorites |
+| `Ctrl+C` | Stop running command |
+| `Escape` | Close overlay |
 
 ## Global Shortcuts
 

--- a/src/ec2_ssh/screens/settings.py
+++ b/src/ec2_ssh/screens/settings.py
@@ -61,17 +61,17 @@ class SettingsScreen(Screen):
 
             # Section 3: Scan Rules (read-only)
             Static("[bold]Scan Rules[/bold]", classes="section_header"),
-            Static("[dim]Edit scan rules in ~/.ec2_ssh_config.json[/dim]", classes="note"),
+            Static("[dim]Edit scan rules in ~/.ec2-ssh/config.json[/dim]", classes="note"),
             DataTable(id="scan_rules_table"),
 
             # Section 4: Connection Profiles (read-only)
             Static("[bold]Connection Profiles[/bold]", classes="section_header"),
-            Static("[dim]Edit connection profiles in ~/.ec2_ssh_config.json[/dim]", classes="note"),
+            Static("[dim]Edit connection profiles in ~/.ec2-ssh/config.json[/dim]", classes="note"),
             DataTable(id="profiles_table"),
 
             # Section 5: Connection Rules (read-only)
             Static("[bold]Connection Rules[/bold]", classes="section_header"),
-            Static("[dim]Edit connection rules in ~/.ec2_ssh_config.json[/dim]", classes="note"),
+            Static("[dim]Edit connection rules in ~/.ec2-ssh/config.json[/dim]", classes="note"),
             DataTable(id="rules_table"),
 
             id="settings_container"

--- a/src/ec2_ssh/services/cache_service.py
+++ b/src/ec2_ssh/services/cache_service.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class CacheService:
     """File-based cache with TTL for EC2 instance lists."""
 
-    CACHE_PATH = Path.home() / '.ec2_ssh_cache.json'
+    CACHE_PATH = Path.home() / '.ec2-ssh' / 'cache.json'
 
     def __init__(self, ttl_seconds: int = 300):
         """Initialize cache service.

--- a/src/ec2_ssh/services/command_history.py
+++ b/src/ec2_ssh/services/command_history.py
@@ -1,0 +1,163 @@
+"""Command history service for persisting command history and saved commands."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Dict
+
+logger = logging.getLogger(__name__)
+
+MAX_GLOBAL_HISTORY = 200
+MAX_INSTANCE_HISTORY = 50
+
+
+class CommandHistoryService:
+    """Persistent command history and saved commands.
+
+    Storage format:
+    {
+        "saved_commands": [
+            {"name": "PM2 Status", "command": "pm2 list"},
+            {"name": "Disk Usage", "command": "df -h"}
+        ],
+        "history": {
+            "_global": ["pm2 list", "df -h"],
+            "i-abc123": ["pm2 list", "tail /var/log/syslog"]
+        }
+    }
+    """
+
+    def __init__(self, store_path: str = "~/.ec2-ssh/command_history.json") -> None:
+        """Initialize command history service.
+
+        Args:
+            store_path: Path to the JSON store file (supports ~ expansion).
+        """
+        self._store_path = Path(store_path).expanduser()
+
+    def add_to_history(self, instance_id: str, command: str) -> None:
+        """Add a command to per-instance and global history.
+
+        Deduplicates consecutive entries and trims to max limits.
+
+        Args:
+            instance_id: EC2 instance ID.
+            command: Command string to record.
+        """
+        data = self._load()
+        history = data.setdefault('history', {})
+
+        # Per-instance history
+        inst_hist = history.setdefault(instance_id, [])
+        if not inst_hist or inst_hist[-1] != command:
+            inst_hist.append(command)
+        if len(inst_hist) > MAX_INSTANCE_HISTORY:
+            history[instance_id] = inst_hist[-MAX_INSTANCE_HISTORY:]
+
+        # Global history
+        global_hist = history.setdefault('_global', [])
+        if not global_hist or global_hist[-1] != command:
+            global_hist.append(command)
+        if len(global_hist) > MAX_GLOBAL_HISTORY:
+            history['_global'] = global_hist[-MAX_GLOBAL_HISTORY:]
+
+        self._save(data)
+
+    def get_instance_history(self, instance_id: str) -> List[str]:
+        """Get command history for a specific instance.
+
+        Args:
+            instance_id: EC2 instance ID.
+
+        Returns:
+            List of commands (oldest first).
+        """
+        data = self._load()
+        return data.get('history', {}).get(instance_id, [])
+
+    def get_global_history(self) -> List[str]:
+        """Get global command history across all instances.
+
+        Returns:
+            List of commands (oldest first).
+        """
+        data = self._load()
+        return data.get('history', {}).get('_global', [])
+
+    def save_command(self, name: str, command: str) -> None:
+        """Save a named command to favorites.
+
+        Args:
+            name: Display name for the saved command.
+            command: The command string.
+        """
+        data = self._load()
+        saved = data.setdefault('saved_commands', [])
+
+        # Overwrite if same name exists
+        saved = [s for s in saved if s['name'] != name]
+        saved.append({'name': name, 'command': command})
+        data['saved_commands'] = saved
+        self._save(data)
+        logger.info("Saved command '%s': %s", name, command)
+
+    def get_saved_commands(self) -> List[Dict[str, str]]:
+        """Get all saved commands.
+
+        Returns:
+            List of dicts with 'name' and 'command' keys.
+        """
+        data = self._load()
+        return data.get('saved_commands', [])
+
+    def delete_saved_command(self, name: str) -> bool:
+        """Delete a saved command by name.
+
+        Args:
+            name: Name of the saved command to delete.
+
+        Returns:
+            True if the command was found and deleted.
+        """
+        data = self._load()
+        saved = data.get('saved_commands', [])
+        new_saved = [s for s in saved if s['name'] != name]
+
+        if len(new_saved) == len(saved):
+            return False
+
+        data['saved_commands'] = new_saved
+        self._save(data)
+        logger.info("Deleted saved command '%s'", name)
+        return True
+
+    def _load(self) -> dict:
+        """Load store from disk.
+
+        Returns:
+            Dictionary with 'saved_commands' and 'history' keys.
+        """
+        if not self._store_path.exists():
+            return {'saved_commands': [], 'history': {}}
+
+        try:
+            with open(self._store_path, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error("Error loading command history: %s", e)
+            return {'saved_commands': [], 'history': {}}
+
+    def _save(self, data: dict) -> None:
+        """Save store to disk.
+
+        Args:
+            data: Dictionary with 'saved_commands' and 'history' keys.
+        """
+        try:
+            self._store_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._store_path, 'w') as f:
+                json.dump(data, f, indent=2)
+        except IOError as e:
+            logger.error("Error saving command history: %s", e)

--- a/src/ec2_ssh/services/keyword_store.py
+++ b/src/ec2_ssh/services/keyword_store.py
@@ -25,7 +25,7 @@ class KeywordStore(KeywordStoreInterface):
     }
     """
 
-    def __init__(self, store_path: str = "~/.ec2_ssh_keywords.json") -> None:
+    def __init__(self, store_path: str = "~/.ec2-ssh/keywords.json") -> None:
         """Initialize the keyword store.
 
         Args:

--- a/src/ec2_ssh/services/terminal_service.py
+++ b/src/ec2_ssh/services/terminal_service.py
@@ -16,7 +16,7 @@ from ec2_ssh.utils.platform_utils import get_os
 logger = logging.getLogger(__name__)
 
 # Directory for wrapper scripts that keep the terminal open on failure
-_WRAPPER_DIR = Path.home() / '.ec2_ssh_logs'
+_WRAPPER_DIR = Path.home() / '.ec2-ssh' / 'logs'
 
 
 class TerminalService(TerminalServiceInterface):

--- a/tests/test_command_history.py
+++ b/tests/test_command_history.py
@@ -1,0 +1,121 @@
+"""Tests for command history service."""
+
+import pytest
+
+from ec2_ssh.services.command_history import CommandHistoryService, MAX_INSTANCE_HISTORY, MAX_GLOBAL_HISTORY
+
+
+class TestCommandHistory:
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        return CommandHistoryService(str(tmp_path / 'history.json'))
+
+
+class TestAddToHistory(TestCommandHistory):
+
+    def test_add_and_get_instance(self, service):
+        service.add_to_history('i-abc123', 'ls -la')
+        assert service.get_instance_history('i-abc123') == ['ls -la']
+
+    def test_add_multiple(self, service):
+        service.add_to_history('i-abc123', 'ls')
+        service.add_to_history('i-abc123', 'pwd')
+        assert service.get_instance_history('i-abc123') == ['ls', 'pwd']
+
+    def test_dedup_consecutive(self, service):
+        service.add_to_history('i-abc123', 'ls')
+        service.add_to_history('i-abc123', 'ls')
+        assert service.get_instance_history('i-abc123') == ['ls']
+
+    def test_allow_non_consecutive_dup(self, service):
+        service.add_to_history('i-abc123', 'ls')
+        service.add_to_history('i-abc123', 'pwd')
+        service.add_to_history('i-abc123', 'ls')
+        assert service.get_instance_history('i-abc123') == ['ls', 'pwd', 'ls']
+
+    def test_global_history_populated(self, service):
+        service.add_to_history('i-abc123', 'ls')
+        service.add_to_history('i-def456', 'pwd')
+        assert service.get_global_history() == ['ls', 'pwd']
+
+    def test_separate_instance_histories(self, service):
+        service.add_to_history('i-abc123', 'ls')
+        service.add_to_history('i-def456', 'pwd')
+        assert service.get_instance_history('i-abc123') == ['ls']
+        assert service.get_instance_history('i-def456') == ['pwd']
+
+    def test_empty_instance(self, service):
+        assert service.get_instance_history('i-nonexistent') == []
+
+    def test_empty_global(self, service):
+        assert service.get_global_history() == []
+
+    def test_instance_history_trimmed(self, service):
+        for i in range(MAX_INSTANCE_HISTORY + 20):
+            service.add_to_history('i-abc123', f'cmd{i}')
+        history = service.get_instance_history('i-abc123')
+        assert len(history) == MAX_INSTANCE_HISTORY
+        assert history[-1] == f'cmd{MAX_INSTANCE_HISTORY + 19}'
+
+    def test_global_history_trimmed(self, service):
+        for i in range(MAX_GLOBAL_HISTORY + 20):
+            service.add_to_history('i-abc123', f'cmd{i}')
+        history = service.get_global_history()
+        assert len(history) == MAX_GLOBAL_HISTORY
+
+
+class TestSavedCommands(TestCommandHistory):
+
+    def test_save_and_get(self, service):
+        service.save_command('Disk Usage', 'df -h')
+        saved = service.get_saved_commands()
+        assert len(saved) == 1
+        assert saved[0] == {'name': 'Disk Usage', 'command': 'df -h'}
+
+    def test_save_multiple(self, service):
+        service.save_command('Disk', 'df -h')
+        service.save_command('Memory', 'free -m')
+        saved = service.get_saved_commands()
+        assert len(saved) == 2
+
+    def test_overwrite_same_name(self, service):
+        service.save_command('Status', 'pm2 list')
+        service.save_command('Status', 'pm2 status')
+        saved = service.get_saved_commands()
+        assert len(saved) == 1
+        assert saved[0]['command'] == 'pm2 status'
+
+    def test_delete_saved(self, service):
+        service.save_command('Disk', 'df -h')
+        service.save_command('Memory', 'free -m')
+        assert service.delete_saved_command('Disk') is True
+        saved = service.get_saved_commands()
+        assert len(saved) == 1
+        assert saved[0]['name'] == 'Memory'
+
+    def test_delete_nonexistent(self, service):
+        assert service.delete_saved_command('nope') is False
+
+    def test_empty_saved(self, service):
+        assert service.get_saved_commands() == []
+
+
+class TestPersistence(TestCommandHistory):
+
+    def test_survives_reload(self, tmp_path):
+        path = str(tmp_path / 'history.json')
+        svc1 = CommandHistoryService(path)
+        svc1.add_to_history('i-abc123', 'ls')
+        svc1.save_command('Test', 'echo hello')
+
+        svc2 = CommandHistoryService(path)
+        assert svc2.get_instance_history('i-abc123') == ['ls']
+        assert svc2.get_saved_commands() == [{'name': 'Test', 'command': 'echo hello'}]
+
+    def test_corrupted_file(self, tmp_path):
+        path = tmp_path / 'history.json'
+        path.write_text('not json{{{')
+        service = CommandHistoryService(str(path))
+        assert service.get_instance_history('anything') == []
+        assert service.get_saved_commands() == []


### PR DESCRIPTION
## Summary

- **Consolidate runtime files** under `~/.ec2-ssh/` (was scattered across `~/.ec2_ssh_config.json`, `~/.ec2_ssh_cache.json`, `~/.ec2_ssh_logs/`, etc.)
- **Auto-migrate** legacy paths on first startup — transparent, one-time move
- **Add CommandHistoryService** with per-instance + global persistent command history
- **Add command picker** (`Ctrl+R`) with search/filter across saved commands and recent history
- **Add save command** (`Ctrl+S`) with custom name prompt modal
- **Keybinding hints bar** in the command overlay showing all available shortcuts

## New files

- `src/ec2_ssh/services/command_history.py` — CommandHistoryService
- `src/ec2_ssh/screens/command_picker.py` — CommandPickerModal + SaveCommandModal
- `tests/test_command_history.py` — 18 tests

## Changed files (19)

**Core path changes:** `schema.py`, `manager.py`, `migration.py`, `cache_service.py`, `terminal_service.py`, `keyword_store.py`, `main.py`

**Command overlay integration:** `command_overlay.py`, `app.py`, `app.css`

**Docs/UI updates:** `help.py`, `settings.py`, `install.sh`, `install.ps1`, `README.md`, `CLAUDE.md`, `docs/configuration.md`, `docs/troubleshooting.md`, `docs/architecture.md`

## Test plan

- [ ] First run with old paths: files auto-migrate to `~/.ec2-ssh/`, app works normally
- [ ] Fresh install: `~/.ec2-ssh/` created automatically
- [ ] Command overlay: execute commands → close → reopen → Up arrow restores history
- [ ] `Ctrl+S` saves command with custom name → `Ctrl+R` shows it in picker → select → populates input
- [ ] Search field in picker filters saved and recent commands
- [ ] Different server: own history via arrows, shared global via `Ctrl+R`
- [ ] `pytest` — all 171 tests pass