### PR TITLE
fix(mcp): support custom servers in all MCP tool operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,20 @@ All runtime files are under `~/.servonaut/`:
 - `httpx>=0.25.0` — AI log analysis (`pip install 'servonaut[ai]'`)
 - `mcp>=1.0.0` — MCP server for AI agents (`pip install 'servonaut[mcp]'`)
 - Install all: `pip install 'servonaut[all]'`
+
+## Workflow Learnings
+
+### Patterns Discovered
+- MCP `ServonautTools` receives `custom_server_service` as constructor argument and uses `list_as_instances()` to merge custom servers alongside AWS instances in both `_find_instance` and `list_instances`.
+- `_find_instance` performs case-insensitive match on both `id` and `name` fields across the merged AWS + custom list. AWS instances are searched first, so they take precedence on name collisions.
+- `SCPService._build_base_args` accepts `port: Optional[int]` and emits `-P <port>` (uppercase P, SCP convention) when port is non-None and not 22.
+- Custom server connection is branched in `_resolve_connection` via `instance.get('is_custom')`: custom servers read `username`, `ssh_key`, and `port` directly from the instance dict; AWS instances use `SSHService.get_key_path` and profile-based username resolution.
+
+### Issues Resolved
+- MCP tools previously ignored `CustomServerService` entirely — `_find_instance` only queried AWS, and `list_instances` never included custom servers. Fixed by injecting `custom_server_service` into `ServonautTools` and merging both lists.
+- Port was not forwarded from custom server instance dict to SSH/SCP commands. Fixed by passing `conn.get('port')` through `build_ssh_command` and `build_upload_command`/`build_download_command`.
+- `SCPServiceInterface` signatures lacked the `port` parameter, causing a mismatch with the implementation. Fixed by adding `port: Optional[int] = None` to both abstract methods.
+
+### Key Decisions
+- Chose Option B (inline resolver in `_find_instance`) rather than a separate `InstanceResolver` class — sufficient for current provider count (AWS + custom) and keeps the surface area small. Can be extracted if a third provider is added.
+- Tool descriptions in `server.py` updated from EC2-specific language to "any managed instance" to reflect multi-provider reality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servonaut"
-version = "2.4.10"
+version = "2.4.11"
 description = "Interactive TUI for managing servers — SSH, SCP, scanning & more"
 readme = "README.md"
 license = "MIT"

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -22,6 +22,7 @@ def create_mcp_server():
     from servonaut.services.ssh_service import SSHService
     from servonaut.services.connection_service import ConnectionService
     from servonaut.services.scp_service import SCPService
+    from servonaut.services.custom_server_service import CustomServerService
     from servonaut.mcp.guards import CommandGuard
     from servonaut.mcp.audit import AuditTrail
     from servonaut.mcp.tools import ServonautTools
@@ -31,6 +32,7 @@ def create_mcp_server():
     config = config_manager.get()
     cache_service = CacheService(ttl_seconds=config.cache_ttl_seconds)
     aws_service = AWSService(cache_service)
+    custom_server_service = CustomServerService(config_manager)
     ssh_service = SSHService(config_manager)
     connection_service = ConnectionService(config_manager)
     scp_service = SCPService()
@@ -39,7 +41,7 @@ def create_mcp_server():
     audit = AuditTrail(config.mcp.audit_path)
 
     tools = ServonautTools(
-        config_manager, aws_service, cache_service,
+        config_manager, aws_service, custom_server_service, cache_service,
         ssh_service, connection_service, scp_service,
         guard, audit,
     )
