### PR TITLE
feat(bug-report): in-TUI bug reporter with consent + dual channels

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -48,6 +48,7 @@ class ServonautApp(App):
     ai_analysis_service = None
     chat_service = None
     update_service = None
+    bug_report_service = None
     redaction_service = None
     ovh_service = None
     ovh_billing_service = None
@@ -317,6 +318,25 @@ class ServonautApp(App):
             logger.debug("httpx not installed; paid-tier services unavailable")
         except Exception as e:
             logger.debug("Paid-tier services init skipped: %s", e)
+
+        # Bug-report service — works for anonymous users too. Backend channel
+        # needs httpx; GitHub channel works regardless. Reuse the existing
+        # api_client when init_paid_services already ran (signed-in user);
+        # otherwise build a standalone unauthenticated APIClient.
+        try:
+            from servonaut.services.bug_report_service import BugReportService
+            from servonaut.services.api_client import APIClient
+            br_client = self.api_client if self.api_client is not None else APIClient(self.auth_service)
+            self.bug_report_service = BugReportService(
+                config_manager=self.config_manager,
+                api_client=br_client,
+                auth_service=self.auth_service,
+                update_service=self.update_service,
+            )
+        except ImportError:
+            logger.debug("httpx not installed; bug report service unavailable")
+        except Exception as e:
+            logger.debug("Bug report service init skipped: %s", e)
 
     def _init_relay_manager(self) -> None:
         """Create the RelayManager the first time; subsequent calls are no-ops."""
@@ -950,6 +970,15 @@ class ServonautApp(App):
         elif target_id == "nav_memory_export":
             from servonaut.screens.memory_export import MemoryExportScreen
             self.switch_screen(MemoryExportScreen())
+        elif target_id == "nav_bug_report":
+            if self.bug_report_service is None:
+                self.notify(
+                    "Bug reporting requires httpx. Install with: pip install 'servonaut[pro]'",
+                    severity="warning",
+                )
+                return
+            from servonaut.screens.bug_report import BugReportScreen
+            self.push_screen(BugReportScreen())
         elif target_id == "nav_quit":
             self.exit()
 

