### PR TITLE
docs(config): correct RelayConfig example URLs to match prod topology

### DIFF
--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -154,9 +154,20 @@ class AzureConfig:
 
 @dataclass
 class RelayConfig:
-    """Mercure relay listener configuration."""
-    base_url: str = ""            # e.g. https://app.servonaut.dev
-    mercure_url: str = ""         # e.g. https://hub.servonaut.dev/.well-known/mercure
+    """Mercure relay listener configuration.
+
+    ``base_url`` is the servonaut.dev REST API where the listener posts
+    heartbeats and fetches the short-lived Mercure subscriber JWT.
+    ``mercure_url`` is the Mercure hub itself — on production, the hub
+    is mounted at the apex domain's ``/.well-known/mercure`` path (no
+    dedicated subdomain). A typical production ``relay`` block in
+    ``~/.servonaut/config.json``:
+
+    * base_url    = ``https://api.servonaut.dev``
+    * mercure_url = ``https://servonaut.dev/.well-known/mercure``
+    """
+    base_url: str = ""            # e.g. https://api.servonaut.dev
+    mercure_url: str = ""         # e.g. https://servonaut.dev/.well-known/mercure
     heartbeat_interval: int = 30
 
 


### PR DESCRIPTION
## Summary

Fix the `RelayConfig` docstring so the example URLs match how production
is actually laid out. The previous examples (`app.servonaut.dev`,
`hub.servonaut.dev`) were speculative — prod serves the API at
`api.servonaut.dev` and mounts the Mercure hub at the apex domain's
`/.well-known/mercure` path (no dedicated subdomain).

Only production URLs are committed. Staging-specific values are kept out
of the public repo because there's no real security benefit to
advertising the staging hostname here — it's trivially discoverable via
certificate transparency, but committing it as a grep-able string
invites drive-by traffic and creates a maintenance risk if staging's
protections ever loosen. Anyone who needs the staging values has access
to them through their team setup.

## Changes

- Rewrote the `RelayConfig` docstring so the prod pair is spelled out
  explicitly:

  ```
  base_url    = https://api.servonaut.dev
  mercure_url = https://servonaut.dev/.well-known/mercure
  ```

- Updated the inline `# e.g. ...` hints on the two fields accordingly.

No code change — doc-only.

## Testing

- [x] 1599 tests still pass (unchanged)
- [x] Docstring renders cleanly