@@ -49,44 +51,44 @@ def create_mcp_server():
     @server.list_tools()
     async def list_tools():
         return [
-            Tool(name="list_instances", description="List EC2 instances", inputSchema={
+            Tool(name="list_instances", description="List all managed server instances (AWS EC2, custom servers)", inputSchema={
                 "type": "object",
                 "properties": {
-                    "region": {"type": "string", "description": "AWS region filter"},
+                    "region": {"type": "string", "description": "Filter by region or provider (e.g. 'us-east-1', 'custom')"},
                     "state": {"type": "string", "description": "Instance state filter"},
                 },
             }),
-            Tool(name="run_command", description="Run command on remote instance via SSH", inputSchema={
+            Tool(name="run_command", description="Run command on any managed instance via SSH", inputSchema={
                 "type": "object",
                 "properties": {
-                    "instance_id": {"type": "string", "description": "Instance ID or name"},
+                    "instance_id": {"type": "string", "description": "Instance ID, name, or custom server name"},
                     "command": {"type": "string", "description": "Command to execute"},
                 },
                 "required": ["instance_id", "command"],
             }),
-            Tool(name="get_logs", description="Get log file content from remote instance", inputSchema={
+            Tool(name="get_logs", description="Get log file content from any managed instance", inputSchema={
                 "type": "object",
                 "properties": {
-                    "instance_id": {"type": "string", "description": "Instance ID or name"},
+                    "instance_id": {"type": "string", "description": "Instance ID, name, or custom server name"},
                     "log_path": {"type": "string", "description": "Log file path", "default": "/var/log/syslog"},
                     "lines": {"type": "integer", "description": "Number of lines to retrieve", "default": 100},
                 },
                 "required": ["instance_id"],
             }),
-            Tool(name="check_status", description="Check instance status", inputSchema={
+            Tool(name="check_status", description="Check status of any managed instance", inputSchema={
                 "type": "object",
-                "properties": {"instance_id": {"type": "string"}},
+                "properties": {"instance_id": {"type": "string", "description": "Instance ID, name, or custom server name"}},
                 "required": ["instance_id"],
             }),
-            Tool(name="get_server_info", description="Get detailed server info", inputSchema={
+            Tool(name="get_server_info", description="Get detailed server info from any managed instance", inputSchema={
                 "type": "object",
-                "properties": {"instance_id": {"type": "string"}},
+                "properties": {"instance_id": {"type": "string", "description": "Instance ID, name, or custom server name"}},
                 "required": ["instance_id"],
             }),
-            Tool(name="transfer_file", description="Transfer file via SCP", inputSchema={
+            Tool(name="transfer_file", description="Transfer file via SCP to/from any managed instance", inputSchema={
                 "type": "object",
                 "properties": {
-                    "instance_id": {"type": "string"},
+                    "instance_id": {"type": "string", "description": "Instance ID, name, or custom server name"},
                     "local_path": {"type": "string"},
                     "remote_path": {"type": "string"},
                     "direction": {"type": "string", "enum": ["upload", "download"]},

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -13,10 +13,12 @@ logger = logging.getLogger(__name__)
 class ServonautTools:
     """Implements all MCP tools using Servonaut services."""
 
-    def __init__(self, config_manager, aws_service, cache_service, ssh_service,
-                 connection_service, scp_service, guard, audit) -> None:
+    def __init__(self, config_manager, aws_service, custom_server_service,
+                 cache_service, ssh_service, connection_service, scp_service,
+                 guard, audit) -> None:
         self._config_manager = config_manager
         self._aws_service = aws_service
+        self._custom_server_service = custom_server_service
         self._cache_service = cache_service
         self._ssh_service = ssh_service
         self._connection_service = connection_service
@@ -26,13 +28,15 @@ class ServonautTools:
         self._max_lines = config_manager.get().mcp.max_output_lines
 
     async def list_instances(self, region: str = "", state: str = "") -> str:
-        """List EC2 instances, optionally filtered by region/state."""
+        """List all managed instances (AWS EC2 + custom servers), optionally filtered."""
         allowed, reason = self._guard.check_tool('list_instances')
         if not allowed:
             self._audit.log('list_instances', {'region': region, 'state': state}, '', False, reason)
             return f"Blocked: {reason}"
 
-        instances = await self._aws_service.fetch_instances_cached()
+        aws_instances = await self._aws_service.fetch_instances_cached()
+        custom_instances = self._custom_server_service.list_as_instances()
+        instances = aws_instances + custom_instances
         if region:
             instances = [i for i in instances if i.get('region') == region]
         if state:
@@ -62,7 +66,8 @@ class ServonautTools:
 
         ssh_cmd = self._ssh_service.build_ssh_command(
             host=conn['host'], username=conn['username'], key_path=conn['key_path'],
-            proxy_args=conn['proxy_args'], remote_command=command
+            proxy_args=conn['proxy_args'], remote_command=command,
+            port=conn.get('port'),
         )
 
         try:
@@ -132,7 +137,8 @@ class ServonautTools:
 
         ssh_cmd = self._ssh_service.build_ssh_command(
             host=conn['host'], username=conn['username'], key_path=conn['key_path'],
-            proxy_args=conn['proxy_args'], remote_command=command
+            proxy_args=conn['proxy_args'], remote_command=command,
+            port=conn.get('port'),
         )
 
         try:
@@ -169,6 +175,7 @@ class ServonautTools:
         key_path = conn['key_path']
         proxy_args = conn['proxy_args']
         profile = conn['profile']
+        port = conn.get('port')
 
         proxy_jump = self._connection_service.get_proxy_jump_string(profile) if profile else None
 
@@ -177,12 +184,14 @@ class ServonautTools:
                 local_path=local_path, remote_path=remote_path,
                 host=host, username=username, key_path=key_path,
                 proxy_jump=proxy_jump, proxy_args=proxy_args or None,
+                port=port,
             )
         else:
             scp_cmd = self._scp_service.build_download_command(
                 remote_path=remote_path, local_path=local_path,
                 host=host, username=username, key_path=key_path,
                 proxy_jump=proxy_jump, proxy_args=proxy_args or None,
+                port=port,
             )
 
         returncode, stdout, stderr = await self._scp_service.execute_transfer(scp_cmd)
@@ -208,9 +217,13 @@ class ServonautTools:
         proxy_args = self._connection_service.get_proxy_args(profile) if profile else []
 
         if instance.get('is_custom'):
-            username = instance.get('username') or 'root'
+            username = (
+                instance.get('username')
+                or self._config_manager.get().default_username
+                or 'root'
+            )
             key_path = instance.get('ssh_key') or instance.get('key_name') or None
-            port = instance.get('port', 22)
+            port = instance.get('port') or None
         else:
             username = (
                 (profile.username if profile else None)
@@ -228,9 +241,16 @@ class ServonautTools:
         }
 
     async def _find_instance(self, instance_id: str) -> Optional[Dict]:
-        instances = await self._aws_service.fetch_instances_cached()
-        for inst in instances:
-            if inst.get('id') == instance_id or inst.get('name') == instance_id:
+        """Find instance by ID or name across all providers (AWS + custom)."""
+        aws_instances = await self._aws_service.fetch_instances_cached()
+        custom_instances = self._custom_server_service.list_as_instances()
+        all_instances = aws_instances + custom_instances
+        instance_id_lower = instance_id.lower()
+        for inst in all_instances:
+            if (inst.get('id') == instance_id
+                    or inst.get('id', '').lower() == instance_id_lower
+                    or inst.get('name') == instance_id
+                    or inst.get('name', '').lower() == instance_id_lower):
                 return inst
         return None
 

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -161,7 +161,9 @@ class SCPServiceInterface(ABC):
         host: str,
         username: str,
         key_path: Optional[str] = None,
-        proxy_jump: Optional[str] = None
+        proxy_jump: Optional[str] = None,
+        proxy_args: Optional[List[str]] = None,
+        port: Optional[int] = None,
     ) -> List[str]:
         """Build SCP upload command.
 
@@ -172,6 +174,8 @@ class SCPServiceInterface(ABC):
             username: SSH username.
             key_path: Path to SSH key (optional if using agent).
             proxy_jump: ProxyJump string (user@host).
+            proxy_args: List of SSH proxy arguments.
+            port: SSH port (omitted if None or 22).
 
         Returns:
             List of command arguments for subprocess.
@@ -186,7 +190,9 @@ class SCPServiceInterface(ABC):
         host: str,
         username: str,
         key_path: Optional[str] = None,
-        proxy_jump: Optional[str] = None
+        proxy_jump: Optional[str] = None,
+        proxy_args: Optional[List[str]] = None,
+        port: Optional[int] = None,
     ) -> List[str]:
         """Build SCP download command.
 
@@ -197,6 +203,8 @@ class SCPServiceInterface(ABC):
             username: SSH username.
             key_path: Path to SSH key (optional if using agent).
             proxy_jump: ProxyJump string (user@host).
+            proxy_args: List of SSH proxy arguments.
+            port: SSH port (omitted if None or 22).
 
         Returns:
             List of command arguments for subprocess.

--- a/src/servonaut/services/scp_service.py
+++ b/src/servonaut/services/scp_service.py
@@ -27,7 +27,8 @@ class SCPService(SCPServiceInterface):
         username: str,
         key_path: Optional[str] = None,
         proxy_jump: Optional[str] = None,
-        proxy_args: Optional[List[str]] = None
+        proxy_args: Optional[List[str]] = None,
+        port: Optional[int] = None,
     ) -> List[str]:
         """Build SCP upload command.
 
@@ -45,7 +46,7 @@ class SCPService(SCPServiceInterface):
         Returns:
             List of command arguments for subprocess.
         """
-        cmd = self._build_base_args(key_path, proxy_jump, proxy_args)
+        cmd = self._build_base_args(key_path, proxy_jump, proxy_args, port)
         cmd.append(os.path.expanduser(local_path))
         cmd.append(f'{username}@{host}:{remote_path}')
         logger.debug("Built SCP upload command: %s", ' '.join(cmd))
@@ -59,7 +60,8 @@ class SCPService(SCPServiceInterface):
         username: str,
         key_path: Optional[str] = None,
         proxy_jump: Optional[str] = None,
-        proxy_args: Optional[List[str]] = None
+        proxy_args: Optional[List[str]] = None,
+        port: Optional[int] = None,
     ) -> List[str]:
         """Build SCP download command.
 
@@ -77,7 +79,7 @@ class SCPService(SCPServiceInterface):
         Returns:
             List of command arguments for subprocess.
         """
-        cmd = self._build_base_args(key_path, proxy_jump, proxy_args)
+        cmd = self._build_base_args(key_path, proxy_jump, proxy_args, port)
         cmd.append(f'{username}@{host}:{remote_path}')
         cmd.append(os.path.expanduser(local_path))
         logger.debug("Built SCP download command: %s", ' '.join(cmd))
@@ -127,7 +129,8 @@ class SCPService(SCPServiceInterface):
         self,
         key_path: Optional[str],
         proxy_jump: Optional[str],
-        proxy_args: Optional[List[str]] = None
+        proxy_args: Optional[List[str]] = None,
+        port: Optional[int] = None,
     ) -> List[str]:
         """Build base SCP command arguments.
 
@@ -144,6 +147,10 @@ class SCPService(SCPServiceInterface):
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
         ]
+
+        # Add non-default port (SCP uses -P uppercase, unlike SSH's -p)
+        if port is not None and port != 22:
+            cmd.extend(['-P', str(port)])
 
         # Add proxy arguments (proxy_args takes precedence over proxy_jump)
         if proxy_args:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -11,6 +11,26 @@ from servonaut.mcp.guards import CommandGuard, GuardLevel
 from servonaut.mcp.tools import ServonautTools
 
 
+SAMPLE_CUSTOM_INSTANCES = [
+    {
+        "id": "custom-ovh-web",
+        "name": "ovh-web",
+        "type": "custom",
+        "state": "unknown",
+        "public_ip": "51.195.151.208",
+        "private_ip": "51.195.151.208",
+        "region": "OVH",
+        "key_name": "~/.ssh/ovh.pem",
+        "ssh_key": "~/.ssh/ovh.pem",
+        "provider": "OVH",
+        "group": "",
+        "tags": {},
+        "port": 2222,
+        "username": "ubuntu",
+        "is_custom": True,
+    },
+]
+
 SAMPLE_INSTANCES = [
     {
         "id": "i-abc123",
@@ -35,7 +55,7 @@ SAMPLE_INSTANCES = [
 ]
 
 
-def make_tools(guard_level=GuardLevel.STANDARD, instances=None, max_output_lines=500):
+def make_tools(guard_level=GuardLevel.STANDARD, instances=None, custom_instances=None, max_output_lines=500):
     if instances is None:
         instances = SAMPLE_INSTANCES
 
@@ -45,6 +65,9 @@ def make_tools(guard_level=GuardLevel.STANDARD, instances=None, max_output_lines
 
     aws_service = MagicMock()
     aws_service.fetch_instances_cached = AsyncMock(return_value=instances)
+
+    custom_server_service = MagicMock()
+    custom_server_service.list_as_instances.return_value = custom_instances or []
 
     cache_service = MagicMock()
 
@@ -71,7 +94,7 @@ def make_tools(guard_level=GuardLevel.STANDARD, instances=None, max_output_lines
     audit.log = MagicMock()
 
     tools = ServonautTools(
-        config_manager, aws_service, cache_service,
+        config_manager, aws_service, custom_server_service, cache_service,
         ssh_service, connection_service, scp_service,
         guard, audit,
     )
@@ -299,3 +322,44 @@ class TestTransferFile:
         run(tools.transfer_file("i-abc123", "/l", "/r", "download"))
         tools._audit.log.assert_called_once()
         assert tools._audit.log.call_args[0][0] == "transfer_file"
+
+
+class TestCustomServerResolution:
+    def test_find_by_custom_name(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.check_status("ovh-web"))
+        assert "custom-ovh-web" in result
+        assert "ovh-web" in result
+
+    def test_find_by_custom_id(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.check_status("custom-ovh-web"))
+        assert "custom-ovh-web" in result
+
+    def test_find_case_insensitive(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.check_status("OVH-Web"))
+        assert "custom-ovh-web" in result
+
+    def test_custom_not_found(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.check_status("nonexistent-server"))
+        assert "not found" in result.lower()
+
+    def test_list_instances_includes_custom(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.list_instances())
+        assert "ovh-web" in result
+        assert "web-server-prod" in result
+
+    def test_list_instances_filter_by_custom_region(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.list_instances(region="OVH"))
+        assert "ovh-web" in result
+        assert "web-server-prod" not in result
+
+    def test_aws_takes_precedence_over_custom(self):
+        """AWS instances are searched first; if names collide, AWS wins."""
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+        result = run(tools.check_status("web-server-prod"))
+        assert "i-abc123" in result


### PR DESCRIPTION
## Summary

- MCP tools (`run_command`, `get_server_info`, `get_logs`, `transfer_file`, `list_instances`, `check_status`) previously only resolved AWS EC2 instances — custom servers added via the TUI were invisible
- Inject `CustomServerService` into `ServonautTools` and merge custom servers into instance resolution and listing
- Pass `port` through to SSH and SCP commands for custom servers on non-default ports
- Update tool descriptions to reflect multi-provider support
- Add 7 custom server resolution tests (39 total MCP tests, 512 full suite)

## Test plan

- [x] `list_instances` shows AWS + custom servers
- [x] `check_status("ovh-web")` resolves custom server by name
- [x] `run_command("ovh-web", "hostname")` executes via SSH successfully
- [x] `get_server_info("ovh-web")` returns hostname, uptime, disk, memory
- [x] AWS instances unaffected (no regression)
- [x] 512/512 tests pass