### PR TITLE
Demo-mode redaction, config-load hardening, and OVH credential feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ pipx install .
 ![IP Ban Manager](docs/screenshots/ip-ban-manager.png)
 *Ban/unban IPs via WAF, Security Groups, or NACLs with audit trail*
 
+All screenshots and the launch video were recorded with `--demo` active, which replaces real IPs, ARNs, paths, and secrets with safe fake equivalents. See [docs/demo-mode.md](docs/demo-mode.md) for what is redacted and how to use it.
+
 ## Features
 
 - **Interactive TUI** with mouse and keyboard support powered by [Textual](https://textual.textualize.io/)

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,0 +1,170 @@
+# Demo Mode
+
+Demo mode makes every screen safe to record, screenshot, or share publicly.
+All identifying data — IP addresses, AWS account IDs, ARNs, home paths, API
+keys, log group names, S3 bucket names, and URLs — is replaced with
+deterministic fake equivalents. The substitutions are consistent within a
+session so the UI looks realistic and coherent, not randomly scrambled.
+
+## Activating demo mode
+
+### At launch (recommended)
+
+```bash
+servonaut --demo
+```
+
+Redaction applies from the first frame. Instances are redacted in memory
+before any screen renders.
+
+### At runtime (toggle)
+
+Press `ctrl+shift+d` from any screen.
+
+A notification confirms the mode change. The status bar shows a
+`[DEMO]` badge while active. Toggle again to restore real data.
+
+> **Recording tip:** toggle, wait one second for any in-flight flushes to
+> complete, then start recording. Mid-stream flushes from the log viewer or
+> CloudWatch events table may land a partial frame of real data during the
+> ~100 ms flush tick immediately after the toggle.
+
+### Kill switch (emergency bypass)
+
+```bash
+SERVONAUT_DEMO_DISABLE_STREAM=1 servonaut --demo
+```
+
+When this environment variable is set to `1`, `scrub_stream` returns its
+input unchanged. Useful when a downstream integration test needs to inject
+raw data through a demo-mode-enabled app without triggering redaction.
+
+---
+
+## What is redacted
+
+| Category | Example input | Redacted output |
+|---|---|---|
+| IPv4 addresses | `1.2.3.4` | `192.0.2.17` (RFC 5737 doc-range) |
+| IPv6 addresses (≥3 colon groups) | `fe80::1234:5678:abcd:ef01` | `2001:db8::1` (RFC 3849 doc-range) |
+| ECR hostnames | `123456789012.dkr.ecr.us-east-1.amazonaws.com` | `000000000000.dkr.ecr.us-east-1.amazonaws.com` |
+| AWS access keys | `AKIAIOSFODNN7EXAMPLE` | `<redacted:aws-access-key>` |
+| AWS secret keys | `aws_secret_access_key = abc123…` | `aws_secret_access_key = <redacted:aws-secret-key>` |
+| GitHub tokens | `ghp_…`, `github_pat_…` | `<redacted:github-token>` |
+| Bearer tokens | `Bearer eyJ…` | `Bearer <redacted:bearer-token>` |
+| Passwords | `password=hunter2` | `password=<redacted:password>` |
+| JWTs | `eyJhbGci…` | `<redacted:jwt>` |
+| SSH/PEM private keys | `-----BEGIN RSA PRIVATE KEY-----` | `<redacted:ssh-private-key>` |
+| Slack tokens | `xoxb-…` | `<redacted:slack-token>` |
+| Stripe keys | `sk_live_…` | `<redacted:stripe-key>` |
+| DB connection strings | `postgres://user:pwd@host/db` | `postgres://<redacted:conn-user>:<redacted:conn-pass>@host/db` |
+| ARN account IDs | `arn:aws:iam::123456789012:user/alice` | `arn:aws:iam::000000000000:user/alice` |
+| Bare 12-digit account IDs | `account 123456789012` | `account 000000000000` |
+| Home paths | `/home/alice/.ssh/id_rsa` | `/home/user/.ssh/id_rsa` |
+| macOS user paths | `/Users/bob/Documents/` | `/Users/user/Documents/` |
+| URLs | `https://api.company.com/v1?token=xyz` | `https://example.com/v1` |
+| Email addresses | `john.doe@company.com` | `<fake-name>@example.com` (deterministic) |
+| CloudWatch log groups | `/aws/lambda/my-function` | `/aws/lambda/<fake-name>` |
+| S3 URIs | `s3://company-prod-data/logs` | `s3://<fake-name>/logs` |
+| Instance names | `web-prod-7` | `api-staging-3` (deterministic) |
+| Instance IPs | `54.234.1.99` | `198.51.100.42` (RFC 5737 doc-range) |
+| Instance IDs | `i-0abc123def456789a` | `i-<sha256-derived>` |
+| Hostnames | `web-prod-7.eu-central-1.compute.internal` | `monitor-12.example.com` |
+| SSH key names | `my-prod-key` | `deploy-key` |
+| Usernames | `alice` | `ubuntu` (from fake pool) |
+
+**Redaction is deterministic:** the same input always maps to the same fake
+output within a session. Repeated IP addresses show the same fake IP.
+
+---
+
+## What is NOT redacted
+
+| Item | Reason |
+|---|---|
+| Event names (`RunInstances`, `CreateBucket`) | AWS public taxonomy |
+| Region codes (`us-east-1`, `eu-west-2`) | AWS public taxonomy |
+| Error codes (`AccessDenied`, `NoSuchBucket`) | AWS public taxonomy |
+| CloudTrail resource *types* | AWS public taxonomy |
+| Memory module names and keys | Taxonomy — scrub would hide which modules ran |
+| Commands the user types in the terminal overlay | User-authored; not a server secret |
+| SCP source/destination paths the user types | User-authored; not a server secret |
+| On-disk chat session content | Session files stay raw; redaction is display-only |
+| 15-digit numbers (GCP project IDs) | Negative-lookaround prevents false positives |
+
+---
+
+## Affected screens and widgets
+
+| Surface | Redaction applied |
+|---|---|
+| Instance list | Instance fields (in-place at startup / on refresh) |
+| Log viewer | Every SSH `tail -f` line via `scrub_stream` |
+| Terminal overlay (command output) | `append_output` and `append_error` |
+| CloudWatch events table | `message` and `log_stream` columns |
+| CloudWatch event detail | Full message text |
+| CloudWatch top-IPs table | IP column (`display_ip`, raw used for network calls) |
+| CloudWatch IP info panel | Header shows `display_ip`; httpx call uses raw IP |
+| CloudTrail events table | `username`, `source_ip`, `resource_name` columns |
+| CloudTrail event detail | All PII fields + raw event JSON blob |
+| IP ban audit log | `ip_address` and `message` fields |
+| IP ban banned-IPs table | Display IP column (`display_ip`) |
+| Memory screen (observed / declared) | `obs_str` and `decl_str` values only |
+| AI chat panel (streaming) | Full scrub on every token (always-scrub; heuristic removed); tool-result rows scrubbed; tool messages scrubbed on reload |
+| AI analysis screen | Log text, `_raw_text` buffer, AI output, and error messages scrubbed |
+| CloudTrail copy buffer | `action_copy_output` payload scrubbed (IPs, ARNs, email usernames, raw event JSON) |
+| CloudWatch copy buffer | `action_copy_output` payload scrubbed (messages, selected IP) |
+| Command overlay copy buffer | `_output_lines` scrubbed before append so copy is safe |
+| CloudWatch IP geo panel | Entire geolocation block hidden in demo mode (`[redacted in demo mode]`) |
+| CloudWatch AbuseIPDB panel | Entire AbuseIPDB block hidden in demo mode (`[redacted in demo mode]`) |
+| Fleet scan summary modal | Failure `reason` and module `message` fields scrubbed |
+| AI analysis SSH stderr | SSH stderr scrubbed before showing in status |
+| AI analysis probe exceptions | Exception messages scrubbed before showing in status |
+| Fleet memory (remote rows) | Remote merged rows scrubbed with `redact_name` / `redact_instance_id` / `redact_provider` |
+| All `App.notify()` call sites | Centrally scrubbed via `ServonautApp.notify()` override (50+ call sites) |
+| Status bar | Adds `[DEMO]` badge |
+
+---
+
+## Known limitations
+
+The following patterns are intentionally **not** redacted. Each entry explains
+why or documents the accepted trade-off.
+
+| Pattern | Reason / workaround |
+|---|---|
+| Quoted S3 bucket names (e.g. `"my-bucket"`) | The DNS-shaped quoted-name regex is too broad — it matches everyday prose like `"hello-world"`. Use the `s3://` URI form to guarantee redaction. |
+| S3 ARNs without an account (e.g. `arn:aws:s3:::bucket`) | No 12-digit account component to match. Resource name is scrubbed only via `s3://` URI path. |
+| Free-form unquoted bucket names in prose | No syntactic anchor — indistinguishable from ordinary words. |
+| `/root/` paths | Not matched by the home-path pattern (only `/home/<user>/` and `/Users/<user>/`). |
+| `~`-prefixed paths (e.g. `~/.ssh/config`) | Tilde expansion is shell-side; the raw string has no `/home/` prefix to anchor. |
+| Windows paths (e.g. `C:\Users\alice\`) | Not matched — Servonaut is Linux/macOS only. |
+| Compressed IPv6 loopback `::1` | Requires only one colon group — the `{2,7}` repetition requires ≥3 colons. Full-form and most abbreviated IPv6 addresses are redacted; loopback is not. |
+| Compressed IPv6 forms with double-colon | Addresses like `2001:db8::1` that use `::` elision may produce malformed display output like `2001:db8::1::1` after substitution. The real address bits are removed, but the rendering can look strange. This is a cosmetic issue only — no real address leaks. |
+| MAC addresses (e.g. `aa:bb:cc:dd:ee:ff`) | The IPv6 regex may match 6-group hex-colon sequences. MAC addresses are not a privacy concern so false-positive replacement is harmless but noted here. |
+| Uppercase `ARN:` prefix | The ARN regex matches only lowercase `arn:`. AWS tooling always emits lowercase, so this is low-priority. |
+| 15-digit numbers (GCP project IDs) | Intentionally excluded by the `(?<![\d.])(\d{12})(?![\d.])` lookaround. |
+| Timestamps containing 12-digit sub-sequences (e.g. `10:23:45.123456789012`) | Excluded by the dot-boundary lookaround (`(?<![\d.])` / `(?![\d.])`). |
+| Process tree / system monitor output | P2 — Not fixable by the demo-mode pipeline. **Do not show a process list or system monitor while recording.** Process names and arguments can reveal real service names, users, and paths that are not captured by any redactor. |
+| Toggle race condition | P3 — If a log-viewer or CloudWatch stream flush lands during the ~100 ms window after `ctrl+shift+d` is pressed, one partial frame of real data may appear. Wait one second after toggling before starting a recording. |
+
+**Fake-name collision probability:** the name pool contains ~62,000 entries (48 prefixes × 43 suffixes × 30 numbers). Collision probability is < 1% for fleets ≤100 servers and < 50% for fleets ≤265 servers (birthday paradox). Fleets larger than ~265 unique server names may see repeated fake names.
+
+---
+
+## Architecture notes
+
+- `scrub_stream` lives on `RedactionService` (no `app` reference).
+- Every call site uses the caller-side guard:
+  ```python
+  if self.app.demo_mode and self.app.redaction_service:
+      line = self.app.redaction_service.scrub_stream(line)
+  ```
+- Composition order: secrets first → IPv4 → ARN → bare account ID →
+  log group → URL → email → path → resource name. This order is critical — see
+  `RedactionService.scrub_stream` docstring for rationale. URL runs before email
+  so URL-embedded credentials (`user:pass@host`) are consumed first.
+- `scrub_stream` is idempotent: calling it twice on the same string
+  returns the same result as calling it once.
+- `redact_ip` is idempotent: doc-range IPs (192.0.2.x, 198.51.100.x,
+  203.0.113.x) are short-circuited and returned unchanged.

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -26,6 +26,7 @@ class ServonautApp(App):
         Binding("q", "quit", "Quit", show=True),
         Binding("question_mark", "show_help", "Help", show=True),
         Binding("f2", "toggle_chat", "Chat", show=True),
+        Binding("ctrl+shift+d", "toggle_demo", "Demo mode", show=False),
     ]
 
     # Service instances - created in on_mount
@@ -90,6 +91,7 @@ class ServonautApp(App):
     # Shared state
     instances: List[dict] = []  # all fetched instances
     demo_mode: bool = False
+    _instances_pristine: Optional[List[dict]] = None  # deepcopy before redaction
 
     # T11: instance IDs that have already triggered the first-connect memory
     # prompt in this session.  Reset every time the app restarts.
@@ -113,6 +115,35 @@ class ServonautApp(App):
         """
         super().__init__(**kwargs)
         self._initial_screen = initial_screen
+
+    def notify(
+        self,
+        message: str,
+        *,
+        title: str = "",
+        severity: str = "information",
+        timeout: Optional[float] = None,
+        markup: bool = True,
+    ) -> None:
+        """Override to scrub PII from notification messages in demo mode.
+
+        This is a single defensive choke point that closes all 50+ call sites
+        (exception messages, SSH errors, tool results, auth failures, etc.)
+        without having to guard each one individually.
+
+        Scrubbing order: message first, then title (if non-empty). Both are
+        scrubbed before being passed to the Textual App.notify() base method.
+        """
+        if self.demo_mode and self.redaction_service is not None:
+            message = self.redaction_service.scrub_stream(message)
+            if title:
+                title = self.redaction_service.scrub_stream(title)
+        # Textual's App.notify signature uses Optional[float] for timeout;
+        # pass only when non-None to avoid overriding the default.
+        if timeout is not None:
+            super().notify(message, title=title, severity=severity, timeout=timeout, markup=markup)
+        else:
+            super().notify(message, title=title, severity=severity, markup=markup)
 
     def pop_screen(self):
         """Pop screen, but navigate to instances if at the root."""
@@ -141,6 +172,12 @@ class ServonautApp(App):
         # contract as OVH — provider-agnostic instant render at startup).
         if self.hetzner_service is not None:
             self.instances.extend(self.hetzner_service.get_cached_instances())
+        # Snapshot pristine instance list BEFORE any redaction — always, so
+        # the toggle path can restore real data even when --demo was set at
+        # launch.  deepcopy prevents in-place mutations from affecting the
+        # snapshot later.
+        import copy
+        self._instances_pristine = copy.deepcopy(self.instances)
         # Apply demo-mode redaction
         if self.demo_mode:
             from servonaut.services.redaction_service import RedactionService
@@ -939,6 +976,55 @@ class ServonautApp(App):
             self.screen.mount(panel)
             panel.focus_input()
 
+    def action_toggle_demo(self) -> None:
+        """Toggle demo mode at runtime (ctrl+shift+d).
+
+        ON  → instantiate RedactionService, redact instances in place, refresh
+              status bar + active screen, notify (information).
+        OFF → restore self.instances from self._instances_pristine (deepcopy),
+              clear redaction_service so guards short-circuit, refresh, notify
+              (warning — "real data restored").
+
+        Race-safety: snapshot captured once at on_mount + re-captured on
+        instance-list refresh; never mutated otherwise. Mid-stream renders
+        may land mid-burst — next flush tick re-syncs. Documented.
+        """
+        import copy
+        from servonaut.services.redaction_service import RedactionService
+
+        if self.demo_mode:
+            if self._instances_pristine is not None:
+                self.instances = copy.deepcopy(self._instances_pristine)
+            self.demo_mode = False
+            self.redaction_service = None
+            self.notify("Demo mode OFF — real data restored.", severity="warning", timeout=4)
+        else:
+            if self.redaction_service is None:
+                self.redaction_service = RedactionService()
+            self.redaction_service.redact_instances(self.instances)
+            self.demo_mode = True
+            self.notify("Demo mode ON — all surfaces redacted.", severity="information", timeout=4)
+
+        # Re-render active screen + StatusBar.
+        try:
+            self.screen.refresh(recompose=False)
+        except Exception:
+            pass
+
+        from servonaut.screens.instance_list import InstanceListScreen
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+        if isinstance(self.screen, InstanceListScreen):
+            self.screen._instances = list(self.instances)
+            self.screen._update_table()
+        elif isinstance(self.screen, FleetMemoryScreen):
+            self.screen._launch_populate()
+
+        try:
+            from servonaut.widgets.status_bar import StatusBar
+            for sb in self.query(StatusBar):
+                sb._update_display()
+        except Exception:
+            pass
 
     def resolve_instance(self, id_or_name: str) -> Optional[dict]:
         """Case-insensitive instance lookup across all providers.

--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -32,6 +32,34 @@ from .secrets import load_secrets_env
 
 logger = logging.getLogger(__name__)
 
+
+def _coerce(cls: type, data: Any, label: str) -> Any:
+    """Build a config dataclass from a dict, dropping keys not in the schema.
+
+    A field removed from the schema in a newer release would otherwise crash
+    ``cls(**data)`` when reading an older on-disk config. That crash makes the
+    whole load fall back to defaults, and the next save overwrites the user's
+    real config — silent data loss. Unknown keys are logged and dropped so the
+    rest of the config still loads.
+
+    Args:
+        cls: The config dataclass to construct.
+        data: Raw dict from the on-disk config (may be empty or None).
+        label: Human-readable section name, used only for the warning log.
+
+    Returns:
+        An instance of ``cls`` — defaults when ``data`` is empty.
+    """
+    if not data:
+        return cls()
+    valid = {f.name for f in fields(cls)}
+    unknown = set(data) - valid
+    if unknown:
+        logger.warning("Ignoring unknown %s config keys: %s", label, sorted(unknown))
+        data = {k: v for k, v in data.items() if k in valid}
+    return cls(**data)
+
+
 CONFIG_DIR = Path.home() / '.servonaut'
 CONFIG_PATH = CONFIG_DIR / 'config.json'
 BACKUP_DIR = CONFIG_DIR / 'backups'
@@ -480,53 +508,38 @@ class ConfigManager:
         Returns:
             AppConfig instance
         """
-        # Extract nested object lists
-        scan_rules_data = raw_data.get('scan_rules', [])
-        connection_profiles_data = raw_data.get('connection_profiles', [])
-        connection_rules_data = raw_data.get('connection_rules', [])
-        custom_servers_data = raw_data.get('custom_servers', [])
-        ip_ban_configs_data = raw_data.get('ip_ban_configs', [])
-        ai_provider_data = raw_data.get('ai_provider', {})
-        mcp_data = raw_data.get('mcp', {})
-        relay_data = raw_data.get('relay', {})
-        ovh_data = raw_data.get('ovh', {})
-        hetzner_data = raw_data.get('hetzner', {})
-        # Forward-compat: drop unknown keys so a developer save-state
-        # from before the schema was finalised doesn't blow up
-        # ``HetznerConfig(**...)``.
-        if hetzner_data:
-            valid_hetzner_fields = {f.name for f in fields(HetznerConfig)}
-            unknown_hetzner = set(hetzner_data) - valid_hetzner_fields
-            if unknown_hetzner:
-                logger.warning(
-                    "Ignoring unknown hetzner config keys: %s", unknown_hetzner,
-                )
-                hetzner_data = {
-                    k: v for k, v in hetzner_data.items()
-                    if k in valid_hetzner_fields
-                }
-        gcp_data = raw_data.get('gcp', {})
-        azure_data = raw_data.get('azure', {})
-        memory_data = raw_data.get('memory', {})
-
-        # Convert to dataclass instances
-        scan_rules = [ScanRule(**rule) for rule in scan_rules_data]
+        # Convert nested dicts to dataclass instances. ``_coerce`` drops keys
+        # that are no longer in the schema so a field removed in a newer
+        # release doesn't crash the load — a crash here falls back to defaults
+        # and the next save silently overwrites the user's real config.
+        scan_rules = [
+            _coerce(ScanRule, r, 'scan_rules')
+            for r in raw_data.get('scan_rules', [])
+        ]
         connection_profiles = [
-            ConnectionProfile(**profile) for profile in connection_profiles_data
+            _coerce(ConnectionProfile, p, 'connection_profiles')
+            for p in raw_data.get('connection_profiles', [])
         ]
         connection_rules = [
-            ConnectionRule(**rule) for rule in connection_rules_data
+            _coerce(ConnectionRule, r, 'connection_rules')
+            for r in raw_data.get('connection_rules', [])
         ]
-        custom_servers = [CustomServer(**s) for s in custom_servers_data]
-        ip_ban_configs = [IPBanConfig(**c) for c in ip_ban_configs_data]
-        ai_provider = AIProviderConfig(**ai_provider_data) if ai_provider_data else AIProviderConfig()
-        mcp = MCPConfig(**mcp_data) if mcp_data else MCPConfig()
-        relay = RelayConfig(**relay_data) if relay_data else RelayConfig()
-        ovh = OVHConfig(**ovh_data) if ovh_data else OVHConfig()
-        hetzner = HetznerConfig(**hetzner_data) if hetzner_data else HetznerConfig()
-        gcp = GCPConfig(**gcp_data) if gcp_data else GCPConfig()
-        azure = AzureConfig(**azure_data) if azure_data else AzureConfig()
-        memory = MemoryConfig(**memory_data) if memory_data else MemoryConfig()
+        custom_servers = [
+            _coerce(CustomServer, s, 'custom_servers')
+            for s in raw_data.get('custom_servers', [])
+        ]
+        ip_ban_configs = [
+            _coerce(IPBanConfig, c, 'ip_ban_configs')
+            for c in raw_data.get('ip_ban_configs', [])
+        ]
+        ai_provider = _coerce(AIProviderConfig, raw_data.get('ai_provider', {}), 'ai_provider')
+        mcp = _coerce(MCPConfig, raw_data.get('mcp', {}), 'mcp')
+        relay = _coerce(RelayConfig, raw_data.get('relay', {}), 'relay')
+        ovh = _coerce(OVHConfig, raw_data.get('ovh', {}), 'ovh')
+        hetzner = _coerce(HetznerConfig, raw_data.get('hetzner', {}), 'hetzner')
+        gcp = _coerce(GCPConfig, raw_data.get('gcp', {}), 'gcp')
+        azure = _coerce(AzureConfig, raw_data.get('azure', {}), 'azure')
+        memory = _coerce(MemoryConfig, raw_data.get('memory', {}), 'memory')
 
         # Build AppConfig with converted objects, filtering out unknown keys
         valid_fields = {f.name for f in fields(AppConfig)}

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -658,7 +658,8 @@ def main() -> None:
     parser.add_argument('--install-desktop', action='store_true',
                         help='Create a desktop shortcut for your OS')
     parser.add_argument('--demo', action='store_true',
-                        help='Demo mode: redact IPs, names, and identifiers for screenshots')
+                        help='Demo mode: redact IPs, names, and identifiers for screenshots. '
+                             'Toggle at runtime with Ctrl+Shift+D. See docs/demo-mode.md for details.')
     parser.add_argument('--mcp', action='store_true',
                         help='Start MCP server (stdio transport)')
     parser.add_argument('--mcp-install', type=str, nargs='?', const='claude',

--- a/src/servonaut/screens/ai_analysis.py
+++ b/src/servonaut/screens/ai_analysis.py
@@ -429,7 +429,12 @@ class AIAnalysisScreen(Screen):
 
         except Exception as exc:
             logger.error("Error probing logs: %s", exc)
-            status.update(f"[red]Error: {exc}[/red]")
+            # Demo-mode: exception strings can carry hostnames / IPs from SSH.
+            # Scrub before embedding in the status widget.
+            exc_str = str(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                exc_str = self.app.redaction_service.scrub_stream(exc_str)
+            status.update(f"[red]Error: {exc_str}[/red]")
         finally:
             progress.stop()
             self._set_buttons_disabled(False)
@@ -524,17 +529,29 @@ class AIAnalysisScreen(Screen):
                 text_area.read_only = False
                 self.query_one("#ai_filter_input", Input).value = ""
 
-                text_area.load_text(log_text)
-                self._raw_text = log_text
+                # Demo-mode: scrub before loading into the editor and before
+                # storing in _raw_text (which feeds the filter / copy path).
+                # On-disk log file is not touched — display-only.
+                display_log_text = log_text
+                display_log_path = log_path
+                if self.app.demo_mode and self.app.redaction_service:
+                    display_log_text = self.app.redaction_service.scrub_stream(log_text)
+                    display_log_path = self.app.redaction_service.scrub_stream(log_path)
+                text_area.load_text(display_log_text)
+                self._raw_text = display_log_text
                 self._update_token_estimate()
                 status.update(
-                    f"[green]Fetched {len(log_text.splitlines())} lines "
-                    f"from {log_path}.[/green] "
+                    f"[green]Fetched {len(display_log_text.splitlines())} lines "
+                    f"from {display_log_path}.[/green] "
                     f"Press [bold]Analyze[/bold] to send to AI."
                 )
             else:
                 err_text = stderr.decode("utf-8", errors="replace").strip()
                 if err_text:
+                    # Demo-mode: SSH stderr can carry hostnames, IPs, or paths.
+                    # Scrub before embedding in the status widget.
+                    if self.app.demo_mode and self.app.redaction_service:
+                        err_text = self.app.redaction_service.scrub_stream(err_text)
                     status.update(
                         f"[yellow]No logs fetched.[/yellow] [dim]{err_text}[/dim]"
                     )
@@ -547,7 +564,12 @@ class AIAnalysisScreen(Screen):
             status.update("[red]Timed out fetching logs from server.[/red]")
         except Exception as exc:
             logger.error("Error fetching log %s: %s", log_path, exc)
-            status.update(f"[red]Error: {exc}[/red]")
+            # Demo-mode: exception messages can carry paths, IPs, or account IDs
+            # from the underlying SSH call. Mirror the pattern from _do_analysis.
+            exc_str = str(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                exc_str = self.app.redaction_service.scrub_stream(exc_str)
+            status.update(f"[red]Error: {exc_str}[/red]")
         finally:
             progress.stop()
             self._set_buttons_disabled(False)
@@ -590,8 +612,13 @@ class AIAnalysisScreen(Screen):
                 text, system_prompt=system_prompt
             )
             status.update("[green]Analysis complete.[/green] Select text to copy.")
-            output.load_text(result['content'])
-            self._output_text = result['content']
+            # Demo-mode: scrub AI output before displaying and before storing
+            # in _output_text (which feeds action_copy_output). Display-only.
+            ai_content = result['content']
+            if self.app.demo_mode and self.app.redaction_service:
+                ai_content = self.app.redaction_service.scrub_stream(ai_content)
+            output.load_text(ai_content)
+            self._output_text = ai_content
 
             input_tok = result.get('input_tokens', 0)
             output_tok = result.get('output_tokens', 0)
@@ -613,7 +640,13 @@ class AIAnalysisScreen(Screen):
                 f"Est. cost: {cost_str}"
             )
         except Exception as exc:
-            status.update(f"[red]Error: {exc}[/red]")
+            # Demo-mode: scrub exception message BEFORE embedding in markup.
+            # Exception strings can carry paths, IPs, or account IDs from
+            # the underlying AI service call.
+            exc_str = str(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                exc_str = self.app.redaction_service.scrub_stream(exc_str)
+            status.update(f"[red]Error: {exc_str}[/red]")
         finally:
             progress.stop()
             self._set_buttons_disabled(False)

--- a/src/servonaut/screens/ai_conversations_screen.py
+++ b/src/servonaut/screens/ai_conversations_screen.py
@@ -546,6 +546,11 @@ class AIConversationsScreen(Screen):
         # Hide the empty-state placeholder when we have rows.
         self.query_one("#convs_empty", Static).update("")
 
+        def _scrub(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         groups = self._group_by_date(items)
         for group_name in ("Today", "Yesterday", "Earlier this week", "Older"):
             bucket = groups.get(group_name) or []
@@ -556,8 +561,19 @@ class AIConversationsScreen(Screen):
             # them with a hidden marker row to keep the visual order, but
             # render the actual labels above the screen container.
             for conv in bucket:
+                # Scrub the conversation title — it may contain server names
+                # or other PII the user typed as part of the chat topic.
+                safe_conv_title = _scrub(conv.title or "(untitled)")
+                scrubbed_conv = type("_SC", (), {
+                    "title": safe_conv_title,
+                    "updated_at": conv.updated_at,
+                    "message_count": conv.message_count,
+                    "last_model": conv.last_model,
+                    "status": conv.status,
+                    "id": conv.id,
+                })()
                 table.add_row(
-                    self._format_title_cell(conv, group_name),
+                    self._format_title_cell(scrubbed_conv, group_name),
                     self._format_age(conv.updated_at),
                     str(conv.message_count),
                     _rich_escape(conv.last_model or "—"),
@@ -1113,6 +1129,11 @@ class AIConversationsScreen(Screen):
             return
         self.query_one("#local_empty", Static).update("")
 
+        def _scrub(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for s in items:
             paired = bool(s.get("remote_conversation_id"))
             where = (
@@ -1121,7 +1142,7 @@ class AIConversationsScreen(Screen):
             )
             provider = s.get("last_provider") or "—"
             table.add_row(
-                _rich_escape(s.get("title") or "(untitled)"),
+                _rich_escape(_scrub(s.get("title") or "(untitled)")),
                 self._format_age(s.get("updated_at") or ""),
                 str(s.get("message_count", 0)),
                 _rich_escape(provider),

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -200,18 +200,24 @@ class CloudTrailBrowserScreen(Screen):
     def _populate_table(self) -> None:
         table = self.query_one("#cloudtrail_table", DataTable)
         table.clear()
+        # _s: scrub helper for PII fields; keeps taxonomy fields raw.
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for ev in self._page_events:
             event_time = ev.get("event_time", "")
             if hasattr(event_time, "strftime"):
                 event_time = event_time.strftime("%Y-%m-%d %H:%M:%S")
             table.add_row(
                 str(event_time),
-                ev.get("event_name", ""),
-                ev.get("username", ""),
-                ev.get("source_ip", ""),
-                ev.get("resource_name", "") or ev.get("resource_type", ""),
-                ev.get("region", ""),
-                ev.get("error_code", "") or "",
+                ev.get("event_name", ""),       # public taxonomy — NOT scrubbed
+                _s(ev.get("username", "")),
+                _s(ev.get("source_ip", "")),
+                _s(ev.get("resource_name", "") or ev.get("resource_type", "")),
+                ev.get("region", ""),            # public taxonomy — NOT scrubbed
+                ev.get("error_code", "") or "",  # public taxonomy — NOT scrubbed
             )
 
     def action_next_page(self) -> None:
@@ -257,16 +263,23 @@ class CloudTrailBrowserScreen(Screen):
         event_time = event.get("event_time", "")
         if hasattr(event_time, "strftime"):
             event_time = event_time.strftime("%Y-%m-%d %H:%M:%S")
+        # _s: scrub PII fields; keep taxonomy (event_name, region, error) raw.
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
+        raw_event = event.get("raw_event", "")
         self.query_one("#event_detail_text", Static).update(
             f"[bold]Event:[/bold] {event.get('event_name', '')}\n"
             f"[bold]Time:[/bold] {event_time}\n"
-            f"[bold]User:[/bold] {event.get('username', '')}\n"
-            f"[bold]Source IP:[/bold] {event.get('source_ip', '')}\n"
-            f"[bold]Resource Type:[/bold] {event.get('resource_type', '')}\n"
-            f"[bold]Resource Name:[/bold] {event.get('resource_name', '')}\n"
+            f"[bold]User:[/bold] {_s(event.get('username', ''))}\n"
+            f"[bold]Source IP:[/bold] {_s(event.get('source_ip', ''))}\n"
+            f"[bold]Resource Type:[/bold] {_s(event.get('resource_type', ''))}\n"
+            f"[bold]Resource Name:[/bold] {_s(event.get('resource_name', ''))}\n"
             f"[bold]Region:[/bold] {event.get('region', '')}\n"
             f"[bold]Error:[/bold] {event.get('error_code', '') or '(none)'}\n\n"
-            f"[bold]Raw Event:[/bold]\n{event.get('raw_event', '')}"
+            f"[bold]Raw Event:[/bold]\n{_s(raw_event)}"
         )
 
     # ------------------------------------------------------------------
@@ -274,6 +287,13 @@ class CloudTrailBrowserScreen(Screen):
     # ------------------------------------------------------------------
 
     def action_copy_output(self) -> None:
+        # _s: mirror the scrub helper from _show_event_detail — scrub PII
+        # fields when demo_mode is on; pass through otherwise.
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         if self._selected_row is not None and self._selected_row < len(self._events):
             event = self._events[self._selected_row]
             event_time = event.get("event_time", "")
@@ -282,10 +302,10 @@ class CloudTrailBrowserScreen(Screen):
             lines = [
                 f"Event:          {event.get('event_name', '')}",
                 f"Time:           {event_time}",
-                f"User:           {event.get('username', '')}",
-                f"Source IP:      {event.get('source_ip', '')}",
-                f"Resource Type:  {event.get('resource_type', '')}",
-                f"Resource Name:  {event.get('resource_name', '')}",
+                f"User:           {_s(event.get('username', ''))}",
+                f"Source IP:      {_s(event.get('source_ip', ''))}",
+                f"Resource Type:  {_s(event.get('resource_type', ''))}",
+                f"Resource Name:  {_s(event.get('resource_name', ''))}",
                 f"Region:         {event.get('region', '')}",
                 f"Error:          {event.get('error_code', '') or '(none)'}",
             ]
@@ -293,11 +313,11 @@ class CloudTrailBrowserScreen(Screen):
             if raw:
                 lines.append("")
                 lines.append("Raw Event:")
-                lines.append(str(raw))
+                lines.append(_s(str(raw)))
             text = "\n".join(lines)
         else:
             text = "\n".join(
-                f"{ev.get('event_name', '')} | {ev.get('username', '')} | {ev.get('source_ip', '')}"
+                f"{ev.get('event_name', '')} | {_s(ev.get('username', ''))} | {_s(ev.get('source_ip', ''))}"
                 for ev in self._events
             )
 

--- a/src/servonaut/screens/cloudwatch_browser.py
+++ b/src/servonaut/screens/cloudwatch_browser.py
@@ -227,7 +227,11 @@ class CloudWatchBrowserScreen(Screen):
             if hasattr(ts, "strftime"):
                 ts = ts.strftime("%Y-%m-%d %H:%M:%S")
             msg = ev.get("message", "").replace("\n", " ")[:120]
-            events_table.add_row(str(ts), ev.get("log_stream", ""), msg)
+            log_stream = ev.get("log_stream", "")
+            if self.app.demo_mode and self.app.redaction_service:
+                msg = self.app.redaction_service.scrub_stream(msg)
+                log_stream = self.app.redaction_service.scrub_stream(log_stream)
+            events_table.add_row(str(ts), log_stream, msg)
 
     # ------------------------------------------------------------------
     # Pagination
@@ -445,7 +449,10 @@ class CloudWatchBrowserScreen(Screen):
                 action_label = "[yellow]MIXED[/yellow]"
             else:
                 action_label = "[dim]—[/dim]"
-            ips_table.add_row(entry["ip"], str(entry["count"]), action_label)
+            display_ip = entry["ip"]
+            if self.app.demo_mode and self.app.redaction_service:
+                display_ip = self.app.redaction_service.redact_ip(display_ip)
+            ips_table.add_row(display_ip, str(entry["count"]), action_label)
 
     # ------------------------------------------------------------------
     # Event detail / selection
@@ -468,14 +475,19 @@ class CloudWatchBrowserScreen(Screen):
         ts = event.get("timestamp", "")
         if hasattr(ts, "strftime"):
             ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+        log_stream = event.get("log_stream", "")
+        message = event.get("message", "")
+        if self.app.demo_mode and self.app.redaction_service:
+            log_stream = self.app.redaction_service.scrub_stream(log_stream)
+            message = self.app.redaction_service.scrub_stream(message)
         from rich.text import Text
         detail = Text()
         detail.append("Time: ", style="bold")
         detail.append(f"{ts}\n")
         detail.append("Stream: ", style="bold")
-        detail.append(f"{event.get('log_stream', '')}\n\n")
+        detail.append(f"{log_stream}\n\n")
         detail.append("Message:\n", style="bold")
-        detail.append(event.get("message", ""))
+        detail.append(message)
         self.query_one("#cloudwatch_detail_text", Static).update(detail)
 
     # ------------------------------------------------------------------
@@ -488,10 +500,18 @@ class CloudWatchBrowserScreen(Screen):
         return focused is not None and getattr(focused, "id", None) == "cloudwatch_ips_table"
 
     def action_copy_output(self) -> None:
+        # _s: scrub PII (IPs, hostnames, ARNs) in demo mode before copying.
+        # Mirror of the cloudtrail_browser.py action_copy_output pattern.
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         # If IPs table is focused, copy the selected IP
         if self._is_ips_table_focused():
             ip = self._get_selected_ip()
             if ip:
+                ip = _s(ip)
                 self._copy_text(ip, "IP copied to clipboard.")
             else:
                 self.app.notify("Select an IP first.", severity="warning")
@@ -500,9 +520,9 @@ class CloudWatchBrowserScreen(Screen):
         if self._selected_event_row is not None and self._selected_event_row < len(
             self._events
         ):
-            text = self._events[self._selected_event_row].get("message", "")
+            text = _s(self._events[self._selected_event_row].get("message", ""))
         else:
-            text = "\n".join(e.get("message", "") for e in self._events)
+            text = "\n".join(_s(e.get("message", "")) for e in self._events)
 
         if not text:
             self.app.notify("Nothing to copy.", severity="warning")
@@ -535,8 +555,12 @@ class CloudWatchBrowserScreen(Screen):
                 "Select an IP from the Top IPs table first.", severity="warning"
             )
             return
+        # display_ip is redacted for the UI; ip (raw) goes to the network call.
+        display_ip = ip
+        if self.app.demo_mode and self.app.redaction_service:
+            display_ip = self.app.redaction_service.redact_ip(ip)
         self.query_one("#cloudwatch_detail_text", Static).update(
-            f"Looking up info for [bold]{ip}[/bold]..."
+            f"Looking up info for [bold]{display_ip}[/bold]..."
         )
         self.run_worker(
             self._fetch_ip_info(ip),
@@ -546,17 +570,34 @@ class CloudWatchBrowserScreen(Screen):
         )
 
     async def _fetch_ip_info(self, ip: str) -> None:
-        """Fetch IP geolocation and abuse data from free APIs."""
+        """Fetch IP geolocation and abuse data from free APIs.
+
+        ``ip`` is ALWAYS the raw (unredacted) IP for network calls.
+        ``display_ip`` is used for all UI text so recordings stay safe.
+        """
         import asyncio
         from rich.text import Text
 
+        # Separate display_ip (redacted, for UI) from ip (raw, for httpx).
+        display_ip = ip
+        if self.app.demo_mode and self.app.redaction_service:
+            display_ip = self.app.redaction_service.redact_ip(ip)
+
         detail = Text()
-        detail.append(f"IP Info: {ip}\n", style="bold")
+        detail.append(f"IP Info: {display_ip}\n", style="bold")
         detail.append("─" * 40 + "\n")
 
         # ip-api.com — free, no key needed
         geo = await self._fetch_ip_geo(ip)
-        if geo:
+        # Demo-mode: geo data (country, city, ISP, org, AS, domain) reveals
+        # real-world infrastructure location. Blanket-redact the entire block
+        # rather than per-field: the geo taxonomy has no reliable redactor and
+        # ISP/org strings are too varied for regex scrubbing.
+        demo = self.app.demo_mode and self.app.redaction_service
+        if demo:
+            detail.append("\nGeolocation: ", style="bold cyan")
+            detail.append("[redacted in demo mode]\n", style="dim")
+        elif geo:
             detail.append("\nGeolocation\n", style="bold cyan")
             detail.append(f"  Country:  {geo.get('country', '?')} ({geo.get('countryCode', '')})\n")
             detail.append(f"  City:     {geo.get('city', '?')}, {geo.get('regionName', '?')}\n")
@@ -575,7 +616,13 @@ class CloudWatchBrowserScreen(Screen):
 
         # AbuseIPDB — only if API key configured
         abuse = await self._fetch_abuse_info(ip)
-        if abuse is not None:
+        # Demo-mode: AbuseIPDB response fields (isp, org, domain, usageType) can
+        # reveal real-world infrastructure. Blanket-redact the entire block —
+        # symmetric with the geo block above.
+        if demo and abuse is not None:
+            detail.append("\nAbuseIPDB: ", style="bold cyan")
+            detail.append("[redacted in demo mode]\n", style="dim")
+        elif abuse is not None:
             score = abuse.get("abuseConfidenceScore", 0)
             total_reports = abuse.get("totalReports", 0)
             detail.append("\nAbuseIPDB\n", style="bold cyan")

--- a/src/servonaut/screens/command_overlay.py
+++ b/src/servonaut/screens/command_overlay.py
@@ -306,6 +306,14 @@ class CommandOverlay(ModalScreen):
             )
             self._running_process = process
 
+            # Demo-mode helper: scrub lines BEFORE appending to _output_lines
+            # so that action_copy_output (which joins _output_lines) is safe.
+            # Mirror the log_viewer iteration-1 fix: buffer holds scrubbed text.
+            def _scrub(text: str) -> str:
+                if self.app.demo_mode and self.app.redaction_service:
+                    return self.app.redaction_service.scrub_stream(text)
+                return text
+
             def _read_stderr() -> None:
                 for raw_line in iter(process.stderr.readline, b''):
                     line = raw_line.decode("utf-8", errors="replace").rstrip("\n")
@@ -314,7 +322,7 @@ class CommandOverlay(ModalScreen):
                     # Filter bash -i job control noise
                     if "no job control" in line or "terminal process group" in line:
                         continue
-                    self._output_lines.append(line)
+                    self._output_lines.append(_scrub(line))
                     self.app.call_from_thread(output_widget.append_error, line)
 
             stderr_thread = threading.Thread(target=_read_stderr, daemon=True)
@@ -323,7 +331,7 @@ class CommandOverlay(ModalScreen):
             # Read stdout line-by-line in this thread
             for raw_line in iter(process.stdout.readline, b''):
                 line = raw_line.decode("utf-8", errors="replace").rstrip("\n")
-                self._output_lines.append(line)
+                self._output_lines.append(_scrub(line))
                 self.app.call_from_thread(output_widget.append_output, line)
 
             stderr_thread.join(timeout=5)
@@ -331,7 +339,7 @@ class CommandOverlay(ModalScreen):
 
             if return_code != 0 and return_code not in (-15, -9):
                 exit_msg = f"Command exited with code {return_code}"
-                self._output_lines.append(exit_msg)
+                self._output_lines.append(_scrub(exit_msg))
                 self.app.call_from_thread(
                     output_widget.append_error,
                     f"[dim]{exit_msg}[/dim]",
@@ -347,6 +355,10 @@ class CommandOverlay(ModalScreen):
                 msg = "Permission denied. Check SSH key and username."
             else:
                 msg = f"Error: {error_str}"
+            # _scrub may not be defined if the Popen() call itself raised.
+            # Inline guard is safer here.
+            if self.app.demo_mode and self.app.redaction_service:
+                msg = self.app.redaction_service.scrub_stream(msg)
             self._output_lines.append(msg)
             self.app.call_from_thread(output_widget.append_error, msg)
             logger.error("SSH command failed: %s", e, exc_info=True)

--- a/src/servonaut/screens/custom_servers.py
+++ b/src/servonaut/screens/custom_servers.py
@@ -112,12 +112,18 @@ class CustomServersScreen(Screen):
         """Populate DataTable with current custom servers."""
         table = self.query_one("#custom_servers_table", DataTable)
         table.clear()
+
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for server in self.app.custom_server_service.list_servers():
             table.add_row(
-                server.name,
-                server.host,
+                _s(server.name),
+                _s(server.host),
                 str(server.port),
-                server.username,
+                _s(server.username),
                 server.ssh_key or "-",
                 server.provider or "-",
                 server.group or "-",

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -214,6 +214,17 @@ class FleetScanSummaryModal(ModalScreen[None]):
 
     def _render_body(self) -> str:
         """Format succeeded + failed lists for the modal body."""
+        # _s: scrub PII (IPs, hostnames, paths) from exception messages BEFORE
+        # escape() so malformed IPs are never visible in demo recordings.
+        # Order: scrub → escape → embed (CLAUDE.md anti-pattern rule).
+        def _s(x: str) -> str:
+            try:
+                if self.app.demo_mode and self.app.redaction_service:
+                    return self.app.redaction_service.scrub_stream(x)
+            except Exception:
+                pass
+            return x
+
         lines: List[str] = []
         if self._succeeded:
             lines.append("[green]Succeeded[/green]:")
@@ -223,15 +234,16 @@ class FleetScanSummaryModal(ModalScreen[None]):
         if self._failed:
             lines.append("[red]Failed[/red]:")
             for entry in self._failed:
-                reason = entry.get("reason", "unknown")
+                reason = _s(entry.get("reason", "unknown"))
                 lines.append(
                     f"  • {escape(entry['instance'])}  "
                     f"[dim](reason: {escape(reason)})[/dim]"
                 )
                 for failure in entry.get("failures", [])[:3]:
+                    msg = _s(failure.get("message", ""))
                     lines.append(
                         f"      ↳ {escape(failure.get('module', ''))}: "
-                        f"{escape(failure.get('message', ''))}"
+                        f"{escape(msg)}"
                     )
                 extra = len(entry.get("failures", [])) - 3
                 if extra > 0:
@@ -408,19 +420,45 @@ class FleetMemoryScreen(Screen):
             for inst in instances
         }
 
+        # Demo-mode redaction helper for remote rows (which are NOT in-place
+        # redacted by on_mount unlike self.app.instances). Use the same typed
+        # primitives as the local _populate_table path for consistency.
+        _rs = getattr(self.app, "redaction_service", None)
+        _demo = self.app.demo_mode and _rs is not None
+
+        def _rname(v: str) -> str:
+            return _rs.redact_name(v) if _demo else v
+
+        def _rid(v: str) -> str:
+            return _rs.redact_instance_id(v) if _demo else v
+
+        def _rprovider(v: str) -> str:
+            return _rs.redact_provider(v) if _demo else v
+
         self._rows = []
         fresh = stale = none_count = opt_out = 0
         source_counts = {"local": 0, "remote": 0, "merged": 0}
 
         for fleet_row in merged:
-            iid = fleet_row.get("id", "")
-            iname = fleet_row.get("name", iid)
-            provider = fleet_row.get("provider", "custom")
+            # Keep raw values for internal lookups (inst_by_id, memory_service)
+            # where redacted IDs would fail to resolve. Apply redaction only to
+            # the display values stored in _rows and rendered in the table.
+            raw_iid = fleet_row.get("id", "")
+            raw_iname = fleet_row.get("name", raw_iid)
+            raw_provider = fleet_row.get("provider", "custom")
+
+            iid = _rid(raw_iid)
+            iname = _rname(raw_iname)
+            provider = _rprovider(raw_provider)
             source = fleet_row.get("source", "local")
             drift_7d = fleet_row.get("drift_7d", 0)
 
-            # Find the matching instance for memory status computation
-            inst = inst_by_id.get(iid, {"id": iid, "name": iname, "provider": provider})
+            # Find the matching instance for memory status computation using
+            # the raw ID (inst_by_id keys are redacted by on_mount for local
+            # instances, but remote rows need raw key for the fallback dict).
+            inst = inst_by_id.get(iid) or inst_by_id.get(raw_iid, {
+                "id": iid, "name": iname, "provider": provider,
+            })
             status = compute_memory_status(inst, memory_service)
 
             if status == STATUS_FRESH:
@@ -438,7 +476,9 @@ class FleetMemoryScreen(Screen):
             age_text = "—"
             if memory_service is not None and status in (STATUS_FRESH, STATUS_STALE):
                 try:
-                    mods = memory_service.get_all_modules(iid, provider)
+                    # Use raw_iid and raw_provider for memory store lookups:
+                    # memory keys are stored under the real (un-redacted) IDs.
+                    mods = memory_service.get_all_modules(raw_iid, raw_provider)
                 except Exception:
                     mods = {}
                 if mods:
@@ -740,6 +780,10 @@ class FleetMemoryScreen(Screen):
         async def scan_one(inst: Dict[str, Any]) -> None:
             nonlocal completed
             name = inst.get("name") or inst.get("id") or "unknown"
+            # Scrub at source so every downstream consumer (succeeded/failed
+            # lists, refresh_progress footer, and the modal render) is safe.
+            if self.app.demo_mode and self.app.redaction_service:
+                name = self.app.redaction_service.redact_name(name)
             logger.info("Fleet scan: probing %s", name)
             async with semaphore:
                 ok = False

--- a/src/servonaut/screens/hetzner_manager.py
+++ b/src/servonaut/screens/hetzner_manager.py
@@ -174,6 +174,11 @@ class HetznerManagerScreen(Screen):
         try:
             instances = await svc.fetch_instances_cached(force_refresh=True)
             self._instances = list(instances)
+            # Redact the fresh list in-place so _render_table never sees raw
+            # names / IPs / regions — mirrors the app-startup redact_instances
+            # pattern (on_mount only redacts self.app.instances, not this list).
+            if self.app.demo_mode and self.app.redaction_service:
+                self.app.redaction_service.redact_instances(self._instances)
             self._render_table()
             n = len(instances)
             if n == 0:
@@ -187,8 +192,11 @@ class HetznerManagerScreen(Screen):
                 )
         except Exception as exc:
             logger.error("Failed to load Hetzner servers: %s", exc)
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]Failed to load servers: {self._short_err(exc)}[/red]"
+                f"[red]Failed to load servers: {err_msg}[/red]"
             )
         finally:
             self._loading = False
@@ -358,8 +366,11 @@ class HetznerManagerScreen(Screen):
             logger.error(
                 "Hetzner %s failed for %s: %s", method, identifier, exc,
             )
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]{method} failed: {self._short_err(exc)}[/red]"
+                f"[red]{method} failed: {err_msg}[/red]"
             )
             self.notify(
                 f"{method} failed: {exc}",
@@ -407,8 +418,11 @@ class HetznerManagerScreen(Screen):
             logger.error(
                 "Hetzner delete failed for %s: %s", identifier, exc,
             )
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]Delete failed: {self._short_err(exc)}[/red]"
+                f"[red]Delete failed: {err_msg}[/red]"
             )
             self.notify(
                 f"Delete failed: {exc}",

--- a/src/servonaut/screens/hetzner_ssh_keys.py
+++ b/src/servonaut/screens/hetzner_ssh_keys.py
@@ -180,12 +180,17 @@ class HetznerSSHKeysScreen(Screen):
             )
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         table = self.query_one("#hetzner_ssh_keys_table", DataTable)
         table.clear()
         for key in self._keys:
             fp = key.get("fingerprint", "") or ""
             table.add_row(
-                str(key.get("name", "")),
+                _s(str(key.get("name", ""))),
                 str(key.get("id", "")),
                 fp[:32],
                 key=str(key.get("id", "")) or str(key.get("name", "")),

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -224,6 +224,10 @@ class InstanceListScreen(Screen):
                 )
             else:
                 new_ovh = event.worker.result or []
+                # Redact the fresh OVH data before merging — only new_ovh is
+                # raw here; non_ovh was already redacted on its own refresh.
+                if self.app.demo_mode and self.app.redaction_service:
+                    self.app.redaction_service.redact_instances(new_ovh)
                 # Rebuild instance list: AWS+custom + fresh OVH data
                 non_ovh = [i for i in self._instances if not i.get('is_ovh')]
                 self._instances = non_ovh + new_ovh
@@ -250,6 +254,10 @@ class InstanceListScreen(Screen):
                 )
             else:
                 new_hetzner = event.worker.result or []
+                # Redact the fresh Hetzner data before merging — only
+                # new_hetzner is raw; non_hetzner was already redacted.
+                if self.app.demo_mode and self.app.redaction_service:
+                    self.app.redaction_service.redact_instances(new_hetzner)
                 non_hetzner = [
                     i for i in self._instances if not i.get('is_hetzner')
                 ]
@@ -295,6 +303,10 @@ class InstanceListScreen(Screen):
                     self._instances = (
                         new_instances + custom + ovh_instances + hetzner_instances
                     )
+                    # Re-snapshot pristine list BEFORE redaction to keep the
+                    # toggle path stale-free on each refresh.
+                    import copy
+                    self.app._instances_pristine = copy.deepcopy(self._instances)
                     # Apply demo-mode redaction to fresh data
                     if self.app.demo_mode and self.app.redaction_service:
                         self.app.redaction_service.redact_instances(self._instances)

--- a/src/servonaut/screens/ip_ban.py
+++ b/src/servonaut/screens/ip_ban.py
@@ -164,6 +164,11 @@ class IPBanScreen(Screen):
                 config = entry.get('config', '')
                 success = entry.get('success', False)
                 msg = entry.get('message', '')
+                # Scrub ip, msg, and config BEFORE embedding in f-string markup.
+                if self.app.demo_mode and self.app.redaction_service:
+                    ip = self.app.redaction_service.redact_ip(ip)
+                    msg = self.app.redaction_service.scrub_stream(msg)
+                    config = self.app.redaction_service.scrub_stream(config)
                 color = "green" if success else "red"
                 audit_log.write(
                     f"[{color}]{ts} {action}[/{color}] "
@@ -199,10 +204,16 @@ class IPBanScreen(Screen):
         try:
             banned = await self.app.ip_ban_service.list_banned(config_name)
             for ip in banned:
-                # Look up count by CIDR or bare IP
+                # Look up count by CIDR or bare IP (use raw ip for lookup)
                 bare_ip = ip.split("/")[0] if "/" in ip else ip
                 count = ban_counts.get(bare_ip, 0) or ban_counts.get(ip, 0)
-                table.add_row(ip, str(count) if count else "-", config_name, method)
+                # display_ip is redacted; ip (raw) used for ban_counts lookup above.
+                display_ip = ip
+                if self.app.demo_mode and self.app.redaction_service:
+                    display_ip = self.app.redaction_service.redact_ip(bare_ip)
+                    if "/" in ip:
+                        display_ip = f"{display_ip}/32"
+                table.add_row(display_ip, str(count) if count else "-", config_name, method)
             if not banned:
                 self.app.notify(f"No IPs currently banned in '{config_name}'")
         except Exception as e:

--- a/src/servonaut/screens/key_management.py
+++ b/src/servonaut/screens/key_management.py
@@ -87,9 +87,14 @@ class KeyManagementScreen(Screen):
         config = self.app.config_manager.get()
         default_key = config.default_key
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         if default_key:
             self.query_one("#current_default_key", Static).update(
-                f"Current: [bold]{default_key}[/bold]"
+                f"Current: [bold]{_s(default_key)}[/bold]"
             )
             # Pre-fill input with current default
             self.query_one("#input_default_key", Input).value = default_key
@@ -107,10 +112,15 @@ class KeyManagementScreen(Screen):
         table.clear(columns=True)
         table.add_columns("Instance ID", "Key Path", "Actions")
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         # Add mappings
         if config.instance_keys:
             for instance_id, key_path in config.instance_keys.items():
-                table.add_row(instance_id, key_path, "[Remove]")
+                table.add_row(_s(instance_id), _s(key_path), "[Remove]")
         else:
             # Show empty state
             table.add_row("[dim]No instance-specific keys configured[/dim]", "", "")
@@ -156,10 +166,15 @@ class KeyManagementScreen(Screen):
         table.clear(columns=True)
         table.add_columns("Key Path")
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         # Add keys
         if keys:
             for key_path in keys:
-                table.add_row(key_path)
+                table.add_row(_s(key_path))
         else:
             table.add_row("[dim]No SSH keys found in ~/.ssh/[/dim]")
 
@@ -344,6 +359,8 @@ class KeyManagementScreen(Screen):
                 )
             else:
                 output = event.worker.result or "No keys in agent"
+                if self.app.demo_mode and self.app.redaction_service:
+                    output = self.app.redaction_service.scrub_stream(output)
                 self.query_one("#agent_keys_output", Static).update(
                     f"[dim]{output}[/dim]"
                 )

--- a/src/servonaut/screens/log_viewer.py
+++ b/src/servonaut/screens/log_viewer.py
@@ -330,8 +330,15 @@ class LogViewerScreen(Screen):
             pass
 
         if lines:
-            self._content_buffer.extend(lines)
             output = self.query_one("#log_output", RichLog)
+            if self.app.demo_mode and self.app.redaction_service:
+                lines = [
+                    self.app.redaction_service.scrub_stream(line)
+                    for line in lines
+                ]
+            # Extend buffer AFTER scrubbing so that copy/AI-analyze actions
+            # never expose raw content even in demo mode.
+            self._content_buffer.extend(lines)
             output.write(Text("\n".join(lines)))
 
             config = self.app.config_manager.get()

--- a/src/servonaut/screens/memory.py
+++ b/src/servonaut/screens/memory.py
@@ -456,6 +456,11 @@ class MemoryScreen(Screen):
                 )
                 obs_str = str(obs_value) if obs_value is not None else ""
                 decl_str = str(decl_value) if decl_value is not None else ""
+                # Scrub observed and declared values (highest-value memory wire).
+                # module_name and key are taxonomy — do NOT scrub.
+                if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None) is not None:
+                    obs_str = self.app.redaction_service.scrub_stream(obs_str)
+                    decl_str = self.app.redaction_service.scrub_stream(decl_str)
 
                 table.add_row(
                     module_name,

--- a/src/servonaut/screens/memory_drift.py
+++ b/src/servonaut/screens/memory_drift.py
@@ -126,7 +126,12 @@ class DriftDiffScreen(ModalScreen[None]):
             new_env = await self._retrieval_service.get_snapshot(
                 instance_id, module, new_id,
             )
-            content.update(self._build_diff_text(old_env, new_env))
+            diff_text = self._build_diff_text(old_env, new_env)
+            # Scrub the raw JSON payload diff — it may contain hostnames,
+            # paths, ports, package versions, and account IDs.
+            if self.app.demo_mode and self.app.redaction_service:
+                diff_text = self.app.redaction_service.scrub_stream(diff_text)
+            content.update(diff_text)
         except Exception as exc:
             logger.exception("Drift diff fetch failed: %s", exc)
             content.update(f"[red]Diff fetch failed: {escape(str(exc))}[/red]")
@@ -271,7 +276,14 @@ class MemoryDriftScreen(Screen):
             else "[dim]Showing: all events[/dim]"
         )
         for idx, evt in enumerate(events):
-            instance_id = escape(str(getattr(evt, "instance_id", "?")))
+            raw_instance_id = str(getattr(evt, "instance_id", "?"))
+            # Use the sharper redact_instance_id primitive — instance IDs are
+            # more identifying than freeform text and deserve precise masking.
+            if self.app.demo_mode and self.app.redaction_service:
+                raw_instance_id = self.app.redaction_service.redact_instance_id(
+                    raw_instance_id
+                )
+            instance_id = escape(raw_instance_id)
             module = escape(str(getattr(evt, "module", "?")))
             severity = str(getattr(evt, "severity", "low"))
             status = "acknowledged" if getattr(evt, "acknowledged_at", None) else "open"

--- a/src/servonaut/screens/memory_export.py
+++ b/src/servonaut/screens/memory_export.py
@@ -120,19 +120,25 @@ class MemoryExportScreen(Screen):
             return
         from_val = self.query_one("#export-from-input", Input).value.strip() or None
         to_val = self.query_one("#export-to-input", Input).value.strip() or None
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         try:
             status.update("[yellow]Starting export…[/yellow]")
             tarball_path = await export_service.export(from_=from_val, to_=to_val)
-            status.update(f"[yellow]Verifying signature: {tarball_path}…[/yellow]")
+            display_path = _s(str(tarball_path))
+            status.update(f"[yellow]Verifying signature: {display_path}…[/yellow]")
             valid = await export_service.verify_export(tarball_path)
             if valid:
                 status.update(
-                    f"[green]Export verified: {tarball_path}[/green]"
+                    f"[green]Export verified: {display_path}[/green]"
                 )
                 self.app.notify(f"Export saved and verified: {tarball_path}")
             else:
                 status.update(
-                    f"[red]Signature INVALID: {tarball_path}[/red]"
+                    f"[red]Signature INVALID: {display_path}[/red]"
                 )
                 self.app.notify(
                     "Export signature verification FAILED — archive may be corrupt.",

--- a/src/servonaut/screens/ovh_billing.py
+++ b/src/servonaut/screens/ovh_billing.py
@@ -259,8 +259,13 @@ class OVHBillingScreen(Screen):
             if not services:
                 tbl.add_row("[dim]No services found[/dim]", "", "", "", "")
                 return
+            def _s(x: str) -> str:
+                if self.app.demo_mode and self.app.redaction_service:
+                    return self.app.redaction_service.scrub_stream(x)
+                return x
+
             for service in services:
-                name = str(service.get("name", ""))
+                name = _s(str(service.get("name", "")))
                 svc_type = str(service.get("type", ""))
                 status = str(service.get("status", ""))
                 status_display = {

--- a/src/servonaut/screens/ovh_billing.py
+++ b/src/servonaut/screens/ovh_billing.py
@@ -11,6 +11,8 @@ from textual.containers import Horizontal, ScrollableContainer
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Static
 
+from rich.markup import escape
+
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.widgets.sidebar import Sidebar
 
@@ -129,10 +131,38 @@ class OVHBillingScreen(Screen):
         self._all_invoices = []
         self._invoice_page = 0
         self._setup_tables()
+        self.run_worker(self._gate_then_load(), exclusive=False)
+
+    async def _gate_then_load(self) -> None:
+        """Verify OVH credentials once, then load every billing section.
+
+        A revoked credential makes every billing endpoint return empty, so
+        without this gate the screen would render four misleading "no data"
+        panels. The one extra ``GET /me`` runs only at screen open.
+        """
+        ovh_svc = getattr(self.app, "ovh_service", None)
+        if ovh_svc is not None:
+            cred_error = await ovh_svc.check_credentials()
+            if cred_error:
+                self._show_credential_error(cred_error)
+                return
         self.run_worker(self._load_current_usage(), exclusive=False)
         self.run_worker(self._load_spend_history(), exclusive=False)
         self.run_worker(self._load_invoices(), exclusive=False)
         self.run_worker(self._load_services(), exclusive=False)
+
+    def _show_credential_error(self, message: str) -> None:
+        """Render an OVH credential failure across the billing panels.
+
+        Args:
+            message: Classified, user-facing error from ``check_credentials``.
+        """
+        if self.app.demo_mode and self.app.redaction_service:
+            message = self.app.redaction_service.scrub_stream(message)
+        self.query_one("#current_usage", Static).update(
+            f"[red]⚠ {escape(message)}[/red]"
+        )
+        self.query_one("#spend_history", Static).update("[dim]—[/dim]")
 
     # ------------------------------------------------------------------
     # Table setup

--- a/src/servonaut/screens/ovh_cloud_create.py
+++ b/src/servonaut/screens/ovh_cloud_create.py
@@ -333,9 +333,15 @@ class OVHCloudCreateScreen(Screen):
             return
         try:
             self._keys = await svc.list_ssh_keys(self._project_id)
+
+            def _s(x: str) -> str:
+                if self.app.demo_mode and self.app.redaction_service:
+                    return self.app.redaction_service.scrub_stream(x)
+                return x
+
             for key in self._keys:
                 tbl.add_row(
-                    key.get("name", ""),
+                    _s(key.get("name", "")),
                     key.get("id", ""),
                 )
             if not self._keys:

--- a/src/servonaut/screens/ovh_dns.py
+++ b/src/servonaut/screens/ovh_dns.py
@@ -11,6 +11,8 @@ from textual.containers import Container, Horizontal, ScrollableContainer
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Static
 
+from rich.markup import escape
+
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.screens.confirm_action import ConfirmActionScreen
 from servonaut.widgets.sidebar import Sidebar
@@ -58,7 +60,10 @@ class OVHDNSScreen(Screen):
             yield ScrollableContainer(
                 Static("[bold cyan]OVH DNS Management[/bold cyan]", id="dns_title"),
 
-                Static("[bold]Domains[/bold]", classes="section_header"),
+                Static(
+                    "[bold]Domains[/bold]", classes="section_header",
+                    id="domains_section_header",
+                ),
                 DataTable(id="domains_table"),
 
                 Static("[bold]DNS Records[/bold]", classes="section_header", id="records_section_header"),
@@ -241,9 +246,40 @@ class OVHDNSScreen(Screen):
             self._domains = domains
             for domain in domains:
                 tbl.add_row(_s(domain))
+            if domains:
+                self._set_domains_status(None)
+            else:
+                # list_domains() swallows API errors and returns [] — an
+                # empty result might be a revoked credential, not zero zones.
+                ovh_svc = getattr(self.app, "ovh_service", None)
+                cred_error = (
+                    await ovh_svc.check_credentials() if ovh_svc else None
+                )
+                self._set_domains_status(cred_error)
         except Exception as exc:
             logger.error("_load_domains failed: %s", exc)
-            self.notify(f"Error loading domains: {exc}", severity="error")
+            self.notify(
+                f"Error loading domains: {exc}",
+                severity="error", markup=False,
+            )
+
+    def _set_domains_status(self, error: Optional[str]) -> None:
+        """Show or clear an OVH credential error under the Domains header.
+
+        Args:
+            error: Classified error message, or None to restore the plain
+                header (no credential problem).
+        """
+        try:
+            header = self.query_one("#domains_section_header", Static)
+        except Exception:  # pragma: no cover - defensive
+            return
+        if not error:
+            header.update("[bold]Domains[/bold]")
+            return
+        if self.app.demo_mode and self.app.redaction_service:
+            error = self.app.redaction_service.scrub_stream(error)
+        header.update(f"[bold]Domains[/bold]\n[red]⚠ {escape(error)}[/red]")
 
     async def _load_records(self, zone_name: str) -> None:
         svc = self._get_dns_service()

--- a/src/servonaut/screens/ovh_dns.py
+++ b/src/servonaut/screens/ovh_dns.py
@@ -231,11 +231,16 @@ class OVHDNSScreen(Screen):
             self.notify("OVH DNS service not available", severity="error")
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         try:
             domains = await svc.list_domains()
             self._domains = domains
             for domain in domains:
-                tbl.add_row(domain)
+                tbl.add_row(_s(domain))
         except Exception as exc:
             logger.error("_load_domains failed: %s", exc)
             self.notify(f"Error loading domains: {exc}", severity="error")
@@ -249,8 +254,13 @@ class OVHDNSScreen(Screen):
         if svc is None:
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         self.query_one("#selected_zone", Static).update(
-            f"Records for: [bold]{zone_name}[/bold]"
+            f"Records for: [bold]{_s(zone_name)}[/bold]"
         )
 
         try:
@@ -260,8 +270,8 @@ class OVHDNSScreen(Screen):
                 sub = rec.get("subDomain") or "@"
                 tbl.add_row(
                     str(rec.get("fieldType", "")),
-                    sub,
-                    str(rec.get("target", "")),
+                    _s(sub),
+                    _s(str(rec.get("target", ""))),
                     str(rec.get("ttl", "")),
                 )
         except Exception as exc:
@@ -284,6 +294,11 @@ class OVHDNSScreen(Screen):
             logger.error("_load_rdns: list_ips failed: %s", exc)
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for ip_info in ip_blocks:
             ip_block = ip_info.get("ip", "")
             if not ip_block:
@@ -300,7 +315,11 @@ class OVHDNSScreen(Screen):
                             "ip_block": ip_block,
                         }
                         self._rdns_entries.append(record)
-                        tbl.add_row(ip_addr, hostname or "[dim]not set[/dim]", ip_block)
+                        tbl.add_row(
+                            _s(ip_addr),
+                            _s(hostname) if hostname else "[dim]not set[/dim]",
+                            _s(ip_block),
+                        )
             except Exception as exc:
                 logger.error("_load_rdns: list_reverse_dns(%r) failed: %s", ip_block, exc)
 

--- a/src/servonaut/screens/ovh_firewall.py
+++ b/src/servonaut/screens/ovh_firewall.py
@@ -252,13 +252,18 @@ class OVHFirewallScreen(Screen):
             self.notify("No firewall rules configured.", severity="information")
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for rule in sorted(self._rules, key=lambda r: r.get("sequence", 0)):
             seq = str(rule.get("sequence", "—"))
             action = str(rule.get("action", "—"))
             protocol = str(rule.get("protocol", "—"))
             port = str(rule.get("destinationPort") or rule.get("port") or "—")
             source = str(rule.get("source") or rule.get("sourcePort") or "any")
-            table.add_row(seq, action, protocol, port, source)
+            table.add_row(seq, action, protocol, port, _s(source))
 
     # ------------------------------------------------------------------
     # Toggle firewall

--- a/src/servonaut/screens/ovh_ip_management.py
+++ b/src/servonaut/screens/ovh_ip_management.py
@@ -205,6 +205,11 @@ class OVHIPManagementScreen(Screen):
             self.notify("No IPs found on this account.", severity="information")
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for ip in self._ips:
             ip_addr = str(ip.get("ip") or ip.get("routedTo") or "—")
             ip_type = str(ip.get("type") or "—")
@@ -214,7 +219,7 @@ class OVHIPManagementScreen(Screen):
                 else ip.get("routedTo") or "—"
             )
             reverse = str(ip.get("reverse") or "—")
-            table.add_row(ip_addr, ip_type, routed_to, reverse)
+            table.add_row(_s(ip_addr), ip_type, _s(routed_to), _s(reverse))
 
     # ------------------------------------------------------------------
     # Move failover IP

--- a/src/servonaut/screens/ovh_manager.py
+++ b/src/servonaut/screens/ovh_manager.py
@@ -31,6 +31,8 @@ from textual.containers import Horizontal, ScrollableContainer
 from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Static
 
+from rich.markup import escape
+
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.widgets.sidebar import Sidebar
 
@@ -173,10 +175,21 @@ class OVHManagerScreen(Screen):
             self._render_table()
             n = len(instances)
             if n == 0:
-                self._set_status(
-                    "[dim]No OVH instances. Press [b]n[/b] to create a "
-                    "Public Cloud instance.[/dim]"
-                )
+                # fetch_instances() swallows API errors and returns [], so an
+                # empty list can't tell "no instances" from "credentials
+                # revoked" — a /me check disambiguates the two.
+                cred_error = await svc.check_credentials()
+                if cred_error:
+                    if self.app.demo_mode and self.app.redaction_service:
+                        cred_error = self.app.redaction_service.scrub_stream(
+                            cred_error
+                        )
+                    self._set_status(f"[red]⚠ {escape(cred_error)}[/red]")
+                else:
+                    self._set_status(
+                        "[dim]No OVH instances. Press [b]n[/b] to create a "
+                        "Public Cloud instance.[/dim]"
+                    )
             else:
                 self._set_status(
                     f"[dim]{n} instance{'s' if n != 1 else ''}.[/dim]"

--- a/src/servonaut/screens/ovh_manager.py
+++ b/src/servonaut/screens/ovh_manager.py
@@ -165,6 +165,11 @@ class OVHManagerScreen(Screen):
         try:
             instances = await svc.fetch_instances_cached(force_refresh=True)
             self._instances = list(instances)
+            # Redact the fresh list in-place; OVH names are often FQDNs
+            # (ns1.bigcorp.com) which are especially identifying.
+            # Mirrors the app-startup redact_instances pattern.
+            if self.app.demo_mode and self.app.redaction_service:
+                self.app.redaction_service.redact_instances(self._instances)
             self._render_table()
             n = len(instances)
             if n == 0:
@@ -178,8 +183,11 @@ class OVHManagerScreen(Screen):
                 )
         except Exception as exc:
             logger.error("Failed to load OVH instances: %s", exc)
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]Failed to load instances: {self._short_err(exc)}[/red]"
+                f"[red]Failed to load instances: {err_msg}[/red]"
             )
         finally:
             self._loading = False
@@ -374,8 +382,11 @@ class OVHManagerScreen(Screen):
                 "OVH %s failed for %s (%s): %s",
                 method, identifier, ptype, exc,
             )
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]{method} failed: {self._short_err(exc)}[/red]"
+                f"[red]{method} failed: {err_msg}[/red]"
             )
             self.notify(
                 f"{method} failed: {exc}",
@@ -445,8 +456,11 @@ class OVHManagerScreen(Screen):
             self._audit_action("cloud_delete", composite_id, ptype,
                                success=False, confirmed=True,
                                error=str(exc)[:200])
+            err_msg = self._short_err(exc)
+            if self.app.demo_mode and self.app.redaction_service:
+                err_msg = self.app.redaction_service.scrub_stream(err_msg)
             self._set_status(
-                f"[red]Delete failed: {self._short_err(exc)}[/red]"
+                f"[red]Delete failed: {err_msg}[/red]"
             )
             self.notify(
                 f"Delete failed: {exc}",

--- a/src/servonaut/screens/ovh_snapshots.py
+++ b/src/servonaut/screens/ovh_snapshots.py
@@ -238,6 +238,11 @@ class OVHSnapshotsScreen(Screen):
             self.notify("No snapshots found.", severity="information")
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for snap in self._snapshots:
             name_or_id = snap.get("name") or snap.get("id") or "—"
             created_at = (
@@ -252,7 +257,7 @@ class OVHSnapshotsScreen(Screen):
                 or snap.get("state")
                 or "—"
             )
-            table.add_row(str(name_or_id), str(created_at), str(description))
+            table.add_row(_s(str(name_or_id)), str(created_at), _s(str(description)))
 
     # ------------------------------------------------------------------
     # Create snapshot

--- a/src/servonaut/screens/ovh_ssh_keys.py
+++ b/src/servonaut/screens/ovh_ssh_keys.py
@@ -193,6 +193,11 @@ class OVHSSHKeysScreen(Screen):
             )
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         table = self.query_one("#ssh_keys_table", DataTable)
         table.clear()
         for key in self._keys:
@@ -201,7 +206,7 @@ class OVHSSHKeysScreen(Screen):
                 public_key[:40] + "…" if len(public_key) > 40 else public_key
             )
             table.add_row(
-                str(key.get("name", "")),
+                _s(str(key.get("name", ""))),
                 str(key.get("fingerprint", "") or "")[:32],
                 truncated,
                 key=str(key.get("id", "")) or str(key.get("name", "")),

--- a/src/servonaut/screens/ovh_storage.py
+++ b/src/servonaut/screens/ovh_storage.py
@@ -203,6 +203,12 @@ class OVHStorageScreen(Screen):
 
         table = self.query_one("#volumes_table", DataTable)
         table.clear()
+
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for vol in all_volumes:
             name = vol.get("name") or vol.get("id", "—")
             size = str(vol.get("size", "—"))
@@ -216,7 +222,7 @@ class OVHStorageScreen(Screen):
                 )
             else:
                 attached_to = "—"
-            table.add_row(name, size, region, status, attached_to)
+            table.add_row(_s(name), size, region, status, _s(attached_to))
 
     # ------------------------------------------------------------------
     # Event handlers

--- a/src/servonaut/screens/scan_results.py
+++ b/src/servonaut/screens/scan_results.py
@@ -88,8 +88,13 @@ class ScanResultsScreen(Screen):
         table = self.query_one("#results_table", DataTable)
         table.clear()
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for result in self._results:
-            source = result.get('source', 'Unknown')
+            source = _s(result.get('source', 'Unknown'))
             content = result.get('content', '')
             timestamp = result.get('timestamp', '')
 
@@ -100,7 +105,7 @@ class ScanResultsScreen(Screen):
                 content_display = content
 
             # Replace newlines with spaces for table display
-            content_display = content_display.replace('\n', ' ')
+            content_display = _s(content_display.replace('\n', ' '))
 
             table.add_row(source, content_display, timestamp)
 

--- a/src/servonaut/screens/scp_transfer.py
+++ b/src/servonaut/screens/scp_transfer.py
@@ -122,13 +122,18 @@ class SCPTransferScreen(Screen):
             remote_path_input.focus()
             return
 
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         # For uploads, validate local path exists
         if self._transfer_direction == "upload":
             expanded_local_path = Path(local_path).expanduser()
             if not expanded_local_path.exists():
                 self.app.notify(f"Local path not found: {local_path}", severity="error")
                 logger.error("Upload failed: local path does not exist: %s", local_path)
-                status_output.update(f"[red]Error:[/red] Local path not found: {local_path}")
+                status_output.update(f"[red]Error:[/red] Local path not found: {_s(local_path)}")
                 return
 
         # Update status
@@ -194,8 +199,13 @@ class SCPTransferScreen(Screen):
             if event.worker.is_finished:
                 status_output = self.query_one("#status_output", Static)
 
+                def _s(x: str) -> str:
+                    if self.app.demo_mode and self.app.redaction_service:
+                        return self.app.redaction_service.scrub_stream(x)
+                    return x
+
                 if event.worker.error:
-                    error_msg = str(event.worker.error)
+                    error_msg = _s(str(event.worker.error))
                     status_output.update(f"[red]Transfer failed:[/red] {error_msg}")
                     self.app.notify(f"Transfer failed: {error_msg}", severity="error")
                 else:
@@ -205,7 +215,7 @@ class SCPTransferScreen(Screen):
                         status_output.update("[green]Transfer completed successfully![/green]")
                         self.app.notify("Transfer completed", severity="information")
                     else:
-                        error_msg = stderr or "Unknown error"
+                        error_msg = _s(stderr or "Unknown error")
                         status_output.update(f"[red]Transfer failed:[/red] {error_msg}")
                         self.app.notify(f"Transfer failed: {error_msg}", severity="error")
 

--- a/src/servonaut/screens/secrets_list.py
+++ b/src/servonaut/screens/secrets_list.py
@@ -102,9 +102,17 @@ class SecretsListScreen(Screen):
                 classes="secrets_list_card",
             ))
             return
+        def _display_name(name: str) -> str:
+            # Secret names are workspace identifiers — use redact_name for
+            # deterministic substitution rather than scrub_stream (which only
+            # replaces IP/path patterns and leaves opaque names unchanged).
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.redact_name(name)
+            return name
+
         body.mount(Container(
             *[
-                Static(escape(name), classes="secrets_list_name")
+                Static(escape(_display_name(name)), classes="secrets_list_name")
                 for name in names
             ],
             classes="secrets_list_card",

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -245,6 +245,8 @@ class ServerActionsScreen(Screen):
             return
         reverse = await vps_service.get_reverse_dns(vps_name, public_ip)
         if reverse:
+            if self.app.demo_mode and self.app.redaction_service:
+                reverse = self.app.redaction_service.redact_hostname(reverse)
             info_widget = self.query_one("#server_info", Static)
             current = str(info_widget.renderable)
             # Insert rDNS line after Public IP line

--- a/src/servonaut/screens/settings.py
+++ b/src/servonaut/screens/settings.py
@@ -988,11 +988,17 @@ class SettingsScreen(Screen):
         table = self.query_one("#profiles_table", DataTable)
         table.clear(columns=True)
         table.add_columns("Profile Name", "Bastion Host", "Bastion User", "SSH Port")
+
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for profile in config.connection_profiles:
             table.add_row(
                 profile.name,
-                profile.bastion_host or "None",
-                profile.bastion_user or "None",
+                _s(profile.bastion_host or "None"),
+                _s(profile.bastion_user or "None"),
                 str(profile.ssh_port),
             )
 

--- a/src/servonaut/screens/snapshot_manager.py
+++ b/src/servonaut/screens/snapshot_manager.py
@@ -210,10 +210,15 @@ class SnapshotManagerScreen(Screen):
     def _render_table(self) -> None:
         table = self.query_one("#snapshots_table", DataTable)
         table.clear()
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for idx, snap in enumerate(self._snapshots, start=1):
             table.add_row(
                 str(idx),
-                str(snap.get("label") or snap.get("name") or "—"),
+                _s(str(snap.get("label") or snap.get("name") or "—")),
                 str(snap.get("version", "—")),
                 self._format_date(snap.get("created_at")),
                 str(snap.get("hash", ""))[:16],

--- a/src/servonaut/screens/team_management.py
+++ b/src/servonaut/screens/team_management.py
@@ -226,7 +226,12 @@ class TeamManagementScreen(Screen):
             self._show_detail_section()
             team_name = team.get("name", slug)
             self._current_team_name = team_name
-            self.query_one("#team_header", Static).update(f"[bold]Team: {team_name}[/bold]")
+            display_team_name = (
+                self.app.redaction_service.redact_name(team_name)
+                if self.app.demo_mode and self.app.redaction_service
+                else team_name
+            )
+            self.query_one("#team_header", Static).update(f"[bold]Team: {display_team_name}[/bold]")
         except Exception as exc:
             logger.error("Failed to load team detail: %s", exc)
             self.notify(f"Failed to load team: {exc}", severity="error")
@@ -291,9 +296,16 @@ class TeamManagementScreen(Screen):
     def _populate_teams_table(self, teams: list[dict]) -> None:
         table = self.query_one("#teams_table", DataTable)
         table.clear()
+
+        def _s(x: str) -> str:
+            # Team names are identifiers — use redact_name for deterministic substitution.
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.redact_name(x)
+            return x
+
         for team in teams:
             table.add_row(
-                team.get("name", ""),
+                _s(team.get("name", "")),
                 team.get("role", ""),
                 str(team.get("member_count", "")),
                 key=team.get("slug", ""),
@@ -302,9 +314,15 @@ class TeamManagementScreen(Screen):
     def _populate_members_table(self, members: list[dict]) -> None:
         table = self.query_one("#members_table", DataTable)
         table.clear()
+
+        def _s(x: str) -> str:
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for member in members:
             table.add_row(
-                member.get("email", ""),
+                _s(member.get("email", "")),
                 member.get("role", ""),
                 member.get("status", ""),
             )
@@ -312,10 +330,23 @@ class TeamManagementScreen(Screen):
     def _populate_servers_table(self, servers: list[dict]) -> None:
         table = self.query_one("#servers_table", DataTable)
         table.clear()
+
+        def _name(x: str) -> str:
+            # Server names are identifiers — use redact_name for deterministic substitution.
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.redact_name(x)
+            return x
+
+        def _host(x: str) -> str:
+            # Hosts may be IPs or hostnames — scrub_stream handles both.
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
         for server in servers:
             table.add_row(
-                server.get("name", ""),
-                server.get("host", ""),
+                _name(server.get("name", "")),
+                _host(server.get("host", "")),
                 server.get("provider", ""),
             )
 

--- a/src/servonaut/services/ovh_service.py
+++ b/src/servonaut/services/ovh_service.py
@@ -21,6 +21,49 @@ logger = logging.getLogger(__name__)
 _OVH_CACHE_PATH = Path.home() / '.servonaut' / 'ovh_cache.json'
 _OVH_CACHE_TTL_SECONDS = 300  # 5 minutes
 
+# OVH does not reliably raise the specific ``InvalidCredential`` subclass —
+# a revoked or expired key surfaces as a plain ``APIError`` whose message
+# text is the only stable signal. Match on substrings, not exception class.
+_OVH_AUTH_ERROR_MARKERS = (
+    "credential is not valid",
+    "invalid credential",
+    "invalid signature",
+    "invalid key",
+    "not authenticated",
+    "must login",
+)
+_OVH_PERMISSION_ERROR_MARKERS = (
+    "not been granted",
+    "forbidden",
+)
+
+
+def _classify_ovh_error(exc: Exception) -> str:
+    """Map a fetch exception to a concise, user-facing message.
+
+    Args:
+        exc: Exception raised by an OVH list call.
+
+    Returns:
+        A short, actionable message safe to show in a TUI notification.
+    """
+    if isinstance(exc, ImportError):
+        return "OVH: python-ovh is not installed — pip install 'servonaut[ovh]'"
+    text = str(exc).lower()
+    if any(marker in text for marker in _OVH_AUTH_ERROR_MARKERS):
+        return (
+            "OVH authentication failed — API credentials are invalid or "
+            "expired. Update them in Settings → OVH."
+        )
+    if any(marker in text for marker in _OVH_PERMISSION_ERROR_MARKERS):
+        return (
+            "OVH access denied — the API token is missing required "
+            "permissions. Regenerate it in Settings → OVH."
+        )
+    # Generic: OVH appends an "OVH-Query-ID:" line — keep only the first.
+    first_line = str(exc).strip().splitlines()[0].strip()
+    return f"OVH refresh failed: {first_line}"
+
 
 class OVHService:
     """Service for fetching OVHcloud instances (dedicated, VPS, Public Cloud)."""
@@ -319,6 +362,25 @@ class OVHService:
                 'account': '',
                 'message': "Authentication failed. Check your API credentials.",
             }
+
+    async def check_credentials(self) -> Optional[str]:
+        """Verify the OVH API credentials with a lightweight GET /me.
+
+        Screens call this to disambiguate an empty result list: "no
+        resources" and "credentials revoked" look identical otherwise,
+        because every fetch helper swallows API errors and returns [].
+
+        Returns:
+            None when the credentials authenticate successfully; otherwise
+            a concise, user-facing error message from ``_classify_ovh_error``.
+        """
+        try:
+            client = self._get_client()
+            await asyncio.to_thread(client.get, "/me")
+            return None
+        except Exception as exc:
+            logger.debug("OVH credential check failed: %s", exc)
+            return _classify_ovh_error(exc)
 
     async def request_consumer_key(self) -> dict:
         """Request a new consumer key via the OVH credential flow.

--- a/src/servonaut/services/redaction_service.py
+++ b/src/servonaut/services/redaction_service.py
@@ -8,21 +8,44 @@ same output across the entire session.
 from __future__ import annotations
 
 import hashlib
+import logging
+import os
 import re
 from typing import Any
+
+from servonaut.services.memory.redaction import default_redactor
+
+logger = logging.getLogger(__name__)
 
 # RFC 5737 documentation IP ranges (safe for public use)
 _DOC_NETS = ["192.0.2", "198.51.100", "203.0.113"]
 
 # Realistic fake server name components
 _NAME_PREFIXES = [
+    # Original 18
     "web", "api", "app", "db", "cache", "worker", "proxy",
     "gateway", "auth", "queue", "monitor", "scheduler",
     "search", "mail", "cdn", "storage", "backup", "deploy",
+    # Expanded to 50 — generic, common, non-loaded English tech words
+    "build", "run", "task", "job", "pipe", "stream", "relay",
+    "node", "edge", "core", "hub", "mesh", "bridge", "link",
+    "log", "trace", "metric", "alert", "event", "audit",
+    "image", "media", "asset", "graph", "data", "sync",
+    "push", "pull", "fetch", "serve",
 ]
 _NAME_SUFFIXES = [
+    # Original 12
     "prod", "staging", "dev", "test", "eu", "us", "ap",
     "primary", "replica", "blue", "green", "canary",
+    # Expanded to 50 — geographic/tier/role suffixes common in infra naming
+    "west", "east", "north", "south", "central",
+    "alpha", "beta", "gamma", "delta",
+    "main", "backup", "secondary", "tertiary",
+    "fast", "slow", "heavy", "light",
+    "a", "b", "c", "d",
+    "v1", "v2", "v3",
+    "internal", "external", "public", "private",
+    "shared", "dedicated", "cluster",
 ]
 
 # Fake provider/group names
@@ -40,6 +63,66 @@ _KEY_NAMES = [
 
 # Fake usernames
 _USERNAMES = ["ubuntu", "ec2-user", "admin", "deploy", "root", "centos"]
+
+# ---------------------------------------------------------------------------
+# Regex patterns for scrub_stream primitives (compiled once at import time)
+# ---------------------------------------------------------------------------
+
+# ARN — replaces account-id component with 000000000000; preserves service/region/rest
+_ARN_RE = re.compile(
+    r"arn:aws:(?P<service>[a-z0-9\-]+):"
+    r"(?P<region>[a-z0-9\-]*):"
+    r"(?P<account>\d{12}):"
+    r"(?P<rest>[\w\-/:.*?]+)"
+)
+
+# Bare 12-digit AWS account ID — negative lookaround prevents 15-digit shredding
+# and excludes numbers adjacent to dots (timestamps, request IDs with dots).
+_AWS_ACCOUNT_ID_RE = re.compile(r"(?<![\d.])(\d{12})(?![\d.])")
+
+# IPv4 addresses in free-form text (e.g. log output)
+_IPV4_RE = re.compile(r'\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b')
+
+# Unix home paths — /home/<user>/ and /Users/<user>/
+_HOME_PATH_RE = re.compile(r"(/home/)([^/\s:'\"]+)")
+_USERS_PATH_RE = re.compile(r"(/Users/)([^/\s:'\"]+)")
+
+# URLs — host → example.com; query params (often signed tokens) stripped
+_URL_RE = re.compile(
+    r"(?P<scheme>https?)://(?P<host>[^\s/?#'\"<>]+)(?P<rest>[^\s'\"<>]*)"
+)
+
+# CloudWatch log group names — /aws/<svc>/<name>
+_LOG_GROUP_RE = re.compile(r"(/aws/[a-z0-9\-]+/)([A-Za-z0-9\-_./]+)")
+
+# ECR hostname — <12-digit-account>.dkr.ecr.<region>.amazonaws.com
+# Must be handled BEFORE the bare account_id regex to avoid the dot-boundary
+# lookaround accidentally excluding accounts adjacent to dots in this pattern.
+_ECR_HOST_RE = re.compile(
+    r"\b(\d{12})\.dkr\.ecr\.([a-z0-9\-]+)\.amazonaws\.com\b"
+)
+
+# IPv6 addresses — require at least 3 colons ({2,7} groups) to avoid matching
+# MAC addresses (aa:bb:cc:dd:ee:ff has only 5 colons with no leading digits of
+# this form). Replace with 2001:db8::1 (RFC 3849 documentation prefix).
+# Known limitation: very short IPv6 forms like "::1" (loopback) are not matched
+# because they contain only 1 colon — see docs/demo-mode.md.
+_IPV6_RE = re.compile(
+    r"\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b"
+)
+
+# S3 bucket names — only explicit s3:// URIs (unambiguous).
+# Quoted DNS-shaped names are NOT matched: pattern is too broad and matches
+# free-form prose such as "hello-world" (Known limitation — see docs/demo-mode.md).
+_S3_URI_RE = re.compile(r"s3://([a-z0-9][a-z0-9\-\.]{2,62}[a-z0-9])")
+
+# Email addresses — matches RFC 5321 local-part @ domain.tld forms.
+# Applied AFTER redact_url so URL-embedded "user:pass@host" forms are consumed
+# first by the URL regex (order matters in scrub_stream pipeline).
+# Idempotent: local parts already in _fake_names pass through unchanged.
+_EMAIL_RE = re.compile(
+    r"\b([A-Za-z0-9._%+\-]+)@([A-Za-z0-9.\-]+\.[A-Za-z]{2,})\b"
+)
 
 
 def _hash_int(value: str, modulo: int) -> int:
@@ -64,11 +147,21 @@ class RedactionService:
         self._ip_cache: dict[str, str] = {}
         self._name_cache: dict[str, str] = {}
         self._counter: int = 0
+        # Tracks every fake name ever emitted by redact_name so that
+        # a second scrub_stream pass does not re-replace already-fake names
+        # (idempotence guarantee for log group and resource name redaction).
+        self._fake_names: set[str] = set()
 
     def redact_ip(self, ip: str) -> str:
         """Map a real IP to a documentation-range IP."""
         if not ip or ip == "-" or ip == "N/A":
             return ip
+        # Idempotence guard: doc-range IP fed back into redact_ip would re-hash
+        # to a DIFFERENT doc-range IP (cache is keyed on original input).
+        # Short-circuit so scrub_stream composes safely across re-renders.
+        for net in _DOC_NETS:
+            if ip.startswith(net + "."):
+                return ip
         if ip in self._ip_cache:
             return self._ip_cache[ip]
 
@@ -87,9 +180,10 @@ class RedactionService:
 
         prefix = _hash_pick(name, _NAME_PREFIXES)
         suffix = _hash_pick(name + "sfx", _NAME_SUFFIXES)
-        num = _hash_int(name + "num", 20) + 1
+        num = _hash_int(name + "num", 30) + 1
         fake = f"{prefix}-{suffix}-{num}"
         self._name_cache[name] = fake
+        self._fake_names.add(fake)
         return fake
 
     def redact_instance_id(self, instance_id: str) -> str:
@@ -181,7 +275,207 @@ class RedactionService:
 
     def redact_text(self, text: str) -> str:
         """Redact IPs found in arbitrary text (e.g., log output)."""
-        ip_pattern = re.compile(r'\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b')
         def _replace(match: re.Match) -> str:
             return self.redact_ip(match.group(1))
-        return ip_pattern.sub(_replace, text)
+        return _IPV4_RE.sub(_replace, text)
+
+    def redact_arn(self, text: str) -> str:
+        """Replace the account-id component inside ARNs with 000000000000.
+
+        Preserves service, region, and resource segments so the ARN remains
+        structurally valid. Only 12-digit accounts are matched to avoid
+        false positives.
+        """
+        def _replace(m: re.Match) -> str:
+            return (
+                f"arn:aws:{m.group('service')}:{m.group('region')}:"
+                f"000000000000:{m.group('rest')}"
+            )
+        return _ARN_RE.sub(_replace, text)
+
+    def redact_account_id(self, text: str) -> str:
+        """Replace bare 12-digit AWS account IDs with 000000000000.
+
+        Negative lookbehind/lookahead prevents replacing longer digit runs
+        such as phone numbers or 15-digit GCP project numbers.
+        """
+        return _AWS_ACCOUNT_ID_RE.sub("000000000000", text)
+
+    def redact_path(self, text: str) -> str:
+        """Replace username component in /home/<user>/ and /Users/<user>/ paths."""
+        text = _HOME_PATH_RE.sub(r"\1user", text)
+        text = _USERS_PATH_RE.sub(r"\1user", text)
+        return text
+
+    def redact_url(self, text: str) -> str:
+        """Replace hostname in URLs with example.com and strip query strings.
+
+        Path segments are preserved so structure is still visible. Query
+        parameters (which often contain signed tokens) are dropped entirely.
+        """
+        def _replace(m: re.Match) -> str:
+            rest = m.group("rest")
+            # Strip query and fragment; keep only path
+            path = rest.split("?")[0].split("#")[0]
+            return f"{m.group('scheme')}://example.com{path}"
+        return _URL_RE.sub(_replace, text)
+
+    def redact_log_group(self, text: str) -> str:
+        """Replace the log-group name component in /aws/<svc>/<name> patterns.
+
+        The service prefix (lambda, ecs, apigateway …) is preserved so the
+        log origin is still identifiable; only the first name component that
+        could reveal a project or function name is scrubbed.
+
+        Idempotent: if the name component is already a fake name produced by
+        a prior scrub_stream pass, it is returned unchanged.
+        """
+        def _replace(m: re.Match) -> str:
+            name = m.group(2)
+            # Idempotence guard: already a fake name → leave it alone
+            if name in self._fake_names:
+                return m.group(0)
+            fake_name = self.redact_name(name)
+            return f"{m.group(1)}{fake_name}"
+        return _LOG_GROUP_RE.sub(_replace, text)
+
+    def redact_ipv6(self, text: str) -> str:
+        """Replace IPv6 addresses with the RFC 3849 documentation address.
+
+        Matches groups of 2-7 hex-colon segments (requiring ≥3 colons total)
+        to avoid false-positives on MAC addresses (aa:bb:cc:dd:ee:ff) which
+        have 5 colons but no leading word boundary matching the ``\b`` anchor
+        combined with the {2,7} repetition in the regex.
+
+        Known limitation: loopback ``::1`` and compressed forms with only one
+        colon group are not matched — see docs/demo-mode.md.
+        """
+        return _IPV6_RE.sub("2001:db8::1", text)
+
+    def redact_ecr_host(self, text: str) -> str:
+        """Replace the AWS account-ID component in ECR hostnames.
+
+        ``123456789012.dkr.ecr.us-east-1.amazonaws.com`` becomes
+        ``000000000000.dkr.ecr.us-east-1.amazonaws.com``.
+
+        Must run BEFORE redact_account_id so the dot-bounded account stays
+        in its ECR-specific syntactic context (the bare-account regex has a
+        negative dot-lookaround that would otherwise exclude the match).
+        """
+        return _ECR_HOST_RE.sub(r"000000000000.dkr.ecr.\2.amazonaws.com", text)
+
+    def redact_email(self, text: str) -> str:
+        """Replace email addresses with a fake local-part @ example.com.
+
+        The local part (before @) is replaced with a deterministic fake name
+        drawn from the same name pool as ``redact_name`` so that the same
+        email address always maps to the same fake name within a session.
+
+        The domain is unconditionally replaced with ``example.com``.
+
+        Idempotent: if the local part is already a member of ``_fake_names``
+        (i.e. already replaced in a prior scrub pass) the address is left
+        unchanged — this prevents double-substitution in re-render scenarios.
+
+        Applied AFTER ``redact_url`` in the ``scrub_stream`` pipeline so that
+        URL-embedded credentials (``user:pass@host``) are consumed first.
+        """
+        def _replace(m: re.Match) -> str:
+            local = m.group(1)
+            # Idempotence guard: local part already fake → leave it alone.
+            if local in self._fake_names:
+                return m.group(0)
+            fake_local = self.redact_name(local)
+            return f"{fake_local}@example.com"
+        return _EMAIL_RE.sub(_replace, text)
+
+    def redact_resource_name(self, text: str) -> str:
+        """Redact S3 bucket names via explicit s3:// URIs only.
+
+        Quoted DNS-shaped bucket names are intentionally excluded: the pattern
+        is too broad and matches free-form prose such as "hello-world". Use
+        the s3:// URI form in chat / logs to guarantee redaction.
+        See docs/demo-mode.md Known Limitations for details.
+
+        Idempotent: if the bucket name is already a fake name produced by a
+        prior scrub_stream pass, it is returned unchanged.
+        """
+        def _replace_uri(m: re.Match) -> str:
+            name = m.group(1)
+            # Idempotence guard: already a fake name → leave it alone
+            if name in self._fake_names:
+                return m.group(0)
+            fake = self.redact_name(name)
+            return f"s3://{fake}"
+
+        text = _S3_URI_RE.sub(_replace_uri, text)
+        return text
+
+    def scrub_stream(self, text: str | None) -> str:
+        """Full-pipeline scrubber for any user-visible streamed string.
+
+        Composition order (tested, order matters — see below):
+          1. memory.redaction.default_redactor — secrets first (API keys, JWTs …)
+          2. self.redact_text             — IPv4 → RFC 5737 doc-range
+          3. self.redact_arn              — ARN account-id → 000000000000
+          4. self.redact_account_id       — bare 12-digit AWS account
+          5. self.redact_log_group        — /aws/<svc>/<name>
+          6. self.redact_url              — host → example.com, query stripped
+          7. self.redact_email            — user@domain → fake@example.com
+          8. self.redact_path             — /home/<user>/, /Users/<user>/
+          9. self.redact_resource_name    — S3 buckets (quoted) + s3:// URI
+
+        Order rationale: secrets before name/IP substitution so embedded keys
+        inside URLs are masked first; IPs before hostnames because doc-range
+        IPs are explicitly guarded; ARN before account_id so ARN-embedded
+        accounts get their in-place replacement, not the bare-account regex.
+        URL before email so URL-embedded credentials (user:pass@host) are
+        consumed by the URL regex first.
+
+        Args:
+            text: Any string. None returns ""; non-str is coerced with str().
+
+        Returns:
+            Idempotent string — scrub_stream(scrub_stream(s)) == scrub_stream(s).
+
+        Performance:
+            ~25–40 µs per 200-char log line; ~5–8 ms per MiB. Safe for
+            tail -f streams ≤200 lines/sec inside the 100 ms flush tick.
+
+        Demo-mode guard: CALLER-SIDE. RedactionService has no app reference.
+        Each call site uses:
+            if self.app.demo_mode and self.app.redaction_service:
+                line = self.app.redaction_service.scrub_stream(line)
+
+        Kill switch: SERVONAUT_DEMO_DISABLE_STREAM=1 returns input unchanged.
+        """
+        if text is None:
+            return ""
+        if not isinstance(text, str):
+            text = str(text)
+        if not text:
+            return text
+
+        if os.environ.get("SERVONAUT_DEMO_DISABLE_STREAM") == "1":
+            return text
+
+        orig = text
+        try:
+            text = default_redactor(text)
+            text = self.redact_text(text)
+            text = self.redact_ipv6(text)
+            text = self.redact_arn(text)
+            text = self.redact_ecr_host(text)
+            text = self.redact_account_id(text)
+            text = self.redact_log_group(text)
+            text = self.redact_url(text)
+            text = self.redact_email(text)
+            text = self.redact_path(text)
+            text = self.redact_resource_name(text)
+            return text
+        except Exception:
+            logger.exception("scrub_stream failed; falling back to redact_text only")
+            try:
+                return self.redact_text(orig)
+            except Exception:
+                return "<redaction-error>"

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -953,13 +953,27 @@ class ChatPanel(Widget):
                 # comes from CLI-side composition (tool name + status +
                 # result_summary, each escaped before storage), not
                 # raw model output, so re-rendering is safe.
+                # Demo-mode: scrub the stored markup before re-rendering.
+                # On-disk session stays raw (ISSUE-1 invariant). The markup
+                # has already been escaped so we scrub the pre-escape
+                # original embedded in the stored string — calling
+                # scrub_stream on already-escaped markup is safe because
+                # scrub_stream only replaces data tokens, not Rich tags.
+                tool_content = msg.content or ""
+                if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None) is not None:
+                    tool_content = self.app.redaction_service.scrub_stream(tool_content)
                 widget = Static(
-                    msg.content or "",
+                    tool_content,
                     classes="chat-message-tool",
                 )
                 container.mount(widget)
                 continue
-            safe_content = _rich_escape(msg.content or "")
+            # Scrub BEFORE _rich_escape: order must be redact → escape → embed.
+            # On-disk session stays raw; redaction is display-only.
+            raw_content = msg.content or ""
+            if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None) is not None:
+                raw_content = self.app.redaction_service.scrub_stream(raw_content)
+            safe_content = _rich_escape(raw_content)
             if msg.role == "user":
                 widget = Static(
                     f"[bold]You[/bold]\n{safe_content}",
@@ -1769,11 +1783,20 @@ class ChatPanel(Widget):
         elif etype == "token":
             delta = str(data.get("text") or "")
             accumulated += delta
+            # Demo-mode: always scrub a DISPLAY COPY on every token;
+            # `accumulated` (the raw text) is kept intact so that
+            # _finalise_servonaut_turn persists the original content to disk.
+            # Redaction is display-only: _refresh_messages applies scrub_stream
+            # again at render time over the full stored message.
+            # Performance: ~25–40µs × ~10 tokens/sec = 0.4ms/sec — invisible.
+            display_accumulated = accumulated
+            if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None) is not None:
+                display_accumulated = self.app.redaction_service.scrub_stream(accumulated)
             # Live-update the thinking bubble with the running text so
             # the user sees streaming output without re-render. A2 —
             # ``_update_thinking_status`` escapes its argument before
             # interpolating into Rich markup.
-            self._update_thinking_status(accumulated or "Thinking...")
+            self._update_thinking_status(display_accumulated or "Thinking...")
         elif etype == "tool_call":
             await self._handle_streamed_tool_call(data)
         elif etype == "tool_result":
@@ -1994,9 +2017,24 @@ class ChatPanel(Widget):
             f"[bold]{tool_id}[/bold] [dim]({status})[/dim]"
         )
         if isinstance(result_summary, str) and result_summary.strip():
+            # Demo-mode: scrub tool result content BEFORE escape so IPs /
+            # ARNs / secrets are never visible on screen. Order: scrub →
+            # escape → embed (CLAUDE.md anti-pattern rule).
+            raw_body = result_summary.strip()
+            try:
+                _app = self.app
+                # getattr defensive access: this row can render before the
+                # widget is fully mounted, when `app` may not expose the
+                # demo-mode attributes yet.
+                if getattr(_app, "demo_mode", False) and getattr(_app, "redaction_service", None):
+                    scrubbed = _app.redaction_service.scrub_stream(raw_body)
+                    if isinstance(scrubbed, str):
+                        raw_body = scrubbed
+            except Exception:
+                pass  # Not mounted or app not available — skip redaction gracefully
             # Server-controlled string — escape every byte before
             # interpolating into Rich markup (CLAUDE.md A2 rule).
-            safe_body = _rich_escape(result_summary.strip())
+            safe_body = _rich_escape(raw_body)
             body = f"\n{safe_body}"
         else:
             body = ""
@@ -2027,7 +2065,19 @@ class ChatPanel(Widget):
         except Exception:
             return
         safe_tool = _rich_escape(tool_name or "?")
-        safe_reason = _rich_escape(reason or "tool unavailable")
+        # Demo-mode: reason comes from result.error which may carry bridge
+        # error details (paths, IPs). Scrub before escape. Defense-in-depth:
+        # the probability is low but the fix is cheap.
+        raw_reason = reason or "tool unavailable"
+        try:
+            _app = self.app
+            if getattr(_app, "demo_mode", False) and getattr(_app, "redaction_service", None):
+                scrubbed = _app.redaction_service.scrub_stream(raw_reason)
+                if isinstance(scrubbed, str):
+                    raw_reason = scrubbed
+        except Exception:
+            pass
+        safe_reason = _rich_escape(raw_reason)
         rendered = (
             f"[yellow]⊘ Skipped tool[/yellow] [bold]{safe_tool}[/bold] "
             f"[dim]— {safe_reason}[/dim]"

--- a/src/servonaut/widgets/command_output.py
+++ b/src/servonaut/widgets/command_output.py
@@ -40,6 +40,8 @@ class CommandOutput(RichLog):
             output: Output text to display.
         """
         if output:
+            if self.app.demo_mode and self.app.redaction_service:
+                output = self.app.redaction_service.scrub_stream(output)
             self.write(output)
 
     def append_error(self, error: str) -> None:
@@ -49,6 +51,10 @@ class CommandOutput(RichLog):
             error: Error text to display.
         """
         if error:
+            # Scrub BEFORE embedding in Rich markup to preserve order:
+            # redact → escape → embed.
+            if self.app.demo_mode and self.app.redaction_service:
+                error = self.app.redaction_service.scrub_stream(error)
             self.write(f"[bold red]{error}[/bold red]")
 
     def clear_output(self) -> None:

--- a/src/servonaut/widgets/status_bar.py
+++ b/src/servonaut/widgets/status_bar.py
@@ -59,6 +59,14 @@ class StatusBar(Static):
         if self._filter_active:
             parts.append("[yellow]Filter: active[/yellow]")
 
+        # Demo mode badge
+        try:
+            if self.app.demo_mode:
+                parts.append("[bold red on yellow] DEMO [/bold red on yellow]")
+        except Exception:
+            # app may not be mounted yet during early initialization
+            pass
+
         self.update(" | ".join(parts))
 
     def _format_age(self, age: timedelta) -> str:

--- a/tests/test_ai_tool_bridge.py
+++ b/tests/test_ai_tool_bridge.py
@@ -808,24 +808,42 @@ def test_request_body_pushes_consent_modal_when_decision_unset():
     app.push_screen = MagicMock(
         side_effect=lambda screen, cb=None: push_screen_calls.append((screen, cb)),
     )
+    # Save original class-level app descriptor so we can restore it after the
+    # test. Not restoring it leaks a MagicMock-backed property onto ChatPanel's
+    # class dict, which poisons later tests that check demo_mode truthiness
+    # (the MagicMock is truthy even when demo_mode=False). Fix: always restore
+    # via finally, using monkeypatch.setattr would also work but requires a
+    # fixture argument.
+    _orig_app_descriptor = type(panel).__dict__.get("app")
     type(panel).app = property(lambda self, _a=app: _a)  # type: ignore[assignment]
 
     chat_service = MagicMock()
     chat_service._max_history = 20
 
-    body = panel._servonaut_build_request_body(
-        session_messages=[MagicMock(role="user", content="status of srv-a?")],
-        instance={"id": "srv-a", "name": "alpha", "provider": "aws"},
-        chat_service=chat_service,
-    )
+    try:
+        body = panel._servonaut_build_request_body(
+            session_messages=[MagicMock(role="user", content="status of srv-a?")],
+            instance={"id": "srv-a", "name": "alpha", "provider": "aws"},
+            chat_service=chat_service,
+        )
 
-    # No memory block injected on this turn.
-    assert len(body["messages"]) == 1
-    assert "CONTEXT" not in body["messages"][0]["content"]
-    # Consent modal was pushed exactly once.
-    assert len(push_screen_calls) == 1
-    pushed = push_screen_calls[0][0]
-    assert type(pushed).__name__ == "MemoryInjectionConsentModal"
+        # No memory block injected on this turn.
+        assert len(body["messages"]) == 1
+        assert "CONTEXT" not in body["messages"][0]["content"]
+        # Consent modal was pushed exactly once.
+        assert len(push_screen_calls) == 1
+        pushed = push_screen_calls[0][0]
+        assert type(pushed).__name__ == "MemoryInjectionConsentModal"
+    finally:
+        # Restore the original descriptor so the class-level patch doesn't
+        # bleed into subsequent tests (M-NEW-1 fixture isolation fix).
+        if _orig_app_descriptor is not None:
+            type(panel).app = _orig_app_descriptor  # type: ignore[assignment]
+        else:
+            try:
+                delattr(type(panel), "app")
+            except AttributeError:
+                pass
 
 
 def test_render_tool_result_row_schedules_follow_tail():

--- a/tests/test_chat_panel_security.py
+++ b/tests/test_chat_panel_security.py
@@ -61,6 +61,11 @@ def _build_panel():
 def _attach_app(panel) -> MagicMock:
     """Wire a :class:`MagicMock` ``app`` onto *panel* and return it."""
     app = MagicMock()
+    # Explicitly disable demo_mode so the redaction guard (which is now truthy-
+    # checked, not `is True`) does not fire on this mock and return a MagicMock
+    # from scrub_stream instead of the actual content string.
+    app.demo_mode = False
+    app.redaction_service = None
     type(panel).app = property(lambda self, _a=app: _a)  # type: ignore[assignment]
     return app
 

--- a/tests/test_demo_mode_coverage.py
+++ b/tests/test_demo_mode_coverage.py
@@ -1,0 +1,2715 @@
+"""Per-surface pilot tests for demo-mode redaction wiring.
+
+Each test verifies that when demo_mode=True and redaction_service is set,
+the relevant screen/widget scrubs the output before writing to the UI widget.
+
+Because Textual's Widget and App classes expose `app` / `screen` as read-only
+properties, these tests patch at a different level: they either call the
+relevant method directly (after patching `self.app` via `object.__setattr__`)
+or mock `self.app` on the object's `__dict__`. Where that isn't feasible,
+tests patch the method under test itself or the service it calls.
+
+The key invariant under test in every case: the GUARD LOGIC in the production
+code (if self.app.demo_mode and self.app.redaction_service: ...) routes through
+scrub_stream / redact_ip BEFORE the data reaches a write/update/add_row call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from servonaut.services.redaction_service import RedactionService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_app(demo: bool = True) -> MagicMock:
+    """Return a mock ServonautApp with demo_mode and redaction_service set."""
+    app = MagicMock()
+    app.demo_mode = demo
+    app.redaction_service = RedactionService() if demo else None
+    return app
+
+
+def _set_app(obj: Any, app: Any) -> None:
+    """Set widget.app via __dict__ to bypass the read-only Textual property."""
+    object.__setattr__(obj, "_app", app)
+    # Patch the `app` property lookup — Textual resolves it via DOMNode.app
+    # which walks the DOM tree. For unit tests we directly patch the property
+    # on the instance's class shadow.
+    type(obj).app = property(lambda self: app)
+
+
+# ---------------------------------------------------------------------------
+# TestCommandOutputDemoMode — append_output / append_error
+# ---------------------------------------------------------------------------
+
+
+class TestCommandOutputDemoMode:
+    """Verify CommandOutput guard logic routes through scrub_stream."""
+
+    def test_append_output_scrubs_ip_in_demo_mode(self) -> None:
+        """append_output must call scrub_stream when demo_mode is True."""
+        from servonaut.widgets.command_output import CommandOutput
+
+        mock_app = _make_mock_app(demo=True)
+
+        with patch.object(CommandOutput, "write") as mock_write:
+            widget = CommandOutput.__new__(CommandOutput)
+            with patch.object(type(widget), "app", new_callable=lambda: property(lambda self: mock_app)):
+                # Manually call append_output — bypasses Textual widget init
+                CommandOutput.append_output(widget, "connection from 1.2.3.4")
+                mock_write.assert_called_once()
+                written = mock_write.call_args[0][0]
+                assert "1.2.3.4" not in written
+
+    def test_append_output_not_scrubbed_without_demo(self) -> None:
+        from servonaut.widgets.command_output import CommandOutput
+
+        mock_app = _make_mock_app(demo=False)
+
+        with patch.object(CommandOutput, "write") as mock_write:
+            widget = CommandOutput.__new__(CommandOutput)
+            with patch.object(type(widget), "app", new_callable=lambda: property(lambda self: mock_app)):
+                CommandOutput.append_output(widget, "connection from 1.2.3.4")
+                mock_write.assert_called_once()
+                written = mock_write.call_args[0][0]
+                assert "1.2.3.4" in written
+
+    def test_append_error_scrubs_before_markup(self) -> None:
+        """Error text must be scrubbed BEFORE embedding in [bold red]...[/bold red]."""
+        from servonaut.widgets.command_output import CommandOutput
+
+        mock_app = _make_mock_app(demo=True)
+
+        with patch.object(CommandOutput, "write") as mock_write:
+            widget = CommandOutput.__new__(CommandOutput)
+            with patch.object(type(widget), "app", new_callable=lambda: property(lambda self: mock_app)):
+                CommandOutput.append_error(widget, "error from 9.9.9.9")
+                mock_write.assert_called_once()
+                written = mock_write.call_args[0][0]
+                assert "9.9.9.9" not in written
+                # Must still be wrapped in bold red markup
+                assert "[bold red]" in written
+
+    def test_append_error_scrubs_aws_key(self) -> None:
+        from servonaut.widgets.command_output import CommandOutput
+
+        mock_app = _make_mock_app(demo=True)
+
+        with patch.object(CommandOutput, "write") as mock_write:
+            widget = CommandOutput.__new__(CommandOutput)
+            with patch.object(type(widget), "app", new_callable=lambda: property(lambda self: mock_app)):
+                CommandOutput.append_error(widget, "AKIAIOSFODNN7EXAMPLE from 1.2.3.4")
+                written = mock_write.call_args[0][0]
+                assert "AKIAIOSFODNN7EXAMPLE" not in written
+                assert "1.2.3.4" not in written
+
+
+# ---------------------------------------------------------------------------
+# TestLogViewerDemoMode — _flush_pending line scrubbing
+# ---------------------------------------------------------------------------
+
+
+class TestLogViewerDemoMode:
+    """Verify _flush_pending applies scrub_stream to queued lines."""
+
+    def test_flush_pending_scrubs_ip(self) -> None:
+        """Lines with IPs in the queue must be redacted before RichLog.write."""
+        import queue as _queue
+        from rich.text import Text
+        from servonaut.screens.log_viewer import LogViewerScreen
+
+        # Build a minimal screen-like object without full Textual init.
+        screen = object.__new__(LogViewerScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        config = MagicMock()
+        config.log_viewer_max_lines = 10000
+        mock_app.config_manager = MagicMock()
+        mock_app.config_manager.get.return_value = config
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen._line_queue = _queue.Queue()
+            screen._content_buffer = []
+            screen._MAX_LINES_PER_FLUSH = 10
+
+            # Enqueue an IP-bearing line
+            screen._line_queue.put("ssh login from 5.6.7.8")
+
+            # Intercept the RichLog write
+            mock_output = MagicMock()
+            with patch.object(screen, "query_one", return_value=mock_output):
+                screen._flush_pending()
+
+            mock_output.write.assert_called_once()
+            written_arg = mock_output.write.call_args[0][0]
+            # The Text object string representation must not contain the raw IP
+            assert "5.6.7.8" not in str(written_arg)
+
+    def test_content_buffer_does_not_contain_raw_ip(self) -> None:
+        """ISSUE-2 regression: _content_buffer must hold scrubbed lines, not raw.
+
+        Copy/AI-analyze actions read from _content_buffer — raw IPs there
+        would leak via clipboard or AI backend calls even in demo mode.
+        """
+        import queue as _queue
+        from servonaut.screens.log_viewer import LogViewerScreen
+
+        screen = object.__new__(LogViewerScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        config = MagicMock()
+        config.log_viewer_max_lines = 10000
+        mock_app.config_manager = MagicMock()
+        mock_app.config_manager.get.return_value = config
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen._line_queue = _queue.Queue()
+            screen._content_buffer = []
+            screen._MAX_LINES_PER_FLUSH = 10
+
+            screen._line_queue.put("connection from 9.8.7.6")
+
+            mock_output = MagicMock()
+            with patch.object(screen, "query_one", return_value=mock_output):
+                screen._flush_pending()
+
+        # _content_buffer must NOT contain the raw IP
+        buffer_text = " ".join(screen._content_buffer)
+        assert "9.8.7.6" not in buffer_text, (
+            f"Raw IP leaked into _content_buffer: {buffer_text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestIPBanDemoMode — audit log and banned table
+# ---------------------------------------------------------------------------
+
+
+class TestIPBanDemoMode:
+    """Verify IPBanScreen scrubs IPs in audit log and banned table."""
+
+    def test_audit_log_ip_scrubbed(self) -> None:
+        """Audit log entries must have their IPs redacted in demo mode."""
+        import json
+        import tempfile
+        from pathlib import Path
+        from servonaut.screens.ip_ban import IPBanScreen
+
+        screen = object.__new__(IPBanScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # Build a minimal audit log file
+        entry = {
+            "timestamp": "2024-01-15T10:23:45Z",
+            "action": "ban",
+            "ip_address": "5.6.7.8",
+            "config": "ufw",
+            "success": True,
+            "message": "banned 5.6.7.8 from ssh",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = Path(tmpdir) / "audit.json"
+            audit_path.write_text(json.dumps([entry]))
+
+            config = MagicMock()
+            config.ip_ban_audit_path = str(audit_path)
+            mock_app.config_manager = MagicMock()
+            mock_app.config_manager.get.return_value = config
+
+            mock_log = MagicMock()
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_log):
+                    screen._load_audit_log()
+
+        # Capture all write() call args
+        all_writes = " ".join(str(c) for c in mock_log.write.call_args_list)
+        assert "5.6.7.8" not in all_writes
+
+    def test_banned_table_display_ip_scrubbed(self) -> None:
+        """_load_banned_ips must use display_ip (redacted) in table rows."""
+        from servonaut.screens.ip_ban import IPBanScreen
+
+        screen = object.__new__(IPBanScreen)
+        mock_app = _make_mock_app(demo=True)
+        screen._selected_config = "ufw"
+
+        # Mock ip_ban_service
+        mock_config = MagicMock()
+        mock_config.name = "ufw"
+        mock_config.method = "ufw"
+        mock_app.ip_ban_service = MagicMock()
+        mock_app.ip_ban_service.get_configs.return_value = [mock_config]
+
+        mock_table = MagicMock()
+        rows = []
+        mock_table.add_row.side_effect = lambda *args: rows.append(args)
+
+        async def _fake_list_banned(config_name):
+            return ["5.6.7.8"]
+
+        mock_app.ip_ban_service.list_banned = _fake_list_banned
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_table):
+                    with patch.object(screen, "_get_ban_counts", return_value={"5.6.7.8": 3}):
+                        await screen._load_banned_ips("ufw")
+
+        asyncio.run(_run())
+
+        # No row should show the real IP 5.6.7.8
+        for row in rows:
+            assert "5.6.7.8" not in str(row)
+
+
+# ---------------------------------------------------------------------------
+# TestStatusBarDemoBadge
+# ---------------------------------------------------------------------------
+
+
+class TestStatusBarDemoBadge:
+    """Status bar shows DEMO badge when demo_mode is True."""
+
+    def test_demo_badge_present_in_demo_mode(self) -> None:
+        from servonaut.widgets.status_bar import StatusBar
+
+        bar = object.__new__(StatusBar)
+        mock_app = _make_mock_app(demo=True)
+        bar._total_count = 3
+        bar._filtered_count = 3
+        bar._cache_age = None
+        bar._filter_active = False
+
+        with patch.object(type(bar), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(StatusBar, "update") as mock_update:
+                bar._update_display()
+
+        updated = mock_update.call_args[0][0]
+        assert "DEMO" in updated
+
+    def test_demo_badge_absent_without_demo_mode(self) -> None:
+        from servonaut.widgets.status_bar import StatusBar
+
+        bar = object.__new__(StatusBar)
+        mock_app = _make_mock_app(demo=False)
+        bar._total_count = 3
+        bar._filtered_count = 3
+        bar._cache_age = None
+        bar._filter_active = False
+
+        with patch.object(type(bar), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(StatusBar, "update") as mock_update:
+                bar._update_display()
+
+        updated = mock_update.call_args[0][0]
+        assert "DEMO" not in updated
+
+
+# ---------------------------------------------------------------------------
+# TestRedactIpIdempotenceScrubStream — integration via scrub_stream
+# ---------------------------------------------------------------------------
+
+
+class TestRedactIpIdempotenceScrubStream:
+    """Verify the doc-range guard in scrub_stream is idempotent."""
+
+    def test_scrub_does_not_double_remap_doc_range_ip(self) -> None:
+        svc = RedactionService()
+        # First pass
+        once = svc.scrub_stream("login from 1.2.3.4")
+        # Extract the doc-range IP from the output
+        import re
+        found = re.findall(r"\d+\.\d+\.\d+\.\d+", once)
+        assert found, "Expected a doc-range IP in output"
+        doc_ip = found[0]
+        # Feed it back — must not change
+        twice = svc.scrub_stream(f"login from {doc_ip}")
+        assert doc_ip in twice
+
+
+# ---------------------------------------------------------------------------
+# TestMemoryScreenDemoMode — _render_table scrubs obs_str and decl_str
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryScreenDemoMode:
+    """_render_table must scrub observed and declared values in demo mode."""
+
+    def test_render_table_scrubs_obs_and_decl(self, tmp_path) -> None:
+        """_render_table must scrub obs_str and decl_str in demo mode.
+
+        We test the guard logic directly in _render_table by mocking
+        the memory_service to return controlled module data and asserting
+        that the add_row calls on the DataTable use scrubbed values.
+        """
+        from servonaut.screens.memory import MemoryScreen
+
+        screen = object.__new__(MemoryScreen)
+        screen._instance = {"id": "i-abc123", "name": "test", "provider": "custom"}
+
+        mock_app = _make_mock_app(demo=True)
+        mock_app.memory_service = MagicMock()
+        # ISSUE-8: five-category payload — all must be scrubbed
+        mock_app.memory_service.get_all_modules.return_value = {
+            "os": {
+                "observed": {
+                    "path": (
+                        "AKIAIOSFODNN7EXAMPLE in /home/alice from 1.2.3.4 "
+                        "arn:aws:iam::123456789012:user/x"
+                    )
+                },
+                "declared": {"path": "/home/bob/data"},
+                "probed_at": "2024-01-15T10:00:00Z",
+                "partial": False,
+                "truncated": False,
+            }
+        }
+        mock_app.memory_service.stale_modules.return_value = []
+
+        mock_table = MagicMock()
+        rows = []
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        mock_banner = MagicMock()
+        mock_banner.classes = []
+
+        def _query_one(selector, widget_type=None):
+            if "memory-table" in str(selector):
+                return mock_table
+            return mock_banner
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                with patch.object(screen, "_is_opted_out", return_value=False):
+                    with patch.object(screen, "_set_empty_state_visible"):
+                        screen._render_table()
+
+        # ISSUE-8: all five PII categories must be absent from every cell
+        all_cells = " ".join(str(cell) for row in rows for cell in row)
+        assert "AKIAIOSFODNN7EXAMPLE" not in all_cells, "AWS key leaked into table"
+        assert "/home/alice" not in all_cells, "Home path (alice) leaked"
+        assert "/home/bob" not in all_cells, "Home path (bob) leaked"
+        assert "1.2.3.4" not in all_cells, "IP leaked into table"
+        assert "123456789012" not in all_cells, "Account ID leaked into table"
+
+    def test_render_table_no_scrub_without_demo(self, tmp_path) -> None:
+        from servonaut.screens.memory import MemoryScreen
+
+        screen = object.__new__(MemoryScreen)
+        screen._instance = {"id": "i-abc123", "name": "test", "provider": "custom"}
+
+        mock_app = _make_mock_app(demo=False)
+        mock_app.memory_service = MagicMock()
+        mock_app.memory_service.get_all_modules.return_value = {
+            "os": {
+                "observed": {"path": "/home/alice/secret"},
+                "declared": {},
+                "probed_at": "2024-01-15T10:00:00Z",
+                "partial": False,
+                "truncated": False,
+            }
+        }
+        mock_app.memory_service.stale_modules.return_value = []
+
+        mock_table = MagicMock()
+        rows = []
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        mock_banner = MagicMock()
+        mock_banner.classes = []
+
+        def _query_one(selector, widget_type=None):
+            if "memory-table" in str(selector):
+                return mock_table
+            return mock_banner
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                with patch.object(screen, "_is_opted_out", return_value=False):
+                    with patch.object(screen, "_set_empty_state_visible"):
+                        screen._render_table()
+
+        all_cells = " ".join(str(cell) for row in rows for cell in row)
+        assert "/home/alice" in all_cells
+
+
+# ---------------------------------------------------------------------------
+# TestChatPanelDemoMode — _refresh_messages scrubs before _rich_escape
+# ---------------------------------------------------------------------------
+
+
+class TestChatPanelDemoMode:
+    """_refresh_messages must scrub msg.content BEFORE _rich_escape."""
+
+    def test_refresh_messages_scrubs_ip_before_escape(self) -> None:
+        """IP in assistant message must be redacted in rendered widget.
+
+        We test the guard logic: when demo_mode=True, scrub_stream is called
+        on msg.content BEFORE _rich_escape. The Static widget mounted into the
+        container must not contain the raw IP.
+        """
+        from textual.widgets import Static
+        from servonaut.widgets.chat_panel import ChatPanel
+
+        panel = object.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=True)
+
+        # Create a mock session with one assistant message
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "Found server at 1.2.3.4"
+        msg.provider = "servonaut"
+
+        session = MagicMock()
+        session.messages = [msg]
+        panel._session = session
+
+        # Intercept container.remove_children and container.mount
+        mock_container = MagicMock()
+        mounted_renderables = []
+
+        def _capture_mount(w):
+            if isinstance(w, Static):
+                # Textual Static stores content as _Static__content (private)
+                # or via the `_render_markup` attribute. We access the raw
+                # markup string that was passed to the constructor via name mangling.
+                content = getattr(w, "_Static__content", None)
+                if content is None:
+                    content = getattr(w, "markup", str(w))
+                mounted_renderables.append(str(content))
+
+        mock_container.mount.side_effect = _capture_mount
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "query_one", return_value=mock_container):
+                with patch.object(panel, "_show_welcome"):
+                    with patch.object(panel, "call_after_refresh"):
+                        with patch.object(panel, "_update_stats"):
+                            panel._refresh_messages()
+
+        # At least one widget must have been captured
+        assert mounted_renderables, "Expected at least one Static widget to be mounted"
+        # The raw IP must not appear in any rendered widget content
+        for content in mounted_renderables:
+            assert "1.2.3.4" not in content, (
+                f"Raw IP leaked into rendered widget content: {content!r}"
+            )
+
+    def test_refresh_messages_scrubs_all_five_categories(self) -> None:
+        """ISSUE-8: display scrub must cover all 5 PII categories at once."""
+        from textual.widgets import Static
+        from servonaut.widgets.chat_panel import ChatPanel
+
+        panel = object.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=True)
+
+        # Five-category payload: AWS key, home path, IP, account ID, ARN account
+        payload = (
+            "AKIAIOSFODNN7EXAMPLE in /home/alice from 1.2.3.4 "
+            "arn:aws:iam::123456789012:user/x"
+        )
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = payload
+        msg.provider = "servonaut"
+
+        session = MagicMock()
+        session.messages = [msg]
+        panel._session = session
+
+        mock_container = MagicMock()
+        mounted_renderables = []
+
+        def _capture_mount(w):
+            if isinstance(w, Static):
+                content = getattr(w, "_Static__content", None)
+                if content is None:
+                    content = getattr(w, "markup", str(w))
+                mounted_renderables.append(str(content))
+
+        mock_container.mount.side_effect = _capture_mount
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "query_one", return_value=mock_container):
+                with patch.object(panel, "_show_welcome"):
+                    with patch.object(panel, "call_after_refresh"):
+                        with patch.object(panel, "_update_stats"):
+                            panel._refresh_messages()
+
+        assert mounted_renderables, "Expected at least one Static widget"
+        all_rendered = " ".join(mounted_renderables)
+        assert "AKIAIOSFODNN7EXAMPLE" not in all_rendered, "AWS key leaked"
+        assert "/home/alice" not in all_rendered, "Home path leaked"
+        assert "1.2.3.4" not in all_rendered, "IP leaked"
+        assert "123456789012" not in all_rendered, "Account ID leaked"
+
+    def test_finalise_turn_persists_raw_ip_not_redacted(self) -> None:
+        """ISSUE-1 regression: _finalise_servonaut_turn must persist RAW text.
+
+        Redaction is display-only; the on-disk session must retain original
+        content so that toggling demo mode OFF restores the real AI response.
+        _refresh_messages re-applies scrub_stream at render time.
+        """
+        from servonaut.widgets.chat_panel import ChatPanel
+        from servonaut.services.chat_service import ChatMessage
+
+        panel = object.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=True)
+
+        session = MagicMock()
+        session.messages = []
+        session.title = "New Chat"
+        panel._session = session
+        panel._turn_tool_calls = 0
+
+        mock_chat_service = MagicMock()
+        mock_chat_service.save_session.return_value = None
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "_hide_thinking"):
+                with patch.object(panel, "_refresh_messages"):
+                    panel._thinking = True
+                    panel._upstream_failures = []
+                    # Finalise with an accumulated string containing a raw IP
+                    panel._finalise_servonaut_turn(mock_chat_service, "server is at 1.2.3.4")
+
+        # The message appended to session.messages must contain the RAW IP
+        assert session.messages, "Expected a message to be appended"
+        last_msg = session.messages[-1]
+        assert isinstance(last_msg, ChatMessage)
+        assert "1.2.3.4" in last_msg.content, (
+            f"Raw IP was NOT persisted — content: {last_msg.content!r}. "
+            "Redaction must be display-only; raw text must reach storage."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRuntimeToggleDemoMode — action_toggle_demo round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeToggleDemoMode:
+    """action_toggle_demo must toggle demo_mode and restore pristine data."""
+
+    def _make_toggle_app(
+        self,
+        *,
+        demo: bool,
+        instances: List[dict],
+        pristine: List[dict],
+    ):
+        """Create a minimal ServonautApp-like mock for toggle tests."""
+        app = MagicMock()
+        app.demo_mode = demo
+        app.redaction_service = RedactionService() if demo else None
+        app.instances = instances
+        app._instances_pristine = copy.deepcopy(pristine)
+        app.query.return_value = []
+        return app
+
+    def test_toggle_on_sets_demo_mode(self) -> None:
+        """Calling action_toggle_demo when OFF should activate demo mode."""
+        from servonaut.app import ServonautApp
+
+        app = self._make_toggle_app(
+            demo=False,
+            instances=[{"name": "web-prod", "public_ip": "5.6.7.8"}],
+            pristine=[{"name": "web-prod", "public_ip": "5.6.7.8"}],
+        )
+
+        # action_toggle_demo imports InstanceListScreen and FleetMemoryScreen
+        # inside the method body (deferred import pattern). We patch builtins
+        # __import__ selectively or just let the isinstance check fail safely
+        # since app.screen is a MagicMock (not InstanceListScreen).
+        ServonautApp.action_toggle_demo(app)
+
+        assert app.demo_mode is True
+        assert app.redaction_service is not None
+
+    def test_toggle_off_restores_pristine(self) -> None:
+        """Calling action_toggle_demo when ON should restore pristine instances."""
+        from servonaut.app import ServonautApp
+
+        pristine = [{"name": "web-prod", "public_ip": "5.6.7.8"}]
+        app = self._make_toggle_app(
+            demo=True,
+            instances=[{"name": "cache-staging-1", "public_ip": "203.0.113.5"}],
+            pristine=pristine,
+        )
+
+        ServonautApp.action_toggle_demo(app)
+
+        assert app.demo_mode is False
+        assert app.redaction_service is None
+        # instances should be restored from pristine deepcopy
+        assert app.instances[0]["name"] == "web-prod"
+        assert app.instances[0]["public_ip"] == "5.6.7.8"
+
+    def test_pristine_isolation_deepcopy(self) -> None:
+        """Mutating instances after toggle-off must not affect _instances_pristine."""
+        from servonaut.app import ServonautApp
+
+        pristine = [{"name": "web-prod", "public_ip": "5.6.7.8"}]
+        app = self._make_toggle_app(
+            demo=True,
+            instances=[{"name": "cache-staging-1", "public_ip": "203.0.113.5"}],
+            pristine=pristine,
+        )
+
+        ServonautApp.action_toggle_demo(app)
+
+        # Mutate instances after restore
+        app.instances[0]["name"] = "mutated"
+        # Pristine must be unaffected (deepcopy isolation)
+        assert app._instances_pristine[0]["name"] == "web-prod"
+
+
+# ---------------------------------------------------------------------------
+# TestNotifyOverride — L1: App.notify scrubs PII in demo mode
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOverride:
+    """ServonautApp.notify override must scrub messages when demo_mode is True."""
+
+    def test_notify_scrubs_ip_in_demo_mode(self) -> None:
+        """notify() must redact IP before forwarding to super().notify()."""
+        from servonaut.app import ServonautApp
+
+        app = MagicMock(spec=ServonautApp)
+        app.demo_mode = True
+        app.redaction_service = RedactionService()
+
+        captured: list = []
+
+        def _super_notify(message, *, title="", severity="information", timeout=None, markup=True):
+            captured.append({"message": message, "title": title})
+
+        with patch.object(ServonautApp, "notify", ServonautApp.notify):
+            # Patch the super() call target directly
+            with patch("textual.app.App.notify", side_effect=_super_notify):
+                ServonautApp.notify(app, "Auth failed for 10.0.0.5")
+
+        assert captured, "super().notify was not called"
+        assert "10.0.0.5" not in captured[0]["message"], (
+            f"IP leaked in notification: {captured[0]['message']!r}"
+        )
+
+    def test_notify_unchanged_without_demo(self) -> None:
+        """notify() must not alter the message when demo_mode is False."""
+        from servonaut.app import ServonautApp
+
+        app = MagicMock(spec=ServonautApp)
+        app.demo_mode = False
+        app.redaction_service = None
+
+        captured: list = []
+
+        def _super_notify(message, *, title="", severity="information", timeout=None, markup=True):
+            captured.append({"message": message})
+
+        with patch("textual.app.App.notify", side_effect=_super_notify):
+            ServonautApp.notify(app, "Auth failed for 10.0.0.5")
+
+        assert captured
+        assert "10.0.0.5" in captured[0]["message"]
+
+    def test_notify_scrubs_title_too(self) -> None:
+        """Title must also be scrubbed when non-empty and demo_mode is True."""
+        from servonaut.app import ServonautApp
+
+        app = MagicMock(spec=ServonautApp)
+        app.demo_mode = True
+        app.redaction_service = RedactionService()
+
+        captured: list = []
+
+        def _super_notify(message, *, title="", severity="information", timeout=None, markup=True):
+            captured.append({"message": message, "title": title})
+
+        with patch("textual.app.App.notify", side_effect=_super_notify):
+            ServonautApp.notify(app, "Connection error", title="Server 1.2.3.4 issue")
+
+        assert captured
+        assert "1.2.3.4" not in captured[0]["title"], (
+            f"IP leaked in notification title: {captured[0]['title']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestToolResultScrub — C2: _render_tool_result_row scrubs result_summary
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultScrub:
+    """_render_tool_result_row must scrub result_summary before _rich_escape."""
+
+    def test_tool_result_ip_scrubbed(self) -> None:
+        """result_summary containing an IP must be redacted in the rendered widget."""
+        from textual.widgets import Static
+        from servonaut.widgets.chat_panel import ChatPanel
+
+        panel = object.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=True)
+
+        mounted: list = []
+        mock_container = MagicMock()
+
+        def _capture_mount(w):
+            if isinstance(w, Static):
+                content = getattr(w, "_Static__content", None) or str(w)
+                mounted.append(str(content))
+
+        mock_container.mount.side_effect = _capture_mount
+
+        data = {
+            "tool_call_id": "call-1",
+            "status": "ok",
+            "result_summary": "Found host at 192.168.1.50 with ARN arn:aws:iam::123456789012:role/x",
+        }
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "query_one", return_value=mock_container):
+                with patch.object(panel, "call_after_refresh"):
+                    with patch.object(panel, "_maybe_persist_tool_message"):
+                        panel._render_tool_result_row(data)
+
+        assert mounted, "Expected a tool-result widget to be mounted"
+        all_content = " ".join(mounted)
+        assert "192.168.1.50" not in all_content, "IP leaked in tool result row"
+        assert "123456789012" not in all_content, "Account ID leaked in tool result row"
+
+    def test_tool_result_unchanged_without_demo(self) -> None:
+        """result_summary must pass through unchanged when demo_mode is False."""
+        from textual.widgets import Static
+        from servonaut.widgets.chat_panel import ChatPanel
+
+        panel = object.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=False)
+
+        mounted: list = []
+        mock_container = MagicMock()
+
+        def _capture_mount(w):
+            if isinstance(w, Static):
+                content = getattr(w, "_Static__content", None) or str(w)
+                mounted.append(str(content))
+
+        mock_container.mount.side_effect = _capture_mount
+
+        data = {
+            "tool_call_id": "call-2",
+            "status": "ok",
+            "result_summary": "Host at 192.168.1.50",
+        }
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "query_one", return_value=mock_container):
+                with patch.object(panel, "call_after_refresh"):
+                    with patch.object(panel, "_maybe_persist_tool_message"):
+                        panel._render_tool_result_row(data)
+
+        assert mounted
+        assert "192.168.1.50" in " ".join(mounted)
+
+
+# ---------------------------------------------------------------------------
+# TestAIAnalysisScrub — C4: ai_analysis screen scrubs log text and output
+# ---------------------------------------------------------------------------
+
+
+class TestAIAnalysisScrub:
+    """ai_analysis._do_fetch_log must scrub log_text and _raw_text in demo mode."""
+
+    def test_raw_text_scrubbed_in_demo_mode(self) -> None:
+        """_raw_text must not contain raw IPs after _do_fetch_log completes."""
+        import asyncio
+        from servonaut.screens.ai_analysis import AIAnalysisScreen
+
+        screen = object.__new__(AIAnalysisScreen)
+        screen._instance = {"id": "i-abc", "name": "test", "provider": "custom"}
+        screen._filter_pattern = ""
+        mock_app = _make_mock_app(demo=True)
+        mock_app.ssh_service = MagicMock()
+        mock_app.connection_service = MagicMock()
+        screen._raw_text = ""
+
+        raw_log = "2024-01-15 10:23 login from 1.2.3.4 arn:aws:iam::123456789012:user/x"
+
+        mock_text_area = MagicMock()
+        mock_status = MagicMock()
+        mock_filter_input = MagicMock()
+        mock_progress = MagicMock()
+        mock_progress.stop = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            sel = str(selector)
+            if "ai_text_input" in sel:
+                return mock_text_area
+            if "ai_status" in sel:
+                return mock_status
+            if "ai_filter_input" in sel:
+                return mock_filter_input
+            return mock_progress
+
+        # Patch run_ssh_subprocess to return our raw log bytes
+        async def _fake_ssh(cmd, timeout=30):
+            return raw_log.encode(), b""
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                with patch.object(screen, "_update_token_estimate"):
+                    with patch.object(screen, "_set_buttons_disabled"):
+                        with patch("servonaut.screens.ai_analysis.run_ssh_subprocess", _fake_ssh):
+                            # Build a fake connection
+                            mock_app.ssh_service.build_ssh_command.return_value = ["ssh", "host"]
+                            mock_app.connection_service.get_connection.return_value = {
+                                "host": "10.0.0.1", "username": "ubuntu",
+                                "key_path": None, "port": 22,
+                                "extra_options": [],
+                            }
+                            asyncio.run(screen._do_fetch_log("/var/log/app.log"))
+
+        assert "1.2.3.4" not in screen._raw_text, (
+            f"Raw IP in _raw_text: {screen._raw_text!r}"
+        )
+        assert "123456789012" not in screen._raw_text, (
+            f"Account ID in _raw_text: {screen._raw_text!r}"
+        )
+        # text_area.load_text must have been called with scrubbed text
+        load_calls = mock_text_area.load_text.call_args_list
+        assert load_calls, "load_text was not called"
+        loaded = str(load_calls[0])
+        assert "1.2.3.4" not in loaded, "IP leaked into text_area.load_text call"
+
+
+# ---------------------------------------------------------------------------
+# TestCloudTrailCopy — C5: action_copy_output scrubs PII fields
+# ---------------------------------------------------------------------------
+
+
+class TestCloudTrailCopy:
+    """CloudTrailBrowserScreen.action_copy_output must scrub PII when demo ON."""
+
+    def test_copy_scrubs_username_ip_resource(self) -> None:
+        """action_copy_output must use _s() helper so copy buffer is safe."""
+        from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+
+        screen = object.__new__(CloudTrailBrowserScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        event = {
+            "event_name": "RunInstances",
+            "event_time": "2024-01-15T10:00:00Z",
+            "username": "alice@example.com",
+            "source_ip": "1.2.3.4",
+            "resource_type": "AWS::EC2::Instance",
+            "resource_name": "my-prod-server",
+            "region": "us-east-1",
+            "error_code": "",
+            "raw_event": '{"account": "123456789012"}',
+        }
+        screen._events = [event]
+        screen._selected_row = 0
+
+        copied: list = []
+
+        def _fake_copy(text):
+            copied.append(text)
+            return True
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            # copy_to_clipboard is imported inline (deferred import pattern).
+            # Patch at the source module so the inline import resolves to our mock.
+            with patch("servonaut.utils.platform_utils.copy_to_clipboard", _fake_copy):
+                screen.action_copy_output()
+
+        assert copied, "copy_to_clipboard was not called"
+        text = copied[0]
+        # IP in source_ip must be scrubbed (redact_text handles IPv4)
+        assert "1.2.3.4" not in text, "IP leaked in copy"
+        # Account ID in raw_event JSON blob must be scrubbed (redact_account_id)
+        assert "123456789012" not in text, "Account ID in raw_event leaked in copy"
+        # Note: email-style usernames ("alice@example.com") are NOT scrubbed —
+        # email addresses are a known limitation (see docs/demo-mode.md).
+        # The _s() helper uses scrub_stream which covers IPs, ARNs, and account IDs.
+
+
+# ---------------------------------------------------------------------------
+# TestCommandOverlayBuffer — C6: _output_lines scrubbed before append
+# ---------------------------------------------------------------------------
+
+
+class TestCommandOverlayBuffer:
+    """Regression for C6: _output_lines must contain scrubbed lines."""
+
+    def test_output_lines_scrubbed_in_demo_mode(self) -> None:
+        """Lines appended to _output_lines must be scrubbed when demo_mode is True."""
+        import subprocess
+        import threading
+        from servonaut.screens.command_overlay import CommandOverlay
+
+        screen = object.__new__(CommandOverlay)
+        screen._output_lines = []
+        screen._running_process = None
+        mock_app = _make_mock_app(demo=True)
+
+        # Simulate the SSH worker by calling _run_ssh_process with a fake process
+        # that emits one stdout line containing an IP.
+        raw_line = b"Connection from 10.20.30.40\n"
+
+        class _FakeProcess:
+            returncode = 0
+
+            def __init__(self):
+                import io
+                self.stdout = io.BytesIO(raw_line)
+                self.stderr = io.BytesIO(b"")
+
+            def wait(self):
+                return 0
+
+        # Patch subprocess.Popen to return our fake process
+        mock_output_widget = MagicMock()
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch("subprocess.Popen", return_value=_FakeProcess()):
+                # stderr thread spawned inside _run_ssh_process will try to
+                # read from process.stderr. Our _FakeProcess.stderr is a BytesIO
+                # that yields empty data, so _read_stderr exits immediately.
+                screen._run_ssh_command(["ssh", "host"], mock_output_widget)
+
+        # _output_lines must NOT contain the raw IP
+        all_lines = " ".join(screen._output_lines)
+        assert "10.20.30.40" not in all_lines, (
+            f"Raw IP leaked into _output_lines: {all_lines!r}"
+        )
+
+    def test_output_lines_unchanged_without_demo(self) -> None:
+        """Lines in _output_lines must pass through when demo_mode is False."""
+        from servonaut.screens.command_overlay import CommandOverlay
+
+        screen = object.__new__(CommandOverlay)
+        screen._output_lines = []
+        screen._running_process = None
+        mock_app = _make_mock_app(demo=False)
+
+        raw_line = b"Connection from 10.20.30.40\n"
+
+        class _FakeProcess:
+            returncode = 0
+
+            def __init__(self):
+                import io
+                self.stdout = io.BytesIO(raw_line)
+                self.stderr = io.BytesIO(b"")
+
+            def wait(self):
+                return 0
+
+        mock_output_widget = MagicMock()
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch("subprocess.Popen", return_value=_FakeProcess()):
+                screen._run_ssh_command(["ssh", "host"], mock_output_widget)
+
+        all_lines = " ".join(screen._output_lines)
+        assert "10.20.30.40" in all_lines
+
+
+# ---------------------------------------------------------------------------
+# TestFleetMemoryRemoteRender — C8: remote rows are scrubbed in merged table
+# ---------------------------------------------------------------------------
+
+
+class TestFleetMemoryRemoteRender:
+    """_populate_table_from_merged must scrub name/id/provider in demo mode."""
+
+    def test_remote_rows_scrubbed(self) -> None:
+        """Remote fleet rows must have name/id/provider scrubbed before add_row."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        mock_app = _make_mock_app(demo=True)
+        mock_app.memory_service = None
+        mock_app.instances = []
+
+        fleet_rows = [
+            {
+                "id": "i-0abc123def456789a",
+                "name": "web-prod-7",
+                "provider": "AWS",
+                "source": "remote",
+                "modules": 3,
+                "drift_7d": 0,
+            }
+        ]
+
+        table_rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args: table_rows.append(args)
+        mock_status = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "fleet-memory-table" in str(selector):
+                return mock_table
+            return mock_status
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._populate_table_from_merged(fleet_rows)
+
+        assert table_rows, "Expected at least one row added to the table"
+        all_cells = " ".join(str(c) for row in table_rows for c in row)
+        assert "web-prod-7" not in all_cells, "Real server name leaked in fleet table"
+        assert "i-0abc123def456789a" not in all_cells, "Real instance ID leaked"
+        assert "AWS" not in all_cells, "Real provider leaked"
+
+    def test_remote_rows_unchanged_without_demo(self) -> None:
+        """Without demo mode, rows render with original values."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        mock_app = _make_mock_app(demo=False)
+        mock_app.memory_service = None
+        mock_app.instances = []
+
+        fleet_rows = [
+            {
+                "id": "i-0abc123def456789a",
+                "name": "web-prod-7",
+                "provider": "AWS",
+                "source": "remote",
+                "modules": 0,
+                "drift_7d": 0,
+            }
+        ]
+
+        table_rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args: table_rows.append(args)
+        mock_status = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "fleet-memory-table" in str(selector):
+                return mock_table
+            return mock_status
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._populate_table_from_merged(fleet_rows)
+
+        assert table_rows
+        all_cells = " ".join(str(c) for row in table_rows for c in row)
+        assert "web-prod-7" in all_cells
+
+
+# ---------------------------------------------------------------------------
+# TestKillSwitch — SERVONAUT_DEMO_DISABLE_STREAM env var bypasses scrubbing
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    """SERVONAUT_DEMO_DISABLE_STREAM=1 must bypass scrub_stream."""
+
+    def test_kill_switch_returns_input_unchanged(self) -> None:
+        """With kill switch set, scrub_stream returns the input unchanged."""
+        import os
+        svc = RedactionService()
+        os.environ["SERVONAUT_DEMO_DISABLE_STREAM"] = "1"
+        try:
+            result = svc.scrub_stream("1.2.3.4")
+            assert result == "1.2.3.4", (
+                f"Kill switch should bypass scrubbing: {result!r}"
+            )
+        finally:
+            del os.environ["SERVONAUT_DEMO_DISABLE_STREAM"]
+
+    def test_normal_scrub_after_kill_switch_cleared(self) -> None:
+        """After clearing the kill switch, scrub_stream resumes normal operation."""
+        import os
+        svc = RedactionService()
+        # Ensure env var is not set
+        os.environ.pop("SERVONAUT_DEMO_DISABLE_STREAM", None)
+        result = svc.scrub_stream("1.2.3.4")
+        assert "1.2.3.4" not in result, (
+            f"IP should be scrubbed when kill switch is not set: {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestCloudWatchCopy — action_copy_output scrubs before clipboard (C-NEW-1/2)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudWatchCopy:
+    """CloudWatch action_copy_output must scrub messages and selected IPs in demo mode."""
+
+    def test_copy_scrubs_message_in_demo_mode(self) -> None:
+        """action_copy_output must scrub message text before sending to clipboard."""
+        from servonaut.screens.cloudwatch_browser import CloudWatchBrowserScreen
+
+        screen = object.__new__(CloudWatchBrowserScreen)
+        screen._events = [{"message": "Error from 1.2.3.4 in prod-env"}]
+        screen._selected_event_row = 0
+        mock_app = _make_mock_app(demo=True)
+
+        copied: list = []
+
+        def _fake_copy(text: str, msg: str) -> None:
+            copied.append(text)
+
+        screen._copy_text = _fake_copy  # type: ignore[method-assign]
+
+        def _fake_is_ips_focused() -> bool:
+            return False
+
+        screen._is_ips_table_focused = _fake_is_ips_focused  # type: ignore[method-assign]
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen.action_copy_output()
+
+        assert copied, "Expected clipboard text to be set"
+        clipboard_text = copied[0]
+        assert "1.2.3.4" not in clipboard_text, (
+            f"Raw IP leaked in clipboard text: {clipboard_text!r}"
+        )
+
+    def test_copy_scrubs_selected_ip_in_demo_mode(self) -> None:
+        """When IPs table is focused, action_copy_output must scrub the selected IP."""
+        from servonaut.screens.cloudwatch_browser import CloudWatchBrowserScreen
+
+        screen = object.__new__(CloudWatchBrowserScreen)
+        screen._events = []
+        mock_app = _make_mock_app(demo=True)
+
+        copied: list = []
+
+        def _fake_copy(text: str, msg: str) -> None:
+            copied.append(text)
+
+        def _fake_is_ips_focused() -> bool:
+            return True
+
+        def _fake_get_selected_ip() -> str:
+            return "45.33.32.156"  # non-doc-range IP that will be remapped
+
+        screen._copy_text = _fake_copy  # type: ignore[method-assign]
+        screen._is_ips_table_focused = _fake_is_ips_focused  # type: ignore[method-assign]
+        screen._get_selected_ip = _fake_get_selected_ip  # type: ignore[method-assign]
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen.action_copy_output()
+
+        assert copied, "Expected IP to be copied"
+        clipboard_text = copied[0]
+        assert "45.33.32.156" not in clipboard_text, (
+            f"Raw IP leaked in clipboard text: {clipboard_text!r}"
+        )
+        # Should have been remapped to a doc-range IP
+        assert any(clipboard_text.startswith(net) for net in ["192.0.2.", "198.51.100.", "203.0.113."])
+
+    def test_copy_not_scrubbed_when_demo_off(self) -> None:
+        """Without demo mode, clipboard text must carry the real message."""
+        from servonaut.screens.cloudwatch_browser import CloudWatchBrowserScreen
+
+        screen = object.__new__(CloudWatchBrowserScreen)
+        screen._events = [{"message": "Error from 1.2.3.4 in prod-env"}]
+        screen._selected_event_row = 0
+        mock_app = _make_mock_app(demo=False)
+
+        copied: list = []
+
+        def _fake_copy(text: str, msg: str) -> None:
+            copied.append(text)
+
+        screen._copy_text = _fake_copy  # type: ignore[method-assign]
+
+        def _fake_is_ips_focused() -> bool:
+            return False
+
+        screen._is_ips_table_focused = _fake_is_ips_focused  # type: ignore[method-assign]
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen.action_copy_output()
+
+        assert copied
+        assert "1.2.3.4" in copied[0], "Real IP should be preserved when demo is off"
+
+
+# ---------------------------------------------------------------------------
+# TestCloudTrailEmailUsername — username as SSO email (C-NEW-3)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudTrailEmailUsername:
+    """CloudTrail username field containing SSO email must be scrubbed."""
+
+    def test_email_username_scrubbed_in_table(self) -> None:
+        """_populate_table must scrub SSO email usernames in demo mode."""
+        from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+
+        screen = object.__new__(CloudTrailBrowserScreen)
+        screen._current_page = 0
+        # _page_events is a computed property from _events — set _events directly
+        screen._events = [
+            {
+                "event_time": "2024-01-01 00:00:00",
+                "event_name": "AssumeRole",
+                "username": "john.doe@company.com",
+                "source_ip": "5.6.7.8",
+                "resource_name": "admin-role",
+                "resource_type": "AWS::IAM::Role",
+                "region": "us-east-1",
+                "error_code": "",
+            }
+        ]
+        mock_app = _make_mock_app(demo=True)
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.clear = MagicMock()
+        mock_table.add_row.side_effect = lambda *args: rows.append(args)
+
+        def _query_one(selector, widget_type=None):
+            return mock_table
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._populate_table()
+
+        assert rows, "Expected a table row"
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "@company.com" not in all_cells, (
+            f"Email domain leaked in table cells: {all_cells!r}"
+        )
+        assert "john.doe" not in all_cells, (
+            f"Email local part leaked in table cells: {all_cells!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestCloudWatchAbuseIPDB — AbuseIPDB block redacted in demo mode (L-NEW-3)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudWatchAbuseIPDB:
+    """AbuseIPDB block must be blanket-redacted in demo mode."""
+
+    def test_abuseipdb_block_redacted_in_demo_mode(self) -> None:
+        """_fetch_ip_info must replace AbuseIPDB block with [redacted] in demo mode."""
+        import asyncio
+        from servonaut.screens.cloudwatch_browser import CloudWatchBrowserScreen
+        from rich.text import Text
+
+        screen = object.__new__(CloudWatchBrowserScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # Fake abuse data that would normally expose ISP/org
+        fake_abuse = {
+            "abuseConfidenceScore": 80,
+            "totalReports": 42,
+            "usageType": "Data Center/Web Hosting/Transit",
+            "domain": "secretisp.com",
+            "isp": "Secret ISP Ltd",
+            "isTor": False,
+        }
+
+        detail_widget = MagicMock()
+        detail_text: list = []
+        detail_widget.update.side_effect = lambda t: detail_text.append(t)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=detail_widget):
+                    with patch.object(screen, "_fetch_ip_geo", return_value=None):
+                        with patch.object(screen, "_fetch_abuse_info", return_value=fake_abuse):
+                            await screen._fetch_ip_info("10.0.0.1")
+
+        asyncio.run(_run())
+
+        assert detail_text, "Expected detail widget to be updated"
+        rendered = str(detail_text[-1])
+        assert "redacted in demo mode" in rendered, (
+            f"AbuseIPDB block not redacted: {rendered!r}"
+        )
+        assert "secretisp.com" not in rendered, "Real domain leaked in AbuseIPDB block"
+        assert "Secret ISP Ltd" not in rendered, "Real ISP leaked in AbuseIPDB block"
+
+
+# ---------------------------------------------------------------------------
+# TestAIAnalysisFetchLogScrubbing — SSH stderr + exception scrubbing (L-NEW-1)
+# ---------------------------------------------------------------------------
+
+
+class TestAIAnalysisFetchLogScrubbing:
+    """_do_fetch_log must scrub SSH stderr and exception messages in demo mode."""
+
+    def test_fetch_log_ssh_stderr_scrubbed(self) -> None:
+        """SSH stderr containing an IP must be scrubbed before status update."""
+        import asyncio
+        from servonaut.screens.ai_analysis import AIAnalysisScreen
+
+        screen = object.__new__(AIAnalysisScreen)
+        mock_app = _make_mock_app(demo=True)
+        screen._filter_pattern = ""
+
+        status_updates: list = []
+        mock_status = MagicMock()
+        mock_status.update.side_effect = lambda t: status_updates.append(t)
+        mock_progress = MagicMock()
+        mock_text_area = MagicMock()
+
+        # Simulate SSH returning empty stdout, stderr with a real IP
+        ssh_stdout = b""
+        ssh_stderr = b"ssh: connect to host 10.20.30.40 port 22: Connection refused"
+
+        def _query_one(selector, widget_type=None):
+            if "ai_status" in str(selector):
+                return mock_status
+            if "ProgressIndicator" in str(widget_type.__name__ if widget_type else ""):
+                return mock_progress
+            if "ai_text_input" in str(selector):
+                return mock_text_area
+            return mock_progress
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_set_buttons_disabled"):
+                        with patch(
+                            "servonaut.screens.ai_analysis.run_ssh_subprocess",
+                            return_value=(ssh_stdout, ssh_stderr),
+                        ):
+                            # Patch the connection build to avoid SSH setup
+                            with patch.object(
+                                screen, "_do_fetch_log",
+                                wraps=screen._do_fetch_log.__func__  # type: ignore[attr-defined]
+                            ):
+                                pass
+                            # Patch service deps
+                            mock_svc = MagicMock()
+                            mock_svc._resolve_connection.return_value = {
+                                "host": "10.20.30.40", "username": "ubuntu",
+                                "key_path": "/tmp/key", "proxy_args": [],
+                                "port": 22, "extra_options": [],
+                            }
+                            mock_svc.classify_log_file.return_value = "text"
+                            mock_svc.get_tail_command.return_value = "tail -n 200 /var/log/syslog"
+                            mock_ssh = MagicMock()
+                            mock_ssh.build_ssh_command.return_value = ["ssh", "fake"]
+                            screen.app.log_viewer_service = mock_svc  # type: ignore[union-attr]
+                            screen.app.ssh_service = mock_ssh  # type: ignore[union-attr]
+                            screen.app.connection_service = MagicMock()  # type: ignore[union-attr]
+                            await screen._do_fetch_log("/var/log/syslog")
+
+        asyncio.run(_run())
+
+        assert status_updates, "Expected status updates"
+        all_status = " ".join(str(u) for u in status_updates)
+        assert "10.20.30.40" not in all_status, (
+            f"Real IP from SSH stderr leaked in status: {all_status!r}"
+        )
+
+    def test_fetch_log_exception_scrubbed(self) -> None:
+        """Exception message containing an IP must be scrubbed before status update."""
+        import asyncio
+        from servonaut.screens.ai_analysis import AIAnalysisScreen
+
+        screen = object.__new__(AIAnalysisScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        status_updates: list = []
+        mock_status = MagicMock()
+        mock_status.update.side_effect = lambda t: status_updates.append(t)
+        mock_progress = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "ai_status" in str(selector):
+                return mock_status
+            return mock_progress
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_set_buttons_disabled"):
+                        mock_svc = MagicMock()
+                        mock_svc._resolve_connection.side_effect = ConnectionError(
+                            "Failed to connect to 10.20.30.40"
+                        )
+                        screen.app.log_viewer_service = mock_svc  # type: ignore[union-attr]
+                        screen.app.ssh_service = MagicMock()  # type: ignore[union-attr]
+                        screen.app.connection_service = MagicMock()  # type: ignore[union-attr]
+                        await screen._do_fetch_log("/var/log/syslog")
+
+        asyncio.run(_run())
+
+        assert status_updates, "Expected status updates from exception path"
+        all_status = " ".join(str(u) for u in status_updates)
+        assert "10.20.30.40" not in all_status, (
+            f"Real IP from exception leaked in status: {all_status!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestAIAnalysisProbeException — probe exception scrubbing (L-NEW-2)
+# ---------------------------------------------------------------------------
+
+
+class TestAIAnalysisProbeException:
+    """_do_probe_and_pick must scrub exception messages in demo mode."""
+
+    def test_probe_exception_scrubbed(self) -> None:
+        """Exception containing an IP must be scrubbed before status update."""
+        import asyncio
+        from servonaut.screens.ai_analysis import AIAnalysisScreen
+
+        screen = object.__new__(AIAnalysisScreen)
+        mock_app = _make_mock_app(demo=True)
+        screen._instance = {"id": "i-abc", "name": "web-1"}
+        screen._available_logs = []
+        screen._discovered_logs = []
+        screen._scan_complete = False
+
+        status_updates: list = []
+        mock_status = MagicMock()
+        mock_status.update.side_effect = lambda t: status_updates.append(t)
+        mock_progress = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "ai_status" in str(selector):
+                return mock_status
+            return mock_progress
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_set_buttons_disabled", create=True):
+                        with patch.object(screen, "run_worker", create=True):
+                            mock_svc = MagicMock()
+                            mock_svc.find_common_log_files.side_effect = ConnectionError(
+                                "Unreachable: 10.20.30.40"
+                            )
+                            screen.app.log_viewer_service = mock_svc  # type: ignore[union-attr]
+                            screen.app.ssh_service = MagicMock()  # type: ignore[union-attr]
+                            screen.app.connection_service = MagicMock()  # type: ignore[union-attr]
+                            await screen._do_probe_and_pick()
+
+        asyncio.run(_run())
+
+        assert status_updates, "Expected status update from exception"
+        all_status = " ".join(str(u) for u in status_updates)
+        assert "10.20.30.40" not in all_status, (
+            f"Real IP from probe exception leaked in status: {all_status!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestFleetScanSummaryModalScrubbing — failure message scrubbing (L-NEW-4)
+# ---------------------------------------------------------------------------
+
+
+class TestFleetScanSummaryModalScrubbing:
+    """FleetScanSummaryModal._render_body must scrub failure messages in demo mode."""
+
+    def test_failure_message_scrubbed_in_demo_mode(self) -> None:
+        """failure.get('message') containing an IP must be scrubbed before escape."""
+        from servonaut.screens.fleet_memory import FleetScanSummaryModal
+
+        failed = [
+            {
+                "instance": "web-prod-7",
+                "reason": "SSH connection refused to 10.20.30.40",
+                "failures": [
+                    {
+                        "module": "os",
+                        "reason": "ssh_error",
+                        "message": "Connection to 10.20.30.40:22 timed out",
+                    }
+                ],
+            }
+        ]
+        modal = FleetScanSummaryModal.__new__(FleetScanSummaryModal)
+        modal._succeeded = []
+        modal._failed = failed
+        mock_app = _make_mock_app(demo=True)
+
+        with patch.object(type(modal), "app", new_callable=lambda: property(lambda self: mock_app)):
+            body = modal._render_body()
+
+        assert "10.20.30.40" not in body, (
+            f"Real IP leaked in fleet scan modal body: {body!r}"
+        )
+
+    def test_failure_reason_scrubbed_in_demo_mode(self) -> None:
+        """entry.get('reason') must be scrubbed before display."""
+        from servonaut.screens.fleet_memory import FleetScanSummaryModal
+
+        failed = [
+            {
+                "instance": "web-prod-7",
+                "reason": "Timeout connecting to 172.16.0.1",
+                "failures": [],
+            }
+        ]
+        modal = FleetScanSummaryModal.__new__(FleetScanSummaryModal)
+        modal._succeeded = []
+        modal._failed = failed
+        mock_app = _make_mock_app(demo=True)
+
+        with patch.object(type(modal), "app", new_callable=lambda: property(lambda self: mock_app)):
+            body = modal._render_body()
+
+        assert "172.16.0.1" not in body, (
+            f"Real IP in reason field leaked: {body!r}"
+        )
+
+    def test_failure_not_scrubbed_when_demo_off(self) -> None:
+        """Without demo mode, failure messages render verbatim."""
+        from servonaut.screens.fleet_memory import FleetScanSummaryModal
+
+        failed = [
+            {
+                "instance": "web-prod-7",
+                "reason": "SSH refused",
+                "failures": [
+                    {"module": "os", "reason": "err", "message": "timed out"}
+                ],
+            }
+        ]
+        modal = FleetScanSummaryModal.__new__(FleetScanSummaryModal)
+        modal._succeeded = []
+        modal._failed = failed
+        mock_app = _make_mock_app(demo=False)
+
+        with patch.object(type(modal), "app", new_callable=lambda: property(lambda self: mock_app)):
+            body = modal._render_body()
+
+        assert "SSH refused" in body
+
+
+# ---------------------------------------------------------------------------
+# TestRenderToolSkippedReason — skipped-tool reason scrubbing (P-NEW-1)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderToolSkippedReason:
+    """_render_tool_skipped_row must scrub reason in demo mode."""
+
+    def test_render_tool_skipped_reason_scrubbed(self) -> None:
+        """reason containing an IP must be scrubbed before Rich markup embedding."""
+        from servonaut.widgets.chat_panel import ChatPanel
+
+        panel = ChatPanel.__new__(ChatPanel)
+        mock_app = _make_mock_app(demo=True)
+
+        mounted: list = []
+        mock_container = MagicMock()
+        mock_container.mount.side_effect = lambda w: mounted.append(w)
+
+        def _query_one(selector, widget_type=None):
+            return mock_container
+
+        with patch.object(type(panel), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(panel, "query_one", side_effect=_query_one):
+                with patch.object(panel, "call_after_refresh"):
+                    with patch.object(panel, "_maybe_persist_tool_message"):
+                        panel._render_tool_skipped_row(
+                            "get_logs",
+                            "Bridge error: host 10.20.30.40 unreachable",
+                        )
+
+        assert mounted, "Expected a widget to be mounted"
+        rendered = mounted[-1].renderable if hasattr(mounted[-1], "renderable") else str(mounted[-1])
+        # The rendered text is in the Static widget's first positional arg
+        import inspect
+        widget = mounted[-1]
+        # Get the markup passed to Static.__init__
+        rendered_text = widget.args[0] if hasattr(widget, "args") else str(widget)
+        # For MagicMock-constructed Statics we check the call args
+        # Actually _render_tool_skipped_row creates a real Static
+        # so we check its _renderable / content attribute
+        if hasattr(widget, "_renderable"):
+            rendered_text = str(widget._renderable)
+        else:
+            rendered_text = str(widget)
+        # The key assertion: real IP must not appear anywhere in the rendered output
+        assert "10.20.30.40" not in rendered_text, (
+            f"Real IP leaked in skipped-tool row: {rendered_text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestHetznerManagerDemoMode — CRITICAL-3.1 fresh fetch + render
+# ---------------------------------------------------------------------------
+
+
+class TestHetznerManagerDemoMode:
+    """fresh-fetch instances are redacted in-place before _render_table."""
+
+    def test_fresh_fetch_redacts_before_render(self) -> None:
+        """_load_instances must redact self._instances before _render_table."""
+        import asyncio
+        from servonaut.screens.hetzner_manager import HetznerManagerScreen
+
+        screen = object.__new__(HetznerManagerScreen)
+        screen._loading = False
+        screen._instances = []
+        mock_app = _make_mock_app(demo=True)
+
+        raw_instances = [
+            {"name": "web-prod-7", "id": "123", "public_ip": "5.6.7.8",
+             "region": "fsn1", "type": "cx22", "state": "running",
+             "created_at": "2024-01-01T00:00:00Z"}
+        ]
+
+        async def _fake_fetch(force_refresh=False):
+            return list(raw_instances)
+
+        mock_svc = MagicMock()
+        mock_svc.fetch_instances_cached = _fake_fetch
+        mock_app.hetzner_service = mock_svc
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        mock_status = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "hetzner_mgr_table" in str(selector):
+                return mock_table
+            return mock_status
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_sync_action_buttons"):
+                        await screen._load_instances()
+
+        asyncio.run(_run())
+
+        assert rows, "Expected table rows"
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "web-prod-7" not in all_cells, "Real server name leaked in Hetzner table"
+        assert "5.6.7.8" not in all_cells, "Real IP leaked in Hetzner table"
+
+    def test_error_path_scrubs_exception(self) -> None:
+        """Exception from fetch must be scrubbed before _set_status in demo mode."""
+        import asyncio
+        from servonaut.screens.hetzner_manager import HetznerManagerScreen
+
+        screen = object.__new__(HetznerManagerScreen)
+        screen._loading = False
+        screen._instances = []
+        mock_app = _make_mock_app(demo=True)
+
+        async def _fake_fetch(force_refresh=False):
+            raise RuntimeError("Connection refused to host 9.8.7.6")
+
+        mock_svc = MagicMock()
+        mock_svc.fetch_instances_cached = _fake_fetch
+        mock_app.hetzner_service = mock_svc
+
+        status_updates: list = []
+        mock_status = MagicMock()
+        mock_status.update.side_effect = lambda t: status_updates.append(t)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_status):
+                    await screen._load_instances()
+
+        asyncio.run(_run())
+
+        assert status_updates, "Expected a status update"
+        all_updates = " ".join(str(u) for u in status_updates)
+        assert "9.8.7.6" not in all_updates, (
+            f"Real IP from exception leaked in Hetzner status: {all_updates!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestOvhManagerDemoMode — CRITICAL-3.2 symmetric to Hetzner
+# ---------------------------------------------------------------------------
+
+
+class TestOvhManagerDemoMode:
+    """OVH manager fresh fetch and error paths are scrubbed in demo mode."""
+
+    def test_fresh_fetch_redacts_before_render(self) -> None:
+        """_load_instances must redact self._instances before _render_table."""
+        import asyncio
+        from servonaut.screens.ovh_manager import OVHManagerScreen
+
+        screen = object.__new__(OVHManagerScreen)
+        screen._loading = False
+        screen._instances = []
+        mock_app = _make_mock_app(demo=True)
+
+        raw_instances = [
+            {"name": "ns1.bigcorp.com", "id": "abc", "public_ip": "1.2.3.4",
+             "region": "GRA9", "type": "s1-2", "state": "active",
+             "provider_type": "vps"}
+        ]
+
+        async def _fake_fetch(force_refresh=False):
+            return list(raw_instances)
+
+        mock_svc = MagicMock()
+        mock_svc.fetch_instances_cached = _fake_fetch
+        mock_app.ovh_service = mock_svc
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        mock_status = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "ovh_mgr_table" in str(selector):
+                return mock_table
+            return mock_status
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_sync_action_buttons"):
+                        await screen._load_instances()
+
+        asyncio.run(_run())
+
+        assert rows, "Expected table rows"
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "ns1.bigcorp.com" not in all_cells, "FQDN leaked in OVH table"
+        assert "1.2.3.4" not in all_cells, "Real IP leaked in OVH table"
+
+    def test_error_path_scrubs_exception(self) -> None:
+        """Exception from fetch must be scrubbed before _set_status in demo mode."""
+        import asyncio
+        from servonaut.screens.ovh_manager import OVHManagerScreen
+
+        screen = object.__new__(OVHManagerScreen)
+        screen._loading = False
+        screen._instances = []
+        mock_app = _make_mock_app(demo=True)
+
+        async def _fake_fetch(force_refresh=False):
+            raise RuntimeError("Cannot reach 10.0.0.1 port 443")
+
+        mock_svc = MagicMock()
+        mock_svc.fetch_instances_cached = _fake_fetch
+        mock_app.ovh_service = mock_svc
+
+        status_updates: list = []
+        mock_status = MagicMock()
+        mock_status.update.side_effect = lambda t: status_updates.append(t)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_status):
+                    await screen._load_instances()
+
+        asyncio.run(_run())
+
+        assert status_updates
+        all_updates = " ".join(str(u) for u in status_updates)
+        assert "10.0.0.1" not in all_updates, (
+            f"Real IP from exception leaked in OVH status: {all_updates!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestMemoryDriftDemoMode — CRITICAL-3.3 diff text + instance_id
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryDriftDemoMode:
+    """Drift diff text is scrubbed and instance_id is redacted in demo mode."""
+
+    def test_diff_text_scrubbed_in_demo_mode(self) -> None:
+        """_fetch_and_render must scrub the diff text before content.update()."""
+        import asyncio
+        from servonaut.screens.memory_drift import DriftDiffScreen
+
+        modal = object.__new__(DriftDiffScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # Build a fake event with envelope IDs
+        event = MagicMock()
+        event.instance_id = "i-abc123"
+        event.module = "os"
+        event.old_envelope_id = "old-id"
+        event.new_envelope_id = "new-id"
+        modal._event = event
+
+        # Fake old/new envelopes with PII
+        old_env = MagicMock()
+        old_env.plaintext = {"host": "10.20.30.40", "path": "/home/alice"}
+        new_env = MagicMock()
+        new_env.plaintext = {"host": "10.20.30.41", "path": "/home/alice"}
+
+        mock_retrieval = MagicMock()
+
+        async def _fake_get_snapshot(instance_id, module, envelope_id):
+            if envelope_id == "old-id":
+                return old_env
+            return new_env
+
+        mock_retrieval.get_snapshot = _fake_get_snapshot
+        modal._retrieval_service = mock_retrieval
+
+        content_updates: list = []
+        mock_content = MagicMock()
+        mock_content.update.side_effect = lambda t: content_updates.append(t)
+
+        async def _run():
+            with patch.object(type(modal), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(modal, "query_one", return_value=mock_content):
+                    await modal._fetch_and_render()
+
+        asyncio.run(_run())
+
+        assert content_updates, "Expected content.update() to be called"
+        rendered = " ".join(str(u) for u in content_updates)
+        assert "10.20.30.40" not in rendered, "Real IP leaked in drift diff"
+        assert "10.20.30.41" not in rendered, "Real IP leaked in drift diff"
+        assert "/home/alice" not in rendered, "Home path leaked in drift diff"
+
+    def test_instance_id_redacted_in_render_table(self) -> None:
+        """_render_table must use redact_instance_id for the instance column."""
+        from servonaut.screens.memory_drift import MemoryDriftScreen
+
+        screen = object.__new__(MemoryDriftScreen)
+        screen._show_unack_only = False
+        mock_app = _make_mock_app(demo=True)
+
+        evt = MagicMock()
+        evt.instance_id = "i-0abc123def456789a"
+        evt.module = "os"
+        evt.severity = "high"
+        evt.acknowledged_at = None
+        evt.detected_at = "2024-01-15T10:00:00Z"
+        screen._events = [evt]
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        mock_label = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "drift-table" in str(selector):
+                return mock_table
+            return mock_label
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._render_table()
+
+        assert rows, "Expected a row"
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "i-0abc123def456789a" not in all_cells, (
+            f"Real instance ID leaked in drift table: {all_cells!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestFleetScanModalNameScrub — CRITICAL-3.4 name scrubbed at source in scan_one
+# ---------------------------------------------------------------------------
+
+
+class TestFleetScanModalNameScrub:
+    """scan_one scrubs name at source so succeeded/failed lists never see raw names."""
+
+    def test_scan_one_scrubs_name_in_succeeded(self) -> None:
+        """Successful scan: name in succeeded list must be scrubbed."""
+        import asyncio
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        screen._scanning = False
+        mock_app = _make_mock_app(demo=True)
+
+        inst = {"name": "web-prod-7", "id": "i-abc123"}
+
+        # Memory service that signals success
+        mock_memory = MagicMock()
+        report = MagicMock()
+        report.has_any_success = True
+
+        async def _fake_build(i):
+            return report
+
+        mock_memory.build_report = _fake_build
+        mock_app.memory_service = mock_memory
+
+        succeeded: list = []
+        failed: list = []
+
+        async def _fake_scan_fleet(instances, memory_service):
+            """Invoke the internal scan_one closure by calling _do_bulk_scan
+            and capturing succeeded/failed via the summary modal."""
+            pass  # Direct test of closure
+
+        # Test scan_one closure directly by running _do_bulk_scan
+        progress_updates: list = []
+        mock_progress = MagicMock()
+        mock_progress.update.side_effect = lambda t: progress_updates.append(t)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_progress):
+                    with patch.object(screen, "_set_progress"):
+                        result = await screen._do_bulk_scan([inst], mock_memory)
+                        return result
+
+        result = asyncio.run(_run())
+
+        # The modal was pushed — check that any names in succeeded/failed are scrubbed.
+        # We verify via the modal constructor arguments
+        # Since _do_bulk_scan calls push_screen internally, we can check
+        # if mock_app.push_screen was called and the arguments don't contain raw name.
+        if mock_app.push_screen.called:
+            call_args = str(mock_app.push_screen.call_args)
+            assert "web-prod-7" not in call_args, (
+                f"Real server name leaked in scan modal call: {call_args!r}"
+            )
+
+    def test_name_in_progress_is_scrubbed(self) -> None:
+        """refresh_progress uses the already-scrubbed name — no raw name in output."""
+        import asyncio
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        screen._scanning = False
+        mock_app = _make_mock_app(demo=True)
+
+        inst = {"name": "web-prod-7", "id": "i-abc123"}
+
+        mock_memory = MagicMock()
+        report = MagicMock()
+        report.has_any_success = True
+
+        async def _fake_build(i):
+            return report
+
+        mock_memory.build_report = _fake_build
+
+        progress_texts: list = []
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "_set_progress",
+                                  side_effect=lambda t: progress_texts.append(t)):
+                    await screen._do_bulk_scan([inst], mock_memory)
+
+        asyncio.run(_run())
+
+        # progress_texts contains the text passed to _set_progress
+        all_progress = " ".join(str(t) for t in progress_texts)
+        assert "web-prod-7" not in all_progress, (
+            f"Real server name leaked in progress text: {all_progress!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestSecretsListDemoMode — LIKELY-3.5 secret names scrubbed
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsListDemoMode:
+    """Secret names must be scrubbed in _render_names when demo mode is active."""
+
+    def test_secret_names_scrubbed_in_demo_mode(self) -> None:
+        """_render_names must scrub each name before mounting Static widgets."""
+        from textual.widgets import Static
+        from servonaut.screens.secrets_list import SecretsListScreen
+
+        screen = object.__new__(SecretsListScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        names = ["aws-prod-deploy-key", "customer-acme-api-token", "db-password"]
+
+        mounted_args: list = []
+        mock_body = MagicMock()
+        mock_body.mount.side_effect = lambda *args: mounted_args.extend(args)
+        mock_body.remove_children = MagicMock()
+        mock_summary = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "secrets_list_body" in str(selector):
+                return mock_body
+            return mock_summary
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._render_names(names, "bitwarden")
+
+        # The Container holding Static widgets is passed as first arg to mount.
+        # Before DOM attachment, children live in _pending_children.
+        assert mounted_args, "Expected body.mount() to be called"
+        container = mounted_args[0]
+        pending = getattr(container, "_pending_children", [])
+        static_texts = [
+            str(getattr(child, "_Static__content", ""))
+            for child in pending
+            if isinstance(child, Static)
+        ]
+        all_text = " ".join(static_texts)
+        for secret_name in names:
+            assert secret_name not in all_text, (
+                f"Secret name '{secret_name}' leaked in rendered output: {all_text!r}"
+            )
+
+    def test_secret_names_unchanged_without_demo(self) -> None:
+        """Without demo mode, secret names render verbatim."""
+        from textual.widgets import Static
+        from servonaut.screens.secrets_list import SecretsListScreen
+
+        screen = object.__new__(SecretsListScreen)
+        mock_app = _make_mock_app(demo=False)
+
+        names = ["aws-prod-deploy-key"]
+
+        mounted_args: list = []
+        mock_body = MagicMock()
+        # Capture all positional args passed to mount so we can inspect Container children.
+        mock_body.mount.side_effect = lambda *args: mounted_args.extend(args)
+        mock_body.remove_children = MagicMock()
+        mock_summary = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            if "secrets_list_body" in str(selector):
+                return mock_body
+            return mock_summary
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._render_names(names, "bitwarden")
+
+        # The Container holding Static widgets is the first positional arg to mount.
+        # Before DOM attachment, children live in _pending_children.
+        assert mounted_args, "Expected body.mount() to be called"
+        container = mounted_args[0]
+        pending = getattr(container, "_pending_children", [])
+        static_texts = [
+            str(getattr(child, "_Static__content", ""))
+            for child in pending
+            if isinstance(child, Static)
+        ]
+        all_text = " ".join(static_texts)
+        assert "aws-prod-deploy-key" in all_text, (
+            f"Secret name should be visible without demo mode; got: {all_text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestTeamManagementDemoMode — LIKELY-3.6 team name + members + servers
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementDemoMode:
+    """Team name, member emails, and server identifiers must be scrubbed."""
+
+    def test_team_header_scrubbed(self) -> None:
+        """_load_team_detail must scrub team_name before writing to #team_header."""
+        import asyncio
+        from servonaut.screens.team_management import TeamManagementScreen
+
+        screen = object.__new__(TeamManagementScreen)
+        screen._members = []
+        screen._current_team_name = ""
+        mock_app = _make_mock_app(demo=True)
+
+        mock_team_svc = MagicMock()
+
+        async def _fake_get_team(slug):
+            return {"name": "acme-corp-infra", "members": []}
+
+        async def _fake_list_servers(slug):
+            return []
+
+        mock_team_svc.get_team = _fake_get_team
+        mock_team_svc.list_shared_servers = _fake_list_servers
+        mock_app.team_service = mock_team_svc
+
+        header_updates: list = []
+        mock_header = MagicMock()
+        mock_header.update.side_effect = lambda t: header_updates.append(t)
+
+        members_table = MagicMock()
+        members_table.clear = MagicMock()
+        members_table.add_row = MagicMock()
+        servers_table = MagicMock()
+        servers_table.clear = MagicMock()
+        servers_table.add_row = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            sel = str(selector)
+            if "team_header" in sel:
+                return mock_header
+            if "members_table" in sel:
+                return members_table
+            if "servers_table" in sel:
+                return servers_table
+            return MagicMock()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_show_detail_section"):
+                        await screen._load_team_detail("acme-corp")
+
+        asyncio.run(_run())
+
+        assert header_updates, "Expected team header to be updated"
+        all_headers = " ".join(str(u) for u in header_updates)
+        assert "acme-corp-infra" not in all_headers, (
+            f"Real team name leaked in header: {all_headers!r}"
+        )
+
+    def test_member_emails_scrubbed(self) -> None:
+        """_populate_members_table must scrub email addresses in demo mode."""
+        from servonaut.screens.team_management import TeamManagementScreen
+
+        screen = object.__new__(TeamManagementScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        members = [
+            {"email": "alice@bigcorp.com", "role": "admin", "status": "active"},
+            {"email": "bob@bigcorp.com", "role": "member", "status": "active"},
+        ]
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.clear = MagicMock()
+        mock_table.add_row.side_effect = lambda *args: rows.append(args)
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_table):
+                screen._populate_members_table(members)
+
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "alice@bigcorp.com" not in all_cells, "Email leaked in members table"
+        assert "bob@bigcorp.com" not in all_cells, "Email leaked in members table"
+
+    def test_server_identifiers_scrubbed(self) -> None:
+        """_populate_servers_table must scrub server names and hosts."""
+        from servonaut.screens.team_management import TeamManagementScreen
+
+        screen = object.__new__(TeamManagementScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        servers = [
+            # Use a private-range IP that scrub_stream will actually replace.
+            {"name": "web-prod-01", "host": "10.50.20.1", "provider": "AWS"},
+        ]
+
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.clear = MagicMock()
+        mock_table.add_row.side_effect = lambda *args: rows.append(args)
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_table):
+                screen._populate_servers_table(servers)
+
+        all_cells = " ".join(str(c) for row in rows for c in row)
+        assert "web-prod-01" not in all_cells, "Server name leaked in servers table"
+        assert "10.50.20.1" not in all_cells, "Host IP leaked in servers table"
+
+
+# ---------------------------------------------------------------------------
+# TestKeyManagementDemoMode — CONCEALED-1 regression
+# ssh-add -l output scrubbed before rendering into Static widget
+# ---------------------------------------------------------------------------
+
+
+class TestKeyManagementDemoMode:
+    """on_worker_state_changed must scrub ssh-add -l output in demo mode.
+
+    ssh-add -l output contains key file paths (/home/<user>/.ssh/...) and
+    key comments (user@hostname) — both are PII in a demo recording context.
+    """
+
+    def test_sshaddl_path_scrubbed_in_demo_mode(self) -> None:
+        """Key file path in ssh-add -l output must not reach the Static widget."""
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # Typical ssh-add -l line: <bits> <fingerprint> <path> (<algorithm>)
+        raw_output = (
+            "2048 SHA256:abc123def456ghi789jkl012mno345pq "
+            "/home/alice/.ssh/acme_prod (RSA)"
+        )
+
+        mock_static = MagicMock()
+        updated_texts: list = []
+        mock_static.update.side_effect = lambda t: updated_texts.append(t)
+
+        # Simulate the worker event
+        mock_worker = MagicMock()
+        mock_worker.name = "list_agent_keys"
+        mock_worker.is_finished = True
+        mock_worker.error = None
+        mock_worker.result = raw_output
+
+        mock_event = MagicMock()
+        mock_event.worker = mock_worker
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_static):
+                screen.on_worker_state_changed(mock_event)
+
+        assert updated_texts, "Static.update was never called"
+        rendered = updated_texts[0]
+        assert "/home/alice/.ssh/acme_prod" not in rendered, (
+            f"Key file path leaked into Static widget: {rendered!r}"
+        )
+
+    def test_sshaddl_not_scrubbed_without_demo(self) -> None:
+        """Without demo mode, the raw ssh-add -l output passes through unchanged."""
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = _make_mock_app(demo=False)
+
+        raw_output = (
+            "2048 SHA256:abc123def456ghi789jkl012mno345pq "
+            "/home/alice/.ssh/acme_prod (RSA)"
+        )
+
+        mock_static = MagicMock()
+        updated_texts: list = []
+        mock_static.update.side_effect = lambda t: updated_texts.append(t)
+
+        mock_worker = MagicMock()
+        mock_worker.name = "list_agent_keys"
+        mock_worker.is_finished = True
+        mock_worker.error = None
+        mock_worker.result = raw_output
+
+        mock_event = MagicMock()
+        mock_event.worker = mock_worker
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_static):
+                screen.on_worker_state_changed(mock_event)
+
+        assert updated_texts, "Static.update was never called"
+        rendered = updated_texts[0]
+        assert "/home/alice/.ssh/acme_prod" in rendered, (
+            "Key path should be present when demo mode is off"
+        )
+
+    def test_sshaddl_key_comment_scrubbed(self) -> None:
+        """Key comment (user@hostname) in ssh-add -l output must be scrubbed."""
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # Comment after the path often takes the form user@hostname
+        raw_output = (
+            "2048 SHA256:xyz /home/bob/.ssh/deploy_key bob@corp-server.internal (RSA)"
+        )
+
+        mock_static = MagicMock()
+        updated_texts: list = []
+        mock_static.update.side_effect = lambda t: updated_texts.append(t)
+
+        mock_worker = MagicMock()
+        mock_worker.name = "list_agent_keys"
+        mock_worker.is_finished = True
+        mock_worker.error = None
+        mock_worker.result = raw_output
+
+        mock_event = MagicMock()
+        mock_event.worker = mock_worker
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_static):
+                screen.on_worker_state_changed(mock_event)
+
+        assert updated_texts, "Static.update was never called"
+        rendered = updated_texts[0]
+        assert "/home/bob/.ssh/deploy_key" not in rendered, (
+            f"Key path leaked: {rendered!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestServerActionsRdnsDemoMode — CONCEALED-2 regression
+# Reverse-DNS hostname scrubbed via redact_hostname before info_widget update
+# ---------------------------------------------------------------------------
+
+
+class TestServerActionsRdnsDemoMode:
+    """_fetch_rdns must scrub the rDNS hostname via redact_hostname in demo mode.
+
+    rDNS commonly resolves to a customer's company domain
+    (vps-acme-corp.ovh.net, mail.bigcorp.com) — must not appear in recording.
+    """
+
+    def test_rdns_hostname_scrubbed_in_demo_mode(self) -> None:
+        """The reverse-DNS hostname must not appear raw in the info_widget."""
+        from servonaut.screens.server_actions import ServerActionsScreen
+
+        screen = object.__new__(ServerActionsScreen)
+        mock_app = _make_mock_app(demo=True)
+
+        # A realistic rDNS hostname that would identify a company
+        rdns_hostname = "vps-acme-corp.ovh.net"
+        public_ip = "192.0.2.10"  # doc-range, already-redacted representation
+
+        mock_vps_service = MagicMock()
+        mock_vps_service.get_reverse_dns = MagicMock(
+            return_value=asyncio.coroutine(lambda *a: rdns_hostname)()
+            if False
+            else None  # replaced below with async mock
+        )
+
+        mock_info_widget = MagicMock()
+        # Simulate current widget content containing the Public IP line
+        mock_info_widget.renderable = (
+            f"[dim]Public IP:[/dim] {public_ip}"
+        )
+
+        updated_texts: list = []
+        mock_info_widget.update.side_effect = lambda t: updated_texts.append(t)
+
+        async def _fake_get_rdns(vps_name, ip):
+            return rdns_hostname
+
+        mock_vps_service.get_reverse_dns = _fake_get_rdns
+        mock_app.ovh_vps_service = mock_vps_service
+
+        screen._instance = {"id": "vps-123"}
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_info_widget):
+                asyncio.run(screen._fetch_rdns(public_ip))
+
+        assert updated_texts, "info_widget.update was never called"
+        rendered = updated_texts[0]
+        assert rdns_hostname not in rendered, (
+            f"rDNS hostname leaked into info_widget: {rendered!r}"
+        )
+        # The replacement must still contain the Reverse DNS label
+        assert "Reverse DNS" in rendered, (
+            "Reverse DNS label missing from info_widget after redaction"
+        )
+
+    def test_rdns_hostname_not_scrubbed_without_demo(self) -> None:
+        """Without demo mode, the raw rDNS hostname passes through."""
+        from servonaut.screens.server_actions import ServerActionsScreen
+
+        screen = object.__new__(ServerActionsScreen)
+        mock_app = _make_mock_app(demo=False)
+
+        rdns_hostname = "vps-acme-corp.ovh.net"
+        public_ip = "192.0.2.10"
+
+        async def _fake_get_rdns(vps_name, ip):
+            return rdns_hostname
+
+        mock_vps_service = MagicMock()
+        mock_vps_service.get_reverse_dns = _fake_get_rdns
+        mock_app.ovh_vps_service = mock_vps_service
+
+        screen._instance = {"id": "vps-123"}
+
+        mock_info_widget = MagicMock()
+        mock_info_widget.renderable = f"[dim]Public IP:[/dim] {public_ip}"
+
+        updated_texts: list = []
+        mock_info_widget.update.side_effect = lambda t: updated_texts.append(t)
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_info_widget):
+                asyncio.run(screen._fetch_rdns(public_ip))
+
+        assert updated_texts, "info_widget.update was never called"
+        rendered = updated_texts[0]
+        assert rdns_hostname in rendered, (
+            "rDNS hostname should be present when demo mode is off"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestInstanceListProviderRefreshDemoMode — ovh_refresh / hetzner_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceListProviderRefreshDemoMode:
+    """Regression: ovh_refresh and hetzner_refresh handlers must redact before
+    the table is populated.
+
+    The fix centralises redaction inside _update_table() so every caller is
+    automatically covered regardless of the path that rebuilds self._instances.
+    """
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_screen(demo: bool) -> Any:
+        """Return a bare InstanceListScreen with mocked app and widgets."""
+        from servonaut.screens.instance_list import InstanceListScreen
+
+        screen = object.__new__(InstanceListScreen)
+        screen._instances = []
+
+        mock_app = _make_mock_app(demo=demo)
+        # _update_table also queries for the search input and memory banner;
+        # stub query_one to return appropriate mocks per widget type.
+        mock_table = MagicMock()
+        mock_table._filtered_instances = []
+        mock_input = MagicMock()
+        mock_input.value = ""
+        mock_banner = MagicMock()
+        mock_status_bar = MagicMock()
+
+        def _query_one(selector, *args, **kwargs):
+            from servonaut.widgets.instance_table import InstanceTable
+            from textual.widgets import Input
+            from servonaut.widgets.status_bar import StatusBar
+            if selector is InstanceTable or selector == InstanceTable:
+                return mock_table
+            if selector is Input or (isinstance(selector, str) and "search_input" in selector):
+                return mock_input
+            if isinstance(selector, str) and "memory_discover_banner" in selector:
+                return mock_banner
+            if selector is StatusBar or selector == StatusBar:
+                return mock_status_bar
+            return MagicMock()
+
+        screen.query_one = _query_one
+
+        # Stub _sync_memory_banner and _update_status_bar (not under test here)
+        screen._sync_memory_banner = lambda: None
+        screen._update_status_bar = lambda: None
+
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: mock_app),
+        ):
+            pass  # just to establish; we'll use the patch below per call
+
+        screen._mock_app = mock_app
+        screen._mock_table = mock_table
+        return screen
+
+    # ------------------------------------------------------------------
+    # OVH refresh — demo_mode=True
+    # ------------------------------------------------------------------
+
+    def test_ovh_refresh_redacts_in_demo_mode(self) -> None:
+        """The ovh_refresh handler guard must redact new_ovh before merging
+        so that raw IPs and names never reach table.populate()."""
+        screen = self._make_screen(demo=True)
+        raw_ovh = [
+            {
+                "name": "prod-web-server-42",
+                "public_ip": "54.12.34.56",
+                "private_ip": "10.0.1.100",
+                "is_ovh": True,
+            }
+        ]
+
+        # Simulate the ovh_refresh handler body (mirrors production code)
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: screen._mock_app),
+        ):
+            new_ovh = raw_ovh
+            if screen.app.demo_mode and screen.app.redaction_service:
+                screen.app.redaction_service.redact_instances(new_ovh)
+            non_ovh = [i for i in screen._instances if not i.get("is_ovh")]
+            screen._instances = non_ovh + new_ovh
+            screen._update_table()
+
+        # After the handler runs, instances must be redacted in-place
+        assert screen._instances[0]["public_ip"] != "54.12.34.56", (
+            "Raw OVH public IP must be redacted in demo mode"
+        )
+        assert screen._instances[0]["name"] != "prod-web-server-42", (
+            "Raw OVH name must be redacted in demo mode"
+        )
+        # table.populate was called with the (now-redacted) list
+        screen._mock_table.populate.assert_called_once_with(screen._instances)
+
+    # ------------------------------------------------------------------
+    # Hetzner refresh — demo_mode=True
+    # ------------------------------------------------------------------
+
+    def test_hetzner_refresh_redacts_in_demo_mode(self) -> None:
+        """The hetzner_refresh handler guard must redact new_hetzner before
+        merging so that raw IPs and names never reach table.populate()."""
+        screen = self._make_screen(demo=True)
+        raw_hetzner = [
+            {
+                "name": "db-primary-node-7",
+                "public_ip": "95.216.1.200",
+                "private_ip": "10.0.2.50",
+                "is_hetzner": True,
+            }
+        ]
+
+        # Simulate the hetzner_refresh handler body (mirrors production code)
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: screen._mock_app),
+        ):
+            new_hetzner = raw_hetzner
+            if screen.app.demo_mode and screen.app.redaction_service:
+                screen.app.redaction_service.redact_instances(new_hetzner)
+            non_hetzner = [
+                i for i in screen._instances if not i.get("is_hetzner")
+            ]
+            screen._instances = non_hetzner + new_hetzner
+            screen._update_table()
+
+        assert screen._instances[0]["public_ip"] != "95.216.1.200", (
+            "Raw Hetzner public IP must be redacted in demo mode"
+        )
+        assert screen._instances[0]["name"] != "db-primary-node-7", (
+            "Raw Hetzner name must be redacted in demo mode"
+        )
+        screen._mock_table.populate.assert_called_once_with(screen._instances)
+
+    # ------------------------------------------------------------------
+    # Negative: demo_mode=False → data passes through unchanged
+    # ------------------------------------------------------------------
+
+    def test_ovh_refresh_passes_raw_data_without_demo(self) -> None:
+        """When demo_mode is False, the ovh_refresh handler must NOT alter
+        instance data."""
+        screen = self._make_screen(demo=False)
+        raw_ovh = [
+            {
+                "name": "prod-web-server-42",
+                "public_ip": "54.12.34.56",
+                "is_ovh": True,
+            }
+        ]
+
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: screen._mock_app),
+        ):
+            new_ovh = raw_ovh
+            if screen.app.demo_mode and screen.app.redaction_service:
+                screen.app.redaction_service.redact_instances(new_ovh)
+            non_ovh = [i for i in screen._instances if not i.get("is_ovh")]
+            screen._instances = non_ovh + new_ovh
+            screen._update_table()
+
+        assert screen._instances[0]["public_ip"] == "54.12.34.56", (
+            "Raw IP must NOT be altered when demo mode is off"
+        )
+        assert screen._instances[0]["name"] == "prod-web-server-42", (
+            "Raw name must NOT be altered when demo mode is off"
+        )
+
+    def test_hetzner_refresh_passes_raw_data_without_demo(self) -> None:
+        """When demo_mode is False, the hetzner_refresh handler must NOT alter
+        instance data."""
+        screen = self._make_screen(demo=False)
+        raw_hetzner = [
+            {
+                "name": "db-primary-node-7",
+                "public_ip": "95.216.1.200",
+                "is_hetzner": True,
+            }
+        ]
+
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: screen._mock_app),
+        ):
+            new_hetzner = raw_hetzner
+            if screen.app.demo_mode and screen.app.redaction_service:
+                screen.app.redaction_service.redact_instances(new_hetzner)
+            non_hetzner = [
+                i for i in screen._instances if not i.get("is_hetzner")
+            ]
+            screen._instances = non_hetzner + new_hetzner
+            screen._update_table()
+
+        assert screen._instances[0]["public_ip"] == "95.216.1.200", (
+            "Raw IP must NOT be altered when demo mode is off"
+        )
+        assert screen._instances[0]["name"] == "db-primary-node-7", (
+            "Raw name must NOT be altered when demo mode is off"
+        )
+
+    # ------------------------------------------------------------------
+    # Per-handler redaction: only NEW provider instances are redacted,
+    # not the already-redacted non_ovh/non_hetzner slice.
+    # ------------------------------------------------------------------
+
+    def test_ovh_handler_only_redacts_new_instances(self) -> None:
+        """The ovh_refresh guard redacts new_ovh before merging, leaving
+        already-redacted non_ovh instances untouched (no double-redaction)."""
+        from servonaut.services.redaction_service import RedactionService
+
+        rs = RedactionService()
+        # Simulate a non-OVH instance that has ALREADY been redacted.
+        # The redacted IP is in the doc range (192.0.2.x) so we can
+        # confirm it stays unchanged after a subsequent OVH refresh.
+        already_redacted_ip = rs.redact_ip("203.0.113.1")
+        already_redacted_name = rs.redact_name("existing-aws-host")
+
+        screen = self._make_screen(demo=True)
+        screen._mock_app.redaction_service = rs  # share same service instance
+        screen._instances = [
+            {
+                "name": already_redacted_name,
+                "public_ip": already_redacted_ip,
+                "is_ovh": False,
+            }
+        ]
+
+        raw_ovh = [
+            {
+                "name": "fresh-ovh-server",
+                "public_ip": "178.32.50.100",
+                "is_ovh": True,
+            }
+        ]
+
+        # Simulate the ovh_refresh handler body (mirrors production code)
+        with patch.object(
+            type(screen), "app",
+            new_callable=lambda: property(lambda self: screen._mock_app),
+        ):
+            new_ovh = raw_ovh
+            if screen.app.demo_mode and screen.app.redaction_service:
+                screen.app.redaction_service.redact_instances(new_ovh)
+            non_ovh = [i for i in screen._instances if not i.get("is_ovh")]
+            screen._instances = non_ovh + new_ovh
+
+        # Non-OVH instance must remain unchanged (not double-redacted)
+        assert screen._instances[0]["public_ip"] == already_redacted_ip, (
+            "Already-redacted non-OVH IP must not be altered by OVH refresh"
+        )
+        assert screen._instances[0]["name"] == already_redacted_name, (
+            "Already-redacted non-OVH name must not be altered by OVH refresh"
+        )
+        # Fresh OVH instance must be redacted
+        assert screen._instances[1]["public_ip"] != "178.32.50.100", (
+            "Raw OVH IP must be redacted"
+        )
+        assert screen._instances[1]["name"] != "fresh-ovh-server", (
+            "Raw OVH name must be redacted"
+        )

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -1,0 +1,913 @@
+"""AST-based lint sweep: every call to .write() / .update() / .append_output()
+/ .append_error() on user-influenced content in screens/*.py and widgets/*.py
+must either appear in the _ALLOWLIST (with justification) or be accompanied by
+a scrub_stream / redact_* call in the same function body.
+
+Why AST and not grep?
+  - grep gives false positives on dict.update(), logging calls, and general
+    method calls that happen to be named ``update``.
+  - The AST walk restricts to Call(func=Attribute(attr=X)) so only method calls
+    match.
+  - The allowlist documents WHY each unchecked call is intentionally safe,
+    making it a living registry that breaks CI when new screens add raw writes.
+
+Failure output lists the offending function+file+line so the developer can
+immediately locate the missing guard.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Set
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Method names that could write user-visible content to widgets.
+# `add_row` is included because CloudTrail/CloudWatch/Memory rows are exactly
+# how server-origin streaming data reaches the user in table screens.
+_GUARDED_ATTRS: Set[str] = {"write", "update", "append_output", "append_error", "add_row", "load_text"}
+
+# Root of the Python source tree
+_SRC_ROOT = Path(__file__).parent.parent / "src" / "servonaut"
+_SCREENS_DIR = _SRC_ROOT / "screens"
+_WIDGETS_DIR = _SRC_ROOT / "widgets"
+
+# Scan ALL screens and widgets so that new screens can't accidentally bypass
+# the lint gate.  The allowlist documents why each un-guarded call is safe.
+# (Previously an opt-in list of 9 files; inverted in iteration-3 to cover
+# all 61 screens + all widgets by default.)
+_TARGET_DIRS: tuple[str, ...] = ("screens", "widgets")
+
+
+class AllowlistEntry(NamedTuple):
+    file: str       # relative to src/servonaut/
+    func: str       # enclosing function name (or "module" for top-level)
+    attr: str       # method name from _GUARDED_ATTRS
+    reason: str     # one-line justification
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — calls that are intentionally NOT guarded by a redaction call.
+# Each entry requires a one-line justification explaining why it is safe.
+# ---------------------------------------------------------------------------
+
+_ALLOWLIST: List[AllowlistEntry] = [
+    # status_bar.py — _update_display writes instance counts, cache age, and
+    # filter status; no user-origin streaming data.  The DEMO badge itself is
+    # only added here when demo_mode is True and comes from a constant string.
+    AllowlistEntry("widgets/status_bar.py", "_update_display", "update",
+                   "Only displays instance counts, cache age, filter state, "
+                   "and the DEMO badge constant — no user-origin streaming data."),
+
+    # command_output.py — append_command writes the command line typed by the
+    # user (echo back) which is not a secret leak; the user typed it.
+    AllowlistEntry("widgets/command_output.py", "append_command", "write",
+                   "Echoes the command the user explicitly typed; not a "
+                   "server-origin secret that needs redaction."),
+
+    # command_output.py — clear_output just calls self.clear() which does not
+    # write any user data. (clear_output body calls self.clear(), not write/update).
+    AllowlistEntry("widgets/command_output.py", "clear_output", "write",
+                   "No-op placeholder: clear_output calls self.clear(), "
+                   "not write(). Listed in case AST walk traverses the body."),
+
+    # log_viewer.py — _on_stream_ended writes static marker strings
+    # ("--- End of file ---", "File is empty") — not user data.
+    AllowlistEntry("screens/log_viewer.py", "_on_stream_ended", "write",
+                   "Writes static marker strings (EOF / empty file) — "
+                   "these are code-controlled constants, not streamed data."),
+
+    # log_viewer.py — _check_empty_output writes a static hint message.
+    AllowlistEntry("screens/log_viewer.py", "_check_empty_output", "write",
+                   "Writes a static UI hint ('No output yet') — "
+                   "no user/server data involved."),
+
+    # ip_ban.py — _load_audit_log: the line `audit_log.write(...)` that
+    # writes the '[dim]No audit log entries yet.[/dim]' placeholder is safe.
+    # The writes with real IP/msg data are guarded by the demo-mode check.
+    AllowlistEntry("screens/ip_ban.py", "_load_audit_log", "write",
+                   "Contains both a guarded write (IP/msg scrubbed) and an "
+                   "unguarded placeholder write ('[dim]No audit log...[/dim]') "
+                   "which is a code-controlled constant string, not user data."),
+
+    # ip_ban.py — error write inside the except block writes a static error msg.
+    AllowlistEntry("screens/ip_ban.py", "_load_audit_log", "write",
+                   "The except-block write is a static error message with "
+                   "the exception type — not raw audit data."),
+
+    # cloudwatch_browser.py — _show_event_detail's update call is guarded
+    # inside the method; the allowlist entry covers `update` calls within this
+    # function only for Static status messages (e.g., 'Looking up info...')
+    # that use display_ip, not raw ip.
+    AllowlistEntry("screens/cloudwatch_browser.py", "action_ip_info", "update",
+                   "Uses display_ip (already redacted) in the status message "
+                   "text — not the raw IP."),
+
+    # chat_panel.py — _update_thinking_status uses update() to show the live
+    # streaming text. The token handler now always scrubs display_accumulated
+    # on every token before passing it here (C1 fix — heuristic removed).
+    AllowlistEntry("widgets/chat_panel.py", "_update_thinking_status", "update",
+                   "Receives display_accumulated which is fully scrubbed on every "
+                   "token by the token handler (C1: always-scrub, heuristic removed). "
+                   "_rich_escape also applied inside _update_thinking_status."),
+
+    # chat_panel.py — _show_welcome writes static UI placeholder content.
+    AllowlistEntry("widgets/chat_panel.py", "_show_welcome", "update",
+                   "Writes static welcome/empty-state content — no user/server data."),
+
+    # Various screens that render instance-dict fields: instance fields are
+    # already redacted by on_mount / redact_instances before any screen sees them.
+    AllowlistEntry("screens/server_actions.py", "_update_header", "update",
+                   "Renders instance dict fields (name, IP) that are already "
+                   "redacted in-place by on_mount redact_instances()."),
+
+    AllowlistEntry("screens/scp_transfer.py", "_update_banner", "update",
+                   "SCP transfer banner shows instance name from already-redacted "
+                   "dict. No file-tree exists; status_output echoes user-typed "
+                   "paths (spec non-goal §1 drift note)."),
+
+    # Memory screen — module-name and key columns are taxonomy (scrub is intentionally
+    # skipped for those). obs_str and decl_str ARE scrubbed inside _render_table.
+    AllowlistEntry("screens/memory.py", "_render_table", "add_row",
+                   "obs_str and decl_str are scrubbed inside _render_table before "
+                   "add_row. module_name and key are taxonomy — not scrubbed by "
+                   "design (plan §8 item 7)."),
+
+    # fleet_memory.py — shows module status summary (count of modules, last probe
+    # time) — no raw output values.
+    AllowlistEntry("screens/fleet_memory.py", "_render_fleet_table", "add_row",
+                   "Fleet memory table shows module-count summaries and timestamps "
+                   "only — no raw_output values that require scrubbing."),
+
+    # ai_analysis.py — status updates are all hard-coded or contain only
+    # token counts and line counts (integers), not raw log content.
+    AllowlistEntry("screens/ai_analysis.py", "on_mount", "update",
+                   "Writes a hard-coded '[dim]Text loaded...[/dim]' status string "
+                   "— no user-origin streaming data."),
+    AllowlistEntry("screens/ai_analysis.py", "_update_provider_info", "update",
+                   "Updates provider picker block with entitlement/plan labels "
+                   "— code-controlled strings, not streamed log content."),
+    AllowlistEntry("screens/ai_analysis.py", "_update_token_estimate", "update",
+                   "Updates token count label with integer estimates — "
+                   "code-controlled numeric output, not raw log data."),
+    AllowlistEntry("screens/ai_analysis.py", "_fetch_recent_logs", "update",
+                   "Writes a hard-coded 'Probing available logs...' status string "
+                   "— not log content."),
+    AllowlistEntry("screens/ai_analysis.py", "_do_probe_and_pick", "update",
+                   "Writes hard-coded status/error strings (no IP, 'No readable log "
+                   "files found', 'Error: ...') — exception str may carry exc type "
+                   "but not raw log streaming data."),
+    AllowlistEntry("screens/ai_analysis.py", "_fetch_log_file", "update",
+                   "Writes '[dim]Fetching <log_path>...[/dim]' where log_path is the "
+                   "user-chosen path from the config picker — not streamed content."),
+    AllowlistEntry("screens/ai_analysis.py", "_run_analysis", "update",
+                   "Clears the status widget with an empty string before analysis "
+                   "starts — no user data involved."),
+
+    # command_overlay.py — on_mount writes welcome and hint strings.
+    # The instance name inside `welcome` is already redacted in-place by
+    # on_mount/redact_instances() before CommandOverlay is pushed.
+    AllowlistEntry("screens/command_overlay.py", "on_mount", "append_output",
+                   "Welcome string uses instance name from already-redacted dict; "
+                   "hint strings are code-controlled constants."),
+    AllowlistEntry("screens/command_overlay.py", "on_mount", "append_error",
+                   "Warning about missing connection profile uses profile name from "
+                   "config (not a server secret) — code-controlled string."),
+
+    # command_overlay.py — _execute_command: the append_error and append_output
+    # calls on lines 247–256 write static/code-controlled interactive-command
+    # error strings and the 'Ctrl+C to stop' hint — not SSH output.
+    # SSH output lines are scrubbed in _run_ssh_process before append_*.
+    AllowlistEntry("screens/command_overlay.py", "_execute_command", "append_error",
+                   "Writes a static 'requires interactive terminal' error for "
+                   "blocked commands — hard-coded string, not SSH output."),
+    AllowlistEntry("screens/command_overlay.py", "_execute_command", "append_output",
+                   "Writes static hint strings ('press Escape...', 'Ctrl+C to stop') "
+                   "— code-controlled constants, not SSH stdout."),
+
+    # command_overlay.py — _stop_running_process writes a static '[dim]Stopped.[/dim]'.
+    AllowlistEntry("screens/command_overlay.py", "_stop_running_process", "append_output",
+                   "Writes a hard-coded '[dim]Stopped.[/dim]' marker — "
+                   "not SSH output data."),
+
+    # fleet_memory.py — _populate_table (local path) uses already-redacted
+    # instance dicts from self.app.instances (in-place redacted by on_mount).
+    AllowlistEntry("screens/fleet_memory.py", "_populate_table", "add_row",
+                   "Renders instance dict fields (name, id, provider) from "
+                   "self.app.instances which are already redacted in-place by "
+                   "on_mount redact_instances()."),
+    AllowlistEntry("screens/fleet_memory.py", "_populate_table", "update",
+                   "Updates status footer with hard-coded count labels (fresh/stale "
+                   "integers) — code-controlled strings, not streaming data."),
+
+    # fleet_memory.py — _set_progress writes scan progress markup. The
+    # just_finished name embedded in the template is scrubbed at source in
+    # scan_one() before being appended to succeeded/failed and passed here.
+    AllowlistEntry("screens/fleet_memory.py", "_set_progress", "update",
+                   "Progress markup embeds `just_finished` name which is scrubbed "
+                   "at source in scan_one() via redact_name() — safe by the time "
+                   "it reaches this template."),
+
+    # server_actions.py — _fetch_rdns now scrubs the rDNS hostname via
+    # redact_hostname() before embedding it in the info widget — no allowlist entry
+    # needed; the lint passes naturally due to the redact_hostname guard.
+
+    # cloudtrail_browser.py — pager update writes static page/total-count strings.
+    AllowlistEntry("screens/cloudtrail_browser.py", "_update_pager", "update",
+                   "Pager shows 'Page N of M (K events total)' — code-controlled "
+                   "count integers, not user streaming data."),
+
+    # cloudtrail_browser.py — fetch status messages are hard-coded strings.
+    AllowlistEntry("screens/cloudtrail_browser.py", "action_fetch", "update",
+                   "Writes a hard-coded 'Fetching...' status string — no user data."),
+    AllowlistEntry("screens/cloudtrail_browser.py", "_fetch_events", "update",
+                   "Writes hard-coded status/error strings ('Loading...', 'Error: ...') "
+                   "— the error message includes an exception str, not raw AWS data."),
+
+    # cloudwatch_browser.py — pager update and fetch status messages.
+    AllowlistEntry("screens/cloudwatch_browser.py", "_update_pager", "update",
+                   "Pager writes hard-coded 'Page N of M' count strings — no user data."),
+    AllowlistEntry("screens/cloudwatch_browser.py", "action_fetch", "update",
+                   "Writes a hard-coded 'Fetching...' status string — no user data."),
+    AllowlistEntry("screens/cloudwatch_browser.py", "_fetch_events", "update",
+                   "Writes hard-coded status/error strings — exception str only, "
+                   "not raw log content."),
+    AllowlistEntry("screens/cloudwatch_browser.py", "_cycle_ip_filter", "update",
+                   "Writes 'Filter: <label>' where label is from a hard-coded "
+                   "tuple of action names — not user-streaming data."),
+
+    # log_viewer.py — probe/start writes hard-coded status and error strings.
+    AllowlistEntry("screens/log_viewer.py", "_probe_and_start", "write",
+                   "Writes hard-coded status messages (connecting, error) and "
+                   "exception strings from SSH probing — not streamed log content."),
+    AllowlistEntry("screens/log_viewer.py", "_update_header", "update",
+                   "Updates a header label with the instance name (already redacted "
+                   "in-place by on_mount redact_instances()) and log path from config."),
+    AllowlistEntry("screens/log_viewer.py", "_start_stream", "write",
+                   "Writes a hard-coded 'Starting stream...' marker — not log data."),
+    AllowlistEntry("screens/log_viewer.py", "_switch_to_log", "write",
+                   "Writes a hard-coded '--- Switching to log: <path> ---' banner "
+                   "where path comes from the config, not live server output."),
+
+    # memory.py — sync status and AI summary update UI labels, not raw data.
+    AllowlistEntry("screens/memory.py", "_refresh_sync_status", "update",
+                   "Updates sync-status labels (last sync time, sync state badge) "
+                   "— code-controlled status strings, not memory raw_output."),
+    AllowlistEntry("screens/memory.py", "_do_ai_summary_flow", "update",
+                   "Updates AI summary UI label with a code-controlled status/error "
+                   "string — not memory raw_output content."),
+    AllowlistEntry("screens/memory.py", "_after_consent", "update",
+                   "Updates AI summary UI label (same function body as "
+                   "_do_ai_summary_flow due to nested def) — code-controlled string."),
+
+    # chat_panel.py — banner, stats, quota, and consent modal UI labels.
+    AllowlistEntry("widgets/chat_panel.py", "_update_memory_banner", "update",
+                   "Updates memory injection status banner with a hard-coded "
+                   "label string — not streaming AI response content."),
+    AllowlistEntry("widgets/chat_panel.py", "_update_stats", "update",
+                   "Updates token count/session stats label with numeric counts "
+                   "— code-controlled integers, not AI response content."),
+    AllowlistEntry("widgets/chat_panel.py", "_update_quota_footer", "update",
+                   "Updates quota/entitlement footer label with plan name and "
+                   "usage counts — code-controlled strings, not AI content."),
+    AllowlistEntry("widgets/chat_panel.py", "_set_banner", "update",
+                   "Updates a UI banner with hard-coded status/warning strings "
+                   "— not streaming AI content or user data."),
+    AllowlistEntry("widgets/chat_panel.py", "_maybe_push_consent_modal", "update",
+                   "Inner _on_dismiss closure updates a config-flag label — "
+                   "code-controlled string, not streaming data."),
+    AllowlistEntry("widgets/chat_panel.py", "_on_dismiss", "update",
+                   "Inner closure of _maybe_push_consent_modal — same justification: "
+                   "writes a hard-coded config-decision notification string."),
+
+    # ---------------------------------------------------------------------------
+    # Scope-inversion additions (iteration-3): all screens + widgets now linted.
+    # Each entry below documents why the un-guarded call is safe.
+    # ---------------------------------------------------------------------------
+
+    # ai_conversations_screen.py — on_mount writes empty-string placeholders;
+    # _show_empty writes hard-coded no-conversations hints; _set_status writes
+    # hard-coded count integers; _set_local_status same pattern.
+    AllowlistEntry("screens/ai_conversations_screen.py", "on_mount", "update",
+                   "Writes empty-string placeholder ('') to clear the status "
+                   "widget on mount — no user-origin data."),
+    AllowlistEntry("screens/ai_conversations_screen.py", "_show_empty", "update",
+                   "Writes hard-coded 'No previous chats yet' / 'No conversations "
+                   "match your filter' hint strings — code-controlled constants."),
+    AllowlistEntry("screens/ai_conversations_screen.py", "_set_status", "update",
+                   "Writes hard-coded count integers ('N conversations shown') "
+                   "— no user-origin streaming data."),
+    AllowlistEntry("screens/ai_conversations_screen.py", "_set_local_status", "update",
+                   "Writes hard-coded count integers for local session tab "
+                   "— same pattern as _set_status."),
+
+    # backup_restore.py — table shows timestamps, file sizes, and config counts
+    # (integers + booleans from local file metadata); _set_status writes static
+    # result strings.  No server-origin streaming data.
+    AllowlistEntry("screens/backup_restore.py", "_render_table", "add_row",
+                   "Rows contain only timestamps, byte-sizes, and boolean flags "
+                   "from local backup-file metadata — no server-origin streaming data."),
+    AllowlistEntry("screens/backup_restore.py", "_set_status", "update",
+                   "Writes hard-coded status strings (e.g., 'Restored.') "
+                   "— code-controlled constants."),
+
+    # bug_report.py — all update() calls are hard-coded status strings, a
+    # redacted-category list (categories are taxonomy like 'ip_address'), a
+    # receipt URL/ID, or empty-string clears.  The preview.update(markdown) renders
+    # a markdown blob that the bug-report service has already redacted internally
+    # (the service redacts before building the payload; _refresh_preview renders
+    # that already-redacted payload).
+    AllowlistEntry("screens/bug_report.py", "_start_collect", "update",
+                   "Writes 'Diagnostics: collecting...' — hard-coded string."),
+    AllowlistEntry("screens/bug_report.py", "_do_collect", "update",
+                   "Writes hard-coded status strings and a redacted-category list "
+                   "(taxonomy like 'ip_address') — no raw server data."),
+    AllowlistEntry("screens/bug_report.py", "_refresh_preview", "update",
+                   "Renders bug-report preview markdown built by the service after "
+                   "its own internal redaction pass — payload is pre-redacted."),
+    AllowlistEntry("screens/bug_report.py", "_do_submit", "update",
+                   "Writes hard-coded 'Submitting...' and failure retry strings "
+                   "— code-controlled constants."),
+    AllowlistEntry("screens/bug_report.py", "_show_submission_error", "update",
+                   "Writes submission error message via _esc() — exception type "
+                   "string from network layer, not raw server data."),
+    AllowlistEntry("screens/bug_report.py", "_clear_submission_error", "update",
+                   "Writes empty string to clear the error panel "
+                   "— no user data involved."),
+    AllowlistEntry("screens/bug_report.py", "_show_receipt", "update",
+                   "Writes receipt URL and report ID from the Servonaut backend "
+                   "— not user-origin server data. URL is a servonaut.io link, "
+                   "not a customer hostname."),
+
+    # hetzner_create.py — server types, images, locations, and SSH keys are
+    # provider taxonomy from the Hetzner API (product names like 'cx22',
+    # 'ubuntu-22.04', 'fsn1'). SSH key names in _load_ssh_keys are user-named
+    # but this is a setup wizard that runs before demo recording starts.
+    AllowlistEntry("screens/hetzner_create.py", "_load_server_types", "add_row",
+                   "Renders Hetzner product taxonomy (server type names, cores, "
+                   "memory, price) — provider-defined strings, not user PII."),
+    AllowlistEntry("screens/hetzner_create.py", "_load_images", "add_row",
+                   "Renders Hetzner image taxonomy (ubuntu-22.04 etc.) "
+                   "— provider-defined strings, not user PII."),
+    AllowlistEntry("screens/hetzner_create.py", "_load_locations", "add_row",
+                   "Renders Hetzner datacenter taxonomy (fsn1, nbg1 etc.) "
+                   "— provider-defined strings, not user PII."),
+    AllowlistEntry("screens/hetzner_create.py", "_load_ssh_keys", "add_row",
+                   "Setup-wizard screen for creating a new server; SSH key names "
+                   "shown here are a selection UI before any demo recording begins "
+                   "— accepted limitation documented in demo-mode spec §2."),
+
+    # hetzner_manager.py — _render_table feeds from self._instances which is
+    # now redacted in-place before _render_table is called (CRITICAL-3.1 fix).
+    # _set_status writes only static count strings.
+    AllowlistEntry("screens/hetzner_manager.py", "_render_table", "add_row",
+                   "self._instances is redacted in-place by redact_instances() "
+                   "in _load_instances() before _render_table is called "
+                   "(CRITICAL-3.1 fix) — safe by the time it reaches add_row."),
+    AllowlistEntry("screens/hetzner_manager.py", "_set_status", "update",
+                   "Writes hard-coded count strings ('N servers.') or error "
+                   "messages that are scrubbed via scrub_stream in the callers "
+                   "(_load_instances, _do_lifecycle, _do_delete)."),
+
+    # hetzner_setup.py — connection test writes hard-coded status/result strings.
+    # The 'detail' in _do_test_connection is a project label from the API (ok=True
+    # path) or an error message (ok=False path). Both are acceptable leakage for
+    # a setup screen that is not in scope for demo recording.
+    AllowlistEntry("screens/hetzner_setup.py", "_test_connection", "update",
+                   "Writes 'Testing connection...' — hard-coded string."),
+    AllowlistEntry("screens/hetzner_setup.py", "_do_test_connection", "update",
+                   "Writes hard-coded success/failure strings and project label "
+                   "from Hetzner API — setup wizard not in demo recording scope."),
+
+    # hetzner_ssh_keys.py — _set_status writes only static count/error strings;
+    # key names are scrubbed in _load_keys (CRITICAL-3.7 addition).
+    AllowlistEntry("screens/hetzner_ssh_keys.py", "_set_status", "update",
+                   "Writes hard-coded count strings ('N keys.') — no user PII."),
+
+    # key_management.py — _check_agent_status writes code-controlled 'Running' /
+    # 'Not Running' / 'Unknown' status labels.  on_worker_state_changed scrubs the
+    # ssh-add -l output (key file paths + key comments) via scrub_stream before
+    # rendering — no allowlist entry needed for on_worker_state_changed.
+    AllowlistEntry("screens/key_management.py", "_check_agent_status", "update",
+                   "Writes code-controlled SSH agent status labels ('Running', "
+                   "'Not Running', 'Unknown') — no user PII."),
+
+    # log_picker.py — _rebuild_options writes count integers only.
+    AllowlistEntry("screens/log_picker.py", "_rebuild_options", "update",
+                   "Writes 'N matches (of M total)' count label — "
+                   "code-controlled integers, not file content."),
+
+    # login.py — all update() calls are hard-coded login-flow status strings
+    # (OAuth device flow URL, 'Logging in...', 'Logged in as ...').
+    # The 'Logged in as' string in _show_logged_in_state may carry a username —
+    # but the login screen is pre-demo (demo mode cannot be active before login).
+    AllowlistEntry("screens/login.py", "_submit", "update",
+                   "Writes hard-coded 'Logging in...' / 'Invalid credentials' "
+                   "strings — code-controlled login-flow status."),
+    AllowlistEntry("screens/login.py", "_show_logged_in_state", "update",
+                   "Shows logged-in username and session info — pre-demo screen "
+                   "(demo mode cannot be active before login completes)."),
+    AllowlistEntry("screens/login.py", "_validate_session", "update",
+                   "Writes hard-coded session-validation status strings "
+                   "— code-controlled constants."),
+    AllowlistEntry("screens/login.py", "_start_login", "update",
+                   "Writes 'Starting login...' — hard-coded string."),
+    AllowlistEntry("screens/login.py", "_cancel_login", "update",
+                   "Writes 'Login cancelled.' — hard-coded string."),
+    AllowlistEntry("screens/login.py", "_do_device_flow", "update",
+                   "Writes OAuth device-flow URL and polling status — "
+                   "pre-demo screen; URL is a servonaut.io auth endpoint."),
+
+    # main_menu.py — _update_stats writes server counts (integers, not names).
+    AllowlistEntry("screens/main_menu.py", "_update_stats", "update",
+                   "Writes total/running/stopped integer counts — "
+                   "no server names or IPs involved."),
+
+    # memory_consent_modal.py — _toggle_details shows/hides static detail text.
+    AllowlistEntry("screens/memory_consent_modal.py", "_toggle_details", "update",
+                   "Toggles display of hard-coded consent detail text "
+                   "— code-controlled static content."),
+
+    # memory_export.py — action_start_export writes static 'not available' error.
+    AllowlistEntry("screens/memory_export.py", "action_start_export", "update",
+                   "Writes '[red]Export service not available.[/red]' — "
+                   "hard-coded error string, no user data."),
+
+    # memory_keys.py — _update_strength and _update_confirm_state write
+    # code-controlled strength labels and match/mismatch indicators.
+    AllowlistEntry("screens/memory_keys.py", "_update_strength", "update",
+                   "Writes password-strength label (Weak/Fair/Strong) "
+                   "— code-controlled taxonomy, not user PII."),
+    AllowlistEntry("screens/memory_keys.py", "_update_confirm_state", "update",
+                   "Writes 'Passwords match / do not match' indicator "
+                   "— code-controlled string."),
+
+    # memory_share.py — _do_share writes hard-coded status strings for each
+    # phase of the share operation; exception is escaped before embedding.
+    AllowlistEntry("screens/memory_share.py", "_do_share", "update",
+                   "Writes hard-coded phase-status strings ('Fetching member keys', "
+                   "'Sharing...', 'Shared successfully') and an _esc()-wrapped "
+                   "exception string — no raw memory content."),
+
+    # memory_sync_setup.py — _set_status writes static Rich markup status;
+    # _show_setup_error writes escaped exception type; _set_busy writes a
+    # caller-supplied message that is always a code-controlled string.
+    AllowlistEntry("screens/memory_sync_setup.py", "_set_status", "update",
+                   "Writes hard-coded sync-setup status markup from _render_state "
+                   "— code-controlled constants, not memory raw_output."),
+    AllowlistEntry("screens/memory_sync_setup.py", "_show_setup_error", "update",
+                   "Writes escaped exception message from setup flow — exception "
+                   "type, not raw server data."),
+    AllowlistEntry("screens/memory_sync_setup.py", "_set_busy", "update",
+                   "Writes a busy-state message passed from _do_setup — "
+                   "always a code-controlled string constant."),
+
+    # ovh_billing.py — current usage and spend history write formatted currency
+    # amounts and dates (no customer hostnames or IPs); invoice page writes
+    # structured billing data (invoice ID, amount, status).
+    AllowlistEntry("screens/ovh_billing.py", "_load_current_usage", "update",
+                   "Writes formatted currency amounts (e.g., '12.50 EUR') "
+                   "from _format_current_usage — no hostnames or IPs."),
+    AllowlistEntry("screens/ovh_billing.py", "_load_spend_history", "update",
+                   "Writes formatted monthly spend table from "
+                   "_format_spend_history — amounts and dates only, no PII."),
+    AllowlistEntry("screens/ovh_billing.py", "_render_invoice_page", "update",
+                   "Writes 'Page N of M' pager string — code-controlled integers."),
+    AllowlistEntry("screens/ovh_billing.py", "_render_invoice_page", "add_row",
+                   "Invoice rows contain date, invoice ID, amount, status — "
+                   "billing metadata, not server hostnames or IPs."),
+
+    # ovh_cloud_create.py — flavors and images are provider taxonomy.
+    AllowlistEntry("screens/ovh_cloud_create.py", "_load_flavors", "add_row",
+                   "Renders OVH flavor taxonomy (b2-7, c2-7 etc.) — "
+                   "provider-defined product names, not user PII."),
+    AllowlistEntry("screens/ovh_cloud_create.py", "_load_images", "add_row",
+                   "Renders OVH image taxonomy (Ubuntu 22.04 etc.) — "
+                   "provider-defined strings, not user PII."),
+
+    # ovh_dns.py — _show_rdns_form displays an IP and IP block the user just
+    # selected from the table (those values are already scrubbed in _load_rdns).
+    AllowlistEntry("screens/ovh_dns.py", "_show_rdns_form", "update",
+                   "Displays IP and IP block from a row already scrubbed in "
+                   "_load_rdns when demo_mode is on — safe by the time the form "
+                   "is populated."),
+
+    # ovh_firewall.py — _update_status_widget writes hard-coded
+    # 'Firewall: Enabled/Disabled' strings.
+    AllowlistEntry("screens/ovh_firewall.py", "_update_status_widget", "update",
+                   "Writes '[green]Firewall: Enabled[/green]' or "
+                   "'[red]Firewall: Disabled[/red]' — hard-coded status strings."),
+
+    # ovh_manager.py — _render_table feeds from self._instances which is now
+    # redacted in-place before rendering (CRITICAL-3.2 fix). _set_status writes
+    # static count strings or error messages scrubbed in callers.
+    AllowlistEntry("screens/ovh_manager.py", "_render_table", "add_row",
+                   "self._instances is redacted in-place by redact_instances() "
+                   "in _load_instances() before _render_table is called "
+                   "(CRITICAL-3.2 fix) — safe by the time it reaches add_row."),
+    AllowlistEntry("screens/ovh_manager.py", "_set_status", "update",
+                   "Writes hard-coded count strings or error messages that are "
+                   "scrubbed via scrub_stream in the callers."),
+
+    # ovh_monitoring.py — metric values are CPU %, memory %, bandwidth bytes —
+    # numeric/structured data from provider monitoring API. No hostnames or IPs
+    # embedded in the formatted output.
+    AllowlistEntry("screens/ovh_monitoring.py", "_load_vps_metrics", "update",
+                   "Writes formatted CPU/memory/bandwidth numeric metrics "
+                   "— structured provider data, no hostnames or IPs."),
+    AllowlistEntry("screens/ovh_monitoring.py", "_load_dedicated_metrics", "update",
+                   "Writes formatted dedicated-server numeric metrics "
+                   "— same pattern as _load_vps_metrics."),
+    AllowlistEntry("screens/ovh_monitoring.py", "_load_cloud_metrics", "update",
+                   "Writes formatted cloud-instance numeric metrics "
+                   "— same pattern as _load_vps_metrics."),
+    AllowlistEntry("screens/ovh_monitoring.py", "_set_loading", "update",
+                   "Writes 'Loading...' — hard-coded string."),
+    AllowlistEntry("screens/ovh_monitoring.py", "_set_error", "update",
+                   "Writes a formatted error string — exception type from the "
+                   "monitoring API, not raw server metrics data."),
+
+    # ovh_reinstall.py / ovh_resize.py — images and models are taxonomy.
+    AllowlistEntry("screens/ovh_reinstall.py", "_load_images", "add_row",
+                   "Renders OVH reinstall image taxonomy "
+                   "— provider-defined strings, not user PII."),
+    AllowlistEntry("screens/ovh_resize.py", "_load_models", "add_row",
+                   "Renders OVH resize model taxonomy (VPS plan names) "
+                   "— provider-defined strings, not user PII."),
+
+    # ovh_setup.py — connection test and consumer-key request write hard-coded
+    # status and result strings.
+    AllowlistEntry("screens/ovh_setup.py", "_do_request_consumer_key", "update",
+                   "Writes hard-coded consumer-key request status strings "
+                   "— code-controlled constants."),
+    AllowlistEntry("screens/ovh_setup.py", "_test_connection", "update",
+                   "Writes 'Testing connection...' — hard-coded string."),
+    AllowlistEntry("screens/ovh_setup.py", "_do_test_connection", "update",
+                   "Writes hard-coded success/failure strings from OVH setup "
+                   "— setup wizard not in demo recording scope."),
+
+    # ovh_snapshots.py — _load_vps_backup_status writes hard-coded
+    # 'No backup' / 'Enabled' status strings.
+    AllowlistEntry("screens/ovh_snapshots.py", "_load_vps_backup_status", "update",
+                   "Writes hard-coded backup-status strings ('No automated backup "
+                   "configured', state label) — code-controlled constants."),
+
+    # ovh_ssh_keys.py — _refresh writes a status label; _set_status writes
+    # count/error strings.  Key names are scrubbed in _load_keys.
+    AllowlistEntry("screens/ovh_ssh_keys.py", "_refresh", "update",
+                   "Writes a loading/refreshing status label — "
+                   "hard-coded string."),
+    AllowlistEntry("screens/ovh_ssh_keys.py", "_set_status", "update",
+                   "Writes hard-coded count strings ('N keys.') "
+                   "— no user PII."),
+
+    # scan_results.py — status messages (_load_cached_results, action_scan_now,
+    # on_worker_state_changed) are count-based or hard-coded; _populate_table
+    # is now scrubbed.
+    AllowlistEntry("screens/scan_results.py", "_load_cached_results", "update",
+                   "Writes 'Loaded N cached results' (count integer) or "
+                   "'No scan results.' — code-controlled strings."),
+    AllowlistEntry("screens/scan_results.py", "action_scan_now", "update",
+                   "Writes 'Scanning server...' — hard-coded string."),
+    AllowlistEntry("screens/scan_results.py", "on_worker_state_changed", "update",
+                   "Writes 'Scan completed: N results found' (count integer) or "
+                   "hard-coded failure/empty strings — no raw content."),
+
+    # secrets.py — _render_state writes hard-coded card-placeholder markup;
+    # _render_unauthenticated / _render_free_tier / _render_bitwarden /
+    # _render_local write hard-coded configuration-state labels (no secret values,
+    # only provider/plan indicators).
+    AllowlistEntry("screens/secrets.py", "_render_state", "update",
+                   "Writes hard-coded card-placeholder markup for the secrets "
+                   "provider state — no secret values, only status labels."),
+    AllowlistEntry("screens/secrets.py", "_render_unauthenticated", "update",
+                   "Writes hard-coded 'login required' markup "
+                   "— code-controlled string."),
+    AllowlistEntry("screens/secrets.py", "_render_free_tier", "update",
+                   "Writes hard-coded 'upgrade required' markup "
+                   "— code-controlled string."),
+    AllowlistEntry("screens/secrets.py", "_render_bitwarden", "update",
+                   "Writes hard-coded Bitwarden config-state labels "
+                   "(project name from config shown in _render_bitwarden is a "
+                   "user-chosen label, but secrets config screens are excluded "
+                   "from demo recording scope per spec §2)."),
+    AllowlistEntry("screens/secrets.py", "_render_local", "update",
+                   "Writes hard-coded 'local store' provider label "
+                   "— code-controlled string."),
+
+    # secrets_list.py — _render_loading writes a static placeholder.
+    AllowlistEntry("screens/secrets_list.py", "_render_loading", "update",
+                   "Writes '[dim]Loading names…[/dim]' — hard-coded placeholder."),
+
+    # settings.py — _refresh_ai_provider_status writes hard-coded plan/status
+    # labels; _refresh_entitlements_then_redraw writes plan-name labels;
+    # memory-settings methods write hard-coded status strings.
+    # _populate_scan_rules writes rule name + condition + paths from user config —
+    # these are user-defined rule names and file paths; scrubbing would break
+    # the UI for legitimate use (paths like /etc/nginx are not PII).
+    # _populate_connection_rules writes rule names + match conditions — config-layer.
+    # _populate_ipban_table writes AWS resource IDs — accepted: setup screen, not
+    # in demo recording scope per spec §2.
+    # _handle_ipban_discover / _discover_aws_resources write hard-coded hint text.
+    # _update_ovh_status / _update_hetzner_status write hard-coded provider status.
+    # action_save writes hard-coded 'Saved.' result string.
+    AllowlistEntry("screens/settings.py", "_refresh_ai_provider_status", "update",
+                   "Writes hard-coded AI provider status labels (plan names, "
+                   "quota summary integers) — code-controlled strings."),
+    AllowlistEntry("screens/settings.py", "_refresh_entitlements_then_redraw", "update",
+                   "Writes hard-coded entitlement / plan preference labels "
+                   "— code-controlled strings."),
+    AllowlistEntry("screens/settings.py", "_set_memory_settings_disabled", "update",
+                   "Writes a hard-coded disabled-state markup passed from callers "
+                   "— code-controlled constant."),
+    AllowlistEntry("screens/settings.py", "_load_memory_settings", "update",
+                   "Writes hard-coded status strings ('Memory settings service "
+                   "unavailable', 'Loaded') — code-controlled constants."),
+    AllowlistEntry("screens/settings.py", "_do_save_memory_settings", "update",
+                   "Writes hard-coded save-flow status strings ('Saving...', "
+                   "'Saved', 'No changes') — code-controlled constants."),
+    AllowlistEntry("screens/settings.py", "_populate_scan_rules", "add_row",
+                   "Renders user-configured scan rule names and file paths — "
+                   "config-layer data; file paths like /etc/nginx are not PII. "
+                   "Settings screens excluded from demo recording scope per spec §2."),
+    AllowlistEntry("screens/settings.py", "_populate_connection_rules", "add_row",
+                   "Renders connection rule names and match conditions from user "
+                   "config — settings screen, not in demo recording scope."),
+    AllowlistEntry("screens/settings.py", "_populate_ipban_table", "add_row",
+                   "Renders IP-ban config entries (AWS SG/NACL IDs, WAF IP set "
+                   "names) — settings screen not in demo recording scope."),
+    AllowlistEntry("screens/settings.py", "_handle_ipban_discover", "update",
+                   "Writes '[dim]Discovering...[/dim]' — hard-coded string."),
+    AllowlistEntry("screens/settings.py", "_discover_aws_resources", "update",
+                   "Writes a hard-coded hint string after discovery finishes "
+                   "— code-controlled constant."),
+    AllowlistEntry("screens/settings.py", "_update_ovh_status", "update",
+                   "Writes hard-coded 'Configured / Not configured' status labels "
+                   "for the OVH provider — no credentials or server data."),
+    AllowlistEntry("screens/settings.py", "_update_hetzner_status", "update",
+                   "Writes hard-coded 'Configured / Not configured' status labels "
+                   "for the Hetzner provider — no credentials or server data."),
+    AllowlistEntry("screens/settings.py", "action_save", "update",
+                   "Writes '[dim]Saved.[/dim]' after saving settings "
+                   "— hard-coded confirmation string."),
+
+    # snapshot_manager.py — _submit writes static validation error strings;
+    # _set_status writes hard-coded count/result strings.
+    AllowlistEntry("screens/snapshot_manager.py", "_submit", "update",
+                   "Writes hard-coded label validation error strings "
+                   "('Label cannot be empty', 'Label must be 100 chars') "
+                   "— code-controlled constants."),
+    AllowlistEntry("screens/snapshot_manager.py", "_set_status", "update",
+                   "Writes hard-coded count strings ('N snapshots.') or static "
+                   "error messages — no server-origin data."),
+
+    # instance_table.py — _refresh_table feeds from self._filtered_instances
+    # which comes from self.app.instances already redacted in-place by
+    # on_mount/redact_instances() — safe by the time add_row is called.
+    AllowlistEntry("widgets/instance_table.py", "_refresh_table", "add_row",
+                   "Feeds from self._filtered_instances from self.app.instances "
+                   "which is already redacted in-place by on_mount redact_instances() "
+                   "— safe by the time add_row is called."),
+
+    # progress_indicator.py — start() receives a caller-supplied message that is
+    # always a hard-coded string constant at all call sites; stop() writes ''.
+    AllowlistEntry("widgets/progress_indicator.py", "start", "update",
+                   "Receives message from callers that are always hard-coded "
+                   "string constants (e.g., 'Loading...') — no user-origin data."),
+    AllowlistEntry("widgets/progress_indicator.py", "stop", "update",
+                   "Writes empty string to hide the indicator — no user data."),
+
+    # relay_indicator.py — _refresh_local writes relay state label and lock owner
+    # PID (integer + mode); _refresh_backend writes connection state, last
+    # heartbeat timestamp, and client_ids from the relay backend. None of these
+    # are user PII — they are internal relay connection metadata.
+    AllowlistEntry("widgets/relay_indicator.py", "_refresh_local", "update",
+                   "Writes relay lock state label and owner PID/mode (integers) "
+                   "— internal relay metadata, not user PII."),
+    AllowlistEntry("widgets/relay_indicator.py", "_refresh_backend", "update",
+                   "Writes relay backend connection state, heartbeat timestamps, "
+                   "and client_ids — internal relay metadata, not user PII."),
+
+    # ---------------------------------------------------------------------------
+    # load_text — TextArea content (added to _GUARDED_ATTRS in iteration-4)
+    # ---------------------------------------------------------------------------
+
+    # ai_analysis.py — on_mount loads self._text into the TextArea. self._text is
+    # the text passed by the caller at construction time; it comes from
+    # log_viewer's scrubbed _content_buffer (already scrubbed before passing here).
+    AllowlistEntry("screens/ai_analysis.py", "on_mount", "load_text",
+                   "Loads self._text which is supplied by the caller from "
+                   "log_viewer's already-scrubbed _content_buffer — safe at "
+                   "the point of load_text."),
+
+    # ai_analysis.py — _apply_filter loads filtered lines from self._raw_text.
+    # self._raw_text is assigned only from display_log_text which is scrubbed
+    # via scrub_stream in _do_fetch_log before being stored — safe.
+    AllowlistEntry("screens/ai_analysis.py", "_apply_filter", "load_text",
+                   "_raw_text is scrubbed at assignment in _do_fetch_log "
+                   "via scrub_stream before being stored — filtered view is safe."),
+
+    # ai_analysis.py — _clear_filter restores self._raw_text directly.
+    # Same reasoning as _apply_filter above.
+    AllowlistEntry("screens/ai_analysis.py", "_clear_filter", "load_text",
+                   "_raw_text is scrubbed at assignment in _do_fetch_log "
+                   "via scrub_stream — restoring the unfiltered view is safe."),
+
+    # ai_analysis.py — _run_analysis clears the output TextArea with an empty
+    # string before analysis starts — no user data involved.
+    AllowlistEntry("screens/ai_analysis.py", "_run_analysis", "load_text",
+                   "Loads empty string ('') to clear the output TextArea before "
+                   "analysis — no user data."),
+
+    # instance_list.py — _update_detail_panel loads either '' (no selection)
+    # or a formatted string built from self._instances fields. All three callers
+    # of _update_table() (fetch_instances/background_refresh, ovh_refresh,
+    # hetzner_refresh) apply redact_instances() before calling _update_table(),
+    # so every path that adds data to self._instances redacts it first. All
+    # fields are fake by the time load_text is called.
+    AllowlistEntry("screens/instance_list.py", "_update_detail_panel", "load_text",
+                   "Loads '' (no selection) or instance fields from "
+                   "self._instances. All three populate-callers redact their "
+                   "fresh provider data before calling _update_table(); safe "
+                   "by the time load_text is called."),
+
+    # chat_panel.py — _send clears the chat input TextArea with '' after reading
+    # the user's message — no server-origin data involved.
+    AllowlistEntry("widgets/chat_panel.py", "_send", "load_text",
+                   "Loads empty string ('') to clear the chat input field after "
+                   "reading the user's own message — no server-origin data."),
+]
+
+# Build a fast lookup set: (relative_file_path, func_name, attr_name)
+_ALLOWLIST_SET: Set[tuple] = {
+    (e.file, e.func, e.attr) for e in _ALLOWLIST
+}
+
+# Some function names appear in the allowlist for multiple attrs
+_ALLOWLIST_FUNC_ATTR_SET: Set[tuple] = {
+    (e.file, e.func, e.attr) for e in _ALLOWLIST
+}
+
+
+# ---------------------------------------------------------------------------
+# AST analysis helpers
+# ---------------------------------------------------------------------------
+
+
+class _GuardedCallFinder(ast.NodeVisitor):
+    """Finds all method calls matching _GUARDED_ATTRS and checks for a
+    scrub_stream / redact_* call in the same function body.
+
+    LIMITATION (intentional): the check is function-scoped, not
+    call-site-scoped. A function that contains one guarded scrub_stream
+    call AND a separate unguarded streaming write in the same body will
+    PASS. This sweep catches "a screen forgot demo mode entirely"; it
+    does NOT catch "row A was scrubbed, row B in the same method was
+    not". Per-call dataflow analysis is out of scope — treat a green
+    lint as necessary, not sufficient. Per-call correctness is the job
+    of the per-screen coverage tests and the security review.
+    """
+
+    def __init__(self, rel_path: str) -> None:
+        self.rel_path = rel_path
+        self.violations: List[str] = []
+        self._current_func: str = "module"
+        self._func_stack: List[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self._current_func = node.name
+        # Collect all Call nodes in this function body
+        calls_in_func = [
+            n for n in ast.walk(node)
+            if isinstance(n, ast.Call)
+        ]
+        guarded_calls = [
+            c for c in calls_in_func
+            if (
+                isinstance(c.func, ast.Attribute)
+                and c.func.attr in _GUARDED_ATTRS
+            )
+        ]
+        # Check whether this function also contains a scrub/redact call
+        has_redaction = any(
+            (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Attribute)
+                and (
+                    n.func.attr.startswith("scrub")
+                    or n.func.attr.startswith("redact")
+                )
+            )
+            or (
+                isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and (
+                    n.func.id.startswith("scrub")
+                    or n.func.id.startswith("redact")
+                )
+            )
+            or (
+                # demo_mode guard check — presence of the guard is sufficient signal
+                isinstance(n, ast.If)
+                and _contains_demo_mode_check(n)
+            )
+            for n in ast.walk(node)
+        )
+
+        for call in guarded_calls:
+            attr = call.func.attr
+            key = (self.rel_path, node.name, attr)
+            if key in _ALLOWLIST_FUNC_ATTR_SET:
+                continue  # Explicitly allow-listed
+            if not has_redaction:
+                self.violations.append(
+                    f"{self.rel_path}::{node.name}() uses .{attr}() "
+                    f"(line {call.lineno}) without a scrub/redact guard "
+                    f"— add demo-mode guard or add to _ALLOWLIST with justification."
+                )
+
+        self.generic_visit(node)
+        self._func_stack.pop()
+        self._current_func = self._func_stack[-1] if self._func_stack else "module"
+
+    # Also handle async functions
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+
+def _contains_demo_mode_check(node: ast.If) -> bool:
+    """Return True if the If-test references demo_mode (heuristic)."""
+    src = ast.unparse(node.test) if hasattr(ast, "unparse") else ""
+    return "demo_mode" in src
+
+
+def _find_violations(path: Path) -> List[str]:
+    """Parse one Python file and return lint violations."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [f"SyntaxError in {path}: {exc}"]
+
+    rel_path = str(path.relative_to(_SRC_ROOT))
+    finder = _GuardedCallFinder(rel_path)
+    finder.visit(tree)
+    return finder.violations
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def _collect_target_files() -> List[Path]:
+    """Return all .py files under screens/ and widgets/, excluding __init__.py."""
+    paths: List[Path] = []
+    for d in _TARGET_DIRS:
+        paths.extend(sorted((_SRC_ROOT / d).glob("*.py")))
+    return [p for p in paths if p.name != "__init__.py"]
+
+
+def test_no_unguarded_streaming_writes() -> None:
+    """Every .write()/.update()/.append_output()/.append_error() on streaming
+    content must either have a demo-mode guard or appear in _ALLOWLIST.
+    """
+    target_files = _collect_target_files()
+    assert target_files, "No target files found — check _SCREENS_DIR / _WIDGETS_DIR paths"
+
+    all_violations: List[str] = []
+    for path in target_files:
+        violations = _find_violations(path)
+        all_violations.extend(violations)
+
+    if all_violations:
+        report = "\n".join(f"  - {v}" for v in all_violations)
+        pytest.fail(
+            f"Demo-mode lint: {len(all_violations)} unguarded streaming write(s) found:\n"
+            f"{report}\n\n"
+            "Fix: add a demo-mode guard (if self.app.demo_mode and self.app.redaction_service:)\n"
+            "  OR add an AllowlistEntry to _ALLOWLIST in tests/test_demo_mode_lint.py\n"
+            "  with a one-line justification."
+        )
+
+
+def test_allowlist_entries_reference_real_files() -> None:
+    """Every allowlist entry must reference an existing file to catch stale entries."""
+    missing = []
+    for entry in _ALLOWLIST:
+        full_path = _SRC_ROOT / entry.file
+        if not full_path.exists():
+            missing.append(f"{entry.file} (allowlist entry for {entry.func}.{entry.attr})")
+    if missing:
+        report = "\n".join(f"  - {m}" for m in missing)
+        pytest.fail(
+            f"Stale _ALLOWLIST entries point to non-existent files:\n{report}\n"
+            "Remove or update the entry."
+        )

--- a/tests/test_ovh_screen_feedback.py
+++ b/tests/test_ovh_screen_feedback.py
@@ -1,0 +1,178 @@
+"""Screen-level tests for OVH credential-failure feedback.
+
+Every OVH fetch helper swallows API errors and returns an empty list, so an
+empty result is indistinguishable from "credentials revoked" until a screen
+runs an explicit ``OVHService.check_credentials()`` probe. These tests verify
+that the OVH Manager, DNS, and Billing screens surface that probe result in
+their UI instead of rendering a misleading empty state.
+
+The screens override ``app`` as a property; ``patch.object`` with
+``PropertyMock`` swaps it for the test and restores it afterwards, so no class
+state leaks between tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from servonaut.screens.ovh_billing import OVHBillingScreen
+from servonaut.screens.ovh_dns import OVHDNSScreen
+from servonaut.screens.ovh_manager import OVHManagerScreen
+
+_AUTH_ERROR = (
+    "OVH authentication failed — API credentials are invalid or expired. "
+    "Update them in Settings → OVH."
+)
+
+
+def _async(value):
+    """Return an async function that resolves to ``value``."""
+    async def _fn(*args, **kwargs):
+        return value
+    return _fn
+
+
+def _mock_app(*, ovh_service=None, dns_service=None, billing_service=None):
+    app = MagicMock()
+    app.demo_mode = False
+    app.redaction_service = None
+    app.ovh_service = ovh_service
+    app.ovh_dns_service = dns_service
+    app.ovh_billing_service = billing_service
+    return app
+
+
+# ---------------------------------------------------------------------------
+# OVH Manager
+# ---------------------------------------------------------------------------
+
+class TestOVHManagerFeedback:
+
+    def _run_load(self, app):
+        screen = OVHManagerScreen()
+        status = MagicMock()
+        with patch.object(
+            OVHManagerScreen, "app", new_callable=PropertyMock,
+            return_value=app,
+        ), patch.object(screen, "query_one", return_value=status), \
+                patch.object(screen, "_render_table"):
+            asyncio.run(screen._load_instances())
+        return status
+
+    def test_credential_failure_shows_error_not_empty_state(self):
+        ovh = MagicMock()
+        ovh.fetch_instances_cached = _async([])
+        ovh.check_credentials = _async(_AUTH_ERROR)
+        status = self._run_load(_mock_app(ovh_service=ovh))
+
+        rendered = status.update.call_args[0][0]
+        assert "authentication failed" in rendered.lower()
+        assert "No OVH instances" not in rendered
+
+    def test_genuinely_empty_shows_normal_empty_state(self):
+        ovh = MagicMock()
+        ovh.fetch_instances_cached = _async([])
+        ovh.check_credentials = _async(None)  # credentials are fine
+        status = self._run_load(_mock_app(ovh_service=ovh))
+
+        rendered = status.update.call_args[0][0]
+        assert "No OVH instances" in rendered
+
+    def test_credentials_not_checked_when_instances_present(self):
+        ovh = MagicMock()
+        ovh.fetch_instances_cached = _async([{"id": "d1", "name": "n"}])
+        ovh.check_credentials = MagicMock(side_effect=AssertionError(
+            "check_credentials must not run when instances are present"))
+        status = self._run_load(_mock_app(ovh_service=ovh))
+
+        rendered = status.update.call_args[0][0]
+        assert "1 instance" in rendered
+
+
+# ---------------------------------------------------------------------------
+# OVH DNS
+# ---------------------------------------------------------------------------
+
+class TestOVHDNSFeedback:
+
+    def _run_load(self, app):
+        screen = OVHDNSScreen()
+        widget = MagicMock()
+        with patch.object(
+            OVHDNSScreen, "app", new_callable=PropertyMock,
+            return_value=app,
+        ), patch.object(screen, "query_one", return_value=widget):
+            asyncio.run(screen._load_domains())
+        return widget
+
+    def test_credential_failure_shown_in_domains_header(self):
+        dns = MagicMock()
+        dns.list_domains = _async([])
+        ovh = MagicMock()
+        ovh.check_credentials = _async(_AUTH_ERROR)
+        widget = self._run_load(_mock_app(ovh_service=ovh, dns_service=dns))
+
+        rendered = " ".join(
+            str(c.args[0]) for c in widget.update.call_args_list
+        )
+        assert "authentication failed" in rendered.lower()
+
+    def test_header_restored_when_domains_present(self):
+        dns = MagicMock()
+        dns.list_domains = _async(["example.com"])
+        ovh = MagicMock()
+        ovh.check_credentials = MagicMock(side_effect=AssertionError(
+            "check_credentials must not run when domains are present"))
+        widget = self._run_load(_mock_app(ovh_service=ovh, dns_service=dns))
+
+        rendered = " ".join(
+            str(c.args[0]) for c in widget.update.call_args_list
+        )
+        assert "authentication failed" not in rendered.lower()
+        assert "Domains" in rendered
+
+
+# ---------------------------------------------------------------------------
+# OVH Billing
+# ---------------------------------------------------------------------------
+
+class TestOVHBillingFeedback:
+
+    def test_credential_failure_gates_the_loaders(self):
+        ovh = MagicMock()
+        ovh.check_credentials = _async(_AUTH_ERROR)
+        screen = OVHBillingScreen()
+        widget = MagicMock()
+        with patch.object(
+            OVHBillingScreen, "app", new_callable=PropertyMock,
+            return_value=_mock_app(ovh_service=ovh),
+        ), patch.object(screen, "query_one", return_value=widget), \
+                patch.object(screen, "run_worker") as mock_worker:
+            asyncio.run(screen._gate_then_load())
+
+        # The four section loaders must NOT run when credentials are bad.
+        mock_worker.assert_not_called()
+        rendered = " ".join(
+            str(c.args[0]) for c in widget.update.call_args_list
+        )
+        assert "authentication failed" in rendered.lower()
+
+    def test_valid_credentials_run_all_loaders(self):
+        ovh = MagicMock()
+        ovh.check_credentials = _async(None)
+        screen = OVHBillingScreen()
+        # Stub the loaders as plain mocks so calling them yields no
+        # un-awaited coroutine when run_worker is mocked out.
+        with patch.object(
+            OVHBillingScreen, "app", new_callable=PropertyMock,
+            return_value=_mock_app(ovh_service=ovh),
+        ), patch.object(screen, "run_worker") as mock_worker, \
+                patch.object(screen, "_load_current_usage", MagicMock()), \
+                patch.object(screen, "_load_spend_history", MagicMock()), \
+                patch.object(screen, "_load_invoices", MagicMock()), \
+                patch.object(screen, "_load_services", MagicMock()):
+            asyncio.run(screen._gate_then_load())
+
+        # current usage, spend history, invoices, services.
+        assert mock_worker.call_count == 4

--- a/tests/test_ovh_service.py
+++ b/tests/test_ovh_service.py
@@ -13,7 +13,11 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 from servonaut.config.schema import OVHConfig
-from servonaut.services.ovh_service import OVHService, _OVH_CACHE_TTL_SECONDS
+from servonaut.services.ovh_service import (
+    OVHService,
+    _OVH_CACHE_TTL_SECONDS,
+    _classify_ovh_error,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -827,6 +831,63 @@ class TestFetchInstances:
             result = asyncio.run(svc.fetch_instances())
 
         assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# _classify_ovh_error + last_fetch_error feedback
+# ---------------------------------------------------------------------------
+
+class TestClassifyOvhError:
+
+    def test_credential_error_maps_to_auth_message(self):
+        msg = _classify_ovh_error(Exception("This credential is not valid"))
+        assert "authentication failed" in msg.lower()
+        assert "Settings" in msg
+
+    def test_invalid_signature_maps_to_auth_message(self):
+        msg = _classify_ovh_error(Exception("Invalid signature"))
+        assert "authentication failed" in msg.lower()
+
+    def test_not_granted_maps_to_permission_message(self):
+        msg = _classify_ovh_error(Exception("This call has not been granted"))
+        assert "access denied" in msg.lower()
+
+    def test_import_error_maps_to_install_hint(self):
+        msg = _classify_ovh_error(ImportError("No module named ovh"))
+        assert "python-ovh" in msg
+
+    def test_generic_error_keeps_first_line_only(self):
+        exc = Exception("Service Unavailable\nOVH-Query-ID: EU.ext-1.abc")
+        msg = _classify_ovh_error(exc)
+        assert "Service Unavailable" in msg
+        assert "OVH-Query-ID" not in msg
+
+
+class TestCheckCredentials:
+
+    def test_returns_none_when_me_succeeds(self, service_with_client, mock_client):
+        mock_client.get.return_value = {"nichandle": "ab12345-ovh"}
+        assert asyncio.run(service_with_client.check_credentials()) is None
+
+    def test_queries_the_me_endpoint(self, service_with_client, mock_client):
+        mock_client.get.return_value = {}
+        asyncio.run(service_with_client.check_credentials())
+        mock_client.get.assert_called_once_with("/me")
+
+    def test_returns_auth_message_on_credential_error(
+        self, service_with_client, mock_client,
+    ):
+        mock_client.get.side_effect = Exception("This credential is not valid")
+        msg = asyncio.run(service_with_client.check_credentials())
+        assert msg is not None
+        assert "authentication failed" in msg.lower()
+
+    def test_returns_permission_message_on_not_granted(
+        self, service_with_client, mock_client,
+    ):
+        mock_client.get.side_effect = Exception("This call has not been granted")
+        msg = asyncio.run(service_with_client.check_credentials())
+        assert "access denied" in msg.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ovh_ssh_keys.py
+++ b/tests/test_ovh_ssh_keys.py
@@ -85,6 +85,9 @@ class _WrapperApp(App):
         )
         self.config_manager = MagicMock()
         self.config_manager.get.return_value = cfg
+        # Required by OVHSSHKeysScreen's demo-mode guards.
+        self.demo_mode = False
+        self.redaction_service = None
 
     def on_mount(self) -> None:
         self.push_screen(OVHSSHKeysScreen())

--- a/tests/test_redaction_service_gaps.py
+++ b/tests/test_redaction_service_gaps.py
@@ -1,0 +1,479 @@
+"""Gap-fill tests for RedactionService — coverage audit pass (workflow 20260519-8967e6).
+
+Covers branches not reached by test_redaction_stream.py or test_demo_mode_coverage.py:
+
+  1. redact_name non-idempotence PIN  — security-audit-mandated regression pin
+  2. scrub_stream try/except fallback → <redaction-error>
+  3. Primitive guard clauses (empty / "-" / "N/A" inputs)
+  4. redact_instance_id custom- prefix branch
+  5. redact_key_name with-path branch
+  6. redact_instance optional-field branches (private_ip, ssh_key, group, username,
+     host, tags, is_custom+region)
+  7. ServonautApp.notify timeout=not-None path
+"""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.services.redaction_service import RedactionService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _svc() -> RedactionService:
+    return RedactionService()
+
+
+# ---------------------------------------------------------------------------
+# 1. redact_name non-idempotence PIN
+#
+# WHY THIS TEST EXISTS:
+#   redact_instance() mutates instance["name"] in-place by calling redact_name().
+#   The per-handler contract (log_viewer, cloudwatch, etc.) depends on the fact
+#   that redact_name("web-prod") == redact_name("web-prod") == same fake value
+#   but redact_name(redact_name("web-prod")) != redact_name("web-prod") for any
+#   *new* service instance, because the output of the first call is NOT in the
+#   _name_cache of the new service.
+#
+#   However, within a SINGLE service instance redact_name IS idempotent (it is
+#   in _name_cache after the first call). The NON-idempotence only matters when
+#   a second RedactionService instance encounters an already-substituted name.
+#   scrub_stream guards against this for free-text via _fake_names; for the
+#   structured field path the guarantee is that redact_instances() is called
+#   only once per data source — NOT twice on the same dict.
+#
+#   This test PINS the known behavior:
+#   - Within one service: idempotent (cache hit).
+#   - A fresh service seeing an already-fake name: can re-substitute it.
+#   If a future "fix" makes redact_name globally idempotent across service
+#   instances the per-handler once-only call assumption changes — this test
+#   catches that so the design decision is re-examined explicitly.
+# ---------------------------------------------------------------------------
+
+
+class TestRedactNameNonIdempotencePin:
+    """PIN test: redact_name non-idempotence across service instances.
+
+    The security audit explicitly required this test to be present so that
+    any future change that alters the across-instance idempotence property
+    surfaces as a visible test failure requiring deliberate review.
+    """
+
+    def test_within_same_service_is_idempotent(self) -> None:
+        """Within one service instance redact_name("x") == redact_name("x")."""
+        svc = _svc()
+        first = svc.redact_name("web-prod-7")
+        second = svc.redact_name("web-prod-7")
+        assert first == second, (
+            "Within one RedactionService, redact_name must return the same "
+            "fake name for the same input on every call (cache hit path)."
+        )
+
+    def test_across_service_instances_may_not_be_idempotent(self) -> None:
+        """A fresh service can re-substitute an already-fake name.
+
+        This is the PINNED behavior: redact_name() output fed into a *new*
+        RedactionService is NOT guaranteed to pass through unchanged — the
+        fresh service's _name_cache is empty and _fake_names is empty, so
+        it will happily re-hash and re-substitute the already-fake name.
+
+        The per-handler design (log_viewer, cloudwatch, etc.) relies on
+        redact_instances() being called ONCE per data load, not repeatedly.
+        If this property ever changes (i.e., the second call returns the
+        same value as the first) the test must be updated with an explicit
+        explanation of why the design is still safe.
+        """
+        svc1 = _svc()
+        fake_name = svc1.redact_name("web-prod-7")
+        # Confirm fake_name is in svc1's _fake_names set
+        assert fake_name in svc1._fake_names
+
+        # A fresh service does NOT have fake_name in its _name_cache or _fake_names
+        svc2 = _svc()
+        assert fake_name not in svc2._fake_names, (
+            "Fresh service must start with empty _fake_names — "
+            "this is the precondition for the non-idempotence property."
+        )
+        # The fresh service CAN re-map the already-fake name
+        result = svc2.redact_name(fake_name)
+        # We don't assert the exact value (it's deterministic but opaque),
+        # but we record that it is DIFFERENT from the fake_name to pin the behavior.
+        # If this assertion fails it means redact_name became globally idempotent
+        # — review the design change before removing this assertion.
+        assert result != fake_name, (
+            f"DESIGN CHANGE DETECTED: redact_name('{fake_name}') on a fresh "
+            f"RedactionService returned the same value ('{result}'). "
+            "This means redact_name is now globally idempotent across service "
+            "instances. Review whether the per-handler once-only call assumption "
+            "is still valid before removing this assertion."
+        )
+
+    def test_scrub_stream_guards_fake_names_for_free_text(self) -> None:
+        """scrub_stream uses _fake_names to protect free-text from double-sub.
+
+        This is the mitigation that makes the across-instance non-idempotence
+        safe for free-text paths: the log_group and resource_name primitives
+        skip names already in _fake_names.  This test verifies the mitigation
+        works correctly within a single service (the typical production case).
+        """
+        svc = _svc()
+        # First scrub: /aws/lambda/my-function gets name redacted
+        once = svc.scrub_stream("/aws/lambda/my-function")
+        assert "my-function" not in once
+        # Second scrub: the already-fake function name must pass through unchanged
+        twice = svc.scrub_stream(once)
+        assert once == twice, (
+            "scrub_stream must be idempotent for already-scrubbed log groups "
+            "because the fake name is in _fake_names."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. scrub_stream try/except fallback path → "<redaction-error>"
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStreamFallback:
+    """The inner try/except must catch errors and return <redaction-error>."""
+
+    def test_fallback_to_redact_text_when_exception(self) -> None:
+        """If a primitive raises, scrub_stream falls back to redact_text only."""
+        svc = _svc()
+        # Patch redact_arn to raise after redact_text already ran
+        with patch.object(svc, "redact_arn", side_effect=RuntimeError("boom")):
+            # Input with an IP so the fallback redact_text still does something
+            raw = "host 5.6.7.8 arn:aws:iam::123456789012:user/x"
+            result = svc.scrub_stream(raw)
+        # Fallback: redact_text was called on the orig text → IP redacted
+        assert "5.6.7.8" not in result
+        # ARN was not redacted (exception fired before redact_arn completed)
+        # Result is not the full pipeline output but it is a string (not an exception)
+        assert isinstance(result, str)
+
+    def test_fallback_returns_redaction_error_when_even_redact_text_fails(self) -> None:
+        """If BOTH the main pipeline AND the fallback redact_text fail, return
+        the literal string '<redaction-error>'."""
+        svc = _svc()
+        with patch.object(svc, "redact_arn", side_effect=RuntimeError("step-fail")):
+            with patch.object(svc, "redact_text", side_effect=RuntimeError("fallback-fail")):
+                result = svc.scrub_stream("AKIAIOSFODNN7EXAMPLE 1.2.3.4")
+        assert result == "<redaction-error>", (
+            f"Expected '<redaction-error>' when all fallbacks fail, got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Primitive guard clauses — empty / "-" / "N/A" inputs
+# ---------------------------------------------------------------------------
+
+
+class TestPrimitiveGuards:
+    """All redact_* methods must return their input unchanged for falsy/sentinel values."""
+
+    def test_redact_ip_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_ip("") == ""
+
+    def test_redact_ip_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_ip("-") == "-"
+
+    def test_redact_ip_na_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_ip("N/A") == "N/A"
+
+    def test_redact_name_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_name("") == ""
+
+    def test_redact_name_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_name("-") == "-"
+
+    def test_redact_hostname_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_hostname("") == ""
+
+    def test_redact_hostname_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_hostname("-") == "-"
+
+    def test_redact_key_name_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_key_name("") == ""
+
+    def test_redact_key_name_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_key_name("-") == "-"
+
+    def test_redact_provider_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_provider("") == ""
+
+    def test_redact_provider_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_provider("-") == "-"
+
+    def test_redact_group_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_group("") == ""
+
+    def test_redact_group_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_group("-") == "-"
+
+    def test_redact_username_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.redact_username("") == ""
+
+    def test_redact_username_dash_sentinel(self) -> None:
+        svc = _svc()
+        assert svc.redact_username("-") == "-"
+
+
+# ---------------------------------------------------------------------------
+# 4. redact_instance_id — custom- prefix branch
+# ---------------------------------------------------------------------------
+
+
+class TestRedactInstanceId:
+    """Verify all format-preserving branches of redact_instance_id."""
+
+    def test_custom_prefix_preserved(self) -> None:
+        svc = _svc()
+        result = svc.redact_instance_id("custom-abc123xyz")
+        assert result.startswith("custom-"), (
+            f"custom- prefix not preserved: {result!r}"
+        )
+        assert result != "custom-abc123xyz", "ID was not redacted"
+
+    def test_i_prefix_preserved(self) -> None:
+        svc = _svc()
+        result = svc.redact_instance_id("i-0abc123def456789a")
+        assert result.startswith("i-"), f"i- prefix not preserved: {result!r}"
+        assert result != "i-0abc123def456789a", "ID was not redacted"
+
+    def test_unknown_format_returned_unchanged(self) -> None:
+        """IDs without known prefixes pass through unchanged (unknown format)."""
+        svc = _svc()
+        result = svc.redact_instance_id("srv-12345")
+        assert result == "srv-12345", (
+            f"Unknown-format ID should pass through unchanged, got {result!r}"
+        )
+
+    def test_empty_instance_id_returned_unchanged(self) -> None:
+        svc = _svc()
+        assert svc.redact_instance_id("") == ""
+
+    def test_custom_prefix_shorter_than_12_hex(self) -> None:
+        """custom- prefix branch uses only first 12 hex chars."""
+        svc = _svc()
+        result = svc.redact_instance_id("custom-short")
+        assert result.startswith("custom-")
+        # The 12-char hex suffix must be exactly 12 chars
+        suffix = result[len("custom-"):]
+        assert len(suffix) == 12, f"Expected 12-char hex suffix, got {suffix!r}"
+
+
+# ---------------------------------------------------------------------------
+# 5. redact_key_name — with-path branch
+# ---------------------------------------------------------------------------
+
+
+class TestRedactKeyName:
+    """Verify key-with-path vs plain-key branches."""
+
+    def test_key_with_path_uses_ssh_prefix(self) -> None:
+        svc = _svc()
+        result = svc.redact_key_name("/home/alice/.ssh/id_rsa")
+        assert result.startswith("~/.ssh/"), (
+            f"Path key should get ~/.ssh/ prefix, got {result!r}"
+        )
+
+    def test_plain_key_no_path_prefix(self) -> None:
+        svc = _svc()
+        result = svc.redact_key_name("my-deploy-key")
+        assert not result.startswith("~/.ssh/"), (
+            f"Plain key should NOT get ~/.ssh/ prefix, got {result!r}"
+        )
+        # Must be one of _KEY_NAMES
+        from servonaut.services.redaction_service import _KEY_NAMES
+        assert result in _KEY_NAMES, (
+            f"Plain key result {result!r} not in _KEY_NAMES"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. redact_instance — optional-field branches
+# ---------------------------------------------------------------------------
+
+
+class TestRedactInstanceOptionalFields:
+    """Each optional field in redact_instance must be covered."""
+
+    def test_private_ip_redacted(self) -> None:
+        svc = _svc()
+        inst = {"private_ip": "10.0.0.1"}
+        svc.redact_instance(inst)
+        assert inst["private_ip"] != "10.0.0.1"
+
+    def test_ssh_key_redacted(self) -> None:
+        svc = _svc()
+        inst = {"ssh_key": "prod-key-v2"}
+        svc.redact_instance(inst)
+        assert inst["ssh_key"] != "prod-key-v2"
+
+    def test_group_redacted(self) -> None:
+        svc = _svc()
+        inst = {"group": "team-backend"}
+        svc.redact_instance(inst)
+        assert inst["group"] != "team-backend"
+
+    def test_username_redacted(self) -> None:
+        svc = _svc()
+        inst = {"username": "alice"}
+        svc.redact_instance(inst)
+        assert inst["username"] != "alice"
+
+    def test_host_redacted(self) -> None:
+        svc = _svc()
+        inst = {"host": "my-server.internal.company.com"}
+        svc.redact_instance(inst)
+        assert inst["host"] != "my-server.internal.company.com"
+        assert inst["host"].endswith(".example.com"), (
+            f"Redacted host should end with .example.com, got {inst['host']!r}"
+        )
+
+    def test_tags_dict_values_redacted(self) -> None:
+        svc = _svc()
+        inst = {"tags": {"Name": "prod-api-gateway", "Env": "production-acme"}}
+        svc.redact_instance(inst)
+        assert inst["tags"]["Name"] != "prod-api-gateway"
+        assert inst["tags"]["Env"] != "production-acme"
+
+    def test_tags_non_dict_not_redacted(self) -> None:
+        """Non-dict tags value is left untouched (isinstance guard)."""
+        svc = _svc()
+        inst = {"tags": ["tag1", "tag2"]}
+        svc.redact_instance(inst)
+        # Should not crash; list is unchanged
+        assert inst["tags"] == ["tag1", "tag2"]
+
+    def test_is_custom_with_non_standard_region_redacted(self) -> None:
+        """Custom server with a non-AWS-region region string gets redact_provider."""
+        svc = _svc()
+        inst = {"is_custom": True, "region": "my-datacenter-rack-3"}
+        svc.redact_instance(inst)
+        assert inst["region"] != "my-datacenter-rack-3", (
+            "Non-standard region on custom server should be redacted"
+        )
+
+    def test_is_custom_with_standard_aws_region_not_redacted(self) -> None:
+        """Custom server with a standard AWS-style region must NOT be redacted."""
+        svc = _svc()
+        for region in ("us-east-1", "eu-west-1", "ap-southeast-2", "sa-east-1"):
+            inst = {"is_custom": True, "region": region}
+            svc.redact_instance(inst)
+            assert inst["region"] == region, (
+                f"Standard AWS region {region!r} should not be redacted"
+            )
+
+    def test_key_name_redacted(self) -> None:
+        svc = _svc()
+        inst = {"key_name": "acme-prod-key"}
+        svc.redact_instance(inst)
+        assert inst["key_name"] != "acme-prod-key"
+
+    def test_provider_redacted(self) -> None:
+        svc = _svc()
+        inst = {"provider": "MyCustomCloud"}
+        svc.redact_instance(inst)
+        assert inst["provider"] != "MyCustomCloud"
+
+    def test_missing_optional_fields_no_crash(self) -> None:
+        """redact_instance must not crash when optional fields are absent."""
+        svc = _svc()
+        inst = {"name": "web-prod-7"}
+        result = svc.redact_instance(inst)
+        # Only name should change
+        assert result["name"] != "web-prod-7"
+        assert "private_ip" not in result
+
+    def test_redact_instances_iterates_all(self) -> None:
+        """redact_instances must redact all instances and return the list."""
+        svc = _svc()
+        instances = [
+            {"name": "web-prod-1", "public_ip": "1.2.3.4"},
+            {"name": "db-prod-1", "public_ip": "5.6.7.8"},
+        ]
+        result = svc.redact_instances(instances)
+        assert result is instances  # same list reference (in-place mutation)
+        assert instances[0]["name"] != "web-prod-1"
+        assert instances[1]["name"] != "db-prod-1"
+        assert instances[0]["public_ip"] != "1.2.3.4"
+        assert instances[1]["public_ip"] != "5.6.7.8"
+
+
+# ---------------------------------------------------------------------------
+# 7. ServonautApp.notify — timeout=not-None path (line 144)
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyTimeoutPath:
+    """The timeout-is-not-None branch of notify() must forward timeout to super."""
+
+    def test_notify_forwards_timeout_when_not_none(self) -> None:
+        """When timeout is provided, super().notify must receive it."""
+        from servonaut.app import ServonautApp
+
+        app = MagicMock(spec=ServonautApp)
+        app.demo_mode = False
+        app.redaction_service = None
+
+        captured: list = []
+
+        def _super_notify(
+            message, *, title="", severity="information", timeout=None, markup=True
+        ):
+            captured.append({
+                "message": message,
+                "timeout": timeout,
+            })
+
+        with patch("textual.app.App.notify", side_effect=_super_notify):
+            ServonautApp.notify(app, "hello", timeout=4.0)
+
+        assert captured, "super().notify was not called"
+        assert captured[0]["timeout"] == 4.0, (
+            f"timeout not forwarded to super().notify: {captured[0]!r}"
+        )
+
+    def test_notify_demo_mode_scrubs_with_timeout(self) -> None:
+        """Demo mode scrubbing must apply even when timeout is provided."""
+        from servonaut.app import ServonautApp
+
+        app = MagicMock(spec=ServonautApp)
+        app.demo_mode = True
+        app.redaction_service = RedactionService()
+
+        captured: list = []
+
+        def _super_notify(
+            message, *, title="", severity="information", timeout=None, markup=True
+        ):
+            captured.append({"message": message, "timeout": timeout})
+
+        with patch("textual.app.App.notify", side_effect=_super_notify):
+            ServonautApp.notify(app, "Server 10.0.0.1 failed", timeout=5.0)
+
+        assert captured
+        assert "10.0.0.1" not in captured[0]["message"], (
+            f"IP leaked despite demo mode: {captured[0]['message']!r}"
+        )
+        assert captured[0]["timeout"] == 5.0

--- a/tests/test_redaction_stream.py
+++ b/tests/test_redaction_stream.py
@@ -1,0 +1,621 @@
+"""Tests for RedactionService.scrub_stream — composition, idempotence, coverage.
+
+Tests are organized into:
+  - TestScrubStreamComposition     — verifies the 8-step pipeline order
+  - TestScrubStreamIdempotence     — scrub_stream(scrub_stream(s)) == scrub_stream(s)
+  - TestRedactIpIdempotenceGuard   — REGRESSION for doc-range short-circuit in redact_ip
+  - TestScrubStreamAllSecretCategories — 12 _REDACTORS + JWT + 7 new primitives
+  - TestScrubStreamEdgeCases       — None / empty / non-str / one-IP line
+  - TestScrubStreamPerformance     — 10 000 typical log lines under 1 s
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from servonaut.services.redaction_service import RedactionService, _DOC_NETS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _svc() -> RedactionService:
+    """Return a fresh, isolated RedactionService."""
+    return RedactionService()
+
+
+# ---------------------------------------------------------------------------
+# TestScrubStreamComposition — secrets redacted first, IPs second, etc.
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStreamComposition:
+    def test_secret_redacted_before_ip(self) -> None:
+        """default_redactor fires before redact_text — embedded key inside IP line."""
+        svc = _svc()
+        raw = "client 1.2.3.4 sent AKIAIOSFODNN7EXAMPLE"
+        out = svc.scrub_stream(raw)
+        assert "<redacted:aws-access-key>" in out
+        # IP also redacted
+        assert "1.2.3.4" not in out
+
+    def test_arn_account_replaced_before_bare_account_regex(self) -> None:
+        """ARN step fires before bare account_id so the account is replaced in-place."""
+        svc = _svc()
+        raw = "arn:aws:iam::123456789012:user/alice"
+        out = svc.scrub_stream(raw)
+        assert "000000000000" in out
+        assert "123456789012" not in out
+
+    def test_ip_before_url_host(self) -> None:
+        """IPs in URL hosts are handled by redact_text before redact_url fires."""
+        svc = _svc()
+        # URL whose host is an IP
+        raw = "http://192.168.0.1/path"
+        out = svc.scrub_stream(raw)
+        assert "192.168.0.1" not in out
+
+    def test_url_query_stripped(self) -> None:
+        """redact_url strips query parameters (which may contain signed tokens)."""
+        svc = _svc()
+        raw = "https://api.example.com/v1?token=supersecret&user=alice"
+        out = svc.scrub_stream(raw)
+        assert "supersecret" not in out
+        assert "alice" not in out
+        assert "example.com" in out
+
+    def test_home_path_replaced(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("/home/alice/.ssh/id_rsa")
+        assert "/home/alice" not in out
+        assert "/home/user" in out
+
+    def test_log_group_name_replaced(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("/aws/lambda/my-secret-function")
+        assert "my-secret-function" not in out
+        assert "/aws/lambda/" in out
+
+    def test_s3_uri_replaced(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("s3://my-company-prod-data/logs/2024.log")
+        assert "my-company-prod-data" not in out
+        assert "s3://" in out
+
+    def test_composition_full_line(self) -> None:
+        """Simulate a realistic log line with multiple redactable elements."""
+        svc = _svc()
+        raw = (
+            "1.2.3.4 requested s3://acme-bucket/obj "
+            "via arn:aws:iam::123456789012:role/deployer "
+            "from /home/alice/.aws AKIAIOSFODNN7EXAMPLE"
+        )
+        out = svc.scrub_stream(raw)
+        assert "1.2.3.4" not in out
+        assert "acme-bucket" not in out
+        assert "123456789012" not in out
+        assert "/home/alice" not in out
+        assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+
+# ---------------------------------------------------------------------------
+# TestScrubStreamIdempotence — double-scrubbing must not change the output
+# ---------------------------------------------------------------------------
+
+
+_IDEMPOTENCE_CASES = [
+    ("empty string", ""),
+    ("plain text", "hello world"),
+    ("IP already doc-range", "203.0.113.42"),
+    ("redacted tag literal", "<redacted:aws-access-key>"),
+    ("scrubbed ARN", "arn:aws:iam::000000000000:user/alice"),
+    ("scrubbed home path", "/home/user/.ssh/id_rsa"),
+    ("realistic log line", "INFO request from 10.0.0.1 to /api/v1 status=200"),
+    # ISSUE-3 regression: log group and s3 URI must be idempotent
+    ("log group with name", "/aws/lambda/my-function"),
+    ("s3 uri", "s3://my-bucket-name/prefix"),
+    # L2 regression: ECR host with zeroed account must remain unchanged
+    ("ecr host zeroed", "000000000000.dkr.ecr.us-east-1.amazonaws.com"),
+    # L3 regression: already-scrubbed IPv6 doc-range must remain unchanged
+    ("ipv6 doc range", "2001:db8::1"),
+]
+
+
+@pytest.mark.parametrize(("label", "text"), _IDEMPOTENCE_CASES)
+def test_scrub_stream_idempotent(label: str, text: str) -> None:
+    """scrub_stream(scrub_stream(s)) == scrub_stream(s) for all inputs."""
+    svc = _svc()
+    once = svc.scrub_stream(text)
+    twice = svc.scrub_stream(once)
+    assert once == twice, (
+        f"[{label}] Idempotence failure:\n"
+        f"  once:  {once!r}\n"
+        f"  twice: {twice!r}"
+    )
+
+
+def test_scrub_stream_idempotent_composite_line() -> None:
+    """Complex line with multiple categories must be idempotent."""
+    svc = _svc()
+    raw = (
+        "1.2.3.4 AKIAIOSFODNN7EXAMPLE arn:aws:iam::123456789012:user/alice "
+        "/home/alice/.aws https://api.acme.com/v1?token=xyz"
+    )
+    once = svc.scrub_stream(raw)
+    twice = svc.scrub_stream(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# TestRedactIpIdempotenceGuard — REGRESSION for the _DOC_NETS short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestRedactIpIdempotenceGuard:
+    def test_doc_range_ip_returned_unchanged(self) -> None:
+        """A doc-range IP fed to redact_ip must be returned as-is."""
+        svc = _svc()
+        for net in _DOC_NETS:
+            doc_ip = f"{net}.1"
+            result = svc.redact_ip(doc_ip)
+            assert result == doc_ip, (
+                f"Doc-range IP {doc_ip!r} was re-mapped to {result!r}"
+            )
+
+    def test_real_ip_not_short_circuited(self) -> None:
+        """A non-doc-range IP must still be replaced."""
+        svc = _svc()
+        result = svc.redact_ip("1.2.3.4")
+        assert result != "1.2.3.4"
+        assert any(result.startswith(net + ".") for net in _DOC_NETS)
+
+    def test_scrub_stream_double_pass_does_not_reshuf_ip(self) -> None:
+        """After first scrub the IP is doc-range; second scrub must not change it."""
+        svc = _svc()
+        raw = "attack from 8.8.8.8"
+        once = svc.scrub_stream(raw)
+        twice = svc.scrub_stream(once)
+        assert once == twice
+
+    def test_toggle_path_regression(self) -> None:
+        """Simulates ON→scrub→ON again: same service, same input → same output."""
+        svc = _svc()
+        line = "ssh login from 45.33.32.156"
+        first = svc.scrub_stream(line)
+        # Second call (simulating re-render after toggle)
+        second = svc.scrub_stream(line)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# TestScrubStreamAllSecretCategories — positive hits for all categories
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStreamAllSecretCategories:
+    """Each _REDACTORS entry plus JWT and every new primitive must fire."""
+
+    def test_aws_access_key(self) -> None:
+        svc = _svc()
+        assert "<redacted:aws-access-key>" in svc.scrub_stream("AKIAIOSFODNN7EXAMPLE")
+
+    def test_aws_secret_key_labelled(self) -> None:
+        svc = _svc()
+        raw = "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        assert "<redacted:aws-secret-key>" in svc.scrub_stream(raw)
+
+    def test_github_classic_pat(self) -> None:
+        svc = _svc()
+        raw = "ghp_1234567890abcdefghijABCDEFGHIJKL1234"
+        assert "<redacted:github-token>" in svc.scrub_stream(raw)
+
+    def test_github_fine_grained_pat(self) -> None:
+        svc = _svc()
+        raw = "github_pat_" + "A" * 22 + "_" + "B" * 59
+        assert "<redacted:github-token>" in svc.scrub_stream(raw)
+
+    def test_github_oauth_token(self) -> None:
+        svc = _svc()
+        assert "<redacted:github-token>" in svc.scrub_stream(
+            "gho_1234567890abcdefghijABCDEFGHIJKL1234"
+        )
+
+    def test_ssh_private_key_block(self) -> None:
+        svc = _svc()
+        raw = (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nMIIJKAIBAAKCAgEAx\n"
+            "-----END OPENSSH PRIVATE KEY-----"
+        )
+        assert "<redacted:ssh-private-key>" in svc.scrub_stream(raw)
+
+    def test_bearer_token(self) -> None:
+        svc = _svc()
+        raw = "Authorization: Bearer abc123XYZ-_=sometokenmaterialhere"
+        assert "<redacted:bearer-token>" in svc.scrub_stream(raw)
+
+    def test_password_literal(self) -> None:
+        svc = _svc()
+        assert "<redacted:password>" in svc.scrub_stream("password=hunter2xyz")
+
+    def test_slack_token(self) -> None:
+        svc = _svc()
+        raw = "xoxb-1234567890-1234567890-1234567890-abcdefghijklmnopqrstuvwx"
+        assert "<redacted:slack-token>" in svc.scrub_stream(raw)
+
+    def test_stripe_key(self) -> None:
+        svc = _svc()
+        assert "<redacted:stripe-key>" in svc.scrub_stream(
+            "sk_test_51ABCDEFghijklmnopqrstuvwx"
+        )
+
+    def test_db_conn_string(self) -> None:
+        svc = _svc()
+        raw = "postgres://appuser:appPw123@db.internal:5432/appdb"
+        out = svc.scrub_stream(raw)
+        assert "<redacted:conn-user>" in out
+        assert "<redacted:conn-pass>" in out
+
+    def test_jwt(self) -> None:
+        svc = _svc()
+        raw = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkFsaWNlIn0."
+            "abc_def-012345678"
+        )
+        assert "<redacted:jwt>" in svc.scrub_stream(raw)
+
+    # New primitives
+    def test_arn(self) -> None:
+        svc = _svc()
+        raw = "arn:aws:iam::123456789012:user/alice"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" not in out
+        assert "000000000000" in out
+
+    def test_arn_lambda(self) -> None:
+        svc = _svc()
+        raw = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" not in out
+
+    def test_bare_account_id(self) -> None:
+        svc = _svc()
+        # bare 12-digit
+        out = svc.scrub_stream("account 123456789012 billed")
+        assert "123456789012" not in out
+        assert "000000000000" in out
+
+    def test_bare_account_id_not_15_digit(self) -> None:
+        """15-digit numbers (e.g. GCP project numbers) must NOT be shredded."""
+        svc = _svc()
+        raw = "gcp project 123456789012345"
+        out = svc.scrub_stream(raw)
+        assert "123456789012345" in out
+
+    def test_path_home(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("/home/alice/.ssh/id_rsa")
+        assert "/home/alice" not in out
+        assert "/home/user" in out
+
+    def test_path_users(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("/Users/bob/Documents/secret.txt")
+        assert "/Users/bob" not in out
+        assert "/Users/user" in out
+
+    def test_url_host_replaced(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("https://internal.company.com/api")
+        assert "internal.company.com" not in out
+        assert "example.com" in out
+
+    def test_url_query_stripped(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("https://api.example.com/v1?token=abc&user=alice")
+        assert "token=abc" not in out
+        assert "user=alice" not in out
+
+    def test_log_group(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("/aws/lambda/my-secret-function")
+        assert "my-secret-function" not in out
+
+    def test_s3_uri(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("s3://company-prod-bucket/logs")
+        assert "company-prod-bucket" not in out
+        assert "s3://" in out
+
+    def test_s3_quoted_not_redacted(self) -> None:
+        """Quoted bucket names without s3:// are NOT redacted (ISSUE-5 fix).
+
+        The quoted-name regex was too broad and matched everyday prose.
+        Only s3:// URIs are redacted. See docs/demo-mode.md Known Limitations.
+        """
+        svc = _svc()
+        out = svc.scrub_stream('"company-prod-bucket"')
+        # Quoted-only names are now intentionally left alone
+        assert "company-prod-bucket" in out
+
+
+# ---------------------------------------------------------------------------
+# TestScrubStreamEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStreamEdgeCases:
+    def test_none_returns_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.scrub_stream(None) == ""
+
+    def test_empty_string_returns_empty_string(self) -> None:
+        svc = _svc()
+        assert svc.scrub_stream("") == ""
+
+    def test_non_str_coerced(self) -> None:
+        svc = _svc()
+        # 42 → "42"
+        assert svc.scrub_stream(42) == "42"  # type: ignore[arg-type]
+
+    def test_short_string_no_ip(self) -> None:
+        svc = _svc()
+        assert svc.scrub_stream("ok") == "ok"
+
+    def test_single_ip_in_line(self) -> None:
+        svc = _svc()
+        out = svc.scrub_stream("from 1.2.3.4")
+        assert "1.2.3.4" not in out
+
+    def test_kill_switch_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SERVONAUT_DEMO_DISABLE_STREAM=1 must return input unchanged."""
+        monkeypatch.setenv("SERVONAUT_DEMO_DISABLE_STREAM", "1")
+        svc = _svc()
+        raw = "1.2.3.4 AKIAIOSFODNN7EXAMPLE"
+        assert svc.scrub_stream(raw) == raw
+
+    def test_kill_switch_unset_still_scrubs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SERVONAUT_DEMO_DISABLE_STREAM", raising=False)
+        svc = _svc()
+        raw = "AKIAIOSFODNN7EXAMPLE"
+        assert "<redacted:aws-access-key>" in svc.scrub_stream(raw)
+
+    def test_no_false_positive_on_redacted_tag(self) -> None:
+        """The literal <redacted:...> placeholder must not be re-tagged."""
+        svc = _svc()
+        raw = "<redacted:aws-access-key>"
+        assert svc.scrub_stream(raw) == raw
+
+    def test_timestamp_not_shredded(self) -> None:
+        """ISSUE-4 regression: 12-digit run inside a timestamp must not be replaced."""
+        svc = _svc()
+        raw = "2024-01-15T10:23:45.123456789012Z"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" in out, (
+            f"Timestamp digit run was incorrectly redacted: {out!r}"
+        )
+
+    def test_request_id_with_dots_not_shredded(self) -> None:
+        """ISSUE-4 regression: 12-digit run flanked by dots must not be replaced."""
+        svc = _svc()
+        raw = "req.123456789012.status=200"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" in out, (
+            f"Request-ID digit run was incorrectly redacted: {out!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestScrubStreamPerformance — 10 000 typical log lines under 1 s
+# ---------------------------------------------------------------------------
+
+
+class TestScrubStreamPerformance:
+    def test_10k_lines_under_1s(self) -> None:
+        """10 000 typical 80-char log lines processed under 1 second."""
+        svc = _svc()
+        line = "INFO 2024-01-15 10:23:45 request from 10.0.0.1 to /api/v1 status=200 in 45ms"
+        lines = [line] * 10_000
+
+        start = time.perf_counter()
+        for ln in lines:
+            svc.scrub_stream(ln)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0, (
+            f"scrub_stream too slow: {elapsed:.3f}s for 10 000 lines "
+            f"({elapsed * 100:.1f} ms/1000 lines)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestEcrHostScrub — L2: ECR hostname account-ID redaction
+# ---------------------------------------------------------------------------
+
+
+class TestEcrHostScrub:
+    """ECR hostnames must have their account-ID component replaced."""
+
+    def test_ecr_host_account_replaced(self) -> None:
+        svc = _svc()
+        raw = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" not in out, f"Account leaked in ECR host: {out!r}"
+        assert "000000000000" in out
+        assert "dkr.ecr.us-east-1.amazonaws.com" in out
+
+    def test_ecr_host_in_docker_pull_command(self) -> None:
+        svc = _svc()
+        raw = "docker pull 123456789012.dkr.ecr.eu-west-1.amazonaws.com/myapp:latest"
+        out = svc.scrub_stream(raw)
+        assert "123456789012" not in out
+        assert "000000000000" in out
+
+    def test_ecr_host_idempotent(self) -> None:
+        svc = _svc()
+        raw = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+        once = svc.scrub_stream(raw)
+        twice = svc.scrub_stream(once)
+        assert once == twice, (
+            f"ECR host scrub is not idempotent:\n  once:  {once!r}\n  twice: {twice!r}"
+        )
+
+    def test_non_ecr_host_not_affected(self) -> None:
+        """Regular hostnames must not be affected by the ECR pattern."""
+        svc = _svc()
+        raw = "internal.company.com"
+        out = svc.scrub_stream(raw)
+        # URL scrubber will replace it, but not the ECR pattern
+        assert "000000000000" not in out
+
+
+# ---------------------------------------------------------------------------
+# TestIpv6Scrub — L3: IPv6 address redaction
+# ---------------------------------------------------------------------------
+
+
+class TestIpv6Scrub:
+    """IPv6 addresses must be replaced with 2001:db8::1."""
+
+    def test_full_ipv6_replaced(self) -> None:
+        svc = _svc()
+        raw = "login from fe80::1234:5678:abcd:ef01"
+        out = svc.scrub_stream(raw)
+        assert "fe80::1234:5678:abcd:ef01" not in out
+        assert "2001:db8::1" in out
+
+    def test_abbreviated_ipv6_replaced(self) -> None:
+        svc = _svc()
+        raw = "address 2001:db8:85a3::8a2e:370:7334"
+        # Note: the doc-range address 2001:db8::1 is the scrubbed output
+        out = svc.scrub_stream(raw)
+        # The original address must not remain
+        assert "2001:db8:85a3" not in out
+
+    def test_mac_address_not_replaced(self) -> None:
+        """MAC address aa:bb:cc:dd:ee:ff must NOT be matched by _IPV6_RE.
+
+        MAC addresses have 5 colons but their segments use exactly 2 hex chars
+        each. The _IPV6_RE requires \\b word-boundaries around hex chars
+        followed by colon — MAC addresses are typically preceded by a space or
+        punctuation, so \\b fires. However, {2,7} requires at minimum 3 colon
+        groups; a MAC has 5 (aa:bb:cc:dd:ee:ff → 5 colons, 6 groups of 2 hex
+        chars). This means MAC addresses ARE technically matched by our regex.
+
+        This is a known limitation: see docs/demo-mode.md. The test documents
+        the current behavior so any future change is visible.
+        """
+        svc = _svc()
+        raw = "mac a1:b2:c3:d4:e5:f6"
+        out = svc.scrub_stream(raw)
+        # Document the current behavior — MAC is matched (known limitation)
+        # If the behavior changes in the future, update this test + docs.
+        # For now, false-positive is acceptable: a MAC in a log is not a
+        # privacy concern, and the scrubbed value is harmless.
+        # So this test is intentionally permissive.
+        assert isinstance(out, str)  # sanity check — must return a string
+
+    def test_ipv6_idempotent(self) -> None:
+        svc = _svc()
+        raw = "request from fe80::1234:5678:abcd:ef01"
+        once = svc.scrub_stream(raw)
+        twice = svc.scrub_stream(once)
+        assert once == twice, (
+            f"IPv6 scrub is not idempotent:\n  once:  {once!r}\n  twice: {twice!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestRedactEmail — email address redaction unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedactEmail:
+    """redact_email: local-part → fake-name, domain → example.com."""
+
+    def test_basic_email_redacted(self) -> None:
+        svc = _svc()
+        result = svc.redact_email("Contact john.doe@company.com for help.")
+        assert "@company.com" not in result
+        assert "john.doe" not in result
+        assert "@example.com" in result
+
+    def test_email_local_part_deterministic(self) -> None:
+        svc = _svc()
+        r1 = svc.redact_email("user@example.org")
+        r2 = svc.redact_email("user@example.org")
+        assert r1 == r2, "Same email must map to same fake consistently"
+
+    def test_different_emails_different_fakes(self) -> None:
+        svc = _svc()
+        r1 = svc.redact_email("alice@corp.io")
+        r2 = svc.redact_email("bob@corp.io")
+        # Both should point at example.com but different local parts
+        assert "@corp.io" not in r1
+        assert "@corp.io" not in r2
+
+    def test_idempotence_via_scrub_stream(self) -> None:
+        """scrub_stream(scrub_stream(email_text)) == scrub_stream(email_text)."""
+        svc = _svc()
+        raw = "jane.smith@enterprise.example triggered event"
+        once = svc.scrub_stream(raw)
+        twice = svc.scrub_stream(once)
+        assert once == twice, (
+            f"Email scrub is not idempotent:\n  once:  {once!r}\n  twice: {twice!r}"
+        )
+
+    def test_already_example_com_passes_through(self) -> None:
+        """Addresses at example.com where local part is already a fake name
+        should pass through unchanged (idempotence guard)."""
+        svc = _svc()
+        # Force a fake name into the pool by redacting a real name first
+        fake = svc.redact_name("alice")
+        # Now an email with that fake local part at example.com
+        addr = f"{fake}@example.com"
+        result = svc.redact_email(addr)
+        # The address should be left unchanged
+        assert result == addr, (
+            f"Idempotence failed: fake local part was re-replaced.\n"
+            f"  input:  {addr!r}\n  output: {result!r}"
+        )
+
+    def test_sso_username_format(self) -> None:
+        """AWS SSO usernames like john.doe@company.com in CloudTrail."""
+        svc = _svc()
+        text = "AssumedRole by john.doe@company.com via AWS SSO"
+        result = svc.scrub_stream(text)
+        assert "@company.com" not in result
+        assert "john.doe" not in result
+
+    def test_url_consumed_before_email(self) -> None:
+        """URL-embedded user:pass@host must not be mis-matched as email."""
+        svc = _svc()
+        raw = "connecting to https://user:pass@internal.host.com/path"
+        result = svc.scrub_stream(raw)
+        # URL regex consumes it first; internal.host.com becomes example.com
+        # The 'pass@' part should not produce 'pass@example.com' output
+        assert "internal.host.com" not in result
+
+    def test_email_corpus(self) -> None:
+        """Corpus covering common email formats seen in AWS CloudTrail logs."""
+        svc = _svc()
+        corpus = [
+            "admin@aws-example.com",
+            "service+tag@domain.co.uk",
+            "first.last+role@sub.domain.org",
+            "ci-bot@github.com",
+            "123numeric@numbers.com",
+        ]
+        for addr in corpus:
+            result = svc.redact_email(addr)
+            domain = addr.split("@", 1)[1]
+            assert domain not in result, (
+                f"Domain {domain!r} not redacted in {result!r}"
+            )
+            assert "@example.com" in result, (
+                f"Expected @example.com in {result!r} for input {addr!r}"
+            )

--- a/tests/test_team_management_screen.py
+++ b/tests/test_team_management_screen.py
@@ -68,6 +68,9 @@ class _WrapperApp(App):
         self.auth_service = auth_service
         self.team_service = team_service
         self.instances = instances or []
+        # Required by TeamManagementScreen's demo-mode guards.
+        self.demo_mode = False
+        self.redaction_service = None
 
     def on_mount(self) -> None:
         self.push_screen(TeamManagementScreen())


### PR DESCRIPTION
## Description of Changes

This branch bundles one feature and two fixes.

### 1. Demo-mode full-surface redaction — `feat(demo)`

A `--demo` CLI flag plus a `Ctrl+Shift+D` runtime toggle that scrubs every
user-visible streamed string before it reaches the screen — for safely
recording a launch/demo video. Redaction is centralised in
`RedactionService.scrub_stream`, with 9 new primitives (ARN, account ID,
ECR host, IPv4/IPv6, path, URL, log group, email) and an AST lint sweep
over all screens/widgets.

Fully opt-in and inert by default: `demo_mode` defaults to `False`,
`redaction_service` defaults to `None`, and **all 90 redaction call sites
are guarded** (verified by an exhaustive sweep). Normal (no-`--demo`)
operation is byte-for-byte unchanged — the redaction engine is never even
instantiated.

### 2. Config-load hardening — `fix(config)`

`ConfigManager._deserialize` only filtered unknown keys for the top-level
`AppConfig` and `HetznerConfig`. Every other nested config (`memory`,
`ovh`, `relay`, `mcp`, `ai_provider`, `gcp`, `azure`) and list item
crashed dataclass construction when the on-disk config carried a field
removed in a newer release. The crash dropped the load to defaults, and
the next save silently overwrote the user's real config — silent data
loss. A single `_coerce()` helper now drops unknown keys uniformly across
every nested config and list item.

### 3. OVH credential feedback — `feat(ovh)`

Every OVH fetch helper swallows API errors and returns `[]`, so a revoked
or expired credential rendered as a misleading empty state ("No OVH
instances", an empty domains table, blank billing panels). New
`OVHService.check_credentials()` — a lightweight `GET /me` probe — lets
the OVH Manager, DNS, and Billing screens distinguish "genuinely empty"
from "credentials invalid" and show an actionable, in-context error.

## Testing

- Full suite: **3615 passed** (8 pre-existing `hcloud`-optional Hetzner
  failures, unrelated to this branch).
- New coverage: `test_demo_mode_coverage`, `test_demo_mode_lint`,
  `test_redaction_stream`, `test_redaction_service_gaps`,
  `test_ovh_screen_feedback`, plus `check_credentials` /
  `_classify_ovh_error` tests.
- Demo-mode AST lint sweep over every screen/widget passes.
- OVH credential feedback live-verified against a real credential failure.

## Related Issues

_None._
