### PR TITLE
feat(mcp): add CloudWatch, CloudTrail, and IP-ban tools

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -375,6 +375,9 @@ class ServonautApp(App):
             audit=AuditTrail(config.mcp.audit_path),
             ovh_service=self.ovh_service,
             hetzner_service=self.hetzner_service,
+            cloudtrail_service=self.cloudtrail_service,
+            cloudwatch_service=self.cloudwatch_service,
+            ip_ban_service=self.ip_ban_service,
             auth_service=self.auth_service,
             memory_service=self.memory_service,
         )

--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -67,6 +67,12 @@ class CommandGuard:
             # Hetzner — readonly catalogue / inventory queries.
             'hetzner_list_servers', 'hetzner_list_server_types',
             'hetzner_list_ssh_keys',
+            # AWS CloudWatch Logs / CloudTrail — purely read-only AWS API
+            # queries (describe / filter / lookup); they mutate nothing.
+            'cloudwatch_list_log_groups', 'cloudwatch_get_log_events',
+            'cloudwatch_top_ips', 'cloudtrail_lookup_events',
+            # IP ban inventory — reads existing WAF/SG/NACL state only.
+            'ip_ban_list_configs', 'ip_ban_list_banned',
         }
         standard_tools = readonly_tools | {
             'run_command', 'get_logs',
@@ -94,6 +100,10 @@ class CommandGuard:
         }
         dangerous_tools = standard_tools | {
             'transfer_file',
+            # IP ban mutation — adds/removes a deny rule in WAF, a security
+            # group, or a NACL. Security-sensitive and immediately affects
+            # live traffic, so it stays at the dangerous tier.
+            'ip_ban_set',
             # Mutating tools that cost money / cannot be undone without
             # re-creating from scratch. Reserved for dangerous mode.
             'hetzner_create_server', 'hetzner_delete_server',

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -132,6 +132,23 @@ def create_mcp_server():
     except Exception as e:
         logger.error("Failed to initialize OVH service for MCP: %s", e)
 
+    # AWS CloudWatch / CloudTrail / IP-ban services — dependency-light
+    # (boto3 is a required dependency; AWS credentials resolve through the
+    # same default chain as AWSService), so they're wired unconditionally.
+    cloudtrail_service = None
+    cloudwatch_service = None
+    ip_ban_service = None
+    try:
+        from servonaut.services.cloudtrail_service import CloudTrailService
+        from servonaut.services.cloudwatch_service import CloudWatchService
+        from servonaut.services.ip_ban_service import IPBanService
+        cloudtrail_service = CloudTrailService(config_manager)
+        cloudwatch_service = CloudWatchService()
+        ip_ban_service = IPBanService(config_manager)
+        logger.info("CloudWatch/CloudTrail/IP-ban services initialized for MCP")
+    except Exception as e:
+        logger.error("Failed to initialize AWS security services for MCP: %s", e)
+
     tools = ServonautTools(
         config_manager, aws_service, custom_server_service, cache_service,
         ssh_service, connection_service, scp_service,
@@ -144,6 +161,9 @@ def create_mcp_server():
         ovh_billing_service=ovh_billing_service,
         ovh_cloud_service=ovh_cloud_service,
         hetzner_service=hetzner_service,
+        cloudtrail_service=cloudtrail_service,
+        cloudwatch_service=cloudwatch_service,
+        ip_ban_service=ip_ban_service,
         auth_service=auth_service,
         memory_service=memory_service,
     )
@@ -186,9 +206,10 @@ def create_mcp_server():
         "hetzner_shutdown, hetzner_reboot, hetzner_create_ssh_key, "
         "ovh_create_instance, ovh_delete_instance, ovh_start_instance, "
         "ovh_stop_instance, ovh_reboot_instance, transfer_file, "
+        "ip_ban_set (bans/unbans an IP — affects live traffic), "
         "run_command (when the command itself mutates state). Read-only "
-        "tools (list_*, check_status, get_*, *_list_*, whoami) do NOT "
-        "require confirmation.\n"
+        "tools (list_*, check_status, get_*, *_list_*, whoami, "
+        "cloudwatch_*, cloudtrail_*) do NOT require confirmation.\n"
         "\n"
         "Servonaut enforces guard-tier permission separately: read tools "
         "run at any level, mutating tools only at standard or dangerous, "
@@ -201,10 +222,16 @@ def create_mcp_server():
     from servonaut.mcp.tool_schemas import mcp_tool_list
     have_ovh = ovh_service is not None
     have_hetzner = hetzner_service is not None
+    # IP-ban tools are only useful once at least one ban target is defined.
+    have_ip_ban = ip_ban_service is not None and bool(config.ip_ban_configs)
 
     @server.list_tools()
     async def list_tools():
-        return mcp_tool_list(have_ovh=have_ovh, have_hetzner=have_hetzner)
+        return mcp_tool_list(
+            have_ovh=have_ovh,
+            have_hetzner=have_hetzner,
+            have_ip_ban=have_ip_ban,
+        )
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict):

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -856,20 +856,239 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
         },
         "chat_exposed": True,
     },