--- a/src/servonaut/screens/bug_report.py
+++ b/src/servonaut/screens/bug_report.py
@@ -1,0 +1,454 @@
+"""Bug report screen — collect diagnostics, preview, and submit.
+
+A regular Screen (not modal) so the persistent Sidebar stays visible
+during the multi-step flow: consent -> collect -> preview -> submit.
+
+Flow:
+  1. on_mount pushes BugReportConsentModal.
+  2. Consent returned -> worker collects diagnostics via BugReportService.
+  3. Preview rendered into the Static widget; Submit button enabled.
+  4. User edits title/description, optionally refreshes preview.
+  5. Submit worker calls service.submit(); on success shows receipt.
+"""
+
+from __future__ import annotations
+
+import logging
+import webbrowser
+from typing import Optional
+
+from rich.markup import escape as _esc
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Header, Input, Label, Static, TextArea
+
+from servonaut.screens._binding_guard import check_action_passthrough
+from servonaut.screens.bug_report_consent_modal import BugReportConsentModal
+from servonaut.services.bug_report_service import (
+    BugReportConsent,
+    BugReportPayload,
+    BugReportReceipt,
+    BugReportSubmissionError,
+)
+from servonaut.widgets.sidebar import Sidebar
+
+logger = logging.getLogger(__name__)
+
+
+class BugReportScreen(Screen):
+    """Multi-step screen for filing a bug report.
+
+    Compose layout (beside the Sidebar):
+      - Title header
+      - Short-summary Input
+      - Multi-line description TextArea
+      - Diagnostics status row
+      - Action buttons: Edit consent / Refresh preview / Submit
+      - Scrollable preview area populated after consent + collect
+    """
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    BugReportScreen #main-layout {
+        height: 1fr;
+    }
+
+    BugReportScreen #bug-report-content {
+        padding: 1 2;
+        height: 1fr;
+    }
+
+    BugReportScreen #bug-title-header {
+        height: auto;
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+
+    BugReportScreen .field-label {
+        height: auto;
+        text-style: bold;
+        color: $accent;
+        margin-top: 1;
+    }
+
+    BugReportScreen .field-help {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    BugReportScreen #title {
+        margin-bottom: 1;
+    }
+
+    BugReportScreen #description {
+        height: 8;
+        margin-bottom: 1;
+    }
+
+    BugReportScreen #submission-error {
+        height: auto;
+        color: $error;
+        background: $error 10%;
+        padding: 1;
+        margin-bottom: 1;
+        display: none;
+    }
+
+    BugReportScreen #submission-error.visible {
+        display: block;
+    }
+
+    BugReportScreen #diagnostics-status {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    BugReportScreen #btn-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    BugReportScreen #btn-row Button {
+        margin-right: 1;
+    }
+
+    BugReportScreen #redact-warning {
+        height: auto;
+        color: $warning;
+        margin-bottom: 1;
+        display: none;
+    }
+
+    BugReportScreen #redact-warning.visible {
+        display: block;
+    }
+
+    BugReportScreen #preview-scroll {
+        height: 1fr;
+        border: round $primary 50%;
+    }
+
+    BugReportScreen #preview {
+        height: auto;
+        padding: 1;
+    }
+
+    BugReportScreen #receipt-row {
+        height: auto;
+        margin-top: 1;
+        display: none;
+    }
+
+    BugReportScreen #receipt-row.visible {
+        display: block;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._consent: Optional[BugReportConsent] = None
+        self._payload: Optional[BugReportPayload] = None
+        self._receipt: Optional[BugReportReceipt] = None
+
+    def check_action(self, action: str, parameters: tuple) -> bool | None:
+        return check_action_passthrough(self, action)
+
+    # ------------------------------------------------------------------
+    # Compose
+    # ------------------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="main-layout"):
+            yield Sidebar()
+            with Container(id="bug-report-content"):
+                yield Static("[bold cyan]Report a bug[/bold cyan]", id="bug-title-header")
+                yield Label("Title", classes="field-label")
+                yield Static(
+                    "One sentence describing the problem (5-200 chars).",
+                    classes="field-help",
+                )
+                yield Input(
+                    placeholder="e.g. Crash when scanning EC2 instances in eu-west-3",
+                    id="title",
+                )
+                yield Label("Description", classes="field-label")
+                yield Static(
+                    "Steps to reproduce, what you expected, what actually happened. "
+                    "The command you ran helps. Logs and stack traces are auto-attached "
+                    "in the preview below — don't paste them here.",
+                    classes="field-help",
+                )
+                yield TextArea(
+                    "",
+                    id="description",
+                )
+                yield Static(
+                    "Diagnostics: not collected yet",
+                    id="diagnostics-status",
+                )
+                with Horizontal(id="btn-row"):
+                    yield Button("Edit consent", id="edit-consent", variant="default")
+                    yield Button("Refresh preview", id="refresh-preview", variant="default")
+                    yield Button(
+                        "Submit",
+                        id="submit",
+                        variant="primary",
+                        disabled=True,
+                    )
+                yield Static("", id="submission-error")
+                yield Static("", id="redact-warning")
+                yield Static("", id="receipt-row")
+                with VerticalScroll(id="preview-scroll"):
+                    yield Static("", id="preview", markup=False)
+        yield Footer()
+
+    # ------------------------------------------------------------------
+    # Mount — immediately push consent modal
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        self.app.push_screen(
+            BugReportConsentModal(),
+            callback=self._on_consent_returned,
+        )
+
+    # ------------------------------------------------------------------
+    # Consent callback
+    # ------------------------------------------------------------------
+
+    def _on_consent_returned(self, consent: Optional[BugReportConsent]) -> None:
+        if consent is None:
+            self.app.notify("Bug report cancelled", markup=False)
+            self.app.pop_screen()
+            return
+        self._consent = consent
+        self._start_collect()
+
+    # ------------------------------------------------------------------
+    # Diagnostics collection
+    # ------------------------------------------------------------------
+
+    def _start_collect(self) -> None:
+        status = self.query_one("#diagnostics-status", Static)
+        status.update("Diagnostics: collecting...")
+        self.run_worker(
+            self._do_collect(),
+            group="bug_report",
+            name="collect_diagnostics",
+        )
+
+    async def _do_collect(self) -> None:
+        service = getattr(self.app, "bug_report_service", None)
+        status = self.query_one("#diagnostics-status", Static)
+        if service is None:
+            status.update("[red]Bug report service not available.[/red]")
+            return
+        try:
+            instances = getattr(self.app, "instances", [])
+            payload = service.collect_diagnostics(
+                consent=self._consent,
+                instances=instances,
+            )
+            self._payload = payload
+
+            # Warn about redacted categories
+            redact_warning = self.query_one("#redact-warning", Static)
+            if payload.redacted_categories_found:
+                cats = ", ".join(payload.redacted_categories_found)
+                redact_warning.update(
+                    f"WARNING: Detected and redacted: {cats} — "
+                    "review preview to confirm before submitting."
+                )
+                redact_warning.add_class("visible")
+            else:
+                redact_warning.remove_class("visible")
+
+            status.update("Diagnostics: collected — review the preview below.")
+            self._refresh_preview()
+            submit_btn = self.query_one("#submit", Button)
+            submit_btn.disabled = False
+        except Exception as exc:
+            logger.error("Failed to collect diagnostics: %s", exc)
+            status.update(f"[red]Collection failed: {_esc(str(exc))}[/red]")
+
+    # ------------------------------------------------------------------
+    # Preview rendering
+    # ------------------------------------------------------------------
+
+    def _refresh_preview(self) -> None:
+        """Re-render preview from current title/description without re-collecting."""
+        service = getattr(self.app, "bug_report_service", None)
+        if service is None or self._payload is None:
+            return
+        title = self.query_one("#title", Input).value
+        description = self.query_one("#description", TextArea).text
+        try:
+            markdown = service.render_preview(
+                payload=self._payload,
+                title=title,
+                description=description,
+            )
+            preview = self.query_one("#preview", Static)
+            preview.update(markdown)
+        except Exception as exc:
+            logger.error("Failed to render preview: %s", exc)
+            self.app.notify(
+                f"Preview render failed: {exc}",
+                severity="warning",
+                markup=False,
+            )
+
+    # ------------------------------------------------------------------
+    # Submit
+    # ------------------------------------------------------------------
+
+    async def _do_submit(self) -> None:
+        service = getattr(self.app, "bug_report_service", None)
+        if service is None:
+            self.app.notify("Bug report service not available.", severity="error", markup=False)
+            return
+
+        title = self.query_one("#title", Input).value.strip()
+        if not title:
+            self.app.notify("Title is required", severity="warning", markup=False)
+            return
+
+        description = self.query_one("#description", TextArea).text
+
+        status = self.query_one("#diagnostics-status", Static)
+        status.update("Submitting...")
+        self._clear_submission_error()
+
+        # Disable submit to prevent double-clicks
+        submit_btn = self.query_one("#submit", Button)
+        submit_btn.disabled = True
+
+        try:
+            receipt = await service.submit(
+                payload=self._payload,
+                consent=self._consent,
+                title=title,
+                description=description,
+            )
+            self._receipt = receipt
+            self._show_receipt(receipt)
+        except BugReportSubmissionError as exc:
+            logger.error("Bug report submission error: %s", exc)
+            status.update("Diagnostics: collected — submission failed, try again.")
+            submit_btn.disabled = False
+            self._show_submission_error(str(exc))
+        except Exception as exc:
+            logger.error("Unexpected submission error: %s", exc)
+            status.update("Diagnostics: collected — submission failed, try again.")
+            submit_btn.disabled = False
+            self._show_submission_error(f"Submission failed: {exc}")
+
+    def _show_submission_error(self, message: str) -> None:
+        """Pin the error message inline AND surface a toast.
+
+        The toast fades; the inline panel stays so the user can read /
+        copy the reason after they look back at the screen.
+        """
+        try:
+            err = self.query_one("#submission-error", Static)
+            err.update(_esc(message))
+            err.add_class("visible")
+        except Exception:  # pragma: no cover — defensive query
+            pass
+        self.app.notify(message, severity="error", markup=False, timeout=10)
+
+    def _clear_submission_error(self) -> None:
+        try:
+            err = self.query_one("#submission-error", Static)
+            err.remove_class("visible")
+            err.update("")
+        except Exception:
+            pass
+
+    def _show_receipt(self, receipt: BugReportReceipt) -> None:
+        """Swap buttons area to success state and open URL if applicable."""
+        status = self.query_one("#diagnostics-status", Static)
+        status.update("[green]Bug report submitted.[/green]")
+
+        btn_row = self.query_one("#btn-row", Horizontal)
+        btn_row.remove()
+
+        receipt_row = self.query_one("#receipt-row", Static)
+        receipt_row.add_class("visible")
+
+        if receipt.channel == "github":
+            receipt_row.update(
+                f"Opened GitHub issue draft in your browser — "
+                f"review and click Submit.\n"
+                f"URL: {receipt.url}"
+            )
+            webbrowser.open(receipt.url)
+            self.app.notify(
+                "Opened GitHub issue draft in your browser — review and click Submit.",
+                markup=False,
+            )
+        else:
+            receipt_row.update(
+                f"Submitted as report {receipt.report_id} — {receipt.url}"
+            )
+            self.app.notify(
+                f"Submitted as report {receipt.report_id} — {receipt.url}",
+                markup=False,
+            )
+
+        # Mount a Back button below the receipt row
+        self.query_one("#bug-report-content", Container).mount(
+            Button("Back", id="back", variant="default")
+        )
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "edit-consent":
+            self.app.push_screen(
+                BugReportConsentModal(),
+                callback=self._on_re_consent,
+            )
+        elif event.button.id == "refresh-preview":
+            self._refresh_preview()
+        elif event.button.id == "submit":
+            self.run_worker(
+                self._do_submit(),
+                group="bug_report",
+                name="submit_bug_report",
+            )
+        elif event.button.id == "back":
+            self.app.pop_screen()
+
+    def _on_re_consent(self, consent: Optional[BugReportConsent]) -> None:
+        """Handle consent returned from the re-open modal."""
+        if consent is None:
+            # User cancelled re-consent; keep existing consent.
+            return
+        self._consent = consent
+        self._payload = None
+        # Disable submit until new diagnostics are collected.
+        try:
+            submit_btn = self.query_one("#submit", Button)
+            submit_btn.disabled = True
+        except Exception:
+            pass
+        self._start_collect()
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/servonaut/screens/bug_report_consent_modal.py
+++ b/src/servonaut/screens/bug_report_consent_modal.py
@@ -1,0 +1,176 @@
+"""Bug report consent modal for Servonaut.
+
+Surfaces the privacy choices before any diagnostic data is collected.
+The user selects which categories to include and where to send the
+report.  A preview of the exact payload is shown on the next screen
+(BugReportScreen) before anything leaves the machine.
+
+Per CLAUDE.md ModalScreen rule: brief blocking choice — dismiss to
+return.  BugReportScreen is the multi-step content-heavy counterpart
+that carries the Sidebar.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, RadioButton, RadioSet, Static
+
+from servonaut.services.bug_report_service import BugReportConsent
+
+
+class BugReportConsentModal(ModalScreen[Optional[BugReportConsent]]):
+    """Capture user consent for bug-report data collection.
+
+    Returns via ``dismiss``:
+      - ``BugReportConsent`` — user pressed Continue; caller collects
+        diagnostics according to the chosen options and proceeds to the
+        preview/submit flow.
+      - ``None`` — user pressed Cancel or Escape; caller aborts the
+        bug-report flow without collecting anything.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    BugReportConsentModal {
+        align: center middle;
+    }
+
+    BugReportConsentModal #consent-container {
+        width: 88;
+        height: auto;
+        max-height: 44;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    BugReportConsentModal #consent-title {
+        height: auto;
+        text-style: bold;
+        color: $accent;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    BugReportConsentModal #consent-copy {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    BugReportConsentModal #checkboxes {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    BugReportConsentModal Checkbox {
+        height: auto;
+        margin-bottom: 0;
+    }
+
+    BugReportConsentModal #channel-label {
+        height: auto;
+        text-style: bold;
+        margin-top: 1;
+        margin-bottom: 0;
+    }
+
+    BugReportConsentModal #channel-selector {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    BugReportConsentModal #footer-buttons {
+        height: auto;
+        align-horizontal: center;
+        margin-top: 1;
+    }
+
+    BugReportConsentModal Button {
+        margin: 0 1;
+        min-width: 14;
+    }
+
+    BugReportConsentModal #continue {
+        background: $primary;
+        color: $text;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Container(id="consent-container"):
+            yield Static("Report a bug", id="consent-title")
+            yield Static(
+                "Choose what to include in your report. You'll see exactly what will be "
+                "sent before anything leaves your machine.",
+                id="consent-copy",
+            )
+            with Vertical(id="checkboxes"):
+                yield Checkbox(
+                    "Last 200 lines of ~/.servonaut/logs/servonaut.log (secrets are scrubbed)",
+                    value=True,
+                    id="chk-include-logs",
+                )
+                yield Checkbox(
+                    "Configuration snapshot (api keys & secrets are removed)",
+                    value=True,
+                    id="chk-include-config",
+                )
+                yield Checkbox(
+                    "Anonymous instance counts by provider (no names, no ids)",
+                    value=True,
+                    id="chk-include-telemetry",
+                )
+            yield Static("Send report via:", id="channel-label")
+            with RadioSet(id="channel-selector"):
+                yield RadioButton(
+                    "Open prefilled GitHub issue (opens in browser)",
+                    value=True,
+                    id="radio-github",
+                )
+                yield RadioButton(
+                    "Submit via Servonaut backend (you can be anonymous)",
+                    id="radio-backend",
+                )
+            with Horizontal(id="footer-buttons"):
+                yield Button("Continue", id="continue", variant="primary")
+                yield Button("Cancel", id="cancel", variant="default")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "continue":
+            self._do_continue()
+        elif event.button.id == "cancel":
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _do_continue(self) -> None:
+        """Assemble a BugReportConsent from current widget state and dismiss."""
+        include_logs = self.query_one("#chk-include-logs", Checkbox).value
+        include_config = self.query_one("#chk-include-config", Checkbox).value
+        include_telemetry = self.query_one("#chk-include-telemetry", Checkbox).value
+
+        radio_set = self.query_one("#channel-selector", RadioSet)
+        # RadioSet.pressed_index gives the 0-based index of the selected button.
+        channel: str
+        if radio_set.pressed_index == 1:
+            channel = "backend"
+        else:
+            channel = "github"
+
+        consent = BugReportConsent(
+            include_logs=include_logs,
+            include_config=include_config,
+            include_anonymous_telemetry=include_telemetry,
+            channel=channel,  # type: ignore[arg-type]
+        )
+        self.dismiss(consent)

