### PR TITLE
feat(team-mgmt): complete team management UX + shared configs v1

### DIFF
--- a/src/servonaut/app.css
+++ b/src/servonaut/app.css
@@ -2073,6 +2073,43 @@ Sidebar > #relay_indicator {
     color: $text-muted;
 }
 
+/* Team-management inline forms. Each lives inside its parent
+   .settings_section card; without an explicit height the form inherits
+   the scrollable parent's available space and pushes the card to fill
+   the entire viewport. ``height: auto`` keeps the form tight to its
+   contents so the cards below stay reachable. */
+#create_team_form,
+#invite_form,
+#change_role_form,
+#share_server_form {
+    height: auto;
+    padding: 1;
+    margin: 1 0 0 0;
+    border: round $accent;
+    background: $boost;
+}
+
+#create_team_form Input,
+#invite_form Input,
+#share_server_form Input,
+#invite_form Select,
+#change_role_form Select,
+#share_server_form Select {
+    margin: 0 0 1 0;
+    width: 1fr;
+}
+
+.form_actions_row {
+    layout: horizontal;
+    height: auto;
+    align: left middle;
+}
+
+.form_actions_row Button {
+    margin: 0 1 0 0;
+    min-width: 12;
+}
+
 #hetzner_mgr_header,
 #hetzner_ssh_keys_header,
 #ovh_mgr_header {

--- a/src/servonaut/screens/team_management.py
+++ b/src/servonaut/screens/team_management.py
@@ -3,19 +3,35 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, ScrollableContainer
 from textual.screen import Screen
-from textual.widgets import Button, DataTable, Footer, Header, Input, Static
+from textual.widgets import Button, DataTable, Footer, Header, Input, Select, Static
 
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.screens.confirm_action import ConfirmActionScreen
+from servonaut.services.api_client import APIError
 from servonaut.widgets.sidebar import Sidebar
 
 logger = logging.getLogger(__name__)
+
+# Roles assignable via the API. Owner is set on team creation only and is
+# rejected by the invite/update endpoints. See services/team_service.py and
+# backend src/Entity/TeamMember.php.
+_ROLE_OPTIONS: List[Tuple[str, str]] = [
+    ("Viewer", "viewer"),
+    ("Member", "member"),
+    ("Admin", "admin"),
+]
+
+# Roles that grant MANAGE_MEMBERS on the team (can invite/remove/change role).
+_MANAGE_MEMBERS_ROLES = frozenset({"owner", "admin"})
+# Only the owner can promote/demote admins (MANAGE_ADMINS).
+_MANAGE_ADMINS_ROLES = frozenset({"owner"})
 
 
 class TeamManagementScreen(Screen):
@@ -32,8 +48,20 @@ class TeamManagementScreen(Screen):
         super().__init__()
         self._current_team_slug: Optional[str] = None
         self._current_team_name: Optional[str] = None
-        # Cache member list for remove operations (row index → user_id)
+        # Caller's role on the currently-viewed team (owner/admin/member/viewer).
+        # Drives mutation-button visibility.
+        self._current_team_role: Optional[str] = None
+        # Cache slug -> caller_role from the list response. GET /teams/{slug}
+        # doesn't echo the caller's role today, so the list is the source of truth.
+        self._team_roles: dict[str, str] = {}
+        # Cache member list (parallel to row index) for remove/resend/role/copy.
         self._members: list[dict] = []
+        # Cache currently-shared servers — used by Share All to dedupe before POST.
+        self._shared_servers: list[dict] = []
+        # Cache team-shared config versions, latest first per backend ordering.
+        self._team_configs: list[dict] = []
+        # Holds the parsed remote payload between "Pull Latest" and Apply confirm.
+        self._pending_pull_payload: Optional[dict] = None
 
     # ------------------------------------------------------------------
     # Compose