+
+    # --- AWS CloudWatch Logs (read-only) --------------------------------
+    "cloudwatch_list_log_groups": {
+        "description": (
+            "List AWS CloudWatch log groups, optionally filtered by name "
+            "prefix. Shows stored bytes and retention per group."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "prefix": {
+                    "type": "string",
+                    "description": "Filter to log groups whose name starts "
+                                   "with this prefix.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region (defaults to the boto3 "
+                                   "default region when empty).",
+                },
+            },
+        },
+        "chat_exposed": True,
+    },
+    "cloudwatch_get_log_events": {
+        "description": (
+            "Fetch recent events from a CloudWatch log group within the "
+            "last N hours, with an optional CloudWatch filter pattern."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "log_group": {
+                    "type": "string",
+                    "description": "CloudWatch log group name.",
+                },
+                "hours_back": {
+                    "type": "integer",
+                    "description": "How many hours back to search.",
+                    "default": 1,
+                },
+                "filter_pattern": {
+                    "type": "string",
+                    "description": "CloudWatch Logs filter pattern (optional).",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region (optional).",
+                },
+                "max_events": {
+                    "type": "integer",
+                    "description": "Maximum events to return (0 = unlimited, "
+                                   "capped at 50000).",
+                    "default": 100,
+                },
+            },
+            "required": ["log_group"],
+        },
+        "chat_exposed": True,
+    },
+    "cloudwatch_top_ips": {
+        "description": (
+            "Rank the top client IPs in a CloudWatch log group. Parses "
+            "WAF/ALB structured logs to report per-IP total, allowed, and "
+            "blocked counts — use it to find abusive IPs before banning."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "log_group": {
+                    "type": "string",
+                    "description": "CloudWatch log group name (e.g. a WAF "
+                                   "or ALB access-log group).",
+                },
+                "hours_back": {
+                    "type": "integer",
+                    "description": "How many hours back to scan.",
+                    "default": 24,
+                },
+                "action_filter": {
+                    "type": "string",
+                    "description": "Count only events with this WAF action: "
+                                   "'ALLOW', 'BLOCK', or empty for all.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region (optional).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum IPs to return.",
+                    "default": 20,
+                },
+                "max_events": {
+                    "type": "integer",
+                    "description": "Maximum events to scan (0 = unlimited, "
+                                   "capped at 50000).",
+                    "default": 0,
+                },
+            },
+            "required": ["log_group"],
+        },
+        "chat_exposed": True,
+    },
+
+    # --- AWS CloudTrail (read-only) -------------------------------------
+    "cloudtrail_lookup_events": {
+        "description": (
+            "Look up AWS CloudTrail management events with optional filters "
+            "(event name, username, resource type). Useful for auditing who "
+            "changed what, and from which source IP."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string",
+                    "description": "AWS region. Empty queries the configured "
+                                   "default region (or all regions if unset).",
+                },
+                "hours_back": {
+                    "type": "integer",
+                    "description": "How many hours back to search. 0 uses the "
+                                   "configured default lookback.",
+                    "default": 0,
+                },
+                "event_name": {
+                    "type": "string",
+                    "description": "Filter by CloudTrail event name "
+                                   "(e.g. 'RunInstances').",
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Filter by the IAM username.",
+                },
+                "resource_type": {
+                    "type": "string",
+                    "description": "Filter by resource type "
+                                   "(e.g. 'AWS::EC2::Instance').",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum events to return (0 = unlimited, "
+                                   "capped at 10000).",
+                    "default": 50,
+                },
+            },
+        },
+        "chat_exposed": True,
+    },
+
+    # --- IP ban (WAF / Security Group / NACL) --------------------------
+    "ip_ban_list_configs": {
+        "description": (
+            "List the configured IP-ban targets (WAF IP sets, security "
+            "groups, or network ACLs) available for ip_ban_set."
+        ),
+        "schema": {"type": "object", "properties": {}},
+        "chat_exposed": True,
+        "required_service": "ip_ban",
+    },
+    "ip_ban_list_banned": {
+        "description": (
+            "List the IP addresses currently banned under a named IP-ban "
+            "configuration."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "config_name": {
+                    "type": "string",
+                    "description": "Name of the IP-ban config "
+                                   "(see ip_ban_list_configs).",
+                },
+            },
+            "required": ["config_name"],
+        },
+        "chat_exposed": True,
+        "required_service": "ip_ban",
+    },
+    "ip_ban_set": {
+        "description": (
+            "Ban or unban an IP address via a named WAF/SecurityGroup/NACL "
+            "config. Set action='ban' to block or action='unban' to remove "
+            "the block. Mutates live traffic rules — confirm with the user "
+            "first."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "ip_address": {
+                    "type": "string",
+                    "description": "The IPv4/IPv6 address to ban or unban.",
+                },
+                "config_name": {
+                    "type": "string",
+                    "description": "Name of the IP-ban config "
+                                   "(see ip_ban_list_configs).",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["ban", "unban"],
+                    "description": "'ban' to block the IP, 'unban' to remove "
+                                   "an existing block.",
+                    "default": "ban",
+                },
+            },
+            "required": ["ip_address", "config_name"],
+        },
+        "chat_exposed": True,
+        "required_service": "ip_ban",
+    },
 }
 
 
