### PR TITLE
chore(positioning): adopt new headline across README and pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Servonaut
 
-A modern Terminal User Interface (TUI) for managing servers — SSH, SCP, scanning & more.
+**Your servers. Your terminal. Your AI agent. One TUI.**
+
+Manage AWS, Hetzner, OVH, and custom servers from one terminal — with a built-in AI assistant and MCP server.
 
 ## Quick Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "servonaut"
 version = "2.9.2"
-description = "Interactive TUI for managing servers — SSH, SCP, scanning & more"
+description = "Manage AWS, Hetzner, OVH, and custom servers from one TUI — with a built-in AI assistant and MCP server"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Sharpen the headline + package description so both the README hero and PyPI search results lead with what Servonaut actually is.

- **README hero** — replaces *"A modern Terminal User Interface (TUI) for managing servers — SSH, SCP, scanning & more."* with a two-tier projection:
  - **Headline:** *Your servers. Your terminal. Your AI agent. One TUI.* (rhythmic, memorable, leans into the privacy/ownership story)
  - **Subhead:** *Manage AWS, Hetzner, OVH, and custom servers from one terminal — with a built-in AI assistant and MCP server.* (keyword-dense, names the multi-provider scope and the AI/MCP differentiators)
- **`pyproject.toml` description** — replaces *"Interactive TUI for managing servers — SSH, SCP, scanning & more"* with the keyword-dense form so PyPI search surfaces Servonaut for AWS / Hetzner / OVH / AI / MCP queries.

Driven by an internal anchor sentence: *"Servonaut is a TUI that gives you and your AI agents one shared, encrypted, multi-provider view of your servers."* Different surfaces are different projections of that same anchor; the README hero is emotional/rhythmic, PyPI/GH-About is keyword-dense.

GitHub repo "About" sidebar + topics will be updated via `gh repo edit` once this lands.

## Test plan

- [x] Confirm the rendered README on the PR page leads with the new headline and subhead.
- [x] Confirm `pyproject.toml` description renders correctly in any local `pip show servonaut` after install.
- [x] No code changes; no runtime tests required.