--- a/src/servonaut/services/bug_report_service.py
+++ b/src/servonaut/services/bug_report_service.py
@@ -1,0 +1,627 @@
+"""Bug report data-collection and submission service.
+
+Gathers diagnostics (version, OS, log tail, config), runs the redactor so
+secrets are scrubbed, and submits either via a prefilled GitHub issue URL or
+via POST to the Servonaut backend.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import platform
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+from importlib.metadata import version as pkg_version
+
+logger = logging.getLogger(__name__)
+
+from servonaut.services.memory.redaction import default_redactor, scan_for_secrets
+from servonaut.services.api_client import APIError
+
+# ---------------------------------------------------------------------------
+# Public dataclasses (frozen — callers cannot mutate after collection)
+# ---------------------------------------------------------------------------
+
+# Last underscore-segment of a key name → treated as secret-bearing.
+# Match is on ``key.lower().rsplit("_", 1)[-1]`` so ``application_secret``,
+# ``openai_api_key``, ``consumer_key``, ``client_secret``, ``db_password``,
+# ``self_privkey`` all hit; while ``max_tokens`` (plural), ``credentials_path``,
+# ``keyword_store_path``, ``client_id``, ``token_endpoint`` do not.
+_SECRET_KEY_SUFFIXES = frozenset({
+    "key",
+    "secret",
+    "token",
+    "password",
+    "passphrase",
+    "credentials",
+    "privkey",
+    "pat",
+})
+
+
+def _is_secret_key_name(key: str) -> bool:
+    if not isinstance(key, str) or not key:
+        return False
+    return key.lower().rsplit("_", 1)[-1] in _SECRET_KEY_SUFFIXES
+
+
+@dataclass(frozen=True)
+class BugReportConsent:
+    include_logs: bool
+    include_config: bool
+    include_anonymous_telemetry: bool   # provider counts only, no instance ids/names
+    channel: Literal["github", "backend"]
+
+
+@dataclass(frozen=True)
+class BugReportPayload:
+    servonaut_version: str
+    python_version: str
+    os_release: str                     # "Linux 6.17.0-23-generic" etc.
+    textual_version: str
+    install_method: str                 # "pipx" | "pip" | "unknown"
+    auth_state: Literal["anonymous", "signed-in"]
+    instance_count_by_provider: Dict[str, int]
+    last_traceback: Optional[str]
+    log_excerpt: Optional[str]          # None when consent.include_logs is False
+    config_snapshot: Optional[Dict]     # None when consent.include_config is False
+    redacted_categories_found: List[str]
+
+
+@dataclass(frozen=True)
+class BugReportReceipt:
+    channel: Literal["github", "backend"]
+    url: str
+    submitted_at_iso: str
+    report_id: Optional[str]            # backend-assigned id; None for github channel
+
+
+# ---------------------------------------------------------------------------
+# Domain exception
+# ---------------------------------------------------------------------------
+
+class BugReportSubmissionError(Exception):
+    """Raised when the backend submission fails.
+
+    Wraps an :class:`~servonaut.services.api_client.APIError` so the screen
+    has one exception type to catch.
+    """
+
+    def __init__(self, message: str, *, cause: Optional[Exception] = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GITHUB_URL_LIMIT = 8000
+
+
+def _scrub_config_dict(obj: Any, redactor: Callable[[str], str]) -> Any:
+    """Recursively scrub *obj*:
+
+    1. Replace values whose key name's last underscore-segment is in
+       ``_SECRET_KEY_SUFFIXES`` with ``"<removed:secret-key>"`` — but only
+       when the value is a non-empty string (boolean flags and integers
+       named e.g. ``max_tokens`` are left alone).
+    2. Run *redactor* on all remaining string values.
+
+    Returns a new dict/list; the original is never mutated.
+    """
+    if isinstance(obj, dict):
+        out: Dict[str, Any] = {}
+        for k, v in obj.items():
+            if _is_secret_key_name(k) and isinstance(v, str) and v:
+                out[k] = "<removed:secret-key>"
+            else:
+                out[k] = _scrub_config_dict(v, redactor)
+        return out
+    if isinstance(obj, list):
+        return [_scrub_config_dict(item, redactor) for item in obj]
+    if isinstance(obj, str):
+        return redactor(obj)
+    return obj
+
+
+def _collect_secret_categories(obj: Any) -> List[str]:
+    """Walk *obj* and return all secret categories found by ``scan_for_secrets``.
+
+    Deduplicates while preserving first-seen order.
+    """
+    seen: list = []
+    seen_set: set = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, str):
+            for cat in scan_for_secrets(node):
+                if cat not in seen_set:
+                    seen_set.add(cat)
+                    seen.append(cat)
+        elif isinstance(node, dict):
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(obj)
+    return seen
+
+
+def _read_last_traceback(log_path: Path, tail_lines: int) -> Optional[str]:
+    """Return the last traceback block in the last *tail_lines* of *log_path*.
+
+    Returns ``None`` when the file does not exist or no traceback is found.
+    """
+    try:
+        text = log_path.read_text(errors="replace")
+    except OSError:
+        return None
+
+    lines = text.splitlines()
+    tail = lines[-tail_lines:] if len(lines) > tail_lines else lines
+
+    last_tb_idx: Optional[int] = None
+    for i, line in enumerate(tail):
+        if line.startswith("Traceback (most recent call last):"):
+            last_tb_idx = i
+
+    if last_tb_idx is None:
+        return None
+
+    return "\n".join(tail[last_tb_idx:])
+
+
+def _read_log_tail(log_path: Path, tail_lines: int) -> Optional[str]:
+    """Return the last *tail_lines* lines of *log_path*, or ``None`` on error."""
+    try:
+        text = log_path.read_text(errors="replace")
+    except OSError:
+        return None
+
+    lines = text.splitlines()
+    return "\n".join(lines[-tail_lines:] if len(lines) > tail_lines else lines)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+class BugReportService:
+    """Collect diagnostics, redact secrets, and submit bug reports."""
+
+    def __init__(
+        self,
+        config_manager,
+        api_client,
+        auth_service,
+        update_service,
+        *,
+        redactor: Callable[[str], str] = default_redactor,
+        log_path: Optional[Path] = None,
+        github_repo: str = "zb-ss/servonaut",
+    ) -> None:
+        self._config_manager = config_manager
+        self._api_client = api_client
+        self._auth_service = auth_service
+        self._update_service = update_service
+        self._redactor = redactor
+        self._log_path: Path = log_path or Path.home() / ".servonaut" / "logs" / "servonaut.log"
+        self._github_repo = github_repo
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def collect_diagnostics(
+        self,
+        *,
+        consent: BugReportConsent,
+        instances: List[Dict],
+        log_tail_lines: int = 200,
+    ) -> BugReportPayload:
+        """Collect all diagnostics and return an immutable :class:`BugReportPayload`.
+
+        Redaction is applied as the LAST step so no secret ever escapes into
+        the frozen dataclass.
+        """
+        # --- Environment info ---
+        servonaut_version = self._update_service.current_version
+        python_version = platform.python_version()
+        os_release = f"{platform.system()} {platform.release()}"
+        textual_version = _safe_pkg_version("textual")
+        install_method = self._update_service.detect_install_method()
+
+        # --- Auth state ---
+        auth_state: Literal["anonymous", "signed-in"] = (
+            "signed-in" if self._auth_service.access_token else "anonymous"
+        )
+
+        # --- Provider telemetry ---
+        if consent.include_anonymous_telemetry:
+            provider_counts: Dict[str, int] = {}
+            for inst in instances:
+                provider = inst.get("provider", "aws")
+                provider_counts[provider] = provider_counts.get(provider, 0) + 1
+        else:
+            provider_counts = {}
+
+        # --- Log data (pre-redaction raw values) ---
+        raw_log_tail = _read_log_tail(self._log_path, log_tail_lines)
+        raw_traceback = _read_last_traceback(self._log_path, log_tail_lines)
+
+        # --- Config snapshot (pre-redaction) ---
+        raw_config: Optional[Dict] = None
+        if consent.include_config:
+            try:
+                cfg = self._config_manager.get()
+                raw_config = dataclasses.asdict(cfg)
+                # Layer 1: remove secret-named keys
+                raw_config = _scrub_config_dict(raw_config, lambda s: s)  # keys only
+            except Exception as exc:
+                logger.warning("Bug report: failed to serialise config: %s", exc)
+                raw_config = {
+                    "error": "could not serialise config",
+                    "reason": f"{type(exc).__name__}: {exc}",
+                }
+
+        # --- Collect secret categories from RAW text BEFORE redaction ---
+        # scan_for_secrets looks for patterns that the redactor will then scrub.
+        # We must scan the raw values — after redaction the patterns are gone.
+        raw_texts_to_scan: List[Any] = []
+        if consent.include_logs and raw_log_tail is not None:
+            raw_texts_to_scan.append(raw_log_tail)
+        if raw_traceback is not None:
+            raw_texts_to_scan.append(raw_traceback)
+        if raw_config is not None:
+            raw_texts_to_scan.append(raw_config)
+
+        redacted_categories: List[str] = _collect_secret_categories(raw_texts_to_scan)
+
+        # --- Redact all text fields (layer 2 for config, only layer for logs) ---
+        redacted_log: Optional[str] = None
+        if consent.include_logs and raw_log_tail is not None:
+            redacted_log = self._redactor(raw_log_tail)
+
+        redacted_traceback: Optional[str] = None
+        if raw_traceback is not None:
+            redacted_traceback = self._redactor(raw_traceback)
+
+        redacted_config: Optional[Dict] = None
+        if raw_config is not None:
+            # Layer 2: run redactor on all remaining string values
+            redacted_config = _scrub_config_dict(raw_config, self._redactor)
+
+        return BugReportPayload(
+            servonaut_version=servonaut_version,
+            python_version=python_version,
+            os_release=os_release,
+            textual_version=textual_version,
+            install_method=install_method,
+            auth_state=auth_state,
+            instance_count_by_provider=provider_counts,
+            last_traceback=redacted_traceback,
+            log_excerpt=redacted_log,
+            config_snapshot=redacted_config,
+            redacted_categories_found=redacted_categories,
+        )
+
+    def render_preview(
+        self,
+        *,
+        payload: BugReportPayload,
+        title: str,
+        description: str,
+    ) -> str:
+        """Return the Markdown the user reviews verbatim before submission.
+
+        Layout::
+
+            <title>
+
+            <description>
+
+            ---
+
+            ## Environment
+            | key | value |
+            ...
+
+            ## Last traceback
+            (if any)
+
+            ## Log excerpt
+            (if included)
+
+            ## Config snapshot
+            (if included, fenced JSON)
+
+            ## Redacted categories detected
+            (if list non-empty)
+        """
+        parts: List[str] = []
+
+        parts.append(f"# {title}")
+        parts.append("")
+        parts.append(description)
+        parts.append("")
+        parts.append("---")
+        parts.append("")
+
+        # Environment table
+        parts.append("## Environment")
+        parts.append("")
+        parts.append("| Key | Value |")
+        parts.append("| --- | --- |")
+        parts.append(f"| servonaut_version | {payload.servonaut_version} |")
+        parts.append(f"| python_version | {payload.python_version} |")
+        parts.append(f"| os_release | {payload.os_release} |")
+        parts.append(f"| textual_version | {payload.textual_version} |")
+        parts.append(f"| install_method | {payload.install_method} |")
+        parts.append(f"| auth_state | {payload.auth_state} |")
+        if payload.instance_count_by_provider:
+            counts_str = ", ".join(
+                f"{k}: {v}" for k, v in payload.instance_count_by_provider.items()
+            )
+            parts.append(f"| instance_count_by_provider | {counts_str} |")
+        parts.append("")
+
+        if payload.last_traceback is not None:
+            parts.append("## Last traceback")
+            parts.append("")
+            parts.append("```")
+            parts.append(payload.last_traceback)
+            parts.append("```")
+            parts.append("")
+
+        if payload.log_excerpt is not None:
+            parts.append("## Log excerpt")
+            parts.append("")
+            parts.append("```")
+            parts.append(payload.log_excerpt)
+            parts.append("```")
+            parts.append("")
+
+        if payload.config_snapshot is not None:
+            parts.append("## Config snapshot")
+            parts.append("")
+            parts.append("```json")
+            parts.append(json.dumps(payload.config_snapshot, indent=2, default=str))
+            parts.append("```")
+            parts.append("")
+
+        if payload.redacted_categories_found:
+            parts.append("## Redacted categories detected")
+            parts.append("")
+            for cat in payload.redacted_categories_found:
+                parts.append(f"- {cat}")
+            parts.append("")
+
+        return "\n".join(parts)
+
+    async def submit(
+        self,
+        *,
+        payload: BugReportPayload,
+        consent: BugReportConsent,
+        title: str,
+        description: str,
+    ) -> BugReportReceipt:
+        """Build and submit the bug report via the chosen *channel*.
+
+        The browser is NOT opened here — that is the screen's responsibility.
+        """
+        submitted_at = _utcnow_iso()
+        markdown_body = self.render_preview(
+            payload=payload, title=title, description=description
+        )
+
+        if consent.channel == "github":
+            return self._submit_github(
+                title=title,
+                body=markdown_body,
+                payload=payload,
+                submitted_at=submitted_at,
+            )
+        else:
+            return await self._submit_backend(
+                title=title,
+                description=description,
+                payload=payload,
+                submitted_at=submitted_at,
+            )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _submit_github(
+        self,
+        *,
+        title: str,
+        body: str,
+        payload: BugReportPayload,
+        submitted_at: str,
+    ) -> BugReportReceipt:
+        url = self._build_github_url(title=title, body=body, payload=payload)
+        return BugReportReceipt(
+            channel="github",
+            url=url,
+            submitted_at_iso=submitted_at,
+            report_id=None,
+        )
+
+    def _build_github_url(
+        self,
+        *,
+        title: str,
+        body: str,
+        payload: BugReportPayload,
+    ) -> str:
+        base = f"https://github.com/{self._github_repo}/issues/new"
+        encoded_title = urllib.parse.quote(title)
+        encoded_body = urllib.parse.quote(body)
+        url = f"{base}?title={encoded_title}&body={encoded_body}"
+
+        if len(url) > _GITHUB_URL_LIMIT:
+            # Truncate log_excerpt and rebuild the preview with shortened payload
+            truncation_note = (
+                "\n... (truncated, full log too large for GitHub URL"
+                " — use backend channel instead)"
+            )
+            # Binary search would be overkill; iteratively chop the excerpt
+            truncated_payload = dataclasses.replace(
+                payload,
+                log_excerpt=(payload.log_excerpt or "") + truncation_note
+                if payload.log_excerpt
+                else truncation_note,
+            )
+            # We need to re-render with the truncated excerpt in the body.
+            # Re-derive the body from the original title/description embedded in body,
+            # but since we only have the rendered body here we rebuild by trimming.
+            # Strategy: trim log_excerpt characters from the encoded body until URL fits.
+            if payload.log_excerpt:
+                excerpt = payload.log_excerpt
+                while True:
+                    # Chop 100 chars at a time from the middle of the excerpt
+                    if len(excerpt) <= 100:
+                        excerpt = ""
+                    else:
+                        excerpt = excerpt[: len(excerpt) - 100]
+                    test_payload = dataclasses.replace(
+                        payload,
+                        log_excerpt=excerpt + truncation_note if excerpt else truncation_note,
+                    )
+                    test_body = self._rebuild_body_with_payload(
+                        original_body=body, original_payload=payload, new_payload=test_payload
+                    )
+                    test_url = (
+                        f"{base}?title={encoded_title}&body={urllib.parse.quote(test_body)}"
+                    )
+                    if len(test_url) <= _GITHUB_URL_LIMIT:
+                        url = test_url
+                        break
+                    if not excerpt:
+                        # Nothing left to trim; just use the truncation note alone
+                        final_payload = dataclasses.replace(
+                            payload, log_excerpt=truncation_note
+                        )
+                        final_body = self._rebuild_body_with_payload(
+                            original_body=body,
+                            original_payload=payload,
+                            new_payload=final_payload,
+                        )
+                        url = f"{base}?title={encoded_title}&body={urllib.parse.quote(final_body)}"
+                        break
+            else:
+                # No log excerpt to trim; URL is long for some other reason.
+                # Return the URL as-is — it may exceed 8000 chars but there is
+                # nothing safe to truncate.
+                pass
+
+        return url
+
+    def _rebuild_body_with_payload(
+        self,
+        *,
+        original_body: str,
+        original_payload: BugReportPayload,
+        new_payload: BugReportPayload,
+    ) -> str:
+        """Re-render the markdown body using *new_payload*.
+
+        We extract title and description from the rendered *original_body*
+        (first line stripped of ``# ``, and second non-empty block before ``---``).
+        """
+        lines = original_body.split("\n")
+        title = lines[0].lstrip("# ").strip() if lines else ""
+        # Description: content between first blank line after title and "---"
+        desc_lines: List[str] = []
+        in_desc = False
+        for line in lines[2:]:
+            if line.strip() == "---":
+                break
+            desc_lines.append(line)
+        description = "\n".join(desc_lines).strip()
+        return self.render_preview(
+            payload=new_payload, title=title, description=description
+        )
+
+    async def _submit_backend(
+        self,
+        *,
+        title: str,
+        description: str,
+        payload: BugReportPayload,
+        submitted_at: str,
+    ) -> BugReportReceipt:
+        try:
+            response = await self._api_client.post(
+                "/api/v1/bug-reports",
+                json={
+                    "title": title,
+                    "description": description,
+                    "payload": dataclasses.asdict(payload),
+                },
+            )
+        except APIError as exc:
+            raise BugReportSubmissionError(
+                _format_api_error(exc), cause=exc
+            ) from exc
+
+        return BugReportReceipt(
+            channel="backend",
+            url=response["url"],
+            submitted_at_iso=submitted_at,
+            report_id=response["id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal utility
+# ---------------------------------------------------------------------------
+
+def _format_api_error(exc: APIError) -> str:
+    """Build a user-facing message that surfaces the server's reason.
+
+    Backend bug-report errors put the actionable cause in
+    ``error.details.reason`` (e.g. "title must be at least 5 characters").
+    Without unpacking it, the user only sees the generic ``code`` label
+    and has to read server logs to know what went wrong.
+    """
+    parts: list[str] = []
+    if exc.message:
+        parts.append(exc.message)
+    if isinstance(exc.details, dict):
+        reason = exc.details.get("reason")
+        if isinstance(reason, str) and reason:
+            parts.append(reason)
+        else:
+            extras = [
+                f"{k}: {v}"
+                for k, v in exc.details.items()
+                if k != "reason" and isinstance(v, (str, int, float, bool))
+            ]
+            if extras:
+                parts.append("; ".join(extras))
+    base = " — ".join(parts) if parts else f"HTTP {exc.status}"
+    return f"Failed to submit bug report ({exc.status} {exc.code}): {base}"
+
+
+def _safe_pkg_version(package: str) -> str:
+    try:
+        return pkg_version(package)
+    except Exception:
+        return "unknown"

--- a/src/servonaut/widgets/sidebar.py
+++ b/src/servonaut/widgets/sidebar.py
@@ -31,6 +31,7 @@ _SCREEN_TO_NAV: dict[str, str] = {
     "OVHSSHKeysScreen": "nav_ovh_ssh_keys",
     "LoginScreen": "nav_login",
     "TeamManagementScreen": "nav_teams",
+    "BugReportScreen": "nav_bug_report",
 }
 
 
@@ -137,6 +138,9 @@ class Sidebar(Widget):
         yield btn
         btn = Button("Teams", id="nav_teams", classes="nav-button")
         btn.tooltip = "Manage team members and shared access"
+        yield btn
+        btn = Button("🐛 Report a bug", id="nav_bug_report", classes="nav-button")
+        btn.tooltip = "Send a bug report — review exactly what's included before anything leaves your machine"
         yield btn
         yield Static("", id="sidebar-spacer")
         from servonaut.widgets.relay_indicator import RelayIndicator

--- a/tests/test_bug_report_service.py
+++ b/tests/test_bug_report_service.py
@@ -1,0 +1,691 @@
+"""Tests for BugReportService — data-layer of the bug-reporting feature."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from servonaut.services.api_client import APIClient, APIError
+from servonaut.services.bug_report_service import (
+    BugReportConsent,
+    BugReportPayload,
+    BugReportReceipt,
+    BugReportService,
+    BugReportSubmissionError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Factories
+# ---------------------------------------------------------------------------
+
+def _make_service(
+    *,
+    log_path: Optional[Path] = None,
+    config_dict: Optional[Dict] = None,
+    auth_token: Optional[str] = None,
+    api_client=None,
+    redactor=None,
+) -> BugReportService:
+    """Build a BugReportService with safe mocked dependencies."""
+    config_manager = MagicMock()
+    # config_manager.config returns a simple mock with asdict()-able fields
+    mock_cfg = MagicMock()
+    # Make dataclasses.asdict() work by supplying a plain dict via __dict__
+    config_manager.config = mock_cfg
+    if config_dict is not None:
+        # Return the dict when asdict is called — we patch asdict in tests that need it.
+        config_manager.config = mock_cfg
+
+    auth_service = MagicMock()
+    auth_service.access_token = auth_token  # None means anonymous
+
+    update_service = MagicMock()
+    update_service.current_version = "2.7.0"
+    update_service.detect_install_method.return_value = "pipx"
+
+    if api_client is None:
+        api_client = MagicMock(spec=APIClient)
+
+    kwargs: Dict[str, Any] = {}
+    if log_path is not None:
+        kwargs["log_path"] = log_path
+    if redactor is not None:
+        kwargs["redactor"] = redactor
+
+    return BugReportService(
+        config_manager=config_manager,
+        api_client=api_client,
+        auth_service=auth_service,
+        update_service=update_service,
+        **kwargs,
+    )
+
+
+def _minimal_consent(
+    *,
+    include_logs: bool = False,
+    include_config: bool = False,
+    include_anonymous_telemetry: bool = False,
+    channel: str = "github",
+) -> BugReportConsent:
+    return BugReportConsent(
+        include_logs=include_logs,
+        include_config=include_config,
+        include_anonymous_telemetry=include_anonymous_telemetry,
+        channel=channel,  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# collect_diagnostics tests
+# ---------------------------------------------------------------------------
+
+class TestCollectDiagnosticsMinimal:
+    """All-off consent → all optional fields are None, telemetry dict empty."""
+
+    def test_optional_fields_none_when_all_off(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent()
+
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        assert payload.log_excerpt is None
+        assert payload.config_snapshot is None
+        assert payload.last_traceback is None
+        assert payload.instance_count_by_provider == {}
+
+    def test_redacted_categories_empty_when_no_text(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.redacted_categories_found == []
+
+    def test_servonaut_version_from_update_service(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.servonaut_version == "2.7.0"
+
+    def test_install_method_from_update_service(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.install_method == "pipx"
+
+    def test_anonymous_auth_when_no_token(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log", auth_token=None)
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.auth_state == "anonymous"
+
+    def test_signed_in_auth_when_token_present(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log", auth_token="tok123")
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.auth_state == "signed-in"
+
+
+class TestCollectDiagnosticsRedaction:
+    """Redaction correctness — planted secrets must be scrubbed."""
+
+    def test_redacts_akia_key_in_log_and_reports_category(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text("INFO starting\nAKIA1234567890ABCDEF is the key\nINFO done\n")
+
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent(include_logs=True)
+        payload = svc.collect_diagnostics(
+            consent=consent, instances=[], log_tail_lines=200
+        )
+
+        assert payload.log_excerpt is not None
+        assert "AKIA1234567890ABCDEF" not in payload.log_excerpt
+        assert "<redacted:aws-access-key>" in payload.log_excerpt
+        assert "aws-access-key" in payload.redacted_categories_found
+
+    def test_redacts_akia_key_in_traceback(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text(
+            "INFO ok\n"
+            "Traceback (most recent call last):\n"
+            "  File 'x.py', line 1\n"
+            "KeyError: AKIA1234567890ABCDEF\n"
+        )
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        assert payload.last_traceback is not None
+        assert "AKIA1234567890ABCDEF" not in payload.last_traceback
+        assert "aws-access-key" in payload.redacted_categories_found
+
+
+class TestCollectDiagnosticsConfigScrubbing:
+    """api_key and other secret-named fields are removed from config snapshot."""
+
+    def test_api_key_removed_before_redaction(self, tmp_path: Path) -> None:
+        import dataclasses as _dc
+
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_config=True)
+
+        # Patch dataclasses.asdict to return a dict with an api_key
+        fake_config = {"provider": "openai", "api_key": "sk-supersecretvalue", "model": "gpt-4"}
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_dc, "asdict", lambda _: dict(fake_config))
+            payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        assert payload.config_snapshot is not None
+        assert payload.config_snapshot.get("api_key") == "<removed:secret-key>"
+        # The real value must never appear
+        assert "sk-supersecretvalue" not in str(payload.config_snapshot)
+
+    def test_nested_secret_key_removed(self, tmp_path: Path) -> None:
+        import dataclasses as _dc
+
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_config=True)
+
+        fake_config = {
+            "relay": {"token": "mytoken", "host": "relay.example.com"},
+        }
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_dc, "asdict", lambda _: dict(fake_config))
+            payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        assert payload.config_snapshot is not None
+        assert payload.config_snapshot["relay"]["token"] == "<removed:secret-key>"
+        assert payload.config_snapshot["relay"]["host"] == "relay.example.com"
+
+    def test_provider_secret_keys_all_removed(self, tmp_path: Path) -> None:
+        """Regression: OVH/AI/abuseipdb keys leaked because layer-1 only matched
+        exact ``api_key`` / ``token`` / ``secret``. Now matches by suffix."""
+        import dataclasses as _dc
+
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_config=True)
+
+        fake_config = {
+            "ai": {
+                "provider": "openai",
+                "api_key": "legacy-sk-LEAK1",
+                "openai_api_key": "sk-LEAK2",
+                "anthropic_api_key": "anth-LEAK3",
+                "gemini_api_key": "AIza-LEAK4",
+                "ollama_api_key": "ollama-LEAK5",
+            },
+            "ovh": {
+                "endpoint": "ovh-eu",
+                "application_key": "app-LEAK6",
+                "application_secret": "secret-LEAK7",
+                "consumer_key": "consumer-LEAK8",
+                "client_id": "client-id-not-secret",
+                "client_secret": "client-secret-LEAK9",
+            },
+            "ip_ban": {"abuseipdb_api_key": "abuse-LEAK10"},
+        }
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_dc, "asdict", lambda _: dict(fake_config))
+            payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        snap = payload.config_snapshot
+        assert snap is not None
+        for path in [
+            ("ai", "api_key"),
+            ("ai", "openai_api_key"),
+            ("ai", "anthropic_api_key"),
+            ("ai", "gemini_api_key"),
+            ("ai", "ollama_api_key"),
+            ("ovh", "application_key"),
+            ("ovh", "application_secret"),
+            ("ovh", "consumer_key"),
+            ("ovh", "client_secret"),
+            ("ip_ban", "abuseipdb_api_key"),
+        ]:
+            section, field = path
+            assert snap[section][field] == "<removed:secret-key>", f"{path} not scrubbed: {snap[section][field]!r}"
+        # client_id is an OAuth identifier, not a secret — must NOT be scrubbed
+        assert snap["ovh"]["client_id"] == "client-id-not-secret"
+        assert snap["ovh"]["endpoint"] == "ovh-eu"
+        # No leaked value anywhere in the snapshot
+        flat = json.dumps(snap)
+        for leak in ["LEAK1", "LEAK2", "LEAK3", "LEAK4", "LEAK5",
+                     "LEAK6", "LEAK7", "LEAK8", "LEAK9", "LEAK10"]:
+            assert leak not in flat, f"{leak} leaked in snapshot: {flat}"
+
+    def test_secret_suffix_does_not_falsely_match(self, tmp_path: Path) -> None:
+        """Layer-1 must not scrub max_tokens (plural int), credentials_path
+        (path), keyword_store_path, or non-string values like booleans."""
+        import dataclasses as _dc
+
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_config=True)
+
+        fake_config = {
+            "ai": {"max_tokens": 4096, "credentials_path": "/etc/svc.json"},
+            "keyword_store_path": "~/.servonaut/keywords.json",
+            "memory": {"redaction_enabled": True, "secret": ""},  # empty secret stays as-is
+            "name_with_password_in_middle": "harmless",  # only last segment matters
+        }
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_dc, "asdict", lambda _: dict(fake_config))
+            payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        snap = payload.config_snapshot
+        assert snap is not None
+        assert snap["ai"]["max_tokens"] == 4096
+        assert snap["ai"]["credentials_path"] == "/etc/svc.json"
+        assert snap["keyword_store_path"] == "~/.servonaut/keywords.json"
+        assert snap["memory"]["redaction_enabled"] is True
+        assert snap["memory"]["secret"] == ""  # empty string left alone
+        assert snap["name_with_password_in_middle"] == "harmless"
+
+
+class TestCollectDiagnosticsTelemetry:
+    """instance_count_by_provider counts correctly."""
+
+    def test_counts_by_provider_key(self, tmp_path: Path) -> None:
+        instances = [
+            {"provider": "aws"},
+            {"provider": "aws"},
+            {"provider": "ovh"},
+            {"provider": "custom"},
+        ]
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_anonymous_telemetry=True)
+        payload = svc.collect_diagnostics(consent=consent, instances=instances)
+        assert payload.instance_count_by_provider == {"aws": 2, "ovh": 1, "custom": 1}
+
+    def test_falls_back_to_aws_when_provider_key_absent(self, tmp_path: Path) -> None:
+        instances = [{"id": "i-abc"}, {"id": "i-def"}]  # no 'provider' key
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_anonymous_telemetry=True)
+        payload = svc.collect_diagnostics(consent=consent, instances=instances)
+        assert payload.instance_count_by_provider == {"aws": 2}
+
+    def test_empty_when_telemetry_disabled(self, tmp_path: Path) -> None:
+        instances = [{"provider": "aws"}, {"provider": "ovh"}]
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(include_anonymous_telemetry=False)
+        payload = svc.collect_diagnostics(consent=consent, instances=instances)
+        assert payload.instance_count_by_provider == {}
+
+
+class TestLastTraceback:
+    """last_traceback extraction from log tail."""
+
+    def test_returns_none_when_no_log_file(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "missing.log")
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.last_traceback is None
+
+    def test_returns_none_when_no_traceback_in_log(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text("INFO ok\nINFO still ok\n")
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.last_traceback is None
+
+    def test_extracts_last_traceback_block(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text(
+            "INFO a\n"
+            "Traceback (most recent call last):\n"
+            "  File 'a.py', line 1\n"
+            "ValueError: first\n"
+            "INFO b\n"
+            "Traceback (most recent call last):\n"
+            "  File 'b.py', line 2\n"
+            "KeyError: second\n"
+        )
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent()
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        # Should return the LAST traceback
+        assert payload.last_traceback is not None
+        assert "KeyError: second" in payload.last_traceback
+        assert "ValueError: first" not in payload.last_traceback
+
+
+class TestLogExcerpt:
+    """log_excerpt behaviour."""
+
+    def test_none_when_include_logs_false(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text("some log content\n")
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent(include_logs=False)
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.log_excerpt is None
+
+    def test_none_when_file_missing(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_file.log")
+        consent = _minimal_consent(include_logs=True)
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.log_excerpt is None
+
+    def test_includes_log_content_when_consented(self, tmp_path: Path) -> None:
+        log = tmp_path / "servonaut.log"
+        log.write_text("line1\nline2\nline3\n")
+        svc = _make_service(log_path=log)
+        consent = _minimal_consent(include_logs=True)
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+        assert payload.log_excerpt is not None
+        assert "line1" in payload.log_excerpt
+
+
+# ---------------------------------------------------------------------------
+# render_preview tests
+# ---------------------------------------------------------------------------
+
+class TestRenderPreview:
+    """Markdown preview structure."""
+
+    def _make_minimal_payload(self) -> BugReportPayload:
+        return BugReportPayload(
+            servonaut_version="2.7.0",
+            python_version="3.12.0",
+            os_release="Linux 6.17.0",
+            textual_version="0.80.0",
+            install_method="pipx",
+            auth_state="anonymous",
+            instance_count_by_provider={},
+            last_traceback=None,
+            log_excerpt=None,
+            config_snapshot=None,
+            redacted_categories_found=[],
+        )
+
+    def test_includes_title_in_output(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(
+            payload=payload, title="My Bug Title", description="desc"
+        )
+        assert "My Bug Title" in preview
+
+    def test_includes_environment_header(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(
+            payload=payload, title="T", description="D"
+        )
+        assert "## Environment" in preview
+
+    def test_omits_log_excerpt_section_when_none(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(
+            payload=payload, title="T", description="D"
+        )
+        assert "## Log excerpt" not in preview
+
+    def test_includes_log_excerpt_when_present(self) -> None:
+        svc = _make_service()
+        payload = dataclasses.replace(
+            self._make_minimal_payload(), log_excerpt="some log line"
+        )
+        preview = svc.render_preview(
+            payload=payload, title="T", description="D"
+        )
+        assert "## Log excerpt" in preview
+        assert "some log line" in preview
+
+    def test_omits_traceback_section_when_none(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(payload=payload, title="T", description="D")
+        assert "## Last traceback" not in preview
+
+    def test_includes_traceback_when_present(self) -> None:
+        svc = _make_service()
+        payload = dataclasses.replace(
+            self._make_minimal_payload(),
+            last_traceback="Traceback (most recent call last):\n  ...\nValueError: boom",
+        )
+        preview = svc.render_preview(payload=payload, title="T", description="D")
+        assert "## Last traceback" in preview
+        assert "ValueError: boom" in preview
+
+    def test_omits_config_section_when_none(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(payload=payload, title="T", description="D")
+        assert "## Config snapshot" not in preview
+
+    def test_includes_redacted_categories_when_present(self) -> None:
+        svc = _make_service()
+        payload = dataclasses.replace(
+            self._make_minimal_payload(),
+            redacted_categories_found=["aws-access-key", "jwt"],
+        )
+        preview = svc.render_preview(payload=payload, title="T", description="D")
+        assert "## Redacted categories detected" in preview
+        assert "aws-access-key" in preview
+        assert "jwt" in preview
+
+    def test_includes_description_in_output(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(
+            payload=payload, title="T", description="This is my description"
+        )
+        assert "This is my description" in preview
+
+    def test_separator_present(self) -> None:
+        svc = _make_service()
+        payload = self._make_minimal_payload()
+        preview = svc.render_preview(payload=payload, title="T", description="D")
+        assert "---" in preview
+
+
+# ---------------------------------------------------------------------------
+# submit — github channel
+# ---------------------------------------------------------------------------
+
+class TestSubmitGitHub:
+    """GitHub channel produces correct URL; no network call."""
+
+    @pytest.mark.asyncio
+    async def test_url_contains_issues_new(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        receipt = await svc.submit(
+            payload=payload,
+            consent=consent,
+            title="Test bug",
+            description="Repro steps here",
+        )
+
+        assert "issues/new?title=" in receipt.url
+
+    @pytest.mark.asyncio
+    async def test_url_contains_urlencoded_title(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        title = "My Bug With Spaces"
+        receipt = await svc.submit(
+            payload=payload, consent=consent, title=title, description="desc"
+        )
+
+        # URL-encoded spaces are either + or %20
+        assert "My+Bug+With+Spaces" in receipt.url or "My%20Bug%20With%20Spaces" in receipt.url
+
+    @pytest.mark.asyncio
+    async def test_report_id_is_none(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        receipt = await svc.submit(
+            payload=payload, consent=consent, title="T", description="D"
+        )
+
+        assert receipt.report_id is None
+
+    @pytest.mark.asyncio
+    async def test_channel_is_github(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        receipt = await svc.submit(
+            payload=payload, consent=consent, title="T", description="D"
+        )
+        assert receipt.channel == "github"
+
+    @pytest.mark.asyncio
+    async def test_submitted_at_iso_format(self, tmp_path: Path) -> None:
+        svc = _make_service(log_path=tmp_path / "no_log.log")
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        receipt = await svc.submit(
+            payload=payload, consent=consent, title="T", description="D"
+        )
+        # Must end with Z and contain T separator
+        assert receipt.submitted_at_iso.endswith("Z")
+        assert "T" in receipt.submitted_at_iso
+
+    @pytest.mark.asyncio
+    async def test_api_client_not_called_for_github(self, tmp_path: Path) -> None:
+        api_client = MagicMock(spec=APIClient)
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="github")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        await svc.submit(payload=payload, consent=consent, title="T", description="D")
+
+        api_client.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# submit — backend channel
+# ---------------------------------------------------------------------------
+
+class TestSubmitBackend:
+    """Backend channel calls api_client.post exactly once with correct args."""
+
+    def _make_api_client(self, response: Dict) -> MagicMock:
+        client = MagicMock(spec=APIClient)
+        client.post = AsyncMock(return_value=response)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_calls_post_with_json_keyword(self, tmp_path: Path) -> None:
+        api_client = self._make_api_client(
+            {"id": "rpt-123", "url": "https://servonaut.dev/bugs/rpt-123"}
+        )
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="backend")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        await svc.submit(payload=payload, consent=consent, title="T", description="D")
+
+        api_client.post.assert_called_once()
+        call_args = api_client.post.call_args
+        # Must be called with json= keyword (not positional)
+        assert call_args.kwargs.get("json") is not None or (
+            "json" in call_args[1]
+        ), "post() must be called with json= keyword argument"
+        assert call_args.args[0] == "/api/v1/bug-reports"
+
+    @pytest.mark.asyncio
+    async def test_receipt_url_from_response(self, tmp_path: Path) -> None:
+        api_client = self._make_api_client(
+            {"id": "rpt-456", "url": "https://servonaut.dev/bugs/rpt-456"}
+        )
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="backend")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        receipt = await svc.submit(
+            payload=payload, consent=consent, title="T", description="D"
+        )
+
+        assert receipt.url == "https://servonaut.dev/bugs/rpt-456"
+        assert receipt.report_id == "rpt-456"
+        assert receipt.channel == "backend"
+
+    @pytest.mark.asyncio
+    async def test_payload_asdict_included_in_post_body(self, tmp_path: Path) -> None:
+        api_client = self._make_api_client(
+            {"id": "rpt-789", "url": "https://servonaut.dev/bugs/rpt-789"}
+        )
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="backend")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        await svc.submit(payload=payload, consent=consent, title="My Title", description="My Desc")
+
+        call_kwargs = api_client.post.call_args.kwargs
+        json_body = call_kwargs["json"]
+        assert json_body["title"] == "My Title"
+        assert json_body["description"] == "My Desc"
+        assert "payload" in json_body
+        assert json_body["payload"]["servonaut_version"] == "2.7.0"
+
+    @pytest.mark.asyncio
+    async def test_api_error_raises_submission_error(self, tmp_path: Path) -> None:
+        api_client = MagicMock(spec=APIClient)
+        api_client.post = AsyncMock(
+            side_effect=APIError(
+                code="server_error",
+                message="Internal server error",
+                status=500,
+            )
+        )
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="backend")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        with pytest.raises(BugReportSubmissionError) as exc_info:
+            await svc.submit(payload=payload, consent=consent, title="T", description="D")
+
+        assert exc_info.value.cause is not None
+        assert isinstance(exc_info.value.cause, APIError)
+
+    @pytest.mark.asyncio
+    async def test_api_error_subclass_also_raises_submission_error(
+        self, tmp_path: Path
+    ) -> None:
+        from servonaut.services.api_client import RateLimitedError
+
+        api_client = MagicMock(spec=APIClient)
+        api_client.post = AsyncMock(
+            side_effect=RateLimitedError(
+                code="rate_limited", message="slow down", status=429
+            )
+        )
+        svc = _make_service(log_path=tmp_path / "no_log.log", api_client=api_client)
+        consent = _minimal_consent(channel="backend")
+        payload = svc.collect_diagnostics(consent=consent, instances=[])
+
+        with pytest.raises(BugReportSubmissionError):
+            await svc.submit(payload=payload, consent=consent, title="T", description="D")
+
+
+# ---------------------------------------------------------------------------
+# Import smoke test (also checked by verify step)
+# ---------------------------------------------------------------------------
+
+def test_public_exports_importable() -> None:
+    from servonaut.services.bug_report_service import (  # noqa: F401
+        BugReportService,
+        BugReportConsent,
+        BugReportPayload,
+        BugReportReceipt,
+        BugReportSubmissionError,
+    )


### PR DESCRIPTION
**Before submitting, please ensure you have:**
- [x] Read the CONTRIBUTING.md guide.
- [x] Based your changes on the `master` branch.
- [x] Ensured your code follows the project's coding style.
- [x] Added tests for your changes (43 new unit tests, all pass).
- [ ] Updated documentation (`README.md` not touched — sidebar entry is self-describing).
- [x] Added a clear and descriptive title for your pull request.
- [x] Written a clear summary of the changes below.

---

**Description of Changes:**

Adds a "Report a bug" sidebar entry (Account section) that walks the user through a privacy-first bug-reporting flow.

**Flow**

1. Consent modal — three checkboxes (logs / config / anonymous telemetry) and channel selector.
2. `BugReportService.collect_diagnostics()` builds a sanitized payload: version, OS, install method, log tail, last traceback, scrubbed config snapshot, anonymized provider counts.
3. Verbatim markdown preview shown to the user with a warning listing any redacted secret categories detected.
4. Submit via either:
   - **GitHub channel** — prefilled `issues/new?title=...&body=...` URL opened in the browser. Works for anonymous users; public — captured by GH Archive within minutes.
   - **Backend channel** — `POST /api/v1/bug-reports`. Requires sign-in (anti-spam). Routes into the existing admin UI under a new "CLI" tab.

**Privacy posture**

Two-layer config scrub before redaction:

- **Layer 1** removes any field whose key name's last underscore-segment matches `key`/`secret`/`token`/`password`/`passphrase`/`credentials`/`privkey`/`pat`. Catches OVH `application_key` / `application_secret` / `consumer_key` / `client_secret`, all four AI provider API keys, `abuseipdb_api_key`, and the legacy `api_key`. False-positive guarded — `max_tokens` (plural int), `credentials_path`, `keyword_store_path`, `client_id`, `token_endpoint`, booleans like `redaction_enabled` are all left intact.
- **Layer 2** runs the existing 11-category regex redactor (AWS keys, GitHub PATs, JWTs, SSH key blocks, etc.) over remaining string values.

**Error surface**

`APIError.details.reason` is unpacked into the user-facing message, so failed submissions explain *why* instead of showing a generic code label. A persistent inline error panel (not just a toast) keeps the message readable after the toast fades — no more "submission failed silently" debugging trips.

**Files**

- `src/servonaut/services/bug_report_service.py` — service + frozen dataclasses (`BugReportConsent`, `BugReportPayload`, `BugReportReceipt`, `BugReportSubmissionError`)
- `src/servonaut/screens/bug_report_consent_modal.py` — `ModalScreen[Optional[BugReportConsent]]`
- `src/servonaut/screens/bug_report.py` — multi-step screen with title/description fields, live preview, submit
- `src/servonaut/app.py` + `src/servonaut/widgets/sidebar.py` — wiring (service init, sidebar button, nav dispatch)
- `tests/test_bug_report_service.py` — 43 unit tests

**Backend dependency**

GitHub channel works today. Backend channel needs the `POST /api/v1/bug-reports` endpoint (separate PR in the backend repo). On 401, the screen shows a useful "Sign in to submit via the backend channel — or use the GitHub option instead" message via the new error formatter.

**Related Issues:**

*(none yet — internal feature)*