-def mcp_tool_list(have_ovh: bool = True, have_hetzner: bool = True) -> list:
+def mcp_tool_list(
+    have_ovh: bool = True,
+    have_hetzner: bool = True,
+    have_ip_ban: bool = True,
+) -> list:
     """Build the list of ``mcp.types.Tool`` objects for the MCP server.
 
-    Provider-gated tools (currently OVH and Hetzner) are dropped when
-    the corresponding service isn't wired up — agents querying
-    ``tools/list`` get a clean view of what's actually callable.
+    Service-gated tools are dropped when the corresponding capability isn't
+    available — agents querying ``tools/list`` get a clean view of what's
+    actually callable. OVH and Hetzner are gated on the provider service
+    being wired up; ``ip_ban`` is gated on at least one ban configuration
+    existing (the service itself is always present).
     """
     from mcp.types import Tool
     gates = {
         'ovh': have_ovh,
         'hetzner': have_hetzner,
+        'ip_ban': have_ip_ban,
     }
     out = []
     for name, spec in TOOL_SCHEMAS.items():

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -52,6 +52,8 @@ class ServonautTools:
                  ovh_snapshot_service=None, ovh_dns_service=None,
                  ovh_billing_service=None, ovh_cloud_service=None,
                  hetzner_service=None,
+                 cloudtrail_service=None, cloudwatch_service=None,
+                 ip_ban_service=None,
                  auth_service=None, memory_service=None) -> None:
         self._config_manager = config_manager
         self._aws_service = aws_service
@@ -70,6 +72,9 @@ class ServonautTools:
         self._ovh_billing_service = ovh_billing_service
         self._ovh_cloud_service = ovh_cloud_service
         self._hetzner_service = hetzner_service
+        self._cloudtrail_service = cloudtrail_service
+        self._cloudwatch_service = cloudwatch_service
+        self._ip_ban_service = ip_ban_service
         self._auth_service = auth_service
         self._memory_service = memory_service
         self._max_lines = config_manager.get().mcp.max_output_lines
@@ -1761,6 +1766,391 @@ class ServonautTools:
             'ovh_reboot_instance', 'reboot_instance',
             instance_id, provider_type, 'reboot sent',
         )