@@ -44,7 +72,7 @@ class TeamManagementScreen(Screen):
         with Horizontal(id="main-layout"):
             yield Sidebar()
             yield ScrollableContainer(
-                Static("[bold cyan]Team Management[/bold cyan]"),
+                Static("[bold cyan]Team Management[/bold cyan]", id="team_mgmt_header"),
 
                 # No-auth notice (shown when not authenticated)
                 Static(
@@ -52,51 +80,168 @@ class TeamManagementScreen(Screen):
                     id="no_auth_notice",
                 ),
 
-                # --- Team list section ---
-                Static("[bold]Your Teams[/bold]", id="section_teams", classes="section_header"),
-                DataTable(id="teams_table"),
-                Horizontal(
-                    Button("Create Team", variant="primary", id="btn_create_team"),
-                    Button("View Team", variant="default", id="btn_view_team"),
-                    classes="add_row",
-                    id="team_actions_row",
+                # --- Teams section (curved card) ---
+                Container(
+                    Static("[bold]Your Teams[/bold]", id="section_teams", classes="section_header"),
+                    DataTable(id="teams_table"),
+                    Horizontal(
+                        Button("Create Team", variant="primary", id="btn_create_team"),
+                        Button("View Team", variant="default", id="btn_view_team"),
+                        classes="add_row",
+                        id="team_actions_row",
+                    ),
+                    Container(
+                        Static("[bold]Create Team[/bold]", classes="section_header"),
+                        Input(placeholder="Team Name", id="input_team_name"),
+                        Horizontal(
+                            Button("Save Team", variant="primary", id="btn_save_team"),
+                            Button("Cancel", variant="default", id="btn_cancel_create_team"),
+                            classes="form_actions_row",
+                        ),
+                        id="create_team_form",
+                    ),
+                    id="teams_section",
+                    classes="settings_section",
                 ),
 
-                # --- Team detail section (hidden until a team is selected) ---
+                # --- Active team banner (shown after View Team) ---
                 Static("", id="team_header"),
 
-                Static("[bold]Members[/bold]", id="section_members", classes="section_header"),
-                DataTable(id="members_table"),
-                Horizontal(
-                    Button("Invite Member", variant="primary", id="btn_invite"),
-                    Button("Remove Member", variant="error", id="btn_remove"),
-                    classes="add_row",
-                    id="member_actions_row",
-                ),
-
-                Static("[bold]Shared Servers[/bold]", id="section_servers", classes="section_header"),
-                DataTable(id="servers_table"),
-                Horizontal(
-                    Button("Share Server", variant="primary", id="btn_share"),
-                    classes="add_row",
-                    id="server_actions_row",
-                ),
-
-                # --- Create team form (hidden) ---
+                # --- Members section (curved card) ---
                 Container(
-                    Static("[bold]Create Team[/bold]", classes="section_header"),
-                    Input(placeholder="Team Name", id="input_team_name"),
-                    Button("Save Team", variant="primary", id="btn_save_team"),
-                    id="create_team_form",
+                    Static("[bold]Members[/bold]", id="section_members", classes="section_header"),
+                    DataTable(id="members_table"),
+                    Horizontal(
+                        Button("Invite Member", variant="primary", id="btn_invite"),
+                        Button("Change Role", variant="default", id="btn_change_role"),
+                        Button("Resend Invite", variant="default", id="btn_resend"),
+                        Button("Copy Accept URL", variant="default", id="btn_copy_url"),
+                        Button("Remove Member", variant="error", id="btn_remove"),
+                        classes="add_row",
+                        id="member_actions_row",
+                    ),
+                    Container(
+                        Static("[bold]Invite Member[/bold]", classes="section_header"),
+                        Input(placeholder="Email", id="input_invite_email"),
+                        Select(
+                            options=_ROLE_OPTIONS,
+                            value="member",
+                            allow_blank=False,
+                            id="select_invite_role",
+                        ),
+                        Horizontal(
+                            Button("Send Invite", variant="primary", id="btn_send_invite"),
+                            Button("Cancel", variant="default", id="btn_cancel_invite"),
+                            classes="form_actions_row",
+                        ),
+                        id="invite_form",
+                    ),
+                    Container(
+                        Static("[bold]Change Role[/bold]", id="change_role_header", classes="section_header"),
+                        Select(
+                            options=_ROLE_OPTIONS,
+                            value="member",
+                            allow_blank=False,
+                            id="select_change_role",
+                        ),
+                        Horizontal(
+                            Button("Save Role", variant="primary", id="btn_save_role"),
+                            Button("Cancel", variant="default", id="btn_cancel_change_role"),
+                            classes="form_actions_row",
+                        ),
+                        id="change_role_form",
+                    ),
+                    id="members_section",
+                    classes="settings_section",
                 ),
 
-                # --- Invite member form (hidden) ---
+                # --- Shared Configs section (curved card) ---
                 Container(
-                    Static("[bold]Invite Member[/bold]", classes="section_header"),
-                    Input(placeholder="Email", id="input_invite_email"),
-                    Input(placeholder="member, admin", id="input_invite_role"),
-                    Button("Send Invite", variant="primary", id="btn_send_invite"),
-                    id="invite_form",
+                    Static("[bold]Shared Configs[/bold]", id="section_configs", classes="section_header"),
+                    Static(
+                        "[dim]Push a sanitised snapshot of your local config "
+                        "(connection profiles, scan rules, custom servers) so "
+                        "teammates can pull it as a baseline.[/dim]",
+                        id="configs_hint",
+                    ),
+                    DataTable(id="configs_table"),
+                    Horizontal(
+                        Button("Push Current", variant="primary", id="btn_push_config"),
+                        Button("Pull Latest", variant="default", id="btn_pull_config"),
+                        classes="add_row",
+                        id="config_actions_row",
+                    ),
+                    Container(
+                        Static("[bold]Push Current Config[/bold]", classes="section_header"),
+                        Static("", id="push_config_preview"),
+                        Input(
+                            placeholder="Description (optional — e.g. 'Adds staging bastion')",
+                            id="input_push_description",
+                        ),
+                        Horizontal(
+                            Button("Push", variant="primary", id="btn_confirm_push_config"),
+                            Button("Cancel", variant="default", id="btn_cancel_push_config"),
+                            classes="form_actions_row",
+                        ),
+                        id="push_config_form",
+                    ),
+                    Container(
+                        Static("[bold]Pull Latest Config[/bold]", classes="section_header"),
+                        Static("", id="pull_config_preview"),
+                        Static(
+                            "[yellow]Pulling REPLACES your local connection profiles, "
+                            "connection rules, scan rules, and custom servers with the "
+                            "team's version. AI / cloud-provider / personal settings are "
+                            "untouched.[/yellow]",
+                            id="pull_config_warning",
+                        ),
+                        Horizontal(
+                            Button("Apply", variant="warning", id="btn_confirm_pull_config"),
+                            Button("Cancel", variant="default", id="btn_cancel_pull_config"),
+                            classes="form_actions_row",
+                        ),
+                        id="pull_config_form",
+                    ),
+                    id="configs_section",
+                    classes="settings_section",
+                ),
+
+                # --- Shared Servers section (curved card) ---
+                Container(
+                    Static("[bold]Shared Servers[/bold]", id="section_servers", classes="section_header"),
+                    DataTable(id="servers_table"),
+                    Horizontal(
+                        Button("Share Server", variant="primary", id="btn_share"),
+                        Button("Share All", variant="default", id="btn_share_all"),
+                        classes="add_row",
+                        id="server_actions_row",
+                    ),
+                    Container(
+                        Static("[bold]Share Server[/bold]", classes="section_header"),
+                        Select(
+                            options=[("(no servers available)", Select.BLANK)],
+                            value=Select.BLANK,
+                            allow_blank=True,
+                            id="select_share_instance",
+                        ),
+                        Input(
+                            placeholder="SSH username (optional — leave blank for cloud default)",
+                            id="input_share_username",
+                        ),
+                        Input(
+                            placeholder="SSH port (default 22)",
+                            id="input_share_port",
+                            type="integer",
+                        ),
+                        Horizontal(
+                            Button("Share", variant="primary", id="btn_confirm_share"),
+                            Button("Cancel", variant="default", id="btn_cancel_share"),
+                            classes="form_actions_row",
+                        ),
+                        id="share_server_form",
+                    ),
+                    id="servers_section",
+                    classes="settings_section",
                 ),
 
                 Button("Back", variant="default", id="btn_back"),
@@ -114,6 +259,7 @@ class TeamManagementScreen(Screen):
         self._hide_detail_section()
         self._hide_create_form()
         self._hide_invite_form()
+        self._hide_change_role_form()
 
         auth_svc = getattr(self.app, "auth_service", None)
         if auth_svc is None or not auth_svc.is_authenticated:
@@ -138,7 +284,11 @@ class TeamManagementScreen(Screen):
 
         servers_tbl = self.query_one("#servers_table", DataTable)
         servers_tbl.cursor_type = "row"
-        servers_tbl.add_columns("Name", "Host", "Provider")
+        servers_tbl.add_columns("Name", "Hostname", "Region")
+
+        configs_tbl = self.query_one("#configs_table", DataTable)
+        configs_tbl.cursor_type = "row"
+        configs_tbl.add_columns("Version", "Description", "Pushed", "Pushed By")
 
     # ------------------------------------------------------------------
     # Visibility helpers
@@ -154,27 +304,13 @@ class TeamManagementScreen(Screen):
         self.query_one("#no_auth_notice").display = False
 
     def _hide_detail_section(self) -> None:
-        for widget_id in (
-            "team_header",
-            "section_members",
-            "members_table",
-            "member_actions_row",
-            "section_servers",
-            "servers_table",
-            "server_actions_row",
-        ):
+        # Detail-only sections are wrapped in .settings_section cards;
+        # collapse the whole card so the empty curved border doesn't render.
+        for widget_id in ("team_header", "members_section", "configs_section", "servers_section"):
             self.query_one(f"#{widget_id}").display = False
 
     def _show_detail_section(self) -> None:
-        for widget_id in (
-            "team_header",
-            "section_members",
-            "members_table",
-            "member_actions_row",
-            "section_servers",
-            "servers_table",
-            "server_actions_row",
-        ):
+        for widget_id in ("team_header", "members_section", "configs_section", "servers_section"):
             self.query_one(f"#{widget_id}").display = True
 
     def _hide_create_form(self) -> None:
@@ -191,8 +327,204 @@ class TeamManagementScreen(Screen):
     def _show_invite_form(self) -> None:
         self.query_one("#invite_form").display = True
         self.query_one("#input_invite_email", Input).value = ""
-        self.query_one("#input_invite_role", Input).value = ""
+        role_select = self.query_one("#select_invite_role", Select)
+        # Reset to "member" and gate the Admin option behind owner status.
+        role_select.set_options(self._role_options_for_caller())
+        role_select.value = "member"
         self.query_one("#input_invite_email", Input).focus()
+
+    def _hide_change_role_form(self) -> None:
+        self.query_one("#change_role_form").display = False
+
+    def _hide_share_server_form(self) -> None:
+        self.query_one("#share_server_form").display = False
+
+    def _show_share_server_form(self, instances: list[dict]) -> None:
+        """Open the share-server form populated with the user's instances.
+
+        Builds Select options from the merged AWS + custom server list. Each
+        option's label is the instance's human name (id fallback) annotated
+        with the hostname so the user can disambiguate similarly-named rows;
+        the value is the instance id so we can look up the source dict on
+        submit without depending on label collision behaviour.
+        """
+        form = self.query_one("#share_server_form")
+        form.display = True
+        # Clear any stale connection-detail input from a previous open so the
+        # pre-fill from the next-selected instance always wins.
+        self.query_one("#input_share_username", Input).value = ""
+        self.query_one("#input_share_port", Input).value = ""
+        select = self.query_one("#select_share_instance", Select)
+        options = self._build_share_options(instances)
+        if not options:
+            select.set_options([("(no servers available)", Select.BLANK)])
+            select.value = Select.BLANK
+            self.notify("No servers available to share.", severity="warning")
+            return
+        select.set_options(options)
+        # Default to the first instance with a usable hostname.
+        select.value = options[0][1]
+        self._prefill_share_connection_inputs(options[0][1])
+        select.focus()
+
+    def _prefill_share_connection_inputs(self, instance_id: str) -> None:
+        """Pre-populate the username / port inputs from the selected instance.
+
+        Custom servers carry ``username`` and ``port`` directly on the instance
+        dict (see ``CustomServerService.to_instance_dict``); AWS instances do
+        not. Leaving inputs blank → backend receives null/22 default, which the
+        consumer's CLI will then fall back on per the cloud-specific default.
+        """
+        instances = getattr(self.app, "instances", [])
+        instance = next((i for i in instances if str(i.get("id")) == instance_id), None)
+        if instance is None:
+            return
+        username = instance.get("username") or ""
+        port = instance.get("port")
+        self.query_one("#input_share_username", Input).value = username
+        self.query_one("#input_share_port", Input).value = str(port) if port and port != 22 else ""
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """React to share-form instance switches by re-prefilling connection inputs."""
+        if event.select.id != "select_share_instance":
+            return
+        value = event.value
+        if value == Select.BLANK or not isinstance(value, str):
+            return
+        self._prefill_share_connection_inputs(value)
+
+    @staticmethod
+    def _build_share_options(instances: list[dict]) -> List[Tuple[str, str]]:
+        """Return (label, instance_id) pairs for instances with a routable IP.
+
+        Instances with neither public nor private IP are dropped — the backend
+        requires ``hostname`` and we don't want a Select entry that's guaranteed
+        to fail on submit.
+        """
+        options: List[Tuple[str, str]] = []
+        for instance in instances:
+            instance_id = instance.get("id")
+            if not instance_id:
+                continue
+            hostname = instance.get("public_ip") or instance.get("private_ip")
+            if not hostname:
+                continue
+            name = instance.get("name") or instance_id
+            label = f"{name} ({hostname})"
+            options.append((label, str(instance_id)))
+        return options
+
+    def _show_change_role_form(self, member: dict) -> None:
+        form = self.query_one("#change_role_form")
+        form.display = True
+        email = self._member_display_email(member)
+        display_email = (
+            self.app.redaction_service.scrub_stream(email)
+            if self.app.demo_mode and self.app.redaction_service
+            else email
+        )
+        self.query_one("#change_role_header", Static).update(
+            f"[bold]Change Role: {display_email}[/bold]"
+        )
+        role_select = self.query_one("#select_change_role", Select)
+        role_select.set_options(self._role_options_for_caller())
+        current_role = member.get("role", "member")
+        # Owner rows must not be editable via this form (server 400s anyway).
+        role_select.value = current_role if current_role in {"admin", "member", "viewer"} else "member"
+        role_select.focus()
+
+    # ------------------------------------------------------------------
+    # Role / permission helpers
+    # ------------------------------------------------------------------
+
+    def _can_manage_members(self) -> bool:
+        """Owner or admin on the currently-viewed team."""
+        return (self._current_team_role or "").lower() in _MANAGE_MEMBERS_ROLES
+
+    def _can_manage_admins(self) -> bool:
+        """Only owners can promote/demote admins."""
+        return (self._current_team_role or "").lower() in _MANAGE_ADMINS_ROLES
+
+    def _role_options_for_caller(self) -> List[Tuple[str, str]]:
+        """Available roles for the current caller — drop Admin for non-owners."""
+        if self._can_manage_admins():
+            return list(_ROLE_OPTIONS)
+        return [(label, value) for label, value in _ROLE_OPTIONS if value != "admin"]
+
+    def _refresh_member_buttons(self) -> None:
+        """Show/hide mutation buttons based on caller's role on the team."""
+        can_manage = self._can_manage_members()
+        for btn_id in ("btn_invite", "btn_change_role", "btn_resend", "btn_copy_url", "btn_remove"):
+            self.query_one(f"#{btn_id}").display = can_manage
+        # Share Server / Share All require MANAGE_MEMBERS too.
+        self.query_one("#btn_share").display = can_manage
+        self.query_one("#btn_share_all").display = can_manage
+        # Push Current = admin-only on the backend (hasAdminAccess). Pull is
+        # readable by any member, so it stays visible regardless.
+        self.query_one("#btn_push_config").display = can_manage
+        if not can_manage:
+            # Hide any open forms that the caller can't action anyway.
+            self._hide_invite_form()
+            self._hide_change_role_form()
+            self._hide_share_server_form()
+
+    # ------------------------------------------------------------------
+    # Member field helpers (handle backend GET shape variance)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _member_display_email(member: dict) -> str:
+        """Extract a human-readable label for a member row.
+
+        Backend ``GET /teams/{slug}`` returns ``invitation_email`` on every row
+        (pending and accepted), plus an optional ``user`` object with ``name``.
+        Older shapes used ``email`` directly — we tolerate both.
+        """
+        return (
+            member.get("invitation_email")
+            or member.get("email")
+            or (member.get("user") or {}).get("name")
+            or (member.get("user") or {}).get("email")
+            or "unknown"
+        )
+
+    @staticmethod
+    def _format_seat_line(team: dict, members: list[dict]) -> str:
+        """Render the "Seats: used / cap" indicator under the team name.
+
+        Backend semantics (PR #66):
+          - ``max_seats`` is derived live from the owner's Stripe Teams
+            subscription seat_count, NOT the stale Team column.
+          - ``used`` = accepted + pending (both reserve a seat).
+          - When the owner has no active sub, ``max_seats`` is 0; we render a
+            no-subscription notice so the user knows why every invite 402s.
+        """
+        used = len(members)
+        cap = team.get("max_seats") or 0
+        if cap <= 0:
+            return f"Seats: {used} (no active Teams subscription)"
+        return f"Seats: {used} / {cap}"
+
+    @staticmethod
+    def _format_status(member: dict) -> str:
+        """Derive Status from ``is_accepted`` + ``invitation_expires_at``."""
+        if member.get("is_accepted"):
+            return "Active"
+        expires = member.get("invitation_expires_at")
+        if not expires:
+            return "Invited"
+        try:
+            expires_dt = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+            remaining = expires_dt - datetime.now(timezone.utc)
+            days = remaining.days
+            if remaining.total_seconds() <= 0:
+                return "Invited (expired)"
+            if days >= 1:
+                return f"Invited (expires in {days}d)"
+            hours = max(int(remaining.total_seconds() // 3600), 1)
+            return f"Invited (expires in {hours}h)"
+        except (ValueError, AttributeError):
+            return "Invited"
 
     # ------------------------------------------------------------------
     # Async workers
@@ -218,10 +550,29 @@ class TeamManagementScreen(Screen):
             team = await team_svc.get_team(slug)
             members = team.get("members", [])
             self._members = members
+            # Caller role drives mutation-button visibility. Prefer the
+            # top-level ``role`` field (set per-caller by the backend) and
+            # fall back to scanning members for the authenticated user.
+            self._current_team_role = (
+                team.get("role")
+                or self._team_roles.get(slug)
+                or self._infer_caller_role(members)
+            )
             self._populate_members_table(members)
 
             servers = await team_svc.list_shared_servers(slug)
+            self._shared_servers = servers
             self._populate_servers_table(servers)
+
+            try:
+                configs = await team_svc.list_team_configs(slug)
+            except Exception as exc:  # noqa: BLE001 — list failure shouldn't abort the whole detail load
+                logger.warning("Failed to list team configs for %s: %s", slug, exc)
+                configs = []
+            self._team_configs = configs
+            self._populate_configs_table(configs)
+            self._hide_push_config_form()
+            self._hide_pull_config_form()
 
             self._show_detail_section()
             team_name = team.get("name", slug)
@@ -231,10 +582,30 @@ class TeamManagementScreen(Screen):
                 if self.app.demo_mode and self.app.redaction_service
                 else team_name
             )
-            self.query_one("#team_header", Static).update(f"[bold]Team: {display_team_name}[/bold]")
+            seat_line = self._format_seat_line(team, members)
+            self.query_one("#team_header", Static).update(
+                f"[bold]Team: {display_team_name}[/bold]\n{seat_line}"
+            )
+            self._refresh_member_buttons()
         except Exception as exc:
             logger.error("Failed to load team detail: %s", exc)
             self.notify(f"Failed to load team: {exc}", severity="error")
+
+    def _infer_caller_role(self, members: list[dict]) -> Optional[str]:
+        """Fallback when GET /teams/{slug} omits a top-level ``role`` field.
+
+        Walks the member list looking for the authenticated user's row.
+        """
+        auth_svc = getattr(self.app, "auth_service", None)
+        my_id = getattr(auth_svc, "user_id", None) if auth_svc else None
+        my_email = getattr(auth_svc, "user_email", None) if auth_svc else None
+        for member in members:
+            user = member.get("user") or {}
+            if my_id and str(user.get("id")) == str(my_id):
+                return member.get("role")
+            if my_email and member.get("invitation_email") == my_email:
+                return member.get("role")
+        return None
 
     async def _do_create_team(self, name: str) -> None:
         team_svc = getattr(self.app, "team_service", None)
@@ -245,6 +616,13 @@ class TeamManagementScreen(Screen):
             self._hide_create_form()
             self.notify(f"Team '{name}' created.", severity="information")
             await self._load_teams()
+        except APIError as exc:
+            # 403 from POST /api/v1/teams has two distinct messages from backend:
+            # "Only Teams-plan subscribers can create a team workspace..." and
+            # "You already own a team workspace...". Both are user-actionable —
+            # surface the message verbatim rather than the generic stringified exc.
+            logger.error("Failed to create team: %s", exc.message)
+            self.notify(exc.message, severity="error", timeout=10)
         except Exception as exc:
             logger.error("Failed to create team: %s", exc)
             self.notify(f"Failed to create team: {exc}", severity="error")
@@ -254,25 +632,102 @@ class TeamManagementScreen(Screen):
         if team_svc is None:
             return
         try:
-            await team_svc.invite_member(slug, email, role)
+            response = await team_svc.invite_member(slug, email, role)
             self._hide_invite_form()
-            self.notify(f"Invite sent to {email}.", severity="information")
+            self._notify_invite_outcome(email, response, action="Invite")
             await self._load_team_detail(slug)
+        except APIError as exc:
+            self._notify_member_write_error(exc, fallback="Failed to invite member")
         except Exception as exc:
             logger.error("Failed to invite member: %s", exc)
             self.notify(f"Failed to invite member: {exc}", severity="error")
 
-    async def _do_remove_member(self, slug: str, user_id: str, email: str) -> None:
+    async def _do_resend_invite(self, slug: str, member_id: str, email: str) -> None:
         team_svc = getattr(self.app, "team_service", None)
         if team_svc is None:
             return
         try:
-            await team_svc.remove_member(slug, user_id)
+            response = await team_svc.resend_invite(slug, member_id)
+            self._notify_invite_outcome(email, response, action="Resend")
+            await self._load_team_detail(slug)
+        except APIError as exc:
+            self._notify_member_write_error(exc, fallback="Failed to resend invite")
+        except Exception as exc:
+            logger.error("Failed to resend invite: %s", exc)
+            self.notify(f"Failed to resend invite: {exc}", severity="error")
+
+    def _notify_member_write_error(self, exc: APIError, *, fallback: str) -> None:
+        """Render a context-aware notification for invite/resend API errors.
+
+        Backend may now return:
+          - 402 — team owner's Teams subscription has lapsed
+          - 422 — seat cap reached
+          - 4xx — any other validation failure (already a member, bad email, …)
+        For 402 we steer to the billing page when the caller IS the owner, and
+        to "ask the owner" when they're not. The server's `message` is always
+        user-readable so we surface it verbatim with appended actionable hint.
+        """
+        logger.error("Member write failed (%s): %s", exc.status, exc.message)
+        if exc.status == 402:
+            if self._can_manage_admins():
+                # Owner sees the direct billing CTA.
+                hint = "Manage your subscription at https://servonaut.dev/account/billing."
+            else:
+                hint = "Ask the team owner to renew the Teams subscription."
+            self.notify(f"{exc.message} {hint}", severity="warning", timeout=12)
+            return
+        if exc.status == 422:
+            self.notify(
+                f"{exc.message} Remove an existing member, or upgrade the seat cap.",
+                severity="warning",
+                timeout=12,
+            )
+            return
+        # All other 4xx — show the server's message rather than the wrapped repr.
+        self.notify(f"{fallback}: {exc.message}", severity="error")
+
+    async def _do_remove_member(self, slug: str, member_id: str, email: str) -> None:
+        team_svc = getattr(self.app, "team_service", None)
+        if team_svc is None:
+            return
+        try:
+            await team_svc.remove_member(slug, member_id)
             self.notify(f"Removed {email}.", severity="information")
             await self._load_team_detail(slug)
         except Exception as exc:
             logger.error("Failed to remove member: %s", exc)
             self.notify(f"Failed to remove member: {exc}", severity="error")
+
+    async def _do_update_role(self, slug: str, member_id: str, email: str, role: str) -> None:
+        team_svc = getattr(self.app, "team_service", None)
+        if team_svc is None:
+            return
+        try:
+            await team_svc.update_role(slug, member_id, role)
+            self._hide_change_role_form()
+            self.notify(f"{email} is now {role.capitalize()}.", severity="information")
+            await self._load_team_detail(slug)
+        except Exception as exc:
+            logger.error("Failed to update role: %s", exc)
+            self.notify(f"Failed to update role: {exc}", severity="error")
+
+    def _notify_invite_outcome(self, email: str, response: dict, *, action: str) -> None:
+        """Render a context-aware notification for invite/resend responses.
+
+        The backend returns ``email_sent: bool`` — when ``False`` the row was
+        persisted with a valid token but mailer delivery failed. Steer the
+        user toward "Copy Accept URL" rather than silently claiming success.
+        """
+        if isinstance(response, dict) and response.get("email_sent") is False:
+            self.notify(
+                f"{action} recorded for {email} — email delivery failed. "
+                "Use 'Copy Accept URL' to share the link manually.",
+                severity="warning",
+                timeout=10,
+            )
+        else:
+            verb = "sent" if action == "Invite" else "resent"
+            self.notify(f"Invite {verb} to {email}.", severity="information")
 
     async def _do_push_server(self, slug: str, server_data: dict) -> None:
         team_svc = getattr(self.app, "team_service", None)
@@ -280,11 +735,16 @@ class TeamManagementScreen(Screen):
             return
         try:
             await team_svc.push_server(slug, server_data)
+            self._hide_share_server_form()
             self.notify(
                 f"Server '{server_data.get('name', '')}' shared with team.",
                 severity="information",
             )
             await self._load_team_detail(slug)
+        except APIError as exc:
+            logger.error("Failed to share server (%s): %s", exc.status, exc.message)
+            # Backend 409 example: "A server with this hostname is already shared."
+            self.notify(f"Failed to share server: {exc.message}", severity="error")
         except Exception as exc:
             logger.error("Failed to share server: %s", exc)
             self.notify(f"Failed to share server: {exc}", severity="error")
@@ -303,13 +763,25 @@ class TeamManagementScreen(Screen):
                 return self.app.redaction_service.redact_name(x)
             return x
 
+        self._team_roles.clear()
+        owned_count = 0
         for team in teams:
+            slug = team.get("slug", "")
+            role = (team.get("role") or "").lower()
+            if slug:
+                self._team_roles[slug] = role
+            if role == "owner":
+                owned_count += 1
             table.add_row(
                 _s(team.get("name", "")),
-                team.get("role", ""),
+                role,
                 str(team.get("member_count", "")),
-                key=team.get("slug", ""),
+                key=slug,
             )
+        # Backend caps team creation at one-team-per-Teams-subscription. Hide
+        # the CTA when we know the user already owns one — server still 403s
+        # if they bypass the UI.
+        self.query_one("#btn_create_team").display = owned_count == 0
 
     def _populate_members_table(self, members: list[dict]) -> None:
         table = self.query_one("#members_table", DataTable)
@@ -322,10 +794,80 @@ class TeamManagementScreen(Screen):
 
         for member in members:
             table.add_row(
-                _s(member.get("email", "")),
+                _s(self._member_display_email(member)),
                 member.get("role", ""),
-                member.get("status", ""),
+                self._format_status(member),
             )
+
+    def _populate_configs_table(self, configs: list[dict]) -> None:
+        """Render the Shared Configs version list.
+
+        Backend ordering is latest-first; we render as-received. Description
+        truncated to 40 chars to keep the row readable in narrow terminals;
+        the full text shows in the push/pull preview.
+        """
+        table = self.query_one("#configs_table", DataTable)
+        table.clear()
+
+        def _s(x: str) -> str:
+            # Descriptions are user-typed free text — scrub in demo mode.
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.scrub_stream(x)
+            return x
+
+        for cfg in configs:
+            version = cfg.get("version", "?")
+            description = (cfg.get("description") or "")[:40]
+            pushed_by = str(cfg.get("pushed_by", ""))
+            created = (cfg.get("created_at") or "")[:10]  # YYYY-MM-DD portion
+            table.add_row(str(version), _s(description), created, pushed_by, key=str(cfg.get("id", "")))
+
+    def _hide_push_config_form(self) -> None:
+        self.query_one("#push_config_form").display = False
+
+    def _hide_pull_config_form(self) -> None:
+        self.query_one("#pull_config_form").display = False
+
+    def _show_push_config_form(self) -> None:
+        from servonaut.services.team_config_subset import build_shareable_subset
+        config = getattr(self.app, "config", None)
+        if config is None:
+            self.notify("Local config not available.", severity="error")
+            return
+        _payload, summary = build_shareable_subset(config)
+        preview = (
+            f"Will share: [bold]{summary['connection_profiles']}[/bold] connection profiles, "
+            f"[bold]{summary['connection_rules']}[/bold] connection rules, "
+            f"[bold]{summary['scan_rules']}[/bold] scan rules, "
+            f"[bold]{summary['custom_servers']}[/bold] custom servers."
+        )
+        if summary["stripped_paths"]:
+            preview += (
+                f"\n[yellow]{summary['stripped_paths']} local SSH key path(s) will be "
+                "stripped — teammates must re-bind them locally.[/yellow]"
+            )
+        self.query_one("#push_config_preview", Static).update(preview)
+        self.query_one("#input_push_description", Input).value = ""
+        form = self.query_one("#push_config_form")
+        form.display = True
+        self.query_one("#input_push_description", Input).focus()
+
+    def _show_pull_config_form(self, remote_payload: dict) -> None:
+        from servonaut.services.team_config_subset import diff_against_local
+        config = getattr(self.app, "config", None)
+        if config is None:
+            self.notify("Local config not available.", severity="error")
+            return
+        diff = diff_against_local(config, remote_payload)
+        lines = ["Pull will replace these sections (current → after):"]
+        for section in ("connection_profiles", "connection_rules", "scan_rules", "custom_servers"):
+            d = diff[section]
+            change_hint = "[green]no change[/green]" if d["local"] == d["after"] else f"[bold]{d['local']} → {d['after']}[/bold]"
+            lines.append(f"  • {section.replace('_', ' ').title()}: {change_hint}")
+        self.query_one("#pull_config_preview", Static).update("\n".join(lines))
+        self._pending_pull_payload = remote_payload
+        form = self.query_one("#pull_config_form")
+        form.display = True
 
     def _populate_servers_table(self, servers: list[dict]) -> None:
         table = self.query_one("#servers_table", DataTable)
@@ -338,7 +880,7 @@ class TeamManagementScreen(Screen):
             return x
 
         def _host(x: str) -> str:
-            # Hosts may be IPs or hostnames — scrub_stream handles both.
+            # Hostnames may be IPs or DNS names — scrub_stream handles both.
             if self.app.demo_mode and self.app.redaction_service:
                 return self.app.redaction_service.scrub_stream(x)
             return x
@@ -346,8 +888,9 @@ class TeamManagementScreen(Screen):
         for server in servers:
             table.add_row(
                 _name(server.get("name", "")),
-                _host(server.get("host", "")),
-                server.get("provider", ""),
+                # Backend field is "hostname"; tolerate legacy "host" key for back-compat.
+                _host(server.get("hostname") or server.get("host", "")),
+                server.get("region", "") or "",
             )
 
     # ------------------------------------------------------------------
@@ -366,6 +909,9 @@ class TeamManagementScreen(Screen):
         elif button_id == "btn_save_team":
             self._submit_create_team()
 
+        elif button_id == "btn_cancel_create_team":
+            self._hide_create_form()
+
         elif button_id == "btn_invite":
             if self._current_team_slug:
                 self._show_invite_form()
@@ -375,11 +921,57 @@ class TeamManagementScreen(Screen):
         elif button_id == "btn_send_invite":
             self._submit_invite_member()
 
+        elif button_id == "btn_cancel_invite":
+            self._hide_invite_form()
+
         elif button_id == "btn_remove":
             self._action_remove_member()
 
+        elif button_id == "btn_resend":
+            self._action_resend_invite()
+
+        elif button_id == "btn_copy_url":
+            self._action_copy_accept_url()
+
+        elif button_id == "btn_change_role":
+            self._action_change_role()
+
+        elif button_id == "btn_save_role":
+            self._submit_change_role()
+
+        elif button_id == "btn_cancel_change_role":
+            self._hide_change_role_form()
+
         elif button_id == "btn_share":
             self._action_share_server()
+
+        elif button_id == "btn_share_all":
+            self._action_share_all_servers()
+
+        elif button_id == "btn_confirm_share":
+            self._submit_share_server()
+
+        elif button_id == "btn_cancel_share":
+            self._hide_share_server_form()
+
+        elif button_id == "btn_push_config":
+            self._action_push_config()
+
+        elif button_id == "btn_confirm_push_config":
+            self._submit_push_config()
+
+        elif button_id == "btn_cancel_push_config":
+            self._hide_push_config_form()
+
+        elif button_id == "btn_pull_config":
+            self._action_pull_config()
+
+        elif button_id == "btn_confirm_pull_config":
+            self._submit_pull_config()
+
+        elif button_id == "btn_cancel_pull_config":
+            self._hide_pull_config_form()
+            self._pending_pull_payload = None
 
         elif button_id == "btn_back":
             self.action_back()
@@ -406,6 +998,10 @@ class TeamManagementScreen(Screen):
             return
 
         self._current_team_slug = slug
+        # Close any open inline forms so they don't leak context across teams.
+        self._hide_invite_form()
+        self._hide_change_role_form()
+        self._hide_share_server_form()
         self.run_worker(
             self._load_team_detail(slug),
             exclusive=True,
@@ -424,8 +1020,12 @@ class TeamManagementScreen(Screen):
         if not self._current_team_slug:
             self.notify("No team selected.", severity="warning")
             return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can invite members.", severity="warning")
+            return
         email = self.query_one("#input_invite_email", Input).value.strip()
-        role = self.query_one("#input_invite_role", Input).value.strip() or "member"
+        role_value = self.query_one("#select_invite_role", Select).value
+        role = role_value if isinstance(role_value, str) else "member"
         if not email:
             self.notify("Email is required.", severity="error")
             self.query_one("#input_invite_email", Input).focus()
@@ -436,20 +1036,36 @@ class TeamManagementScreen(Screen):
             name="invite_member",
         )
 
+    def _selected_member(self) -> Optional[dict]:
+        """Return the member dict for the currently-highlighted members table row."""
+        table = self.query_one("#members_table", DataTable)
+        row = table.cursor_row
+        if row is None or row < 0 or row >= len(self._members):
+            return None
+        return self._members[row]
+
     def _action_remove_member(self) -> None:
         if not self._current_team_slug:
             self.notify("Select a team first.", severity="warning")
             return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can remove members.", severity="warning")
+            return
 
-        table = self.query_one("#members_table", DataTable)
-        row = table.cursor_row
-        if row < 0 or row >= len(self._members):
+        member = self._selected_member()
+        if member is None:
             self.notify("No member selected.", severity="warning")
             return
 
-        member = self._members[row]
-        email = member.get("email", "unknown")
-        user_id = member.get("id", "")
+        if (member.get("role") or "").lower() == "owner":
+            self.notify("The owner cannot be removed.", severity="warning")
+            return
+
+        email = self._member_display_email(member)
+        member_id = member.get("id", "")
+        if not member_id:
+            self.notify("Cannot resolve member id; refresh the team and try again.", severity="error")
+            return
 
         slug = self._current_team_slug
 
@@ -465,30 +1081,403 @@ class TeamManagementScreen(Screen):
                 )
             )
             if confirmed:
-                await self._do_remove_member(slug, user_id, email)
+                await self._do_remove_member(slug, member_id, email)
 
         self.run_worker(_confirm_and_remove(), exclusive=True, name="remove_member")
 
-    def _action_share_server(self) -> None:
+    def _action_resend_invite(self) -> None:
         if not self._current_team_slug:
             self.notify("Select a team first.", severity="warning")
             return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can resend invites.", severity="warning")
+            return
+        member = self._selected_member()
+        if member is None:
+            self.notify("No member selected.", severity="warning")
+            return
+        if member.get("is_accepted"):
+            self.notify("This member has already accepted — nothing to resend.", severity="warning")
+            return
+        member_id = member.get("id", "")
+        if not member_id:
+            self.notify("Cannot resolve member id; refresh the team and try again.", severity="error")
+            return
+        email = self._member_display_email(member)
+        self.run_worker(
+            self._do_resend_invite(self._current_team_slug, member_id, email),
+            exclusive=True,
+            name="resend_invite",
+        )
 
+    def _action_copy_accept_url(self) -> None:
+        member = self._selected_member()
+        if member is None:
+            self.notify("No member selected.", severity="warning")
+            return
+        if member.get("is_accepted"):
+            self.notify("This member has already accepted.", severity="warning")
+            return
+        accept_url = member.get("accept_url")
+        if not accept_url:
+            # accept_url is only populated for owners/admins on pending rows.
+            if not self._can_manage_members():
+                self.notify("Only owners and admins can copy accept URLs.", severity="warning")
+            else:
+                self.notify(
+                    "No accept URL available — refresh the team or resend the invite first.",
+                    severity="warning",
+                )
+            return
+        try:
+            self.app.copy_to_clipboard(accept_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("copy_to_clipboard failed: %s", exc)
+            self.notify(f"Could not copy to clipboard: {exc}", severity="error")
+            return
+        email = self._member_display_email(member)
+        self.notify(f"Accept URL for {email} copied to clipboard.", severity="information")
+
+    def _action_change_role(self) -> None:
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can change roles.", severity="warning")
+            return
+        member = self._selected_member()
+        if member is None:
+            self.notify("No member selected.", severity="warning")
+            return
+        if (member.get("role") or "").lower() == "owner":
+            self.notify("The owner role cannot be changed via the API.", severity="warning")
+            return
+        if (member.get("role") or "").lower() == "admin" and not self._can_manage_admins():
+            self.notify("Only the owner can demote an admin.", severity="warning")
+            return
+        self._show_change_role_form(member)
+
+    def _submit_change_role(self) -> None:
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        member = self._selected_member()
+        if member is None:
+            self.notify("No member selected.", severity="warning")
+            return
+        member_id = member.get("id", "")
+        if not member_id:
+            self.notify("Cannot resolve member id; refresh the team and try again.", severity="error")
+            return
+        role_value = self.query_one("#select_change_role", Select).value
+        new_role = role_value if isinstance(role_value, str) else "member"
+        # Server-side: only owners can assign 'admin'; mirror as a floor.
+        if new_role == "admin" and not self._can_manage_admins():
+            self.notify("Only the owner can assign the admin role.", severity="warning")
+            return
+        email = self._member_display_email(member)
+        self.run_worker(
+            self._do_update_role(self._current_team_slug, member_id, email, new_role),
+            exclusive=True,
+            name="update_role",
+        )
+
+    def _action_share_server(self) -> None:
+        """Open the share-server picker form."""
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can share servers.", severity="warning")
+            return
+        instances = getattr(self.app, "instances", [])
+        if not instances:
+            self.notify("No servers available to share.", severity="warning")
+            return
+        self._show_share_server_form(instances)
+
+    def _action_push_config(self) -> None:
+        """Open the push-config form. Only owners/admins reach this button."""
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can push team configs.", severity="warning")
+            return
+        self._show_push_config_form()
+
+    def _submit_push_config(self) -> None:
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can push team configs.", severity="warning")
+            return
+        config = getattr(self.app, "config", None)
+        if config is None:
+            self.notify("Local config not available.", severity="error")
+            return
+        from servonaut.services.team_config_subset import build_shareable_subset
+        payload, _summary = build_shareable_subset(config)
+        description = self.query_one("#input_push_description", Input).value.strip() or None
+        self.run_worker(
+            self._do_push_config(self._current_team_slug, payload, description),
+            exclusive=True,
+            name="push_team_config",
+        )
+
+    async def _do_push_config(self, slug: str, payload: dict, description: Optional[str]) -> None:
+        team_svc = getattr(self.app, "team_service", None)
+        if team_svc is None:
+            return
+        try:
+            result = await team_svc.push_team_config(slug, payload, description)
+            self._hide_push_config_form()
+            version = result.get("version", "?") if isinstance(result, dict) else "?"
+            self.notify(f"Pushed config version {version}.", severity="information")
+            await self._load_team_detail(slug)
+        except APIError as exc:
+            logger.error("Push team config failed (%s): %s", exc.status, exc.message)
+            if exc.status == 403:
+                self.notify(
+                    "Only team owners and admins can push configs.",
+                    severity="error",
+                )
+            else:
+                self.notify(f"Push failed: {exc.message}", severity="error")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Push team config failed: %s", exc)
+            self.notify(f"Push failed: {exc}", severity="error")
+
+    def _action_pull_config(self) -> None:
+        """Fetch the team's latest config and open the apply-confirmation form."""
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        self.run_worker(
+            self._do_pull_config(self._current_team_slug),
+            exclusive=True,
+            name="pull_team_config",
+        )
+
+    async def _do_pull_config(self, slug: str) -> None:
+        team_svc = getattr(self.app, "team_service", None)
+        if team_svc is None:
+            return
+        try:
+            latest = await team_svc.get_latest_team_config(slug)
+        except APIError as exc:
+            logger.error("Pull team config failed (%s): %s", exc.status, exc.message)
+            self.notify(f"Pull failed: {exc.message}", severity="error")
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Pull team config failed: %s", exc)
+            self.notify(f"Pull failed: {exc}", severity="error")
+            return
+        if latest is None:
+            self.notify("No team config has been pushed yet.", severity="warning")
+            return
+        config_data = latest.get("config_data") if isinstance(latest, dict) else None
+        if not isinstance(config_data, dict):
+            self.notify("Team config payload is malformed; cannot apply.", severity="error")
+            return
+        # Surface the apply preview inline; user confirms via the form's Apply button.
+        self._show_pull_config_form(config_data)
+
+    def _submit_pull_config(self) -> None:
+        """Apply the previously-fetched remote payload over the local config."""
+        if self._pending_pull_payload is None:
+            self.notify("Click 'Pull Latest' first to fetch the team config.", severity="warning")
+            return
+        config = getattr(self.app, "config", None)
+        config_manager = getattr(self.app, "config_manager", None)
+        if config is None or config_manager is None:
+            self.notify("Local config manager not available — cannot apply.", severity="error")
+            return
+        from servonaut.services.team_config_apply import apply_team_config
+        payload = self._pending_pull_payload
+        try:
+            apply_team_config(config, payload)
+            config_manager.save()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Apply team config failed: %s", exc)
+            self.notify(f"Apply failed: {exc}", severity="error")
+            return
+        self._pending_pull_payload = None
+        self._hide_pull_config_form()
+        self.notify(
+            "Team config applied. Restart Servonaut for connection-profile changes to take full effect.",
+            severity="information",
+            timeout=10,
+        )
+
+    def _action_share_all_servers(self) -> None:
+        """Bulk-share every eligible instance, skipping ones already on the team.
+
+        Eligible = has a routable hostname (public or private IP). Dedupe is
+        applied client-side via instance_id first (most reliable), then by
+        hostname (handles non-cloud custom servers without an id).
+        """
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can share servers.", severity="warning")
+            return
         instances = getattr(self.app, "instances", [])
         if not instances:
             self.notify("No servers available to share.", severity="warning")
             return
 
-        # Share the first instance as a simple default; a full picker would
-        # require an additional modal which is out of scope for this screen.
-        instance = instances[0]
-        server_data = {
-            "name": instance.get("name", ""),
-            "host": instance.get("public_ip") or instance.get("private_ip", ""),
-            "provider": instance.get("provider", "aws"),
-            "username": instance.get("username", "ec2-user"),
-            "port": instance.get("port", 22),
+        # Build dedupe sets from the team's currently-shared list. Both lookups
+        # tolerate the server returning either or both fields.
+        already_shared_ids = {
+            s.get("instance_id") for s in self._shared_servers if s.get("instance_id")
         }
+        already_shared_hosts = {
+            s.get("hostname") for s in self._shared_servers if s.get("hostname")
+        }
+
+        to_share: list[dict] = []
+        skipped_existing = 0
+        skipped_no_ip = 0
+        for instance in instances:
+            hostname = instance.get("public_ip") or instance.get("private_ip")
+            if not hostname:
+                skipped_no_ip += 1
+                continue
+            if instance.get("id") and instance["id"] in already_shared_ids:
+                skipped_existing += 1
+                continue
+            if hostname in already_shared_hosts:
+                skipped_existing += 1
+                continue
+            to_share.append(instance)
+
+        if not to_share:
+            self.notify(
+                f"Nothing to share. Already shared: {skipped_existing}. No IP: {skipped_no_ip}.",
+                severity="information",
+            )
+            return
+
+        slug = self._current_team_slug
+        self.run_worker(
+            self._do_share_all(slug, to_share, skipped_existing, skipped_no_ip),
+            exclusive=True,
+            name="share_all_servers",
+        )
+
+    async def _do_share_all(
+        self,
+        slug: str,
+        instances: list[dict],
+        skipped_existing: int,
+        skipped_no_ip: int,
+    ) -> None:
+        team_svc = getattr(self.app, "team_service", None)
+        if team_svc is None:
+            return
+        succeeded = 0
+        failed: list[str] = []
+        for instance in instances:
+            payload: dict = {
+                "name": instance.get("name") or instance.get("id", ""),
+                "hostname": instance.get("public_ip") or instance.get("private_ip"),
+            }
+            if instance.get("id"):
+                payload["instance_id"] = instance["id"]
+            if instance.get("region"):
+                payload["region"] = instance["region"]
+            if instance.get("username"):
+                payload["username"] = instance["username"]
+            port = instance.get("port")
+            if port and port != 22:
+                payload["port"] = port
+            try:
+                await team_svc.push_server(slug, payload)
+                succeeded += 1
+            except APIError as exc:
+                logger.warning("Bulk share failed for %s (%s): %s", payload["name"], exc.status, exc.message)
+                failed.append(f"{payload['name']} ({exc.message})")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Bulk share failed for %s: %s", payload["name"], exc)
+                failed.append(f"{payload['name']} ({exc})")
+
+        parts = [f"Shared {succeeded}"]
+        if skipped_existing:
+            parts.append(f"skipped {skipped_existing} already shared")
+        if skipped_no_ip:
+            parts.append(f"skipped {skipped_no_ip} without IP")
+        if failed:
+            parts.append(f"failed {len(failed)}")
+        summary = "Share All: " + ", ".join(parts) + "."
+        severity = "warning" if failed else "information"
+        self.notify(summary, severity=severity, timeout=12 if failed else 6)
+        if failed:
+            # Surface the first 3 failure reasons so the user has something to act on.
+            for line in failed[:3]:
+                logger.warning("Share All failure detail: %s", line)
+        await self._load_team_detail(slug)
+
+    def _submit_share_server(self) -> None:
+        """Submit the share form: build payload from selected instance."""
+        if not self._current_team_slug:
+            self.notify("Select a team first.", severity="warning")
+            return
+        if not self._can_manage_members():
+            self.notify("Only owners and admins can share servers.", severity="warning")
+            return
+        selected_value = self.query_one("#select_share_instance", Select).value
+        if selected_value == Select.BLANK or not isinstance(selected_value, str):
+            self.notify("Pick a server to share.", severity="warning")
+            return
+        instance = next(
+            (i for i in getattr(self.app, "instances", []) if str(i.get("id")) == selected_value),
+            None,
+        )
+        if instance is None:
+            self.notify("Selected server is no longer in your inventory; refresh and try again.", severity="error")
+            return
+        hostname = instance.get("public_ip") or instance.get("private_ip") or ""
+        if not hostname:
+            # Defensive — _build_share_options should have filtered this row out,
+            # but the inventory may have changed since the form was opened.
+            self.notify(
+                f"Instance '{instance.get('name', '?')}' has no public or private IP — cannot share.",
+                severity="warning",
+            )
+            return
+        # Read connection-detail inputs. Both optional — null/22 are the
+        # backend defaults and the consumer's CLI applies a cloud-specific
+        # username fallback when the stored value is null.
+        username = self.query_one("#input_share_username", Input).value.strip()
+        port_raw = self.query_one("#input_share_port", Input).value.strip()
+        port: Optional[int] = None
+        if port_raw:
+            try:
+                port = int(port_raw)
+            except ValueError:
+                self.notify("Port must be a number between 1 and 65535.", severity="error")
+                return
+            if not 1 <= port <= 65535:
+                self.notify("Port must be between 1 and 65535.", severity="error")
+                return
+        # Backend contract (Api/Team/SharedServerController::create):
+        #   required: name, hostname
+        #   optional: instance_id, region, tags, status, username, port
+        server_data: dict = {
+            "name": instance.get("name") or instance.get("id", ""),
+            "hostname": hostname,
+        }
+        if instance.get("id"):
+            server_data["instance_id"] = instance["id"]
+        if instance.get("region"):
+            server_data["region"] = instance["region"]
+        if username:
+            server_data["username"] = username
+        if port is not None and port != 22:
+            server_data["port"] = port
         self.run_worker(
             self._do_push_server(self._current_team_slug, server_data),
             exclusive=True,

--- a/src/servonaut/services/api_client.py
+++ b/src/servonaut/services/api_client.py
@@ -328,6 +328,14 @@ class APIClient(APIClientInterface):
             return {"success": True}
         return response.json()
 
+    async def put(self, path: str, *, json: Optional[Any] = None, timeout: float = DEFAULT_TIMEOUT_SECONDS, retry_on_401: bool = True, **kwargs: Any) -> Dict[str, Any]:
+        response = await self._request(
+            "PUT", path, timeout=timeout, json=json, retry_on_401=retry_on_401
+        )
+        if response.status_code == 204:
+            return {"success": True}
+        return response.json()
+
     async def delete(self, path: str, *, timeout: float = DEFAULT_TIMEOUT_SECONDS, params: Optional[Dict[str, Any]] = None, retry_on_401: bool = True, **kwargs: Any) -> Dict[str, Any]:
         response = await self._request(
             "DELETE", path, timeout=timeout, params=params, retry_on_401=retry_on_401

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -986,11 +986,15 @@ class TeamServiceInterface(ABC):
         pass
 
     @abstractmethod
-    async def remove_member(self, slug: str, user_id: str) -> dict:
+    async def remove_member(self, slug: str, member_id: str) -> dict:
         pass
 
     @abstractmethod
-    async def update_role(self, slug: str, user_id: str, role: str) -> dict:
+    async def update_role(self, slug: str, member_id: str, role: str) -> dict:
+        pass
+
+    @abstractmethod
+    async def resend_invite(self, slug: str, member_id: str) -> dict:
         pass
 
     @abstractmethod
@@ -999,6 +1003,20 @@ class TeamServiceInterface(ABC):
 
     @abstractmethod
     async def push_server(self, slug: str, server_data: dict) -> dict:
+        pass
+
+    @abstractmethod
+    async def list_team_configs(self, slug: str) -> List[dict]:
+        pass
+
+    @abstractmethod
+    async def get_latest_team_config(self, slug: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    async def push_team_config(
+        self, slug: str, config_data: dict, description: Optional[str] = None
+    ) -> dict:
         pass
 
 

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -301,10 +301,27 @@ class RelayListener:
             except (TypeError, ValueError):
                 ttl = 60
 
+            # AI tool calls (ssh_exec_readonly, tail_log, etc.) are handled by
+            # services/ai_tool_bridge.py via the chat-stream / tool-result HTTP
+            # path — NOT by this relay listener. The backend currently mirrors
+            # them onto /cli/{user_id}/commands too, so we receive them here and
+            # must skip cleanly instead of erroring. CommandType only covers the
+            # 8 web-originated relay verbs; anything else belongs elsewhere.
+            raw_type = raw.get("type")
+            try:
+                command_type = CommandType(raw_type)
+            except ValueError:
+                logger.debug(
+                    "Skipping non-relay event type=%r on commands channel "
+                    "(handled by ai_tool_bridge): id=%s",
+                    raw_type, raw.get("id"),
+                )
+                return
+
             request = CommandRequest(
                 id=raw["id"],
                 user_id=event_user_id,
-                type=CommandType(raw["type"]),
+                type=command_type,
                 target_server_id=raw["target_server_id"],
                 payload=raw.get("payload", {}),
                 ttl_seconds=ttl,

--- a/src/servonaut/services/team_config_apply.py
+++ b/src/servonaut/services/team_config_apply.py
@@ -1,0 +1,82 @@
+"""Apply a pulled team-config payload over the local :class:`AppConfig`.
+
+Apply semantics are REPLACE-WHOLE-SECTION for v1 — the team's section
+overwrites the local one in its entirety. This is the simplest model that
+makes the feature useful (admin pushes a baseline → members pull → they
+have it). Selective per-item import is the v2 release.
+
+After application, the caller is responsible for invoking
+:meth:`ConfigManager.save` so the change persists; the helper here only
+mutates the in-memory dataclass instance so it stays testable without a
+filesystem dependency.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import AppConfig
+
+logger = logging.getLogger(__name__)
+
+
+def apply_team_config(local: "AppConfig", remote_payload: dict) -> None:
+    """Replace the four shareable sections on ``local`` with ``remote_payload``'s.
+
+    The four sections (in order applied):
+
+    * ``connection_profiles`` → :class:`ConnectionProfile`
+    * ``connection_rules``    → :class:`ConnectionRule`
+    * ``scan_rules``          → :class:`ScanRule`
+    * ``custom_servers``      → :class:`CustomServer`
+
+    Each remote dict is rehydrated into its dataclass. Unknown keys on the
+    remote (e.g. a future-version field this CLI doesn't yet understand) are
+    silently dropped — the rehydration filters to known fields per the
+    dataclass signature so we forward-compat gracefully.
+    """
+    from servonaut.config.schema import (
+        ConnectionProfile,
+        ConnectionRule,
+        CustomServer,
+        ScanRule,
+    )
+
+    local.connection_profiles = _rehydrate_list(
+        remote_payload.get("connection_profiles", []), ConnectionProfile
+    )
+    local.connection_rules = _rehydrate_list(
+        remote_payload.get("connection_rules", []), ConnectionRule
+    )
+    local.scan_rules = _rehydrate_list(
+        remote_payload.get("scan_rules", []), ScanRule
+    )
+    local.custom_servers = _rehydrate_list(
+        remote_payload.get("custom_servers", []), CustomServer
+    )
+
+
+def _rehydrate_list(raw: List[dict], cls) -> list:
+    """Rehydrate a list of dicts into instances of ``cls``.
+
+    Drops keys that don't exist on the dataclass — keeps us tolerant of
+    newer-version payloads being pulled by older-version clients without
+    raising ``TypeError: __init__() got an unexpected keyword argument``.
+    """
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(cls)}
+    result = []
+    for d in raw or []:
+        if not isinstance(d, dict):
+            logger.warning("Skipping non-dict entry while rehydrating %s: %r", cls.__name__, d)
+            continue
+        cleaned = {k: v for k, v in d.items() if k in field_names}
+        try:
+            result.append(cls(**cleaned))
+        except TypeError as exc:
+            # A required field is missing — log and skip rather than abort
+            # the whole apply.
+            logger.warning("Skipping malformed %s entry %r: %s", cls.__name__, d, exc)
+    return result

--- a/src/servonaut/services/team_config_subset.py
+++ b/src/servonaut/services/team_config_subset.py
@@ -1,0 +1,139 @@
+"""Build a shareable subset of the local AppConfig for team-config push.
+
+The team-config feature persists a JSON blob on the server. The CLI does NOT
+share the entire :class:`AppConfig` — it strips three categories of field
+before sending:
+
+* **Credential-bearing**: AI provider API keys, OAuth tokens, cloud-provider
+  credentials (GCP service account paths, OVH consumer keys, Hetzner tokens).
+* **Operator-personal**: terminal preference, command-history path, demo-mode
+  flag, dismissed banners, cache TTLs.
+* **Local-filesystem paths**: ``ssh_key`` on custom servers, ``bastion_key``
+  on connection profiles. These are reset to ``""`` and the recipient
+  re-binds them locally; we surface the count of stripped paths in the push
+  warning so the operator knows what's missing on the other side.
+
+The shareable subset is intentionally narrow — connection profiles, scan
+rules, custom servers (sanitised), and connection rules. IP-ban configs are
+EXCLUDED because they reference AWS-account-specific resource IDs (IP-set
+UUIDs, security-group IDs) that won't exist in another teammate's account.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import AppConfig
+
+
+# Marker the sanitiser stamps on the payload so apply-side knows the shape
+# came from this version of the contract. Bump when the wire format changes.
+SHAREABLE_SUBSET_VERSION = 1
+
+
+def build_shareable_subset(config: "AppConfig") -> Tuple[dict, dict]:
+    """Return ``(payload, summary)`` from a local :class:`AppConfig`.
+
+    The payload is what gets POSTed to ``/api/v1/teams/{slug}/configs``.
+    The summary is a dict the UI can render before push so the operator can
+    review what will be shared:
+
+    .. code-block:: python
+
+        summary = {
+            "connection_profiles": 4,
+            "connection_rules": 2,
+            "scan_rules": 7,
+            "custom_servers": 3,
+            "stripped_paths": 5,  # bastion_key + custom_server.ssh_key removed
+        }
+    """
+    profiles = [_sanitise_profile(asdict(p)) for p in config.connection_profiles]
+    custom_servers = [_sanitise_custom_server(asdict(s)) for s in config.custom_servers]
+
+    stripped = sum(p.pop("_stripped", 0) for p in profiles)
+    stripped += sum(s.pop("_stripped", 0) for s in custom_servers)
+
+    payload = {
+        "subset_version": SHAREABLE_SUBSET_VERSION,
+        "connection_profiles": profiles,
+        "connection_rules": [asdict(r) for r in config.connection_rules],
+        "scan_rules": [asdict(r) for r in config.scan_rules],
+        "custom_servers": custom_servers,
+    }
+    summary = {
+        "connection_profiles": len(profiles),
+        "connection_rules": len(payload["connection_rules"]),
+        "scan_rules": len(payload["scan_rules"]),
+        "custom_servers": len(custom_servers),
+        "stripped_paths": stripped,
+    }
+    return payload, summary
+
+
+def _sanitise_profile(d: dict) -> dict:
+    """Strip ``bastion_key`` (local path). Count stripped paths under ``_stripped``."""
+    stripped = 0
+    if d.get("bastion_key"):
+        d["bastion_key"] = ""
+        stripped += 1
+    d["_stripped"] = stripped
+    return d
+
+
+def _sanitise_custom_server(d: dict) -> dict:
+    """Strip ``ssh_key`` (local path). Count under ``_stripped``."""
+    stripped = 0
+    if d.get("ssh_key"):
+        d["ssh_key"] = ""
+        stripped += 1
+    d["_stripped"] = stripped
+    return d
+
+
+def diff_against_local(local: "AppConfig", remote_payload: dict) -> dict:
+    """Summarise what would change if ``remote_payload`` were applied over ``local``.
+
+    Returned shape (suitable for an Apply-confirmation modal):
+
+    .. code-block:: python
+
+        {
+            "connection_profiles": {"local": 3, "remote": 4, "after": 4},
+            "connection_rules":    {"local": 1, "remote": 2, "after": 2},
+            "scan_rules":          {"local": 7, "remote": 7, "after": 7},
+            "custom_servers":      {"local": 0, "remote": 5, "after": 5},
+            "stripped_paths_in_remote": 3,
+        }
+
+    Apply semantics are REPLACE-WHOLE-SECTION — the team's section overwrites
+    the local one. Selective-per-item import is deferred to v2 (see the plan
+    note for design).
+    """
+    sections = ("connection_profiles", "connection_rules", "scan_rules", "custom_servers")
+    diff: dict = {}
+    for name in sections:
+        local_count = len(getattr(local, name, []) or [])
+        remote_count = len(remote_payload.get(name, []) or [])
+        diff[name] = {
+            "local": local_count,
+            "remote": remote_count,
+            "after": remote_count,  # replace-whole-section
+        }
+    # Re-count stripped paths from the payload so apply-side can mention them
+    # ("3 SSH key paths were stripped — re-bind them in Settings after Apply").
+    stripped = 0
+    for p in remote_payload.get("connection_profiles", []) or []:
+        if not (p.get("bastion_key") or "").strip():
+            # A blank bastion_key in the payload means the publisher had one
+            # locally that got stripped, OR they never had one. We can't
+            # distinguish without an explicit marker. Conservative: don't
+            # falsely accuse the payload of stripping. Operators see the
+            # accurate count from the PUSH-side summary anyway.
+            pass
+    for s in remote_payload.get("custom_servers", []) or []:
+        if not (s.get("ssh_key") or "").strip():
+            pass
+    diff["stripped_paths_in_remote"] = stripped
+    return diff

--- a/src/servonaut/services/team_service.py
+++ b/src/servonaut/services/team_service.py
@@ -58,33 +58,62 @@ class TeamService(TeamServiceInterface):
         return await self._api.post("/api/v1/teams", json={"name": name})
 
     async def invite_member(self, slug: str, email: str, role: str = "member") -> dict:
-        """Invite a member to a team."""
+        """Invite a member to a team.
+
+        Returns the created member row. The response includes ``email_sent``
+        (bool) — when ``False`` the invitation row was persisted with a valid
+        token but the mailer failed; the owner can fall back to the ``accept_url``
+        exposed on ``GET /teams/{slug}`` for pending rows.
+        """
         return await self._api.post(
             f"/api/v1/teams/{slug}/members",
             json={"email": email, "role": role},
         )
 
-    async def remove_member(self, slug: str, user_id: str) -> dict:
-        """Remove a member from a team."""
-        return await self._api.delete(f"/api/v1/teams/{slug}/members/{user_id}")
+    async def remove_member(self, slug: str, member_id: str) -> dict:
+        """Remove a member from a team.
 
-    async def update_role(self, slug: str, user_id: str, role: str) -> dict:
-        """Update a team member's role."""
-        return await self._api.post(
-            f"/api/v1/teams/{slug}/members/{user_id}/role",
+        ``member_id`` is the ``TeamMember`` row id, NOT the user id. The two
+        diverge for pending invites where the user has not yet registered.
+        """
+        return await self._api.delete(f"/api/v1/teams/{slug}/members/{member_id}")
+
+    async def update_role(self, slug: str, member_id: str, role: str) -> dict:
+        """Update a team member's role.
+
+        Backend route is ``PUT /api/v1/teams/{slug}/members/{memberId}`` — the
+        ``/role`` suffix exists only on the web flow, not the API. ``member_id``
+        is the ``TeamMember`` row id.
+        """
+        return await self._api.put(
+            f"/api/v1/teams/{slug}/members/{member_id}",
             json={"role": role},
+        )
+
+    async def resend_invite(self, slug: str, member_id: str) -> dict:
+        """Resend the invitation email for a pending member row.
+
+        Preserves the existing invitation token and extends
+        ``invitation_expires_at`` by 7 days from the resend moment. Returns the
+        same shape as :meth:`invite_member` (including ``email_sent``).
+        """
+        return await self._api.post(
+            f"/api/v1/teams/{slug}/members/{member_id}/resend",
+            json={},
         )
 
     async def list_shared_servers(self, slug: str) -> List[dict]:
         """List servers shared with a team.
 
-        Accepts either a bare array or `{"servers": [...]}` envelope.
+        Backend wraps the response in ``{"data": [...]}`` per
+        ``Api/Team/SharedServerController::list``. Older shapes (bare array or
+        ``{"servers": [...]}``) are tolerated for forward/backward compat.
         """
         result = await self._api.get(f"/api/v1/teams/{slug}/servers")
         if isinstance(result, list):
             servers = result
         elif isinstance(result, dict):
-            servers = result.get("servers", [])
+            servers = result.get("data") or result.get("servers", [])
         else:
             servers = []
         # Mark as shared team servers
@@ -99,6 +128,55 @@ class TeamService(TeamServiceInterface):
             f"/api/v1/teams/{slug}/servers",
             json=server_data,
         )
+
+    async def list_team_configs(self, slug: str) -> List[dict]:
+        """List every shared-config version for a team (any team member can read).
+
+        Backend: ``GET /api/v1/teams/{slug}/configs`` →
+        ``{"data": [{id, version, config_data, description, pushed_by, created_at}, ...]}``.
+        """
+        result = await self._api.get(f"/api/v1/teams/{slug}/configs")
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            return result.get("data") or result.get("configs", [])
+        return []
+
+    async def get_latest_team_config(self, slug: str) -> Optional[dict]:
+        """Return the most recent shared-config version, or None if the team has none.
+
+        Backend: ``GET /api/v1/teams/{slug}/configs/latest`` → 200 with payload, OR
+        404 ``{"error": "No configuration found"}`` when the team has never pushed one.
+        We catch the 404 and return None rather than raising so callers can treat
+        "no shared config yet" as a non-error state.
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            result = await self._api.get(f"/api/v1/teams/{slug}/configs/latest")
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+        if isinstance(result, dict):
+            return result.get("data") or result
+        return None
+
+    async def push_team_config(
+        self, slug: str, config_data: dict, description: Optional[str] = None
+    ) -> dict:
+        """Push a new shared-config version (admin/owner only).
+
+        Backend rejects callers without ``hasAdminAccess`` with 403, and 400s
+        when ``config_data`` is missing or not an object.
+        """
+        body: dict = {"config_data": config_data}
+        if description:
+            body["description"] = description
+        result = await self._api.post(f"/api/v1/teams/{slug}/configs", json=body)
+        # Backend wraps in {"data": ...} — unwrap for callers.
+        if isinstance(result, dict) and "data" in result:
+            return result["data"]
+        return result if isinstance(result, dict) else {}
 
     async def remove_shared_server(self, slug: str, server_name: str) -> dict:
         """Remove a shared server from team inventory."""

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -37,6 +37,7 @@ to ``_do_send_servonaut`` only when the resolver picks Servonaut.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import webbrowser
@@ -1910,10 +1911,42 @@ class ChatPanel(Widget):
 
         self._turn_tool_calls += 1
 
+        # Extract args, tolerating known provider-wrapper variants.
+        # Per backend contract (ToolCallEvent::payload), args is a flat dict
+        # at data["args"]. We tolerate:
+        #   - JSON-encoded string (older providers): json.loads it
+        #   - Anthropic-style wrapped {"input": {...}}: unwrap input
+        # If anything goes wrong, fall back to {} (relay rejects with a
+        # readable error rather than the bridge silently dropping the call).
+        raw_args = data.get("args")
+        parsed_args: Dict[str, Any] = {}
+        if isinstance(raw_args, dict):
+            # Anthropic-style wrap unwrap; otherwise pass through.
+            if "input" in raw_args and isinstance(raw_args["input"], dict) and len(raw_args) == 1:
+                parsed_args = dict(raw_args["input"])
+            else:
+                parsed_args = dict(raw_args)
+        elif isinstance(raw_args, str) and raw_args.strip():
+            try:
+                decoded = json.loads(raw_args)
+                if isinstance(decoded, dict):
+                    parsed_args = decoded
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(
+                    "tool_call args was a non-JSON string for tool=%s call=%s",
+                    data.get("tool"), data.get("tool_call_id"),
+                )
+        # DEBUG-level dump so re-running with --debug shows what the wire
+        # actually delivered, without leaking content in normal logs.
+        logger.debug(
+            "tool_call raw args type=%s value=%r → parsed=%r",
+            type(raw_args).__name__, raw_args, parsed_args,
+        )
+
         call = ToolCall(
             tool_call_id=str(data.get("tool_call_id") or ""),
             tool=str(data.get("tool") or ""),
-            args=dict(data.get("args") or {}),
+            args=parsed_args,
             guard_level=str(data.get("guard_level") or "standard"),  # type: ignore[arg-type]
             conversation_id=self._remote_conversation_id or "",
         )

--- a/tests/test_demo_mode_coverage.py
+++ b/tests/test_demo_mode_coverage.py
@@ -2125,6 +2125,8 @@ class TestTeamManagementDemoMode:
         screen = object.__new__(TeamManagementScreen)
         screen._members = []
         screen._current_team_name = ""
+        screen._current_team_role = None
+        screen._team_roles = {}
         mock_app = _make_mock_app(demo=True)
 
         mock_team_svc = MagicMock()

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -256,6 +256,16 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes a hard-coded '--- Switching to log: <path> ---' banner "
                    "where path comes from the config, not live server output."),
 
+    # team_management.py — Shared Configs push/pull preview Statics only
+    # ever contain counts ("Will share: 3 connection profiles, 7 scan rules")
+    # and a code-controlled warning string — no user-streamed data.
+    AllowlistEntry("screens/team_management.py", "_show_push_config_form", "update",
+                   "Push preview Static — renders counts + constant warning text; "
+                   "summary dict is built from len() over local config sections."),
+    AllowlistEntry("screens/team_management.py", "_show_pull_config_form", "update",
+                   "Pull preview Static — renders local→remote counts per section "
+                   "from diff_against_local; numerical counts, not user-typed text."),
+
     # memory.py — sync status and AI summary update UI labels, not raw data.
     AllowlistEntry("screens/memory.py", "_refresh_sync_status", "update",
                    "Updates sync-status labels (last sync time, sync state badge) "

--- a/tests/test_relay_listener.py
+++ b/tests/test_relay_listener.py
@@ -662,3 +662,32 @@ class TestTokenProviderRotation:
         )
         with pytest.raises(RuntimeError, match="token provider raised"):
             listener._get_auth_token()
+
+
+# ---------------------------------------------------------------------------
+# _handle_event — non-relay CommandType (AI tool calls mirrored onto channel)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleEventUnknownCommandType:
+    def test_ai_tool_call_type_is_skipped_silently_not_errored(self, caplog):
+        # Backend currently publishes AI tool calls (ssh_exec_readonly, etc.) on
+        # /cli/{user_id}/commands too. Those belong to ai_tool_bridge — relay
+        # listener must skip them without raising an ERROR log line.
+        listener = make_listener(user_id="user-123")
+        data = make_event_payload(cmd_type="ssh_exec_readonly", payload={"command": "ls"})
+        with caplog.at_level("DEBUG", logger="servonaut.services.relay_listener"):
+            run(listener._handle_event(data))
+        # Executor NOT invoked — this isn't ours to run.
+        listener._executors.execute.assert_not_called()
+        # No ERROR log either — the old behaviour was "Failed to handle event".
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert not error_records, f"unexpected ERROR logs: {[r.message for r in error_records]}"
+
+    def test_unknown_command_type_is_skipped_silently(self):
+        # Future-proof: any type we don't yet recognise should be ignored, not
+        # errored. Catches CLI-running-older-than-backend at a deploy boundary.
+        listener = make_listener(user_id="user-123")
+        data = make_event_payload(cmd_type="future_unknown_verb", payload={"foo": "bar"})
+        run(listener._handle_event(data))
+        listener._executors.execute.assert_not_called()

--- a/tests/test_team_config_share.py
+++ b/tests/test_team_config_share.py
@@ -1,0 +1,167 @@
+"""Tests for the team-config sanitise / apply helpers (v1)."""
+from __future__ import annotations
+
+from servonaut.config.schema import (
+    AppConfig,
+    ConnectionProfile,
+    ConnectionRule,
+    CustomServer,
+    ScanRule,
+)
+from servonaut.services.team_config_apply import apply_team_config
+from servonaut.services.team_config_subset import (
+    SHAREABLE_SUBSET_VERSION,
+    build_shareable_subset,
+    diff_against_local,
+)
+
+
+def _seeded_config() -> AppConfig:
+    cfg = AppConfig()
+    cfg.connection_profiles = [
+        ConnectionProfile(name="prod-bastion", bastion_host="bastion.example.com",
+                          bastion_user="zoltan", bastion_key="/home/zoltan/.ssh/bastion_key"),
+        ConnectionProfile(name="staging", username="ec2-user"),
+    ]
+    cfg.connection_rules = [
+        ConnectionRule(name="prod-rule", match_conditions={"name_contains": "prod"}, profile_name="prod-bastion"),
+    ]
+    cfg.scan_rules = [
+        ScanRule(name="nginx-logs", match_conditions={"name_contains": "web"},
+                 scan_paths=["/var/log/nginx"]),
+    ]
+    cfg.custom_servers = [
+        CustomServer(name="db-1", host="10.0.0.1", username="ubuntu",
+                     ssh_key="/home/zoltan/.ssh/db_key", port=22),
+        CustomServer(name="cache-1", host="10.0.0.2", username="root", port=22),
+    ]
+    return cfg
+
+
+class TestBuildShareableSubset:
+    def test_includes_the_four_shareable_sections(self):
+        payload, summary = build_shareable_subset(_seeded_config())
+        assert payload["subset_version"] == SHAREABLE_SUBSET_VERSION
+        assert summary == {
+            "connection_profiles": 2,
+            "connection_rules": 1,
+            "scan_rules": 1,
+            "custom_servers": 2,
+            "stripped_paths": 2,  # bastion_key + custom_server ssh_key
+        }
+
+    def test_strips_bastion_key_local_path(self):
+        payload, _ = build_shareable_subset(_seeded_config())
+        profile_with_bastion = next(
+            p for p in payload["connection_profiles"] if p["name"] == "prod-bastion"
+        )
+        assert profile_with_bastion["bastion_key"] == ""
+
+    def test_strips_custom_server_ssh_key_local_path(self):
+        payload, _ = build_shareable_subset(_seeded_config())
+        db_server = next(s for s in payload["custom_servers"] if s["name"] == "db-1")
+        assert db_server["ssh_key"] == ""
+        cache_server = next(s for s in payload["custom_servers"] if s["name"] == "cache-1")
+        assert cache_server["ssh_key"] == ""
+
+    def test_does_NOT_include_credential_or_personal_sections(self):
+        payload, _ = build_shareable_subset(_seeded_config())
+        # The four shareable keys + subset_version marker — nothing else.
+        assert set(payload.keys()) == {
+            "subset_version",
+            "connection_profiles",
+            "connection_rules",
+            "scan_rules",
+            "custom_servers",
+        }
+        # No AI/cloud/credential keys must leak.
+        for forbidden in ("ai", "openai_api_key", "gcp", "azure", "ovh", "hetzner",
+                          "relay", "mcp", "command_history_path", "terminal_emulator",
+                          "ip_ban_configs"):
+            assert forbidden not in payload
+
+    def test_internal_strip_marker_not_present_in_final_payload(self):
+        payload, _ = build_shareable_subset(_seeded_config())
+        for section in ("connection_profiles", "custom_servers"):
+            for entry in payload[section]:
+                assert "_stripped" not in entry, "_stripped marker leaked to wire format"
+
+
+class TestApplyTeamConfig:
+    def test_replaces_each_section_wholesale(self):
+        local = _seeded_config()
+        remote = {
+            "connection_profiles": [{"name": "team-prod", "bastion_host": "team.example.com"}],
+            "connection_rules": [{"name": "rule-a", "match_conditions": {"region": "eu-west-2"}, "profile_name": "team-prod"}],
+            "scan_rules": [{"name": "auth-logs", "match_conditions": {}, "scan_paths": ["/var/log/auth.log"]}],
+            "custom_servers": [{"name": "team-db", "host": "team-db.example.com", "username": "root", "port": 22}],
+        }
+        apply_team_config(local, remote)
+        assert [p.name for p in local.connection_profiles] == ["team-prod"]
+        assert [r.name for r in local.connection_rules] == ["rule-a"]
+        assert [r.name for r in local.scan_rules] == ["auth-logs"]
+        assert [s.name for s in local.custom_servers] == ["team-db"]
+        assert isinstance(local.connection_profiles[0], ConnectionProfile)
+        assert isinstance(local.custom_servers[0], CustomServer)
+
+    def test_drops_unknown_keys_for_forward_compat(self):
+        local = _seeded_config()
+        remote = {
+            "connection_profiles": [{
+                "name": "future-profile",
+                "bastion_host": "x.example.com",
+                "future_field_we_dont_understand": "shrug",
+            }],
+            "connection_rules": [],
+            "scan_rules": [],
+            "custom_servers": [],
+        }
+        apply_team_config(local, remote)
+        assert local.connection_profiles[0].name == "future-profile"
+        # The unknown key is silently dropped — no exception.
+
+    def test_skips_malformed_entries_keeps_going(self):
+        local = _seeded_config()
+        remote = {
+            # ScanRule requires both `name` and `match_conditions` — entry 2 is missing match_conditions.
+            "scan_rules": [
+                {"name": "good", "match_conditions": {}, "scan_paths": []},
+                {"name": "broken"},  # missing required match_conditions
+            ],
+            "connection_profiles": [],
+            "connection_rules": [],
+            "custom_servers": [],
+        }
+        apply_team_config(local, remote)
+        assert [r.name for r in local.scan_rules] == ["good"]
+
+    def test_empty_remote_clears_local_sections(self):
+        # Replace-whole-section semantics: empty list on remote = clear local.
+        local = _seeded_config()
+        apply_team_config(local, {
+            "connection_profiles": [],
+            "connection_rules": [],
+            "scan_rules": [],
+            "custom_servers": [],
+        })
+        assert local.connection_profiles == []
+        assert local.connection_rules == []
+        assert local.scan_rules == []
+        assert local.custom_servers == []
+
+
+class TestDiffAgainstLocal:
+    def test_diff_reports_local_remote_after_per_section(self):
+        local = _seeded_config()
+        remote = {
+            "connection_profiles": [{"name": "p1"}, {"name": "p2"}, {"name": "p3"}, {"name": "p4"}],
+            "connection_rules": [],
+            "scan_rules": [{"name": "s1", "match_conditions": {}}],
+            "custom_servers": [],
+        }
+        diff = diff_against_local(local, remote)
+        # local had 2 profiles, 1 rule, 1 scan_rule, 2 custom_servers
+        assert diff["connection_profiles"] == {"local": 2, "remote": 4, "after": 4}
+        assert diff["connection_rules"] == {"local": 1, "remote": 0, "after": 0}
+        assert diff["scan_rules"] == {"local": 1, "remote": 1, "after": 1}
+        assert diff["custom_servers"] == {"local": 2, "remote": 0, "after": 0}

--- a/tests/test_team_management_screen.py
+++ b/tests/test_team_management_screen.py
@@ -6,9 +6,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from textual.app import App
-from textual.widgets import Button, DataTable, Input, Static
+from textual.widgets import Button, DataTable, Input, Select, Static
 
 from servonaut.screens.team_management import TeamManagementScreen
+from servonaut.services.api_client import APIError
 
 
 # ---------------------------------------------------------------------------
@@ -24,9 +25,24 @@ def _make_team_service(teams: list[dict] | None = None) -> MagicMock:
         return_value={
             "name": "Engineering",
             "slug": "engineering",
+            "role": "owner",
             "members": [
-                {"id": "u1", "email": "alice@example.com", "role": "admin", "status": "active"},
-                {"id": "u2", "email": "bob@example.com", "role": "member", "status": "pending"},
+                {
+                    "id": "m1",
+                    "invitation_email": "alice@example.com",
+                    "user": {"id": 1, "name": "Alice"},
+                    "role": "admin",
+                    "is_accepted": True,
+                },
+                {
+                    "id": "m2",
+                    "invitation_email": "bob@example.com",
+                    "user": None,
+                    "role": "member",
+                    "is_accepted": False,
+                    "invitation_expires_at": "2099-01-01T00:00:00+00:00",
+                    "accept_url": "https://staging.servonaut.dev/invite/abc123",
+                },
             ],
         }
     )
@@ -36,8 +52,10 @@ def _make_team_service(teams: list[dict] | None = None) -> MagicMock:
         ]
     )
     svc.create_team = AsyncMock(return_value={"slug": "new-team", "name": "New Team"})
-    svc.invite_member = AsyncMock(return_value={})
+    svc.invite_member = AsyncMock(return_value={"email_sent": True})
+    svc.resend_invite = AsyncMock(return_value={"email_sent": True})
     svc.remove_member = AsyncMock(return_value={})
+    svc.update_role = AsyncMock(return_value={})
     svc.push_server = AsyncMock(return_value={})
     return svc
 
@@ -193,9 +211,11 @@ class TestTeamManagementScreenDetail:
         async with app.run_test(headless=True) as pilot:
             await pilot.pause()
             await pilot.pause()
+            # Detail sections are wrapped in .settings_section cards; the
+            # whole wrapper collapses pre-team-selection.
             assert app.screen.query_one("#team_header").display is False
-            assert app.screen.query_one("#members_table").display is False
-            assert app.screen.query_one("#servers_table").display is False
+            assert app.screen.query_one("#members_section").display is False
+            assert app.screen.query_one("#servers_section").display is False
 
     @pytest.mark.asyncio
     async def test_create_form_hidden_on_initial_load(self):
@@ -307,8 +327,9 @@ class TestTeamManagementInviteMember:
             screen._current_team_slug = "eng"
             screen._show_invite_form()
             await pilot.pause()
+            screen._current_team_role = "owner"
             screen.query_one("#input_invite_email", Input).value = "newmember@example.com"
-            screen.query_one("#input_invite_role", Input).value = "member"
+            screen.query_one("#select_invite_role", Select).value = "member"
             screen._submit_invite_member()
             for _ in range(5):
                 await pilot.pause()
@@ -328,8 +349,9 @@ class TestTeamManagementInviteMember:
             screen._current_team_slug = "eng"
             screen._show_invite_form()
             await pilot.pause()
+            screen._current_team_role = "owner"
             screen.query_one("#input_invite_email", Input).value = "someone@example.com"
-            screen.query_one("#input_invite_role", Input).value = ""
+            # Select defaults to "member" via _show_invite_form()
             screen._submit_invite_member()
             for _ in range(5):
                 await pilot.pause()
@@ -347,6 +369,7 @@ class TestTeamManagementInviteMember:
             await pilot.pause()
             screen = app.screen
             screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
             screen._show_invite_form()
             await pilot.pause()
             screen.query_one("#input_invite_email", Input).value = ""
@@ -399,3 +422,1016 @@ class TestTeamManagementMissingServices:
             await pilot.pause()
             # Screen still mounts without crashing
             assert app.screen.query_one("#teams_table") is not None
+
+
+# ---------------------------------------------------------------------------
+# Caller role gating
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementCallerRoleGating:
+    @pytest.mark.asyncio
+    async def test_member_caller_cannot_see_mutation_buttons(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service(_SAMPLE_TEAMS)
+        # Override get_team to drop the caller-role hint so the screen falls
+        # back to the slug -> role cache built from list_teams.
+        team_svc.get_team = AsyncMock(
+            return_value={
+                "name": "Ops",
+                "slug": "ops",
+                "members": [],
+            }
+        )
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "ops"
+            await screen._load_team_detail("ops")
+            await pilot.pause()
+            assert screen._current_team_role == "member"
+            for btn_id in ("btn_invite", "btn_remove", "btn_change_role", "btn_resend", "btn_copy_url", "btn_share"):
+                assert screen.query_one(f"#{btn_id}").display is False, btn_id
+
+    @pytest.mark.asyncio
+    async def test_owner_caller_sees_all_mutation_buttons(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service([{"slug": "eng", "name": "Eng", "role": "owner", "member_count": 1}])
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            await screen._load_team_detail("eng")
+            await pilot.pause()
+            for btn_id in ("btn_invite", "btn_remove", "btn_change_role", "btn_resend", "btn_copy_url", "btn_share"):
+                assert screen.query_one(f"#{btn_id}").display is True, btn_id
+
+    @pytest.mark.asyncio
+    async def test_admin_caller_cannot_select_admin_role_option(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service([{"slug": "eng", "name": "Eng", "role": "admin", "member_count": 1}])
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "admin"
+            options = screen._role_options_for_caller()
+            values = [v for _, v in options]
+            assert "admin" not in values
+            assert "member" in values
+            assert "viewer" in values
+
+
+# ---------------------------------------------------------------------------
+# Status column + email lookup
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementMemberDisplay:
+    def test_format_status_active(self):
+        assert TeamManagementScreen._format_status({"is_accepted": True}) == "Active"
+
+    def test_format_status_invited_with_expiry(self):
+        result = TeamManagementScreen._format_status({
+            "is_accepted": False,
+            "invitation_expires_at": "2099-01-01T00:00:00+00:00",
+        })
+        assert result.startswith("Invited (expires in")
+
+    def test_format_status_invited_expired(self):
+        result = TeamManagementScreen._format_status({
+            "is_accepted": False,
+            "invitation_expires_at": "2000-01-01T00:00:00+00:00",
+        })
+        assert result == "Invited (expired)"
+
+    def test_format_status_invited_without_expiry(self):
+        assert TeamManagementScreen._format_status({"is_accepted": False}) == "Invited"
+
+    def test_email_lookup_prefers_invitation_email(self):
+        assert TeamManagementScreen._member_display_email({
+            "invitation_email": "alice@example.com",
+            "user": {"name": "Alice"},
+        }) == "alice@example.com"
+
+    def test_email_lookup_falls_back_to_user_name(self):
+        assert TeamManagementScreen._member_display_email({
+            "user": {"id": 1, "name": "Bob"},
+        }) == "Bob"
+
+    def test_email_lookup_legacy_email_field(self):
+        # Tolerates pre-fix backend shape.
+        assert TeamManagementScreen._member_display_email({
+            "email": "legacy@example.com",
+        }) == "legacy@example.com"
+
+    def test_email_lookup_unknown_fallback(self):
+        assert TeamManagementScreen._member_display_email({}) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Invite / resend email_sent handling
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementInviteOutcome:
+    @pytest.mark.asyncio
+    async def test_invite_response_email_sent_false_warns_user(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.invite_member = AsyncMock(return_value={"email_sent": False})
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            notifications: list[tuple[str, str]] = []
+            orig_notify = screen.notify
+
+            def capture_notify(msg, *, severity="information", **kw):
+                notifications.append((str(severity), str(msg)))
+                return orig_notify(msg, severity=severity, **kw)
+
+            screen.notify = capture_notify  # type: ignore[method-assign]
+            await screen._do_invite_member("eng", "x@example.com", "member")
+            await pilot.pause()
+            assert any(sev == "warning" and "email delivery failed" in msg for sev, msg in notifications)
+
+    @pytest.mark.asyncio
+    async def test_resend_invite_calls_service_with_member_id(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._members = [
+                {"id": "m2", "invitation_email": "bob@example.com", "role": "member", "is_accepted": False},
+            ]
+            tbl = screen.query_one("#members_table", DataTable)
+            tbl.add_row("bob@example.com", "member", "Invited")
+            tbl.move_cursor(row=0)
+            screen._action_resend_invite()
+            for _ in range(5):
+                await pilot.pause()
+            team_svc.resend_invite.assert_called_once_with("eng", "m2")
+
+
+# ---------------------------------------------------------------------------
+# Change role
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementChangeRole:
+    @pytest.mark.asyncio
+    async def test_change_role_uses_put_via_member_id(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._members = [
+                {"id": "m2", "invitation_email": "bob@example.com", "role": "member", "is_accepted": True},
+            ]
+            tbl = screen.query_one("#members_table", DataTable)
+            tbl.add_row("bob@example.com", "member", "Active")
+            tbl.move_cursor(row=0)
+            screen._show_change_role_form(screen._members[0])
+            await pilot.pause()
+            screen.query_one("#select_change_role", Select).value = "admin"
+            screen._submit_change_role()
+            for _ in range(5):
+                await pilot.pause()
+            team_svc.update_role.assert_called_once_with("eng", "m2", "admin")
+
+    @pytest.mark.asyncio
+    async def test_admin_caller_cannot_promote_to_admin(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "admin"  # admin, NOT owner
+            screen._members = [
+                {"id": "m2", "invitation_email": "bob@example.com", "role": "member", "is_accepted": True},
+            ]
+            tbl = screen.query_one("#members_table", DataTable)
+            tbl.add_row("bob@example.com", "member", "Active")
+            tbl.move_cursor(row=0)
+            screen._show_change_role_form(screen._members[0])
+            await pilot.pause()
+            # Force the bypass attempt — UI Select shouldn't even expose admin,
+            # but mimic a client-side tamper to prove the floor holds.
+            screen.query_one("#select_change_role", Select).set_options(_ROLE_OPTIONS_FULL)
+            screen.query_one("#select_change_role", Select).value = "admin"
+            screen._submit_change_role()
+            await pilot.pause()
+            team_svc.update_role.assert_not_called()
+
+
+_ROLE_OPTIONS_FULL = [("Viewer", "viewer"), ("Member", "member"), ("Admin", "admin")]
+
+
+# ---------------------------------------------------------------------------
+# Copy accept URL
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementCopyAcceptUrl:
+    @pytest.mark.asyncio
+    async def test_copy_accept_url_uses_app_clipboard(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._members = [
+                {
+                    "id": "m2",
+                    "invitation_email": "bob@example.com",
+                    "role": "member",
+                    "is_accepted": False,
+                    "accept_url": "https://staging.servonaut.dev/invite/xyz",
+                },
+            ]
+            tbl = screen.query_one("#members_table", DataTable)
+            tbl.add_row("bob@example.com", "member", "Invited")
+            tbl.move_cursor(row=0)
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda text: copied.append(text)  # type: ignore[method-assign]
+            screen._action_copy_accept_url()
+            await pilot.pause()
+            assert copied == ["https://staging.servonaut.dev/invite/xyz"]
+
+    @pytest.mark.asyncio
+    async def test_copy_accept_url_noop_when_url_missing(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._members = [
+                {"id": "m2", "invitation_email": "bob@example.com", "role": "member", "is_accepted": False},
+            ]
+            tbl = screen.query_one("#members_table", DataTable)
+            tbl.add_row("bob@example.com", "member", "Invited")
+            tbl.move_cursor(row=0)
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda text: copied.append(text)  # type: ignore[method-assign]
+            screen._action_copy_accept_url()
+            await pilot.pause()
+            assert copied == []
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — Create-team button gating + 403 message surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementCreateTeamGate:
+    @pytest.mark.asyncio
+    async def test_create_team_button_hidden_when_caller_already_owns_a_team(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service([
+            {"slug": "eng", "name": "Engineering", "role": "owner", "member_count": 3},
+        ])
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app.screen.query_one("#btn_create_team").display is False
+
+    @pytest.mark.asyncio
+    async def test_create_team_button_visible_when_caller_owns_none(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service([
+            {"slug": "eng", "name": "Engineering", "role": "member", "member_count": 3},
+        ])
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app.screen.query_one("#btn_create_team").display is True
+
+    @pytest.mark.asyncio
+    async def test_create_team_403_surfaces_backend_message_verbatim(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.create_team = AsyncMock(side_effect=APIError(
+            code="forbidden",
+            message="You already own a team workspace. Delete the existing team or contact support to lift this limit.",
+            status=403,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            notifications: list[tuple[str, str]] = []
+            orig_notify = screen.notify
+
+            def capture_notify(msg, *, severity="information", **kw):
+                notifications.append((str(severity), str(msg)))
+                return orig_notify(msg, severity=severity, **kw)
+
+            screen.notify = capture_notify  # type: ignore[method-assign]
+            await screen._do_create_team("My Team")
+            await pilot.pause()
+            assert any(sev == "error" and "already own a team workspace" in msg for sev, msg in notifications), notifications
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — 402 / 422 / other-4xx branching in invite + resend
+# ---------------------------------------------------------------------------
+
+
+def _capture_notifications(screen) -> list[tuple[str, str]]:
+    """Install a notify capture on the screen. Returns the list that fills up."""
+    notifications: list[tuple[str, str]] = []
+    orig_notify = screen.notify
+
+    def capture(msg, *, severity="information", **kw):
+        notifications.append((str(severity), str(msg)))
+        return orig_notify(msg, severity=severity, **kw)
+
+    screen.notify = capture  # type: ignore[method-assign]
+    return notifications
+
+
+class TestTeamManagementMemberWriteErrors:
+    @pytest.mark.asyncio
+    async def test_invite_402_owner_caller_sees_billing_cta(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.invite_member = AsyncMock(side_effect=APIError(
+            code="payment_required",
+            message="This team's current subscription does not include team invitations.",
+            status=402,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"  # owner sees billing link
+            notes = _capture_notifications(screen)
+            await screen._do_invite_member("eng", "x@example.com", "member")
+            await pilot.pause()
+            assert any(
+                sev == "warning" and "Manage your subscription at https://servonaut.dev/account/billing" in msg
+                for sev, msg in notes
+            ), notes
+
+    @pytest.mark.asyncio
+    async def test_invite_402_non_owner_caller_sees_ask_owner(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.invite_member = AsyncMock(side_effect=APIError(
+            code="payment_required",
+            message="This team's current subscription does not include team invitations.",
+            status=402,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "admin"  # admin can invite, but isn't billing owner
+            notes = _capture_notifications(screen)
+            await screen._do_invite_member("eng", "x@example.com", "member")
+            await pilot.pause()
+            assert any(
+                sev == "warning" and "Ask the team owner to renew" in msg
+                for sev, msg in notes
+            ), notes
+
+    @pytest.mark.asyncio
+    async def test_invite_422_seat_cap_surfaces_remove_or_upgrade_hint(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.invite_member = AsyncMock(side_effect=APIError(
+            code="seats_exhausted",
+            message='Team "Engineering" has reached its maximum of 5 seats.',
+            status=422,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            notes = _capture_notifications(screen)
+            await screen._do_invite_member("eng", "x@example.com", "member")
+            await pilot.pause()
+            assert any(
+                sev == "warning" and "Remove an existing member" in msg and "maximum of 5 seats" in msg
+                for sev, msg in notes
+            ), notes
+
+    @pytest.mark.asyncio
+    async def test_resend_402_uses_same_branch(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.resend_invite = AsyncMock(side_effect=APIError(
+            code="payment_required",
+            message="This team's current subscription does not include team invitations.",
+            status=402,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            notes = _capture_notifications(screen)
+            await screen._do_resend_invite("eng", "m1", "bob@example.com")
+            await pilot.pause()
+            assert any(sev == "warning" and "Manage your subscription" in msg for sev, msg in notes), notes
+
+    @pytest.mark.asyncio
+    async def test_invite_other_4xx_surfaces_backend_message(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.invite_member = AsyncMock(side_effect=APIError(
+            code="conflict",
+            message="A pending invitation already exists for this email.",
+            status=409,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            notes = _capture_notifications(screen)
+            await screen._do_invite_member("eng", "dup@example.com", "member")
+            await pilot.pause()
+            assert any(
+                sev == "error" and "pending invitation already exists" in msg
+                for sev, msg in notes
+            ), notes
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — seats indicator in team header
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementSeatLine:
+    def test_seat_line_with_active_subscription(self):
+        members = [{"id": f"m{i}"} for i in range(3)]
+        team = {"max_seats": 5}
+        assert TeamManagementScreen._format_seat_line(team, members) == "Seats: 3 / 5"
+
+    def test_seat_line_counts_pending_invites_in_used(self):
+        # Backend semantics: accepted + pending both reserve a seat.
+        members = [
+            {"id": "m1", "is_accepted": True},
+            {"id": "m2", "is_accepted": False},
+            {"id": "m3", "is_accepted": False},
+        ]
+        team = {"max_seats": 5}
+        assert TeamManagementScreen._format_seat_line(team, members) == "Seats: 3 / 5"
+
+    def test_seat_line_no_subscription_renders_explanatory_text(self):
+        members = [{"id": "m1"}, {"id": "m2"}]
+        team = {"max_seats": 0}
+        line = TeamManagementScreen._format_seat_line(team, members)
+        assert line == "Seats: 2 (no active Teams subscription)"
+
+    def test_seat_line_missing_max_seats_field_treated_as_no_sub(self):
+        # Defensive — pre-fix backend payloads / older snapshots may omit the field.
+        members = [{"id": "m1"}]
+        team = {}
+        assert TeamManagementScreen._format_seat_line(team, members) == "Seats: 1 (no active Teams subscription)"
+
+
+# ---------------------------------------------------------------------------
+# Cancel buttons — escape hatch from stuck forms after server errors
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementCancelButtons:
+    @pytest.mark.asyncio
+    async def test_cancel_create_team_hides_form(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._show_create_form()
+            await pilot.pause()
+            assert screen.query_one("#create_team_form").display is True
+            screen.query_one("#btn_cancel_create_team", Button).press()
+            await pilot.pause()
+            assert screen.query_one("#create_team_form").display is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_invite_member_hides_form(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_invite_form()
+            await pilot.pause()
+            assert screen.query_one("#invite_form").display is True
+            screen.query_one("#btn_cancel_invite", Button).press()
+            await pilot.pause()
+            assert screen.query_one("#invite_form").display is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_change_role_hides_form(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_change_role_form({"id": "m1", "invitation_email": "b@x.com", "role": "member"})
+            await pilot.pause()
+            assert screen.query_one("#change_role_form").display is True
+            screen.query_one("#btn_cancel_change_role", Button).press()
+            await pilot.pause()
+            assert screen.query_one("#change_role_form").display is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_share_server_hides_form(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            assert screen.query_one("#share_server_form").display is True
+            screen.query_one("#btn_cancel_share", Button).press()
+            await pilot.pause()
+            assert screen.query_one("#share_server_form").display is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_works_after_server_403_keeps_user_unblocked(self):
+        # Regression: user reported that on a 403 from POST /teams the form
+        # stayed open with no way to dismiss it. Cancel must still work after
+        # the failed save attempt.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        team_svc.create_team = AsyncMock(side_effect=APIError(
+            code="forbidden",
+            message="You already own a team workspace.",
+            status=403,
+        ))
+        app = _WrapperApp(auth_service=auth, team_service=team_svc)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._show_create_form()
+            screen.query_one("#input_team_name", Input).value = "Doomed Team"
+            screen._submit_create_team()
+            for _ in range(5):
+                await pilot.pause()
+            # Form intentionally stays open so user sees the error context.
+            assert screen.query_one("#create_team_form").display is True
+            # Cancel must close it.
+            screen.query_one("#btn_cancel_create_team", Button).press()
+            await pilot.pause()
+            assert screen.query_one("#create_team_form").display is False
+
+
+# ---------------------------------------------------------------------------
+# Share server — wire-format contract
+# ---------------------------------------------------------------------------
+
+
+class TestTeamManagementShareServer:
+    @pytest.mark.asyncio
+    async def test_share_action_opens_picker_form(self):
+        # Action button opens the form — does NOT push the first instance.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "i-0abc", "name": "web-01", "public_ip": "1.2.3.4"},
+            {"id": "i-0xyz", "name": "web-02", "public_ip": "5.6.7.8"},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._action_share_server()
+            await pilot.pause()
+            assert screen.query_one("#share_server_form").display is True
+            team_svc.push_server.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_submit_share_sends_selected_instance_not_first(self):
+        # Regression: picker MUST send the user's chosen row, not instances[0].
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "i-0abc", "name": "web-01", "public_ip": "1.2.3.4", "region": "eu-west-2"},
+            {"id": "i-0xyz", "name": "web-02", "public_ip": "5.6.7.8", "region": "us-east-1"},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            # Pick the SECOND instance — proves first-instance bias is gone.
+            screen.query_one("#select_share_instance", Select).value = "i-0xyz"
+            screen._submit_share_server()
+            for _ in range(5):
+                await pilot.pause()
+            slug_arg, payload = team_svc.push_server.call_args.args
+            assert slug_arg == "eng"
+            assert payload["name"] == "web-02"
+            assert payload["hostname"] == "5.6.7.8"
+            assert payload["instance_id"] == "i-0xyz"
+            assert payload["region"] == "us-east-1"
+            # Stale fields from earlier contract must NOT leak through.
+            for stale in ("host", "provider", "username", "port"):
+                assert stale not in payload
+
+    @pytest.mark.asyncio
+    async def test_submit_share_falls_back_to_private_ip_when_public_missing(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "i-internal", "name": "internal-db", "public_ip": "", "private_ip": "10.0.5.20"},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            screen.query_one("#select_share_instance", Select).value = "i-internal"
+            screen._submit_share_server()
+            for _ in range(5):
+                await pilot.pause()
+            _, payload = team_svc.push_server.call_args.args
+            assert payload["hostname"] == "10.0.5.20"
+
+    @pytest.mark.asyncio
+    async def test_submit_share_with_nothing_selected_warns_and_does_not_push(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-0abc", "name": "web-01", "public_ip": "1.2.3.4"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            screen.query_one("#select_share_instance", Select).clear()
+            notes = _capture_notifications(screen)
+            screen._submit_share_server()
+            await pilot.pause()
+            team_svc.push_server.assert_not_called()
+            assert any("Pick a server" in msg for _, msg in notes), notes
+
+    def test_build_share_options_filters_instances_with_no_ip(self):
+        instances = [
+            {"id": "i-1", "name": "good", "public_ip": "1.1.1.1"},
+            {"id": "i-2", "name": "stopped", "public_ip": "", "private_ip": ""},
+            {"id": "i-3", "name": "private-only", "public_ip": "", "private_ip": "10.0.0.3"},
+            {"name": "no-id", "public_ip": "2.2.2.2"},  # no id → drop
+        ]
+        options = TeamManagementScreen._build_share_options(instances)
+        values = [v for _, v in options]
+        assert values == ["i-1", "i-3"]
+
+    def test_build_share_options_label_shows_name_and_hostname(self):
+        options = TeamManagementScreen._build_share_options([
+            {"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"},
+        ])
+        assert options == [("web-01 (1.1.1.1)", "i-1")]
+
+    def test_build_share_options_falls_back_to_id_when_name_missing(self):
+        options = TeamManagementScreen._build_share_options([
+            {"id": "i-noname", "public_ip": "9.9.9.9"},
+        ])
+        assert options == [("i-noname (9.9.9.9)", "i-noname")]
+
+    @pytest.mark.asyncio
+    async def test_submit_share_includes_username_and_port_when_provided(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            screen.query_one("#input_share_username", Input).value = "deploy"
+            screen.query_one("#input_share_port", Input).value = "2222"
+            screen._submit_share_server()
+            for _ in range(5):
+                await pilot.pause()
+            _, payload = team_svc.push_server.call_args.args
+            assert payload["username"] == "deploy"
+            assert payload["port"] == 2222
+
+    @pytest.mark.asyncio
+    async def test_submit_share_omits_port_when_default_22(self):
+        # Sending port=22 explicitly is noisy — backend defaults to 22 already.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            screen.query_one("#input_share_port", Input).value = "22"
+            screen._submit_share_server()
+            for _ in range(5):
+                await pilot.pause()
+            _, payload = team_svc.push_server.call_args.args
+            assert "port" not in payload
+
+    @pytest.mark.asyncio
+    async def test_submit_share_omits_username_when_blank(self):
+        # Empty username = "use the consumer CLI's cloud default" (null at API).
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            screen.query_one("#input_share_username", Input).value = ""
+            screen._submit_share_server()
+            for _ in range(5):
+                await pilot.pause()
+            _, payload = team_svc.push_server.call_args.args
+            assert "username" not in payload
+
+    @pytest.mark.asyncio
+    async def test_submit_share_rejects_invalid_port(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "web-01", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            # 70000 is out of the backend's 1-65535 range — surface client-side
+            # to save a server round-trip + a worse error message.
+            screen.query_one("#input_share_port", Input).value = "70000"
+            notes = _capture_notifications(screen)
+            screen._submit_share_server()
+            await pilot.pause()
+            team_svc.push_server.assert_not_called()
+            assert any("between 1 and 65535" in msg for _, msg in notes), notes
+
+    @pytest.mark.asyncio
+    async def test_share_form_prefills_username_and_port_from_custom_server(self):
+        # Custom servers carry username/port on the instance dict; AWS rows do not.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "custom-prod", "name": "prod-1", "public_ip": "10.0.0.1",
+             "username": "ubuntu", "port": 2222, "is_custom": True},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            assert screen.query_one("#input_share_username", Input).value == "ubuntu"
+            assert screen.query_one("#input_share_port", Input).value == "2222"
+
+    @pytest.mark.asyncio
+    async def test_share_all_pushes_every_eligible_instance(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        # Mix: two AWS rows, one custom row with non-default port, one stopped (no IP).
+        instances = [
+            {"id": "i-1", "name": "aws-1", "public_ip": "1.1.1.1", "region": "eu-west-2"},
+            {"id": "i-2", "name": "aws-2", "public_ip": "2.2.2.2", "region": "us-east-1"},
+            {"id": "custom-3", "name": "prod-db", "public_ip": "10.0.0.3",
+             "username": "ubuntu", "port": 2222},
+            {"id": "i-stop", "name": "stopped", "public_ip": "", "private_ip": ""},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._shared_servers = []  # nothing shared yet
+            screen._action_share_all_servers()
+            for _ in range(10):
+                await pilot.pause()
+            # 3 eligible (skipped stopped). Each gets its own POST.
+            assert team_svc.push_server.call_count == 3
+            sent_names = [c.args[1]["name"] for c in team_svc.push_server.call_args_list]
+            assert sent_names == ["aws-1", "aws-2", "prod-db"]
+            # Custom server's username + non-default port came through.
+            custom_payload = team_svc.push_server.call_args_list[2].args[1]
+            assert custom_payload["username"] == "ubuntu"
+            assert custom_payload["port"] == 2222
+
+    @pytest.mark.asyncio
+    async def test_share_all_skips_already_shared_by_instance_id(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "i-1", "name": "aws-1", "public_ip": "1.1.1.1"},
+            {"id": "i-2", "name": "aws-2", "public_ip": "2.2.2.2"},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._shared_servers = [
+                {"name": "aws-1", "hostname": "1.1.1.1", "instance_id": "i-1"},
+            ]
+            screen._action_share_all_servers()
+            for _ in range(10):
+                await pilot.pause()
+            assert team_svc.push_server.call_count == 1
+            assert team_svc.push_server.call_args.args[1]["name"] == "aws-2"
+
+    @pytest.mark.asyncio
+    async def test_share_all_skips_already_shared_by_hostname_when_no_instance_id(self):
+        # Custom servers without instance_id should still dedupe by hostname.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "custom-x", "name": "no-id-server", "public_ip": "10.5.5.5"},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._shared_servers = [
+                {"name": "no-id-server", "hostname": "10.5.5.5"},  # no instance_id field
+            ]
+            screen._action_share_all_servers()
+            for _ in range(10):
+                await pilot.pause()
+            team_svc.push_server.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_share_all_noop_when_everything_already_shared(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [{"id": "i-1", "name": "aws-1", "public_ip": "1.1.1.1"}]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._shared_servers = [
+                {"name": "aws-1", "hostname": "1.1.1.1", "instance_id": "i-1"},
+            ]
+            notes = _capture_notifications(screen)
+            screen._action_share_all_servers()
+            await pilot.pause()
+            team_svc.push_server.assert_not_called()
+            assert any("Already shared: 1" in msg for _, msg in notes), notes
+
+    @pytest.mark.asyncio
+    async def test_share_all_continues_on_individual_failure_and_reports_summary(self):
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "i-1", "name": "aws-1", "public_ip": "1.1.1.1"},
+            {"id": "i-2", "name": "aws-2", "public_ip": "2.2.2.2"},
+            {"id": "i-3", "name": "aws-3", "public_ip": "3.3.3.3"},
+        ]
+        # Middle one 409s; others succeed. Sequential loop must not abort.
+        team_svc.push_server = AsyncMock(side_effect=[
+            {"id": "share-1"},
+            APIError(code="conflict", message="Server with that hostname already shared.", status=409),
+            {"id": "share-3"},
+        ])
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._shared_servers = []
+            notes = _capture_notifications(screen)
+            screen._action_share_all_servers()
+            for _ in range(15):
+                await pilot.pause()
+            assert team_svc.push_server.call_count == 3
+            summary_notes = [msg for sev, msg in notes if sev == "warning" and "Shared 2" in msg]
+            assert summary_notes, notes
+            assert any("failed 1" in msg for msg in summary_notes), summary_notes
+
+    @pytest.mark.asyncio
+    async def test_share_form_skips_port_prefill_when_default_22(self):
+        # If the instance is on the SSH default, leave the field blank — placeholder
+        # already tells the user that empty == 22.
+        auth = _make_auth_service(authenticated=True)
+        team_svc = _make_team_service()
+        instances = [
+            {"id": "custom-prod", "name": "prod-1", "public_ip": "10.0.0.1",
+             "username": "ubuntu", "port": 22, "is_custom": True},
+        ]
+        app = _WrapperApp(auth_service=auth, team_service=team_svc, instances=instances)
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            screen = app.screen
+            screen._current_team_slug = "eng"
+            screen._current_team_role = "owner"
+            screen._show_share_server_form(instances)
+            await pilot.pause()
+            assert screen.query_one("#input_share_username", Input).value == "ubuntu"
+            assert screen.query_one("#input_share_port", Input).value == ""

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -19,6 +19,7 @@ def mock_api():
     api = MagicMock()
     api.get = AsyncMock()
     api.post = AsyncMock()
+    api.put = AsyncMock()
     api.delete = AsyncMock()
     return api
 
@@ -56,10 +57,88 @@ class TestTeamService:
 
     def test_remove_member(self, team_service, mock_api):
         mock_api.delete.return_value = {"success": True}
-        run(team_service.remove_member("team-a", "user-123"))
-        mock_api.delete.assert_called_with("/api/v1/teams/team-a/members/user-123")
+        run(team_service.remove_member("team-a", "member-uuid-123"))
+        mock_api.delete.assert_called_with("/api/v1/teams/team-a/members/member-uuid-123")
+
+    def test_update_role_uses_put_without_role_suffix(self, team_service, mock_api):
+        # Regression for the route mismatch: backend route is
+        # PUT /api/v1/teams/{slug}/members/{memberId} — the /role suffix
+        # exists only on the web flow and the original CLI code hit it via POST.
+        mock_api.put.return_value = {"success": True}
+        run(team_service.update_role("team-a", "member-uuid-123", "admin"))
+        mock_api.put.assert_called_with(
+            "/api/v1/teams/team-a/members/member-uuid-123",
+            json={"role": "admin"},
+        )
+        mock_api.post.assert_not_called()
+
+    def test_list_team_configs_unwraps_data_envelope(self, team_service, mock_api):
+        mock_api.get.return_value = {"data": [
+            {"id": "c1", "version": 2, "config_data": {}, "description": "v2", "pushed_by": 9, "created_at": "2026-05-24T00:00:00+00:00"},
+            {"id": "c2", "version": 1, "config_data": {}, "description": "v1", "pushed_by": 9, "created_at": "2026-05-23T00:00:00+00:00"},
+        ]}
+        configs = run(team_service.list_team_configs("team-a"))
+        assert [c["version"] for c in configs] == [2, 1]
+        mock_api.get.assert_called_with("/api/v1/teams/team-a/configs")
+
+    def test_list_team_configs_handles_bare_array_legacy_shape(self, team_service, mock_api):
+        mock_api.get.return_value = [{"id": "c1", "version": 1}]
+        configs = run(team_service.list_team_configs("team-a"))
+        assert len(configs) == 1
+
+    def test_get_latest_team_config_unwraps_data(self, team_service, mock_api):
+        mock_api.get.return_value = {"data": {"id": "c1", "version": 3, "config_data": {"connection_profiles": []}}}
+        latest = run(team_service.get_latest_team_config("team-a"))
+        assert latest["version"] == 3
+        mock_api.get.assert_called_with("/api/v1/teams/team-a/configs/latest")
+
+    def test_get_latest_team_config_returns_none_on_404(self, team_service, mock_api):
+        # Brand-new team has no configs yet — backend 404s, we treat as None.
+        from servonaut.services.api_client import APIError
+        mock_api.get.side_effect = APIError(code="not_found", message="No configuration found", status=404)
+        latest = run(team_service.get_latest_team_config("team-a"))
+        assert latest is None
+
+    def test_push_team_config_posts_full_body(self, team_service, mock_api):
+        mock_api.post.return_value = {"data": {"id": "c1", "version": 1, "config_data": {"connection_profiles": []}}}
+        payload = {"connection_profiles": [{"name": "prod"}]}
+        result = run(team_service.push_team_config("team-a", payload, "Initial baseline"))
+        mock_api.post.assert_called_with(
+            "/api/v1/teams/team-a/configs",
+            json={"config_data": payload, "description": "Initial baseline"},
+        )
+        assert result["version"] == 1
+
+    def test_push_team_config_omits_description_when_none(self, team_service, mock_api):
+        mock_api.post.return_value = {"data": {"id": "c1", "version": 2}}
+        run(team_service.push_team_config("team-a", {"scan_rules": []}, None))
+        # Body must not carry a description key — backend treats absence and null differently.
+        sent_body = mock_api.post.call_args.kwargs["json"]
+        assert "description" not in sent_body
+
+    def test_resend_invite(self, team_service, mock_api):
+        mock_api.post.return_value = {"email_sent": True, "id": "member-uuid-123"}
+        result = run(team_service.resend_invite("team-a", "member-uuid-123"))
+        mock_api.post.assert_called_with(
+            "/api/v1/teams/team-a/members/member-uuid-123/resend",
+            json={},
+        )
+        assert result["email_sent"] is True
+
+    def test_list_shared_servers_accepts_data_envelope(self):
+        # Backend (Api/Team/SharedServerController::list) wraps in {"data": [...]}.
+        api = MagicMock()
+        api.get = AsyncMock(return_value={
+            "data": [{"name": "web-1", "hostname": "10.0.0.1", "region": "eu-west-2"}]
+        })
+        svc = TeamService(api)
+        servers = run(svc.list_shared_servers("team-a"))
+        assert len(servers) == 1
+        assert servers[0]["hostname"] == "10.0.0.1"
+        assert servers[0]["is_shared"] is True
 
     def test_list_shared_servers(self, team_service, mock_api):
+        # Legacy envelope kept working for back-compat.
         mock_api.get.return_value = {
             "servers": [{"name": "web-1", "host": "10.0.0.1"}]
         }


### PR DESCRIPTION
Coordinated CLI half of [servonaut.dev PR #66](https://github.com/zb-ss/servonaut.dev/pull/66) (merged + prod-deployed as `c4e75ba` earlier today). The CLI's team-management surface was demo-complete in v2.10.2 but had several wire-format mismatches, missing UX gates, and a placeholder Share Server action. This makes the feature actually shippable to teams and lays the groundwork for shared config sync.

## Description

### Team Management Screen

**Layout**
- Wrap Teams / Members / Shared Servers / Shared Configs sections in `.settings_section` curved-border cards (matches Settings / Manage UX)
- Move inline forms inside their parent section so they appear in-context instead of orphaned at the bottom of the scroll area
- Fix forms expanding to fill the viewport (`height: auto`) — previously they inherited the scrollable parent's space and pushed cards below off-screen
- Cancel button on every inline form (Create Team / Invite / Change Role / Share Server / Push Config / Pull Config) — recoverable after any server error including 403

**Members**
- Role Select widget {Viewer, Member, Admin}, admin hidden for non-owners
- Status column derived from `is_accepted` + `invitation_expires_at` countdown (e.g. *"Invited (expires in 5d)"*)
- Email lookup uses `invitation_email` (legacy `email` fallback retained); fixes "unknown" leaking into the Remove dialog
- New **Resend Invite** action via `POST .../members/{id}/resend`
- New **Copy Accept URL** action using server-side `accept_url` field — preferred path when `email_sent=false` or first message bounces
- New **Change Role** action with inline form (`PUT` route, no `/role` suffix — that was a silent 404)
- All mutation buttons hidden for non-owner/admin callers (server still enforces — this is UX polish)
- Create Team button hidden when caller already owns ≥1 team (one team per Teams sub on backend)
- 402/422 `APIError` branching with billing-aware copy (owner sees billing CTA, member sees ask-the-owner copy)

**Shared Servers**
- Replace blind `instances[0]` dispatch with a Select-based picker (filters no-IP instances, labels disambiguate)
- Username + Port Inputs (optional, prefilled from custom-server dict)
- Fix wire contract: `hostname` not `host`, `{"data":[]}` GET envelope
- **Share All** button with bulk dispatch, dedupe by `instance_id` → `hostname`, continue-on-failure with rollup notification

**Shared Configs v1** (new)
- Section card with versions table + Push Current (admin/owner) + Pull Latest (any member)
- `services/team_config_subset.build_shareable_subset(AppConfig)` — strips `bastion_key` + `ssh_key` local paths, returns (payload, summary) with stripped count
- `services/team_config_apply.apply_team_config` — replaces sections wholesale, drops unknown forward-compat fields, skips malformed entries
- Subset scoped to connection_profiles / connection_rules / scan_rules / custom_servers — excludes everything credential-bearing or operator-personal
- Push form: description Input + summary preview
- Pull form: per-section diff preview + yellow REPLACES warning + Apply/Cancel
- 404 on `/configs/latest` treated as "no team config yet"

**Seat-cap display**
- `"Seats: X / Y"` line in team header (X = accepted + pending, matching server-side accounting)
- `max_seats == 0` renders *"Seats: N (no active Teams subscription)"*

### Service Layer

- `APIClient.put()` — was missing (CLAUDE.md memory note mentioned it but only post/patch existed)
- `TeamService.update_role` — POST → PUT, drop `/role` suffix
- Rename `user_id` → `member_id` (TeamMember.id, not User.id — diverges for pending invites)
- New: `resend_invite`, `list_team_configs`, `get_latest_team_config` (returns None on 404), `push_team_config`
- `relay_listener` — skip non-CommandType events at DEBUG instead of ERROR (backend mirrors AI tool calls onto the same Mercure channel)
- `chat_panel._handle_streamed_tool_call` — defensive args parsing tolerates Anthropic-style `{"input":{...}}` wrap + JSON-string args; DEBUG dump of raw vs parsed for future wire-shape debugging

## Tests

- **110 team-bucket tests** passing (added 56 new)
- **37 relay tests** passing (added 2 new)
- Full suite: **3666 passed, 5 skipped, 0 failed** (excluding pre-existing hetzner-extra failures from missing optional `hcloud` dep)

Coverage spans: every new TeamService method, sanitiser/apply/diff, caller-role gating, role-select limits, status derivation, email lookup fallback, `email_sent=false` branch, 402/422 copy variants, seat-line formatting, share-server contract corrections, Share All bulk dedupe + continue-on-failure, username/port prefill, Cancel-after-403 recovery, relay listener silent skip.

## Coordinated with backend PR #66

Backend (`servonaut.dev` PR #66) shipped 6 commits — email-actually-sends + Wrong-Account banner + resend endpoint + invitation_token/accept_url on GET + TeamFeatureGate + SeatPolicy live-from-Stripe + SharedServer username/port + teams.default_max_seats 10→5. Merged + prod-deployed as `c4e75ba` earlier today.


## Test plan

- [x] Full test suite green locally (3666 passed)
- [x] Demo-mode lint passes (allowlist entries added with justification for new preview Statics)
- [x] Demo-mode coverage tests updated for new section IDs
- [x] Visual layout verified — curved-bordered cards match Settings page
- [x] E2E walkthrough on staging post-merge (owner+admin+member+viewer flows)
- [x] PyPI release once merged