+
+    # ------------------------------------------------------------------
+    # AWS CloudWatch Logs tools (read-only)
+    # ------------------------------------------------------------------
+
+    async def cloudwatch_list_log_groups(
+        self, prefix: str = "", region: str = ""
+    ) -> str:
+        """List CloudWatch log groups, optionally filtered by name prefix."""
+        args = {'prefix': prefix, 'region': region}
+        allowed, reason = self._guard.check_tool('cloudwatch_list_log_groups')
+        if not allowed:
+            self._audit.log('cloudwatch_list_log_groups', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._cloudwatch_service is None:
+            self._audit.log(
+                'cloudwatch_list_log_groups', args, '', False, 'service_unavailable',
+            )
+            return "Error: CloudWatch service is not available."
+
+        try:
+            groups = await self._cloudwatch_service.list_log_groups(prefix, region)
+        except Exception as e:
+            self._audit.log(
+                'cloudwatch_list_log_groups', args, '', False, f"api_error: {e}",
+            )
+            return f"Error listing CloudWatch log groups: {e}"
+
+        if not groups:
+            self._audit.log('cloudwatch_list_log_groups', args, '0 groups', True)
+            return "No CloudWatch log groups found."
+
+        lines = [
+            f"CloudWatch log groups ({len(groups)} total):",
+            f"  {'Name':<56} {'Stored bytes':<14} Retention",
+            '  ' + '-' * 86,
+        ]
+        for g in groups:
+            retention = g.get('retention_days')
+            retention_str = f"{retention}d" if retention else "never expire"
+            lines.append(
+                f"  {str(g.get('name', ''))[:56]:<56} "
+                f"{str(g.get('stored_bytes', 0)):<14} {retention_str}"
+            )
+
+        result = '\n'.join(lines)
+        self._audit.log('cloudwatch_list_log_groups', args, result, True)
+        return result
+
+    async def cloudwatch_get_log_events(
+        self, log_group: str, hours_back: int = 1,
+        filter_pattern: str = "", region: str = "", max_events: int = 100,
+    ) -> str:
+        """Get recent log events from a CloudWatch log group."""
+        args = {
+            'log_group': log_group, 'hours_back': hours_back,
+            'filter_pattern': filter_pattern, 'region': region,
+            'max_events': max_events,
+        }
+        allowed, reason = self._guard.check_tool('cloudwatch_get_log_events')
+        if not allowed:
+            self._audit.log('cloudwatch_get_log_events', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._cloudwatch_service is None:
+            self._audit.log(
+                'cloudwatch_get_log_events', args, '', False, 'service_unavailable',
+            )
+            return "Error: CloudWatch service is not available."
+
+        from datetime import datetime, timedelta
+        end_time = datetime.utcnow()
+        start_time = end_time - timedelta(hours=max(int(hours_back), 1))
+
+        try:
+            events = await self._cloudwatch_service.get_log_events(
+                log_group, start_time, end_time,
+                filter_pattern, region, max_events,
+            )
+        except Exception as e:
+            self._audit.log(
+                'cloudwatch_get_log_events', args, '', False, f"api_error: {e}",
+            )
+            return f"Error fetching CloudWatch log events: {e}"
+
+        if not events:
+            self._audit.log('cloudwatch_get_log_events', args, '0 events', True)
+            return f"No log events in {log_group} for the last {hours_back}h."
+
+        lines = [
+            f"CloudWatch events: {log_group} "
+            f"(last {hours_back}h, {len(events)} events)"
+        ]
+        display = events
+        if len(display) > self._max_lines:
+            display = display[-self._max_lines:]
+            lines.append(
+                f"... (showing the most recent {self._max_lines} "
+                f"of {len(events)} events)"
+            )
+        for e in display:
+            ts = e.get('timestamp')
+            ts_str = (
+                ts.isoformat(sep=' ', timespec='seconds')
+                if hasattr(ts, 'isoformat') else str(ts)
+            )
+            msg = str(e.get('message', '')).rstrip()
+            lines.append(f"  [{ts_str}] {msg}")
+
+        result = '\n'.join(lines)
+        self._audit.log('cloudwatch_get_log_events', args, result, True)
+        return result
+
+    async def cloudwatch_top_ips(
+        self, log_group: str, hours_back: int = 24,
+        action_filter: str = "", region: str = "",
+        limit: int = 20, max_events: int = 0,
+    ) -> str:
+        """Rank the top client IPs seen in a CloudWatch log group.
+
+        Parses WAF/ALB structured JSON logs to extract ``clientIp`` and the
+        WAF ``action``, returning per-IP allowed/blocked counts. Use this to
+        spot abusive IPs before banning them with ``ip_ban_set``.
+        """
+        args = {
+            'log_group': log_group, 'hours_back': hours_back,
+            'action_filter': action_filter, 'region': region,
+            'limit': limit, 'max_events': max_events,
+        }
+        allowed, reason = self._guard.check_tool('cloudwatch_top_ips')
+        if not allowed:
+            self._audit.log('cloudwatch_top_ips', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._cloudwatch_service is None:
+            self._audit.log(
+                'cloudwatch_top_ips', args, '', False, 'service_unavailable',
+            )
+            return "Error: CloudWatch service is not available."
+
+        action = (action_filter or "").strip().upper()
+        if action and action not in ('ALLOW', 'BLOCK'):
+            self._audit.log(
+                'cloudwatch_top_ips', args, '', False, 'invalid_action_filter',
+            )
+            return (
+                f"Error: action_filter must be 'ALLOW', 'BLOCK', or empty; "
+                f"got {action_filter!r}."
+            )
+
+        from datetime import datetime, timedelta
+        end_time = datetime.utcnow()
+        start_time = end_time - timedelta(hours=max(int(hours_back), 1))
+
+        try:
+            events = await self._cloudwatch_service.get_log_events(
+                log_group, start_time, end_time, "", region, max_events,
+            )
+        except Exception as e:
+            self._audit.log(
+                'cloudwatch_top_ips', args, '', False, f"api_error: {e}",
+            )
+            return f"Error fetching CloudWatch log events: {e}"
+
+        top = self._cloudwatch_service.extract_top_ips(
+            events, limit, action or None,
+        )
+        if not top:
+            self._audit.log('cloudwatch_top_ips', args, '0 ips', True)
+            return (
+                f"No client IPs found in {log_group} over the last "
+                f"{hours_back}h ({len(events)} events scanned)."
+            )
+
+        filt_note = f", action={action}" if action else ""
+        lines = [
+            f"Top {len(top)} client IPs in {log_group} "
+            f"(last {hours_back}h, {len(events)} events{filt_note}):",
+            f"  {'IP':<22} {'Total':<10} {'Allowed':<10} {'Blocked':<10}",
+            '  ' + '-' * 54,
+        ]
+        for row in top:
+            lines.append(
+                f"  {str(row.get('ip', '')):<22} "
+                f"{str(row.get('count', 0)):<10} "
+                f"{str(row.get('allowed', 0)):<10} "
+                f"{str(row.get('blocked', 0)):<10}"
+            )
+
+        result = '\n'.join(lines)
+        self._audit.log('cloudwatch_top_ips', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # AWS CloudTrail tools (read-only)
+    # ------------------------------------------------------------------
+
+    async def cloudtrail_lookup_events(
+        self, region: str = "", hours_back: int = 0,
+        event_name: str = "", username: str = "",
+        resource_type: str = "", max_results: int = 50,
+    ) -> str:
+        """Look up AWS CloudTrail management events with optional filters."""
+        args = {
+            'region': region, 'hours_back': hours_back,
+            'event_name': event_name, 'username': username,
+            'resource_type': resource_type, 'max_results': max_results,
+        }
+        allowed, reason = self._guard.check_tool('cloudtrail_lookup_events')
+        if not allowed:
+            self._audit.log('cloudtrail_lookup_events', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._cloudtrail_service is None:
+            self._audit.log(
+                'cloudtrail_lookup_events', args, '', False, 'service_unavailable',
+            )
+            return "Error: CloudTrail service is not available."
+
+        start_time = None
+        if hours_back and int(hours_back) > 0:
+            from datetime import datetime, timedelta
+            start_time = datetime.utcnow() - timedelta(hours=int(hours_back))
+
+        try:
+            events = await self._cloudtrail_service.lookup_events(
+                region=region, start_time=start_time,
+                event_name=event_name, username=username,
+                resource_type=resource_type, max_results=max_results,
+            )
+        except Exception as e:
+            self._audit.log(
+                'cloudtrail_lookup_events', args, '', False, f"api_error: {e}",
+            )
+            return f"Error looking up CloudTrail events: {e}"
+
+        if not events:
+            self._audit.log('cloudtrail_lookup_events', args, '0 events', True)
+            return "No CloudTrail events matched the given filters."
+
+        lines = [
+            f"CloudTrail events ({len(events)} found):",
+            f"  {'Time':<20} {'Event':<26} {'User':<20} "
+            f"{'Source IP':<16} {'Region':<14} Error",
+            '  ' + '-' * 110,
+        ]
+        for e in events:
+            ev_time = e.get('event_time', '')
+            ev_time_str = (
+                ev_time.isoformat(sep=' ', timespec='seconds')
+                if hasattr(ev_time, 'isoformat') else str(ev_time)
+            )
+            lines.append(
+                f"  {ev_time_str[:20]:<20} "
+                f"{str(e.get('event_name', ''))[:26]:<26} "
+                f"{str(e.get('username', ''))[:20]:<20} "
+                f"{str(e.get('source_ip', ''))[:16]:<16} "
+                f"{str(e.get('region', ''))[:14]:<14} "
+                f"{e.get('error_code', '')}"
+            )
+
+        result = '\n'.join(lines)
+        self._audit.log('cloudtrail_lookup_events', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # IP ban tools (WAF / Security Group / NACL)
+    # ------------------------------------------------------------------
+
+    async def ip_ban_list_configs(self) -> str:
+        """List the configured IP-ban targets (WAF IP sets, SGs, NACLs)."""
+        allowed, reason = self._guard.check_tool('ip_ban_list_configs')
+        if not allowed:
+            self._audit.log('ip_ban_list_configs', {}, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._ip_ban_service is None:
+            self._audit.log(
+                'ip_ban_list_configs', {}, '', False, 'service_unavailable',
+            )
+            return "Error: IP ban service is not available."
+
+        configs = self._ip_ban_service.get_configs()
+        if not configs:
+            self._audit.log('ip_ban_list_configs', {}, '0 configs', True)
+            return (
+                "No IP ban configurations defined. Add one in Settings "
+                "(WAF IP set, Security Group, or NACL) before banning."
+            )
+
+        lines = [
+            f"IP ban configurations ({len(configs)} total):",
+            f"  {'Name':<24} {'Method':<16} {'Region':<14} Target",
+            '  ' + '-' * 80,
+        ]
+        for c in configs:
+            method = getattr(c, 'method', '')
+            if method == 'waf':
+                target = getattr(c, 'ip_set_name', '') or getattr(c, 'ip_set_id', '')
+            elif method == 'security_group':
+                target = getattr(c, 'security_group_id', '')
+            elif method == 'nacl':
+                target = getattr(c, 'nacl_id', '')
+            else:
+                target = ''
+            lines.append(
+                f"  {str(getattr(c, 'name', ''))[:24]:<24} "
+                f"{str(method)[:16]:<16} "
+                f"{str(getattr(c, 'region', '') or '-')[:14]:<14} "
+                f"{target}"
+            )
+
+        result = '\n'.join(lines)
+        self._audit.log('ip_ban_list_configs', {}, result, True)
+        return result
+
+    async def ip_ban_list_banned(self, config_name: str) -> str:
+        """List the IP addresses currently banned under a named config."""
+        args = {'config_name': config_name}
+        allowed, reason = self._guard.check_tool('ip_ban_list_banned')
+        if not allowed:
+            self._audit.log('ip_ban_list_banned', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._ip_ban_service is None:
+            self._audit.log(
+                'ip_ban_list_banned', args, '', False, 'service_unavailable',
+            )
+            return "Error: IP ban service is not available."
+
+        try:
+            banned = await self._ip_ban_service.list_banned(config_name)
+        except ValueError as e:
+            self._audit.log('ip_ban_list_banned', args, '', False, f"config: {e}")
+            return f"Error: {e}"
+        except Exception as e:
+            self._audit.log('ip_ban_list_banned', args, '', False, f"api_error: {e}")
+            return f"Error listing banned IPs for {config_name!r}: {e}"
+
+        if not banned:
+            self._audit.log('ip_ban_list_banned', args, '0 banned', True)
+            return f"No IPs currently banned under config {config_name!r}."
+
+        lines = [f"Banned IPs under {config_name!r} ({len(banned)} total):"]
+        for cidr in banned:
+            lines.append(f"  {cidr}")
+
+        result = '\n'.join(lines)
+        self._audit.log('ip_ban_list_banned', args, result, True)
+        return result
+
+    async def ip_ban_set(
+        self, ip_address: str, config_name: str, action: str = "ban",
+    ) -> str:
+        """Ban or unban an IP address via a named WAF/SG/NACL config.
+
+        ``action`` must be ``"ban"`` or ``"unban"``. The underlying
+        IPBanService validates the IP and records every action to its own
+        audit trail in addition to the MCP audit log.
+        """
+        args = {
+            'ip_address': ip_address, 'config_name': config_name,
+            'action': action,
+        }
+        allowed, reason = self._guard.check_tool('ip_ban_set')
+        if not allowed:
+            self._audit.log('ip_ban_set', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._ip_ban_service is None:
+            self._audit.log('ip_ban_set', args, '', False, 'service_unavailable')
+            return "Error: IP ban service is not available."
+
+        action_norm = (action or "").strip().lower()
+        if action_norm not in ('ban', 'unban'):
+            self._audit.log('ip_ban_set', args, '', False, 'invalid_action')
+            return f"Error: action must be 'ban' or 'unban', got {action!r}."
+
+        try:
+            if action_norm == 'ban':
+                result = await self._ip_ban_service.ban_ip(ip_address, config_name)
+            else:
+                result = await self._ip_ban_service.unban_ip(ip_address, config_name)
+        except Exception as e:
+            self._audit.log('ip_ban_set', args, '', False, f"error: {e}")
+            return f"Error during {action_norm} of {ip_address}: {e}"
+
+        success = bool(result.get('success'))
+        message = result.get('message', '')
+        self._audit.log('ip_ban_set', args, message, success)
+        return f"{'OK' if success else 'Failed'}: {message}"
 
     def _resolve_connection(self, instance: Dict) -> Dict:
         """Resolve SSH connection parameters for an instance."""

--- a/tests/test_mcp_aws_security_tools.py
+++ b/tests/test_mcp_aws_security_tools.py
@@ -1,0 +1,291 @@
+"""Tests for the AWS CloudWatch / CloudTrail / IP-ban MCP tools.
+
+Covers ``cloudwatch_list_log_groups``, ``cloudwatch_get_log_events``,
+``cloudwatch_top_ips``, ``cloudtrail_lookup_events``, ``ip_ban_list_configs``,
+``ip_ban_list_banned``, and ``ip_ban_set``.
+
+For each tool we assert: service-unavailable handling, guard rejection at
+the wrong tier, dispatch to the right underlying service method, output
+formatting, and that error/edge paths surface a useful message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from servonaut.config.schema import AppConfig, IPBanConfig, MCPConfig
+from servonaut.mcp.guards import CommandGuard, GuardLevel
+from servonaut.mcp.tools import ServonautTools
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_tools(
+    *,
+    guard_level: str = GuardLevel.DANGEROUS,
+    cloudwatch_service=None,
+    cloudtrail_service=None,
+    ip_ban_service=None,
+    ip_ban_configs=None,
+):
+    """Construct a ServonautTools wired with mocked AWS security services."""
+    config = AppConfig(mcp=MCPConfig(guard_level=guard_level))
+    if ip_ban_configs is not None:
+        config.ip_ban_configs = ip_ban_configs
+    config_manager = MagicMock()
+    config_manager.get.return_value = config
+
+    aws_service = MagicMock()
+    aws_service.fetch_instances_cached = AsyncMock(return_value=[])
+    custom_server_service = MagicMock()
+    custom_server_service.list_as_instances.return_value = []
+    cache_service = MagicMock()
+    ssh_service = MagicMock()
+    connection_service = MagicMock()
+    scp_service = MagicMock()
+    audit = MagicMock()
+    audit.log = MagicMock()
+    guard = CommandGuard(config.mcp, config_manager)
+
+    return ServonautTools(
+        config_manager, aws_service, custom_server_service, cache_service,
+        ssh_service, connection_service, scp_service,
+        guard, audit,
+        cloudwatch_service=cloudwatch_service,
+        cloudtrail_service=cloudtrail_service,
+        ip_ban_service=ip_ban_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CloudWatch: list_log_groups
+# ---------------------------------------------------------------------------
+
+class TestCloudWatchListLogGroups:
+    def test_unavailable_when_no_service(self):
+        tools = _make_tools()
+        out = _run(tools.cloudwatch_list_log_groups())
+        assert "CloudWatch service is not available" in out
+        tools._audit.log.assert_called_once()
+
+    def test_lists_groups(self):
+        cw = MagicMock()
+        cw.list_log_groups = AsyncMock(return_value=[
+            {"name": "/aws/waf/prod", "stored_bytes": 2048, "retention_days": 30},
+            {"name": "/aws/alb/prod", "stored_bytes": 99, "retention_days": None},
+        ])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_list_log_groups(prefix="/aws/"))
+        assert "/aws/waf/prod" in out
+        assert "30d" in out
+        assert "never expire" in out
+        cw.list_log_groups.assert_awaited_once_with("/aws/", "")
+
+    def test_empty(self):
+        cw = MagicMock()
+        cw.list_log_groups = AsyncMock(return_value=[])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_list_log_groups())
+        assert "No CloudWatch log groups found" in out
+
+
+# ---------------------------------------------------------------------------
+# CloudWatch: get_log_events
+# ---------------------------------------------------------------------------
+
+class TestCloudWatchGetLogEvents:
+    def test_dispatch_and_format(self):
+        cw = MagicMock()
+        cw.get_log_events = AsyncMock(return_value=[
+            {"timestamp": datetime(2026, 5, 21, 10, 0, 0),
+             "message": "hello", "log_stream": "s1"},
+        ])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_get_log_events("/aws/waf/prod", hours_back=3))
+        assert "hello" in out
+        assert "2026-05-21 10:00:00" in out
+        # log_group is the first positional arg; start/end are datetimes.
+        call = cw.get_log_events.await_args
+        assert call.args[0] == "/aws/waf/prod"
+        assert isinstance(call.args[1], datetime)
+        assert isinstance(call.args[2], datetime)
+
+    def test_empty(self):
+        cw = MagicMock()
+        cw.get_log_events = AsyncMock(return_value=[])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_get_log_events("/aws/waf/prod"))
+        assert "No log events" in out
+
+
+# ---------------------------------------------------------------------------
+# CloudWatch: top_ips
+# ---------------------------------------------------------------------------
+
+class TestCloudWatchTopIps:
+    def test_invalid_action_filter(self):
+        cw = MagicMock()
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_top_ips("/aws/waf/prod", action_filter="MAYBE"))
+        assert "action_filter must be" in out
+
+    def test_ranks_ips(self):
+        cw = MagicMock()
+        cw.get_log_events = AsyncMock(return_value=[{"message": "x"}])
+        cw.extract_top_ips = MagicMock(return_value=[
+            {"ip": "1.2.3.4", "count": 50, "allowed": 10, "blocked": 40},
+        ])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_top_ips("/aws/waf/prod", action_filter="block"))
+        assert "1.2.3.4" in out
+        assert "40" in out
+        # action_filter is upper-cased before reaching the service.
+        cw.extract_top_ips.assert_called_once()
+        assert cw.extract_top_ips.call_args.args[2] == "BLOCK"
+
+    def test_no_ips_found(self):
+        cw = MagicMock()
+        cw.get_log_events = AsyncMock(return_value=[])
+        cw.extract_top_ips = MagicMock(return_value=[])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_top_ips("/aws/waf/prod"))
+        assert "No client IPs found" in out
+
+
+# ---------------------------------------------------------------------------
+# CloudTrail: lookup_events
+# ---------------------------------------------------------------------------
+
+class TestCloudTrailLookupEvents:
+    def test_unavailable_when_no_service(self):
+        tools = _make_tools()
+        out = _run(tools.cloudtrail_lookup_events())
+        assert "CloudTrail service is not available" in out
+
+    def test_dispatch_and_format(self):
+        ct = MagicMock()
+        ct.lookup_events = AsyncMock(return_value=[
+            {"event_time": datetime(2026, 5, 21, 9, 0, 0),
+             "event_name": "RunInstances", "username": "alice",
+             "source_ip": "203.0.113.5", "resource_type": "AWS::EC2::Instance",
+             "resource_name": "i-abc", "region": "us-east-1", "error_code": ""},
+        ])
+        tools = _make_tools(cloudtrail_service=ct)
+        out = _run(tools.cloudtrail_lookup_events(event_name="RunInstances"))
+        assert "RunInstances" in out
+        assert "alice" in out
+        assert "203.0.113.5" in out
+        ct.lookup_events.assert_awaited_once()
+        assert ct.lookup_events.await_args.kwargs["event_name"] == "RunInstances"
+
+    def test_empty(self):
+        ct = MagicMock()
+        ct.lookup_events = AsyncMock(return_value=[])
+        tools = _make_tools(cloudtrail_service=ct)
+        out = _run(tools.cloudtrail_lookup_events())
+        assert "No CloudTrail events matched" in out
+
+
+# ---------------------------------------------------------------------------
+# IP ban: list_configs / list_banned
+# ---------------------------------------------------------------------------
+
+class TestIPBanListConfigs:
+    def test_lists_configs(self):
+        svc = MagicMock()
+        svc.get_configs = MagicMock(return_value=[
+            IPBanConfig(name="prod-waf", method="waf", region="us-east-1",
+                        ip_set_name="blocklist"),
+        ])
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_list_configs())
+        assert "prod-waf" in out
+        assert "waf" in out
+        assert "blocklist" in out
+
+    def test_no_configs(self):
+        svc = MagicMock()
+        svc.get_configs = MagicMock(return_value=[])
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_list_configs())
+        assert "No IP ban configurations defined" in out
+
+
+class TestIPBanListBanned:
+    def test_lists_banned(self):
+        svc = MagicMock()
+        svc.list_banned = AsyncMock(return_value=["1.2.3.4/32", "5.6.7.8/32"])
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_list_banned("prod-waf"))
+        assert "1.2.3.4/32" in out
+        assert "5.6.7.8/32" in out
+
+    def test_unknown_config(self):
+        svc = MagicMock()
+        svc.list_banned = AsyncMock(side_effect=ValueError("Unknown IP ban config: nope"))
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_list_banned("nope"))
+        assert "Unknown IP ban config" in out
+
+
+# ---------------------------------------------------------------------------
+# IP ban: set (ban / unban)
+# ---------------------------------------------------------------------------
+
+class TestIPBanSet:
+    def test_blocked_in_standard_mode(self):
+        # ip_ban_set is a dangerous-tier tool — standard mode must refuse it.
+        svc = MagicMock()
+        svc.ban_ip = AsyncMock()
+        tools = _make_tools(guard_level=GuardLevel.STANDARD, ip_ban_service=svc)
+        out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="ban"))
+        assert out.startswith("Blocked: ")
+        svc.ban_ip.assert_not_called()
+
+    def test_unavailable_when_no_service(self):
+        tools = _make_tools()
+        out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf"))
+        assert "IP ban service is not available" in out
+
+    def test_invalid_action(self):
+        svc = MagicMock()
+        svc.ban_ip = AsyncMock()
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="purge"))
+        assert "action must be 'ban' or 'unban'" in out
+        svc.ban_ip.assert_not_called()
+
+    def test_ban_success(self):
+        svc = MagicMock()
+        svc.ban_ip = AsyncMock(
+            return_value={"success": True, "message": "Banned 1.2.3.4 via WAF IP set"}
+        )
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="ban"))
+        assert out.startswith("OK: ")
+        assert "Banned 1.2.3.4" in out
+        svc.ban_ip.assert_awaited_once_with("1.2.3.4", "prod-waf")
+
+    def test_unban_dispatch(self):
+        svc = MagicMock()
+        svc.unban_ip = AsyncMock(
+            return_value={"success": True, "message": "Unbanned 1.2.3.4"}
+        )
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="unban"))
+        assert out.startswith("OK: ")
+        svc.unban_ip.assert_awaited_once_with("1.2.3.4", "prod-waf")
+
+    def test_ban_failure_surfaces_message(self):
+        svc = MagicMock()
+        svc.ban_ip = AsyncMock(
+            return_value={"success": False, "message": "Invalid IP address: nope"}
+        )
+        tools = _make_tools(ip_ban_service=svc)
+        out = _run(tools.ip_ban_set("nope", "prod-waf", action="ban"))
+        assert out.startswith("Failed: ")
+        assert "Invalid IP address" in out


### PR DESCRIPTION
## Summary

Exposes the AWS log-analysis and IP-banning capabilities already used by the TUI as MCP server tools, so AI agents can run the full investigate-and-remediate loop: surface abusive IPs from WAF/ALB logs, corroborate against the CloudTrail audit trail, then block them.

## Changes

- **7 new MCP tools** (`mcp/tools.py`, `mcp/tool_schemas.py`):
  - `cloudwatch_list_log_groups`, `cloudwatch_get_log_events`, `cloudwatch_top_ips` (per-IP allowed/blocked ranking from WAF/ALB structured logs)
  - `cloudtrail_lookup_events`
  - `ip_ban_list_configs`, `ip_ban_list_banned`, `ip_ban_set` (ban/unban via `action` param)
- **Service wiring** (`mcp/server.py`): `CloudWatchService` / `CloudTrailService` / `IPBanService` constructed unconditionally (boto3 is a required dependency, AWS credentials resolve via the same chain as `AWSService`). The same services are wired into the chat-side `ServonautTools` (`app.py`) so the built-in TUI chat sees the tools too.
- **Guard tiers** (`mcp/guards.py`): the six read tools sit at the `readonly` tier; `ip_ban_set` is `dangerous`-tier and added to the server's confirmation protocol since it changes live traffic rules.
- **`tools/list` gating**: IP-ban tools are dropped from the tool list when no ban configuration exists; CloudWatch/CloudTrail are never gated.

## Notes

- MCP arguments are JSON, so the CloudWatch/CloudTrail tools accept an `hours_back` integer and compute `datetime` boundaries internally (the underlying services require `datetime` objects).
- `datetime.utcnow()` is used to match the existing convention in `cloudtrail_service.py` / `ip_ban_service.py`.

## Testing

- [x] Unit tests pass — new `tests/test_mcp_aws_security_tools.py` (24 tests): guard rejection, service-unavailable handling, dispatch, output formatting, invalid-input paths
- [x] Full suite: 3636 passed (8 pre-existing `test_hetzner_service.py` failures, unrelated to this change and present on `master`)
- [x] `create_mcp_server()` builds end-to-end; `tools/list` exposes all 7 tools; verified live against the running MCP server