### PR TITLE
feat(ssh-ref): offline scaffolding for BW Password Manager SSH integration

### DIFF
--- a/src/servonaut/app.css
+++ b/src/servonaut/app.css
@@ -3278,6 +3278,40 @@ BackupConfirmModal {
     padding: 0 0 0 1;
 }
 
+/* ─── ssh verify modal ─── */
+
+ConfirmSshVerifyModal {
+    align: center middle;
+}
+
+#ssh_verify_modal_container {
+    width: 72;
+    height: 11;
+    background: $surface;
+    border: round $accent;
+    padding: 1 2;
+}
+
+#ssh_verify_modal_title {
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#ssh_verify_modal_body {
+    height: 5;
+}
+
+.ssh_verify_actions_row {
+    height: auto;
+    align: right middle;
+    margin-top: 1;
+}
+
+.ssh_verify_actions_row Button {
+    margin-left: 1;
+    min-width: 12;
+}
+
 /* ---- Clear-cache confirmation modal ---- */
 
 #confirm_clear_container {

--- a/src/servonaut/app.css
+++ b/src/servonaut/app.css
@@ -3338,3 +3338,51 @@ ConfirmSshVerifyModal {
     margin-left: 1;
     min-width: 12;
 }
+
+/* ─── bw ssh vault settings ─── */
+#bw_ssh_vault_section {
+    /* uses .settings_section base — no overrides needed */
+}
+
+#bw_ssh_vault_form {
+    height: auto;
+    padding: 1;
+    margin: 1 0 0 0;
+    border: round $accent;
+    background: $boost;
+}
+
+#bw_ssh_vault_form Input {
+    margin: 0 0 1 0;
+}
+
+/* ─── ssh ref editor ─── */
+SshRefEditorModal {
+    align: center middle;
+}
+
+#ssh_ref_editor_container {
+    width: 70;
+    height: 19;
+    padding: 1;
+    border: round $accent;
+    background: $surface;
+}
+
+#ssh_ref_editor_container Label {
+    margin: 0 0 1 0;
+}
+
+#ssh_ref_editor_container Input {
+    margin: 0 0 1 0;
+}
+
+.ssh_ref_actions_row {
+    height: 3;
+    align: center middle;
+    margin: 1 0 0 0;
+}
+
+.ssh_ref_actions_row Button {
+    margin: 0 1 0 1;
+}

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -73,6 +73,7 @@ class ServonautApp(App):
     gcp_service = None
     azure_service = None
     servonaut_tools = None  # shared MCP-layer implementation (chat + MCP server)
+    bw_ssh_config_service = None
 
     # Memory cloud-sync layer (Stream 2 + 3 services)
     memory_rate_limiter = None
@@ -189,6 +190,13 @@ class ServonautApp(App):
             self.push_screen(self._initial_screen)
         # Check for updates in background
         self.run_worker(self._check_for_update(), name="version_check", exclusive=True)
+        # Decorate instances with SSH verify sidecar data (no-op if not logged in)
+        self.run_worker(
+            self._refresh_ssh_verify_status(),
+            name="ssh_verify_sidecar",
+            group="memory_io",
+            exclusive=False,
+        )
         # Auto-start the in-process relay listener if the user is already
         # authenticated and their plan allows it. For users who log in later
         # via LoginScreen, that screen triggers the same hook.
@@ -419,6 +427,17 @@ class ServonautApp(App):
             logger.debug("httpx not installed; bug report service unavailable")
         except Exception as e:
             logger.debug("Bug report service init skipped: %s", e)
+
+        # BwSshConfigService — gated on api_client availability (paid tier /
+        # authenticated). Constructed here so it's ready immediately after
+        # init_paid_services; the ssh_verify refresh worker is kicked off in
+        # on_mount after the instance list is populated.
+        if self.api_client is not None:
+            try:
+                from servonaut.services.bw_ssh_config_service import BwSshConfigService
+                self.bw_ssh_config_service = BwSshConfigService(self.api_client)
+            except Exception as e:
+                logger.debug("BwSshConfigService init skipped: %s", e)
 
     def _init_relay_manager(self) -> None:
         """Create the RelayManager the first time; subsequent calls are no-ops."""
@@ -1249,6 +1268,39 @@ class ServonautApp(App):
         success, message = await self.update_service.run_upgrade()
         severity = "information" if success else "error"
         self.notify(message, severity=severity, timeout=10)
+
+    async def _refresh_ssh_verify_status(self) -> None:
+        """Fetch ssh_verify_status sidecar data and decorate self.instances.
+
+        Defensive — if the call fails (not logged in, 402 Free tier, network),
+        silently leaves instances un-decorated. The TUI column gracefully
+        renders "—" for missing data.
+        """
+        if self.bw_ssh_config_service is None:
+            return
+        try:
+            rows = await self.bw_ssh_config_service.list_personal_instances()
+        except Exception as exc:
+            logger.debug("Failed to load SSH verify status sidecar: %s", exc)
+            return
+        by_key = {
+            (r.get("provider"), r.get("instance_id")): r
+            for r in rows
+        }
+        for inst in self.instances:
+            sidecar = by_key.get(
+                (inst.get("provider", "aws").lower(), inst.get("id"))
+            )
+            if sidecar:
+                inst["ssh_verify_status"] = sidecar.get("ssh_verify_status")
+                inst["ssh_verified_at"] = sidecar.get("ssh_verified_at")
+        # Trigger instance table refresh if the list screen is mounted
+        try:
+            from servonaut.screens.instance_list import InstanceListScreen
+            if isinstance(self.screen, InstanceListScreen):
+                self.screen._update_table()
+        except Exception:
+            pass
 
     def on_user_logout(self) -> None:
         """Called after a successful logout to clean up session state."""

--- a/src/servonaut/cli/servers.py
+++ b/src/servonaut/cli/servers.py
@@ -1,0 +1,535 @@
+"""CLI subcommand handlers for ``servonaut servers``.
+
+Currently exposes one action: ``servonaut servers verify <id>``
+
+The verify flow probes whether the configured Bitwarden Password Manager SSH
+key can actually SSH into a managed instance, then POSTs the outcome to the
+server-side audit endpoint.  Three outcomes per the locked wire contract:
+
+- ``verified``   — ``bw get item`` returns the key AND ``ssh -o BatchMode=yes``
+                   connects successfully.
+- ``not_found``  — ``bw get item`` reports the item does not exist in the vault.
+- ``auth_failed``— ``bw get item`` returns the key but ``ssh`` exits non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import re
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+from servonaut.services.aws_service import AWSService
+from servonaut.services.bw_resolver import (
+    BwResolver,
+    BwCliMissingError,
+    BwSessionMissingError,
+)
+from servonaut.services.cache_service import CacheService
+from servonaut.utils.ephemeral_key import ephemeral_ssh_key
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+_EXIT_SUCCESS = 0
+_EXIT_VERIFY_FAILED = 1   # BW or SSH probe returned a non-verified status
+_EXIT_FATAL = 2           # No ref stored / BW CLI missing / session locked / not logged in
+
+# UUID-v4 regex for detecting team SharedServer ids.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Async wrapper
+# ---------------------------------------------------------------------------
+
+def _run_async(coro: Any) -> Any:
+    """Run *coro* synchronously via ``asyncio.run``."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Headless service initialisation
+# ---------------------------------------------------------------------------
+
+def _init_headless_services() -> Tuple[Any, Any, Any, Any, Any, Any]:
+    """Initialise services needed by ``servers verify``.
+
+    Returns:
+        ``(config_manager, auth_service, api_client,
+           bw_ssh_config_service, team_service, custom_server_service)``
+    """
+    from servonaut.config.manager import ConfigManager
+    from servonaut.services.auth_service import AuthService
+    from servonaut.services.api_client import APIClient
+    from servonaut.services.bw_ssh_config_service import BwSshConfigService
+    from servonaut.services.team_service import TeamService
+    from servonaut.services.custom_server_service import CustomServerService
+
+    config_manager = ConfigManager()
+    auth_service = AuthService()
+    api_client = APIClient(auth_service)
+    bw_ssh_config_service = BwSshConfigService(api_client)
+    team_service = TeamService(api_client)
+    custom_server_service = CustomServerService(config_manager)
+
+    return (
+        config_manager,
+        auth_service,
+        api_client,
+        bw_ssh_config_service,
+        team_service,
+        custom_server_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instance resolution helpers
+# ---------------------------------------------------------------------------
+
+def _load_all_instances(
+    aws_service: Any,
+    custom_server_service: Any,
+) -> List[Dict[str, Any]]:
+    """Return combined list of cached AWS + custom server instances."""
+    instances: List[Dict[str, Any]] = []
+    try:
+        cached = aws_service._cache.load_any()
+        if cached:
+            instances.extend(cached)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load AWS cached instances: %s", exc)
+    try:
+        instances.extend(custom_server_service.list_as_instances())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load custom server instances: %s", exc)
+    return instances
+
+
+def _find_instance(
+    id_or_name: str,
+    instances: List[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Case-insensitive match on ``id`` or ``name`` across the instance list."""
+    needle = id_or_name.lower()
+    for inst in instances:
+        if str(inst.get("id", "")).lower() == needle:
+            return inst
+        if str(inst.get("name", "")).lower() == needle:
+            return inst
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SSH probe
+# ---------------------------------------------------------------------------
+
+def _run_ssh_probe(
+    key_path: str,
+    user: str,
+    host: str,
+    port: Optional[int],
+    timeout: int,
+) -> int:
+    """Run ``ssh -o BatchMode=yes ... true`` and return the exit code.
+
+    Treats :class:`subprocess.TimeoutExpired` as a connection failure (returns
+    255 — same as ssh's own timeout exit code — so the caller maps it to
+    ``auth_failed`` without crashing).
+    """
+    cmd = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", f"ConnectTimeout={timeout}",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-i", key_path,
+        f"{user}@{host}",
+        "true",
+    ]
+    if port is not None and port != 22:
+        # Insert -p <port> right after "ssh"
+        cmd[1:1] = ["-p", str(port)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=timeout + 5,
+        )
+        return result.returncode
+    except subprocess.TimeoutExpired:
+        logger.debug("SSH probe timed out for %s@%s:%s", user, host, port)
+        return 255
+
+
+# ---------------------------------------------------------------------------
+# Personal probe
+# ---------------------------------------------------------------------------
+
+async def _probe_personal(
+    bw_ssh_cfg: Any,
+    bw_resolver: Any,
+    instance: Dict[str, Any],
+    host: str,
+    user: str,
+    port: Optional[int],
+    timeout: int,
+) -> Optional[str]:
+    """Probe personal instance.  Returns a status string or None if no ref stored.
+
+    ``None`` means the caller should exit with a friendly "no ref stored" message
+    rather than POSTing anything.
+
+    Raises :class:`BwCliMissingError` or :class:`BwSessionMissingError` when
+    the BW CLI is unusable — the caller handles these without POSTing.
+    """
+    from servonaut.services.bw_resolver import BwItemNotFoundError
+    from servonaut.services.bw_ssh_config_service import (
+        STATUS_VERIFIED,
+        STATUS_NOT_FOUND,
+        STATUS_AUTH_FAILED,
+    )
+
+    provider = instance.get("provider", "aws")
+    instance_id = instance["id"]
+
+    ref = await bw_ssh_cfg.get_personal_instance_ref(provider, instance_id)
+    if ref is None:
+        return None
+
+    item_id = ref["ssh_credential_ref"]["item_id"]
+
+    try:
+        key_body = bw_resolver.resolve_ssh_key(item_id)
+    except BwItemNotFoundError:
+        return STATUS_NOT_FOUND
+    except (BwCliMissingError, BwSessionMissingError):
+        raise
+
+    with ephemeral_ssh_key(key_body) as key_path:
+        rc = _run_ssh_probe(key_path, user, host, port, timeout)
+
+    return STATUS_VERIFIED if rc == 0 else STATUS_AUTH_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Team probe
+# ---------------------------------------------------------------------------
+
+async def _probe_team(
+    team_svc: Any,
+    bw_resolver: Any,
+    slug: str,
+    server_id: str,
+    host: str,
+    user: str,
+    port: Optional[int],
+    timeout: int,
+) -> str:
+    """Probe a team SharedServer.  Always returns a status string.
+
+    Raises :class:`BwCliMissingError` or :class:`BwSessionMissingError` for
+    unusable BW CLI — caller handles without POSTing.
+    """
+    from servonaut.services.bw_resolver import BwItemNotFoundError
+    from servonaut.services.bw_ssh_config_service import (
+        STATUS_VERIFIED,
+        STATUS_NOT_FOUND,
+        STATUS_AUTH_FAILED,
+    )
+
+    ref = await team_svc.get_team_server_ssh_ref(slug, server_id)
+    if ref is None:
+        return None  # type: ignore[return-value]  # caller checks for None
+
+    item_id = ref["ssh_credential_ref"]["item_id"]
+
+    try:
+        key_body = bw_resolver.resolve_ssh_key(item_id)
+    except BwItemNotFoundError:
+        return STATUS_NOT_FOUND
+    except (BwCliMissingError, BwSessionMissingError):
+        raise
+
+    with ephemeral_ssh_key(key_body) as key_path:
+        rc = _run_ssh_probe(key_path, user, host, port, timeout)
+
+    return STATUS_VERIFIED if rc == 0 else STATUS_AUTH_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Resolve connection details for an instance
+# ---------------------------------------------------------------------------
+
+def _resolve_host(instance: Dict[str, Any], host_override: Optional[str]) -> Optional[str]:
+    """Return the effective target host. None if neither override nor IP are available."""
+    if host_override:
+        return host_override
+    host = instance.get("public_ip") or instance.get("private_ip")
+    return host or None
+
+
+def _resolve_user(instance: Dict[str, Any], user_override: Optional[str]) -> str:
+    """Return the effective SSH username."""
+    if user_override:
+        return user_override
+    return instance.get("username") or "ec2-user"
+
+
+# ---------------------------------------------------------------------------
+# Main verify handler
+# ---------------------------------------------------------------------------
+
+async def _cmd_verify(args: Any) -> int:
+    """Async body of ``servers verify``."""
+    from servonaut import __version__
+    from servonaut.services.bw_ssh_config_service import STATUS_VERIFIED
+
+    checked_by_client = f"servonaut-cli/{__version__}"
+
+    (
+        config_manager,
+        auth_service,
+        api_client,
+        bw_ssh_cfg,
+        team_svc,
+        custom_server_service,
+    ) = _init_headless_services()
+
+    if not auth_service.is_authenticated:
+        print(
+            "Not logged in. Run `servonaut --login` first.",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+
+    config = config_manager.get()
+    cache_service = CacheService(ttl_seconds=config.cache_ttl_seconds)
+    aws_service = AWSService(cache_service)
+
+    instance_arg: str = args.instance
+    host_override: Optional[str] = getattr(args, "host", None)
+    user_override: Optional[str] = getattr(args, "user", None)
+    port_override: Optional[int] = getattr(args, "port", None)
+    timeout: int = getattr(args, "timeout", 5)
+
+    bw_resolver = BwResolver()
+
+    # ------------------------------------------------------------------
+    # Resolution: personal first, then teams
+    # ------------------------------------------------------------------
+
+    # Determine whether this looks like a team SharedServer UUID.
+    is_uuid = bool(_UUID_RE.match(instance_arg))
+
+    personal_instance: Optional[Dict[str, Any]] = None
+    team_slug: Optional[str] = None
+    team_server_id: Optional[str] = None
+
+    if not is_uuid:
+        # Must be a personal instance id/name — look it up in cached lists.
+        all_instances = _load_all_instances(aws_service, custom_server_service)
+        personal_instance = _find_instance(instance_arg, all_instances)
+        if personal_instance is None:
+            print(
+                f"Instance not found: {instance_arg!r}",
+                file=sys.stderr,
+            )
+            return _EXIT_FATAL
+    else:
+        # UUID: try personal first (provider unknown — try each allowed provider).
+        # Walk the instance list to find a matching entry; if found use its provider.
+        all_instances = _load_all_instances(aws_service, custom_server_service)
+        personal_instance = _find_instance(instance_arg, all_instances)
+
+        if personal_instance is None:
+            # Not in local cache by uuid — try team lookup.
+            try:
+                teams = await team_svc.list_teams()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Could not list teams: %s", exc)
+                teams = []
+
+            for team in teams:
+                slug = team.get("slug") or team.get("team_slug", "")
+                if not slug:
+                    continue
+                ref = await team_svc.get_team_server_ssh_ref(slug, instance_arg)
+                if ref is not None:
+                    team_slug = slug
+                    team_server_id = instance_arg
+                    break
+
+    # ------------------------------------------------------------------
+    # Determine host/user for the probe
+    # ------------------------------------------------------------------
+
+    if personal_instance is not None:
+        host = _resolve_host(personal_instance, host_override)
+        user = _resolve_user(personal_instance, user_override)
+        port = port_override
+        label = (
+            f"{personal_instance.get('name') or personal_instance.get('id')} "
+            f"({personal_instance.get('provider', 'unknown')}/{personal_instance.get('id')})"
+        )
+    elif team_slug is not None:
+        host = host_override
+        user = user_override or "root"
+        port = port_override
+        label = f"team:{team_slug}/{team_server_id}"
+    else:
+        # UUID not in any local cache and not in any team — no ref stored.
+        print(
+            f"No SSH ref stored for instance {instance_arg!r}. "
+            "Run `servonaut bw link` to register a Bitwarden item ref first.",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+
+    if host is None:
+        print(
+            f"No target host available for {instance_arg!r}. "
+            "Pass --host to override.",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+
+    # ------------------------------------------------------------------
+    # Run the appropriate probe
+    # ------------------------------------------------------------------
+
+    status: Optional[str] = None
+
+    try:
+        if personal_instance is not None:
+            status = await _probe_personal(
+                bw_ssh_cfg, bw_resolver,
+                personal_instance, host, user, port, timeout,
+            )
+            if status is None:
+                print(
+                    f"No SSH ref stored for {label}. "
+                    "Run `servonaut bw link` to register a Bitwarden item ref first.",
+                    file=sys.stderr,
+                )
+                return _EXIT_FATAL
+            # POST result
+            provider = personal_instance.get("provider", "aws")
+            instance_id = personal_instance["id"]
+            await bw_ssh_cfg.report_personal_instance_verify(
+                provider, instance_id, status,
+                checked_by_client=checked_by_client,
+            )
+        else:
+            # Team path
+            status = await _probe_team(
+                team_svc, bw_resolver,
+                team_slug, team_server_id,  # type: ignore[arg-type]
+                host, user, port, timeout,
+            )
+            if status is None:
+                print(
+                    f"No SSH ref stored for {label}. "
+                    "Run `servonaut bw link` to register a Bitwarden item ref first.",
+                    file=sys.stderr,
+                )
+                return _EXIT_FATAL
+            await team_svc.report_team_server_ssh_verify(
+                team_slug, team_server_id,  # type: ignore[arg-type]
+                status,
+                checked_by_client=checked_by_client,
+            )
+
+    except BwCliMissingError as exc:
+        print(
+            f"Bitwarden CLI not found: {exc.message}",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+    except BwSessionMissingError as exc:
+        print(
+            f"Bitwarden vault is locked: {exc.message}\n"
+            "Run `bw unlock` and export BW_SESSION, then retry.",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+
+    # ------------------------------------------------------------------
+    # Human-readable summary
+    # ------------------------------------------------------------------
+
+    if status == STATUS_VERIFIED:
+        print(f"[OK] Verified: {label}")
+        return _EXIT_SUCCESS
+    else:
+        print(f"[FAIL] {status}: {label}")
+        return _EXIT_VERIFY_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+def add_servers_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``servers`` subcommand group with a ``verify`` action."""
+    servers = subparsers.add_parser("servers", help="Manage servers and SSH access.")
+    servers_sub = servers.add_subparsers(dest="servers_command")
+
+    verify = servers_sub.add_parser(
+        "verify",
+        help="Probe whether the configured BW SSH key actually opens this server.",
+    )
+    verify.add_argument("instance", help="Instance id or name.")
+    verify.add_argument(
+        "--host",
+        default=None,
+        help="Override target host (default: instance.public_ip or private_ip).",
+    )
+    verify.add_argument(
+        "--user", "-u",
+        default=None,
+        help="Override SSH username.",
+    )
+    verify.add_argument(
+        "--port", "-p",
+        type=int,
+        default=None,
+        help="Override SSH port.",
+    )
+    verify.add_argument(
+        "--timeout",
+        type=int,
+        default=5,
+        help="SSH connection timeout in seconds (default: 5).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def handle_servers_command(args: Any) -> int:
+    """Dispatch ``servers`` sub-subcommands.  Returns an integer exit code."""
+    servers_command = getattr(args, "servers_command", None)
+    if servers_command is None:
+        print(
+            "Error: specify a servers subcommand. Use --help for usage.",
+            file=sys.stderr,
+        )
+        return _EXIT_FATAL
+
+    if servers_command == "verify":
+        return _run_async(_cmd_verify(args))
+
+    print(
+        f"Error: unknown servers subcommand {servers_command!r}",
+        file=sys.stderr,
+    )
+    return _EXIT_FATAL

--- a/src/servonaut/cli/ssh.py
+++ b/src/servonaut/cli/ssh.py
@@ -1,0 +1,410 @@
+"""CLI subcommand handler for ``servonaut ssh <instance>``.
+
+Resolves SSH credentials through the three-tier chain
+(personal BW ref → team BW ref → local ~/.ssh) and opens an interactive
+SSH session with the resolved key.
+
+Registration:
+    :func:`add_ssh_parser` is called from ``main.py`` once, passing the
+    top-level ``subparsers`` action.  The corresponding dispatch line in
+    ``main.py`` calls :func:`handle_ssh_command` and exits with the returned
+    integer.
+
+Non-goals (handled elsewhere):
+    - ``servonaut servers ssh-ref set`` — BW ref CRUD
+    - ``servonaut auth login`` / ``servonaut auth logout`` — auth flows
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+_EXIT_SUCCESS = 0
+_EXIT_NOT_FOUND = 1
+_EXIT_NO_CREDENTIAL = 2
+_EXIT_BW_ERROR = 3
+_EXIT_GENERIC_ERROR = 4
+_EXIT_AMBIGUOUS = 5
+
+
+# ---------------------------------------------------------------------------
+# Async helper
+# ---------------------------------------------------------------------------
+
+def _run_async(coro: Any) -> Any:
+    """Run *coro* synchronously via ``asyncio.run``."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+def add_ssh_parser(subparsers: Any) -> None:
+    """Register the ``servonaut ssh <instance>`` subcommand."""
+    p = subparsers.add_parser(
+        "ssh",
+        help="Connect to a managed instance, resolving the SSH key from Bitwarden if configured.",
+    )
+    p.add_argument(
+        "instance",
+        help="Instance name or id (case-insensitive match).",
+    )
+    p.add_argument(
+        "--user", "-u",
+        default=None,
+        help="Override SSH username (default: per-instance config).",
+    )
+    p.add_argument(
+        "--port", "-p",
+        type=int,
+        default=None,
+        help="Override SSH port (default: 22 or per-instance config).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Headless service initialisation
+# ---------------------------------------------------------------------------
+
+def _init_headless_services() -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """Construct the minimum service set needed for the ssh subcommand.
+
+    Returns:
+        ``(config, auth_service, api_client, bw_ssh_config_service,
+        team_service, ssh_service, custom_server_service)``
+
+    When the user is not logged in, ``api_client``, ``bw_ssh_config_service``,
+    and ``team_service`` are returned as ``None``.  In that case only the local
+    ``~/.ssh`` fallback is available.
+    """
+    from servonaut.config.manager import ConfigManager
+    from servonaut.services.ssh_service import SSHService
+    from servonaut.services.custom_server_service import CustomServerService
+    from servonaut.services.auth_service import AuthService
+
+    config_manager = ConfigManager()
+    config = config_manager.get()
+    ssh_service = SSHService(config_manager)
+    custom_server_service = CustomServerService(config_manager)
+    auth_service = AuthService()
+
+    api_client = None
+    bw_ssh_config_service = None
+    team_service = None
+
+    if auth_service.is_authenticated:
+        try:
+            from servonaut.services.api_client import APIClient
+            from servonaut.services.bw_ssh_config_service import BwSshConfigService
+            from servonaut.services.team_service import TeamService
+
+            api_client = APIClient(auth_service)
+            bw_ssh_config_service = BwSshConfigService(api_client)
+            team_service = TeamService(api_client)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Could not initialise API-backed services: %s — only local ~/.ssh keys available.",
+                exc,
+            )
+    else:
+        logger.info("Not logged in — only local ~/.ssh keys available")
+
+    return (
+        config,
+        auth_service,
+        api_client,
+        bw_ssh_config_service,
+        team_service,
+        ssh_service,
+        custom_server_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Instance lookup
+# ---------------------------------------------------------------------------
+
+def _load_instances(
+    custom_server_service: Any,
+) -> List[Dict[str, Any]]:
+    """Return merged list of cached AWS + custom instances."""
+    instances: List[Dict[str, Any]] = []
+
+    # AWS — load from disk cache (no network round-trip for the CLI)
+    try:
+        from servonaut.config.manager import ConfigManager
+        from servonaut.services.cache_service import CacheService
+        from servonaut.services.aws_service import AWSService
+
+        _config_manager = ConfigManager()
+        _config = _config_manager.get()
+        _cache_service = CacheService(ttl_seconds=_config.cache_ttl_seconds)
+        _aws_service = AWSService(_cache_service)
+        cached = _aws_service._cache.load_any()
+        if cached:
+            instances.extend(cached)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load AWS cached instances: %s", exc)
+
+    # Custom servers
+    try:
+        instances.extend(custom_server_service.list_as_instances())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load custom server instances: %s", exc)
+
+    return instances
+
+
+def _find_instance(instances: List[Dict[str, Any]], search: str) -> List[Dict[str, Any]]:
+    """Return all instances whose ``id`` or ``name`` match *search* (case-insensitive)."""
+    needle = search.lower()
+    return [
+        inst for inst in instances
+        if (inst.get("id") or "").lower() == needle
+        or (inst.get("name") or "").lower() == needle
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Username resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_username(args: Any, instance: Dict[str, Any], config: Any) -> str:
+    """Resolve SSH username in priority order.
+
+    Priority: args.user > instance username > config default_username > 'ubuntu'
+    """
+    if args.user:
+        return args.user
+    inst_username = instance.get("username")
+    if inst_username:
+        return inst_username
+    config_default = getattr(config, "default_username", None)
+    if config_default:
+        return config_default
+    return "ubuntu"
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def handle_ssh_command(args: Any) -> int:
+    """Entry point for ``servonaut ssh <instance>``.
+
+    Returns an integer exit code suitable for ``sys.exit()``.
+    """
+    return _run_async(_handle_ssh_async(args))
+
+
+async def _handle_ssh_async(args: Any) -> int:
+    from servonaut.services.ssh_ref_resolver import SshRefResolver
+    from servonaut.services.bw_resolver import (
+        BwResolver,
+        BwCliMissingError,
+        BwSessionMissingError,
+        BwItemNotFoundError,
+        BwItemShapeError,
+    )
+    from servonaut.utils.ephemeral_key import ephemeral_ssh_key
+
+    # --- Init services ---
+    (
+        config,
+        auth_service,
+        api_client,
+        bw_ssh_config_service,
+        team_service,
+        ssh_service,
+        custom_server_service,
+    ) = _init_headless_services()
+
+    # --- Load instances ---
+    instances = _load_instances(custom_server_service)
+
+    # --- Find instance ---
+    matches = _find_instance(instances, args.instance)
+    if not matches:
+        print(
+            f"No instance found matching {args.instance!r}. "
+            "Run `servonaut servers list` to see available instances.",
+            file=sys.stderr,
+        )
+        return _EXIT_NOT_FOUND
+
+    if len(matches) > 1:
+        print(
+            f"Multiple instances match {args.instance!r}. Be more specific:",
+            file=sys.stderr,
+        )
+        for i, inst in enumerate(matches, 1):
+            iid = inst.get("id", "?")
+            iname = inst.get("name", "?")
+            print(f"  {i}. {iname} ({iid})", file=sys.stderr)
+        return _EXIT_AMBIGUOUS
+
+    instance = matches[0]
+    iid = instance.get("id") or instance.get("name") or args.instance
+
+    # --- Build resolver ---
+    teams_supplier = None
+    if team_service is not None and auth_service.is_authenticated:
+        # Lazy loader — called at most once during resolve()
+        _teams_cache: Optional[List[dict]] = None
+
+        async def _load_teams_async() -> List[dict]:
+            nonlocal _teams_cache
+            if _teams_cache is None:
+                try:
+                    _teams_cache = await team_service.list_teams()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Could not load teams list: %s", exc)
+                    _teams_cache = []
+            return _teams_cache
+
+        # teams_supplier must be synchronous (SshRefResolver contract)
+        # We run it before constructing resolver and pass a frozen callable.
+        _teams: List[dict] = []
+        try:
+            _teams = await _load_teams_async()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Team list fetch failed, skipping team tier: %s", exc)
+
+        def _teams_supplier_fn() -> List[dict]:
+            return _teams
+
+        teams_supplier = _teams_supplier_fn
+
+    resolver = SshRefResolver(
+        bw_ssh_config_service=bw_ssh_config_service or _NullBwService(),
+        team_service=team_service or _NullTeamService(),
+        ssh_service=ssh_service,
+        teams_supplier=teams_supplier,
+    )
+
+    # --- Resolve ---
+    resolved = await resolver.resolve(instance)
+
+    if resolved is None:
+        print(
+            f"No SSH key configured for {iid!r}. "
+            "Add one with `servonaut servers ssh-ref set <id>` "
+            "or place a key in ~/.ssh/.",
+            file=sys.stderr,
+        )
+        return _EXIT_NO_CREDENTIAL
+
+    # --- Determine host ---
+    host = (
+        instance.get("public_ip")
+        or instance.get("private_ip")
+        or instance.get("host")
+        or iid
+    )
+
+    # --- Determine username ---
+    username = _resolve_username(args, instance, config)
+
+    # --- Determine port ---
+    port = args.port or instance.get("port")
+
+    # --- Build + run SSH ---
+    if resolved.source in ("personal", "team"):
+        if not resolved.item_id:
+            print(
+                f"BW ref for {iid!r} is missing item_id — the stored ref may be corrupt. "
+                "Re-register with `servonaut servers ssh-ref set <id>`.",
+                file=sys.stderr,
+            )
+            return _EXIT_BW_ERROR
+
+        bw_resolver = BwResolver()
+        try:
+            key_body = bw_resolver.resolve_ssh_key(resolved.item_id)
+        except BwCliMissingError as exc:
+            print(
+                f"Bitwarden CLI not found: {exc.message}\n"
+                "Install it from https://bitwarden.com/help/cli/ and ensure it is on your PATH.",
+                file=sys.stderr,
+            )
+            return _EXIT_BW_ERROR
+        except BwSessionMissingError as exc:
+            print(
+                f"Bitwarden vault is locked: {exc.message}\n"
+                "Run `bw unlock` and export the BW_SESSION environment variable, then retry.",
+                file=sys.stderr,
+            )
+            return _EXIT_BW_ERROR
+        except BwItemNotFoundError as exc:
+            print(
+                f"Bitwarden item not found: {exc.message}\n"
+                "Verify the item UUID or re-register with `servonaut servers ssh-ref set <id>`.",
+                file=sys.stderr,
+            )
+            return _EXIT_BW_ERROR
+        except BwItemShapeError as exc:
+            print(
+                f"Bitwarden item has unexpected shape: {exc.message}\n"
+                "Ensure it is a native SSH item (BW 2023.10+) with .sshKey.privateKey.",
+                file=sys.stderr,
+            )
+            return _EXIT_BW_ERROR
+
+        with ephemeral_ssh_key(key_body) as tmpfile:
+            cmd = ssh_service.build_ssh_command(
+                host=host,
+                username=username,
+                key_path=tmpfile,
+                port=port,
+            )
+            logger.debug("Running SSH (BW key): %s", " ".join(cmd))
+            result = subprocess.run(cmd)  # interactive — inherit stdin/stdout/stderr
+            return result.returncode
+
+    else:
+        # source == "local"
+        cmd = ssh_service.build_ssh_command(
+            host=host,
+            username=username,
+            key_path=resolved.local_key_path,
+            port=port,
+        )
+        logger.debug("Running SSH (local key): %s", " ".join(cmd))
+        result = subprocess.run(cmd)
+        return result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Null object stubs used when API services are unavailable
+# ---------------------------------------------------------------------------
+
+class _NullBwService:
+    """Drop-in for BwSshConfigService when not logged in.
+
+    Every method that the resolver calls returns None immediately so the
+    personal tier gracefully passes through to local fallback.
+    """
+
+    async def get_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> None:
+        return None
+
+
+class _NullTeamService:
+    """Drop-in for TeamService when not logged in."""
+
+    async def get_team_server_ssh_ref(
+        self, slug: str, server_id: str
+    ) -> None:
+        return None

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -827,6 +827,14 @@ def main() -> None:
     from servonaut.cli.secrets import add_secrets_parser, handle_secrets_command
     add_secrets_parser(subparsers)
 
+    # ---- ssh subcommand (BW Password Manager SSH integration) ----
+    from servonaut.cli.ssh import add_ssh_parser, handle_ssh_command
+    add_ssh_parser(subparsers)
+
+    # ---- servers subcommand (verify, etc.) ----
+    from servonaut.cli.servers import add_servers_parser, handle_servers_command
+    add_servers_parser(subparsers)
+
     args = parser.parse_args()
 
     # Top-level --ai-provider / --no-tools flags propagate via env vars so
@@ -849,6 +857,14 @@ def main() -> None:
     if getattr(args, 'subcommand', None) == 'secrets':
         _setup_logging(debug=args.debug)
         sys.exit(handle_secrets_command(args))
+
+    if getattr(args, 'subcommand', None) == 'ssh':
+        _setup_logging(debug=args.debug)
+        sys.exit(handle_ssh_command(args))
+
+    if getattr(args, 'subcommand', None) == 'servers':
+        _setup_logging(debug=args.debug)
+        sys.exit(handle_servers_command(args))
 
     if getattr(args, 'subcommand', None) == 'memory':
         _setup_logging(debug=args.debug)

--- a/src/servonaut/screens/_binding_guard.py
+++ b/src/servonaut/screens/_binding_guard.py
@@ -27,14 +27,28 @@ from textual.widgets import Input, TextArea
 
 
 def check_action_passthrough(screen, action: str) -> bool | None:
-    """Return False for single-printable-key bindings when Input/TextArea is focused.
+    """Return None for single-printable-key bindings when Input/TextArea is focused.
 
-    When ``check_action`` returns False, Textual skips the binding and the
-    key event falls through to the focused widget so it can handle it
-    normally (i.e. insert the character).
+    Textual's ``check_action`` has three return values:
 
-    Non-printable key bindings (escape, f5, enter, ctrl+*, arrows) are
-    always allowed regardless of focus.
+    - ``True``  → binding enabled; action fires; footer shows the key bright.
+    - ``None``  → binding disabled-but-visible; action does NOT fire (key event
+                  falls through to the focused widget); footer shows the key
+                  greyed-out so the user can still discover it.
+    - ``False`` → binding hidden entirely; gone from the footer too.
+
+    We return ``None`` (not ``False``) so the footer keeps advertising
+    every shortcut even while the user is typing in a search box. Two UX
+    journeys preserved:
+
+    1. **Find-a-server-fast**: search Input is focused on mount; typing
+       letters filters the table; footer shows greyed shortcuts as a hint
+       of "what you can do after you Tab into a result".
+    2. **Act-on-a-row**: Tab/↓/Escape moves focus to the table; the same
+       bindings light up bright and fire normally.
+
+    Non-printable keys (escape, f5, enter, ctrl+*, arrows) are always
+    allowed regardless of focus.
     """
     focused = screen.focused
     if not isinstance(focused, (Input, TextArea)):
@@ -48,6 +62,6 @@ def check_action_passthrough(screen, action: str) -> bool | None:
             key, bind_action = binding[0], binding[1]
 
         if bind_action == action and len(key) == 1 and key.isprintable():
-            return False
+            return None  # disabled-but-visible — footer still advertises it
 
     return True

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -31,7 +31,12 @@ class InstanceListScreen(Screen):
     BINDINGS = [
         Binding("r", "refresh", "Refresh", show=True),
         Binding("/", "focus_search", "Search", show=True),
-        Binding("enter", "select_instance", "Select", show=True),
+        Binding("enter", "select_instance", "Actions", show=True),
+        # Explicit footer-visible alternative — DataTable consumes Enter for
+        # row-selected, which hides the Enter binding from the footer. ``o``
+        # (for "Open") shows up in the footer so users can discover the
+        # actions menu without needing to guess that Enter works.
+        Binding("o", "select_instance", "Actions", show=True),
         Binding("s", "ssh_connect", "SSH", show=True),
         Binding("b", "browse_files", "Browse", show=True),
         Binding("c", "run_command", "Command", show=True),
@@ -39,6 +44,8 @@ class InstanceListScreen(Screen):
         Binding("l", "view_logs", "Logs", show=True),
         Binding("a", "ai_analysis", "AI", show=True),
         Binding("m", "open_memory", "Memory", show=True),
+        Binding("k", "manage_ssh_ref", "SSH Ref", show=True),
+        Binding("v", "verify_ssh", "Verify", show=True),
         Binding("y", "copy_row", "Copy", show=True),
     ]
 
@@ -144,6 +151,13 @@ class InstanceListScreen(Screen):
             self._fetch_instances()
             self._fetch_ovh_instances()
             self._fetch_hetzner_instances()
+
+        # Default focus = search Input. The "find a server fast" journey
+        # is the primary entry point: type a name fragment, then Tab/↓
+        # into the filtered results and press a shortcut. The footer still
+        # advertises every binding (check_action_passthrough returns None,
+        # not False, when an Input is focused — bindings render greyed-out
+        # rather than disappearing) so discoverability stays intact.
 
     def _fetch_instances(self, force_refresh: bool = False) -> None:
         """Fetch instances from AWS via worker (blocking with progress indicator).
@@ -421,6 +435,16 @@ class InstanceListScreen(Screen):
         """Update detail panel when table cursor moves."""
         self._update_detail_panel()
 
+    def on_data_table_row_selected(self, event) -> None:
+        """Open the actions menu when the user presses Enter or clicks a row.
+
+        ``cursor_type="row"`` on InstanceTable makes DataTable post
+        ``RowSelected`` for Enter key + double-click. Without this handler
+        the events fall through to nothing — the screen-level ``enter``
+        binding never fires because DataTable consumes the key first.
+        """
+        self.action_select_instance()
+
     def _update_detail_panel(self) -> None:
         """Show selected instance metadata in the detail panel."""
         table = self.query_one(InstanceTable)
@@ -544,6 +568,75 @@ class InstanceListScreen(Screen):
             self.app.push_screen(ServerActionsScreen(instance))
         else:
             self.app.notify("No instance selected", severity="warning")
+
+    def action_manage_ssh_ref(self) -> None:
+        """Open the BW SSH ref editor for the selected instance.
+
+        Top-level shortcut so users can manage SSH refs without drilling
+        into ServerActionsScreen. Loads the existing ref (if any) so the
+        modal opens in edit mode when appropriate.
+        """
+        table = self.query_one(InstanceTable)
+        instance = table.get_selected_instance()
+        if not instance:
+            self.app.notify("No instance selected", severity="warning")
+            return
+        if not getattr(self.app, "bw_ssh_config_service", None):
+            self.app.notify(
+                "BW SSH service unavailable — sign in to manage SSH refs",
+                severity="warning",
+            )
+            return
+        self.run_worker(
+            self._open_ssh_ref_editor(instance),
+            group="ssh_ref_edit",
+            exclusive=True,
+        )
+
+    async def _open_ssh_ref_editor(self, instance: dict) -> None:
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        provider = (instance.get("provider") or "aws").lower()
+        instance_id = instance.get("id")
+        existing = None
+        try:
+            existing = await self.app.bw_ssh_config_service.get_personal_instance_ref(
+                provider, instance_id,
+            )
+        except Exception as exc:
+            # 404 → no ref yet (add mode). Any other error: log + assume add mode.
+            import logging
+            logging.getLogger(__name__).debug(
+                "Failed to preload SSH ref for %s/%s: %s",
+                provider, instance_id, exc,
+            )
+        saved = await self.app.push_screen_wait(
+            SshRefEditorModal(instance, existing_ref=existing),
+        )
+        if saved and hasattr(self.app, "_refresh_ssh_verify_status"):
+            self.run_worker(
+                self.app._refresh_ssh_verify_status(),
+                group="memory_io",
+            )
+
+    def action_verify_ssh(self) -> None:
+        """Run the SSH verify probe for the selected instance.
+
+        Top-level shortcut mirroring ServerActionsScreen's V binding so the
+        user can probe a key without diving into the action menu.
+        """
+        from servonaut.screens.server_actions import ServerActionsScreen
+        table = self.query_one(InstanceTable)
+        instance = table.get_selected_instance()
+        if not instance:
+            self.app.notify("No instance selected", severity="warning")
+            return
+        # Delegate to ServerActionsScreen's existing verify flow so behaviour
+        # stays in lockstep — push the screen, then trigger its action.
+        screen = ServerActionsScreen(instance)
+        self.app.push_screen(screen)
+        # ServerActionsScreen.action_verify_ssh runs in a worker; calling it
+        # right after push is safe (the screen mounts then the action fires).
+        self.app.call_later(screen.action_verify_ssh)
 
     def _get_selected_running_instance(self) -> Optional[dict]:
         """Get the selected instance, validate it's connectable.

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -114,6 +114,7 @@ class ServerActionsScreen(Screen):
         Binding("7", "action_7", "AI Analysis", show=True),
         Binding("8", "action_8", "Ban IP", show=True),
         Binding("m", "open_memory", "Memory", show=True),
+        Binding("r", "manage_ssh_ref", "SSH Ref", show=True),
         Binding("v", "verify_ssh", "Verify SSH", show=True),
         Binding("9", "back", "Back", show=True),
         Binding("escape", "back", "Back", show=False),
@@ -210,6 +211,8 @@ class ServerActionsScreen(Screen):
                     Static("[dim]  Analyze log text with AI (OpenAI, Anthropic, or Ollama)[/dim]", classes="help_text"),
                     Button("8. Ban IP", id="btn_ban_ip"),
                     Static("[dim]  Ban this server's public IP via WAF, Security Group, or NACL[/dim]", classes="help_text"),
+                    Button("R. Manage SSH Ref", id="btn_manage_ssh_ref"),
+                    Static("[dim]  Add, edit, or remove the Bitwarden SSH item ref for this server[/dim]", classes="help_text"),
                     Button("V. Verify SSH", id="btn_verify_ssh"),
                     Static("[dim]  Run a local BW SSH probe and report the result[/dim]", classes="help_text"),
                     Button("9. Back", id="btn_back", variant="error"),
@@ -373,6 +376,8 @@ class ServerActionsScreen(Screen):
         elif button_id == "btn_ovh_firewall":
             from servonaut.screens.ovh_firewall import OVHFirewallScreen
             self.app.push_screen(OVHFirewallScreen(self._instance))
+        elif button_id == "btn_manage_ssh_ref":
+            self.action_manage_ssh_ref()
         elif button_id == "btn_verify_ssh":
             self.action_verify_ssh()
         elif button_id == "btn_back":
@@ -428,150 +433,330 @@ class ServerActionsScreen(Screen):
         self.app.push_screen(CommandOverlay(self._instance))
 
     def action_action_3(self) -> None:
-        """SSH Connect — launch SSH in external terminal."""
-        import logging
-        logger = logging.getLogger(__name__)
+        """SSH Connect — walk SshRefResolver chain then launch in external terminal.
 
+        Dispatches to a worker so a double-click or rapid key press cannot
+        double-launch.  The 'ssh_connect' group is distinct from 'ssh_verify'
+        so the two flows don't cancel each other.
+        """
         if not self._validate_instance_connection():
             return
 
-        try:
-            if self._instance.get('is_ovh'):
-                host = self._instance.get('public_ip') or self._instance.get('private_ip')
-                provider_type = self._instance.get('provider_type', '')
-                instance_id = self._instance.get('id', '')
-                config = self.app.config_manager.get()
+        self.run_worker(
+            self._ssh_connect_flow(),
+            group="ssh_connect",
+            exclusive=True,
+        )
 
-                # Username: OVH config override > auto by provider type
-                if config.ovh.default_username:
-                    username = config.ovh.default_username
-                else:
-                    username = self._ovh_default_username(provider_type)
+    async def _ssh_connect_flow(self) -> None:
+        """Async SSH connect: resolve credentials via three-tier chain, launch.
 
-                # SSH key: instance_keys mapping > OVH default > global default > auto-discover
-                key_path = (
-                    config.instance_keys.get(instance_id)
-                    or config.ovh.default_ssh_key
-                    or config.default_key
-                    or self.app.ssh_service.discover_key(instance_id)
-                    or None
+        Resolution order (mirrors the CLI ``servonaut ssh <id>`` surface):
+          1. Personal Bitwarden ref  (requires Servonaut account)
+          2. Team Bitwarden ref      (requires Servonaut Teams plan)
+          3. Local ~/.ssh discovery  (existing TUI behaviour)
+          4. None → notify user, stop
+
+        BW tiers (source == 'personal' | 'team')
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ``launch_ssh_in_terminal`` spawns a detached external window — the
+        ephemeral key context manager would exit before SSH finishes reading
+        the key.  We therefore use ``persistent_bw_ssh_key()`` (Option A):
+        the file is written to ``~/.servonaut/tmp/bw-<random>.key`` with 0600
+        perms and an ``atexit`` cleanup so normal TUI exit removes it.
+        ``cleanup_stale_bw_keys()`` is called by ``ServonautApp`` on startup to
+        catch crash-left files older than 24 h.
+        """
+        from rich.markup import escape as rich_escape
+
+        from servonaut.services.ssh_ref_resolver import SshRefResolver
+        from servonaut.services.bw_resolver import (
+            BwResolver,
+            BwCliMissingError,
+            BwSessionMissingError,
+            BwItemNotFoundError,
+            BwItemShapeError,
+        )
+        from servonaut.utils.ephemeral_key import persistent_bw_ssh_key
+
+        instance = self._instance
+        name = instance.get("name") or instance.get("id", "instance")
+
+        # ------------------------------------------------------------------
+        # Build teams_supplier (mirrors cli/ssh.py _handle_ssh_async)
+        # ------------------------------------------------------------------
+        teams_supplier = None
+        team_service = getattr(self.app, "team_service", None)
+        if team_service is not None:
+            _teams: list = []
+            try:
+                _teams = await team_service.list_teams()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Could not load teams list for SSH connect: %s", exc)
+
+            def _teams_supplier_fn() -> list:
+                return _teams
+
+            teams_supplier = _teams_supplier_fn
+
+        # ------------------------------------------------------------------
+        # Build resolver — use Null stubs when services are unavailable
+        # ------------------------------------------------------------------
+        bw_ssh_config_service = getattr(self.app, "bw_ssh_config_service", None)
+        if bw_ssh_config_service is None:
+            bw_ssh_config_service = _NullBwService()
+        if team_service is None:
+            team_service = _NullTeamService()
+
+        resolver = SshRefResolver(
+            bw_ssh_config_service=bw_ssh_config_service,
+            team_service=team_service,
+            ssh_service=self.app.ssh_service,
+            teams_supplier=teams_supplier,
+        )
+
+        resolved = await resolver.resolve(instance)
+
+        if resolved is None:
+            self.app.notify(
+                "No SSH key configured for this instance.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        # ------------------------------------------------------------------
+        # Build the SSH command depending on the resolution source
+        # ------------------------------------------------------------------
+        source = resolved.source
+
+        if source in ("personal", "team"):
+            # BW path — resolve key body via bw CLI, write persistent tmpfile
+            if not resolved.item_id:
+                self.app.notify(
+                    "Bitwarden ref is missing item_id — re-register via Settings.",
+                    severity="error",
+                    markup=False,
                 )
-                proxy_args = []
-                extra_options = self.app.connection_service.get_extra_options(self._instance, None)
+                return
 
-                ssh_cmd = self.app.ssh_service.build_ssh_command(
-                    host=host,
-                    username=username,
-                    key_path=key_path,
-                    proxy_args=proxy_args,
-                    port=None,
-                    extra_options=extra_options,
+            bw_resolver = BwResolver()
+            try:
+                import asyncio
+                key_body = await asyncio.to_thread(
+                    bw_resolver.resolve_ssh_key, resolved.item_id
                 )
-                name = self._instance.get('name', host)
-                logger.info(
-                    "SSH connect (OVH %s): host=%s, user=%s, key=%s",
-                    provider_type, host, username, key_path
+            except BwCliMissingError:
+                self.app.notify(
+                    "Bitwarden CLI (bw) not found. Install it and ensure it is on your PATH.",
+                    severity="error",
+                    markup=False,
                 )
-            elif self._instance.get('is_custom'):
-                host = self._instance.get('public_ip') or self._instance.get('private_ip')
-                username = self._instance.get('username') or 'root'
-                port = self._instance.get('port', 22)
-                key_path = self._instance.get('ssh_key') or self._instance.get('key_name') or None
-                proxy_args = []
-                extra_options = self.app.connection_service.get_extra_options(self._instance, None)
-
-                ssh_cmd = self.app.ssh_service.build_ssh_command(
-                    host=host,
-                    username=username,
-                    key_path=key_path,
-                    proxy_args=proxy_args,
-                    port=port,
-                    extra_options=extra_options,
+                return
+            except BwSessionMissingError:
+                self.app.notify(
+                    "Bitwarden vault is locked. Run 'bw unlock' and export BW_SESSION, then retry.",
+                    severity="error",
+                    markup=False,
                 )
-                name = self._instance.get('name', host)
-                logger.info("SSH connect (custom): host=%s, user=%s, port=%s", host, username, port)
-            elif self._instance.get('is_hetzner'):
-                host = self._instance.get('public_ip') or self._instance.get('private_ip')
-                username = self._instance.get('username') or 'root'
-                config = self.app.config_manager.get()
-                key_path = (
-                    self._instance.get('ssh_key')
-                    or config.default_key
-                    or None
+                return
+            except BwItemNotFoundError:
+                self.app.notify(
+                    "Bitwarden item not found. Verify the item UUID or re-register via Settings.",
+                    severity="error",
+                    markup=False,
                 )
-                proxy_args = []
-                extra_options = self.app.connection_service.get_extra_options(self._instance, None)
-
-                ssh_cmd = self.app.ssh_service.build_ssh_command(
-                    host=host,
-                    username=username,
-                    key_path=key_path,
-                    proxy_args=proxy_args,
-                    port=None,
-                    extra_options=extra_options,
+                return
+            except BwItemShapeError:
+                self.app.notify(
+                    "Bitwarden item shape unexpected — ensure it is a native SSH item (BW 2023.10+).",
+                    severity="error",
+                    markup=False,
                 )
-                name = self._instance.get('name', host)
-                logger.info(
-                    "SSH connect (hetzner): host=%s, user=%s, key=%s",
-                    host, username, key_path,
+                return
+            except Exception as exc:  # noqa: BLE001
+                logger.error("BW key resolution failed: %s", exc, exc_info=True)
+                self.app.notify(
+                    "Bitwarden key resolution failed. See logs for details.",
+                    severity="error",
+                    markup=False,
                 )
-            else:
-                # Resolve connection profile (bastion, proxy, etc.)
-                profile = self.app.connection_service.resolve_profile(self._instance)
-                host = self.app.connection_service.get_target_host(self._instance, profile)
+                return
 
-                if not host:
-                    self.app.notify("No IP address available for this instance.", severity="error")
-                    return
+            # Write a long-lived tmpfile (see docstring for rationale).
+            key_path = persistent_bw_ssh_key(key_body)
+            logger.debug(
+                "Persistent BW SSH key written to %s for instance %s",
+                key_path,
+                instance.get("id"),
+            )
 
-                proxy_args = []
-                if profile:
-                    proxy_args = self.app.connection_service.get_proxy_args(profile)
+            host = (
+                instance.get("public_ip")
+                or instance.get("private_ip")
+                or instance.get("host")
+                or instance.get("id", "")
+            )
+            username = (
+                instance.get("username")
+                or self.app.config_manager.get().default_username
+                or "ubuntu"
+            )
+            port = instance.get("port")
 
-                username = (
-                    (profile.username if profile else None)
-                    or self.app.config_manager.get().default_username
-                )
-                key_path = self.app.ssh_service.get_key_path(self._instance['id'])
+            ssh_cmd = self.app.ssh_service.build_ssh_command(
+                host=host,
+                username=username,
+                key_path=key_path,
+                port=port,
+            )
 
-                if not key_path and self._instance.get('key_name'):
-                    key_path = self.app.ssh_service.discover_key(self._instance['key_name'])
-
-                extra_options = self.app.connection_service.get_extra_options(self._instance, profile)
-
-                ssh_cmd = self.app.ssh_service.build_ssh_command(
-                    host=host,
-                    username=username,
-                    key_path=key_path,
-                    proxy_args=proxy_args,
-                    extra_options=extra_options,
-                )
-                name = self._instance.get('name') or self._instance.get('id', 'instance')
-                via = f" via {profile.bastion_host}" if profile and profile.bastion_host else ""
-
-                logger.info(
-                    "SSH connect: host=%s, user=%s, key=%s, proxy=%s, profile=%s",
-                    host, username, key_path,
-                    'yes' if proxy_args else 'no',
-                    profile.name if profile else 'direct',
-                )
-
-            # Launch in terminal
+            tier_label = "personal" if source == "personal" else "team"
             if self.app.terminal_service.launch_ssh_in_terminal(ssh_cmd):
-                if (self._instance.get('is_ovh')
-                        or self._instance.get('is_custom')
-                        or self._instance.get('is_hetzner')):
-                    self.app.notify(f"SSH session launched for {name}")
-                else:
-                    self.app.notify(f"SSH session launched for {name}{via}")
+                self.app.notify(
+                    f"Connected via BW ({tier_label}): {rich_escape(name)}",
+                    markup=True,
+                )
+                logger.info(
+                    "SSH connect (BW %s): host=%s, user=%s, item=%s",
+                    tier_label, host, username, resolved.item_id,
+                )
             else:
                 self.app.notify(
                     "Could not detect terminal emulator. Set 'terminal_emulator' in settings.",
-                    severity="error"
+                    severity="error",
+                    markup=False,
                 )
-        except Exception as e:
-            logger.error("Error launching SSH terminal: %s", e, exc_info=True)
-            self.app.notify(f"Error launching SSH: {e}", severity="error")
+
+        else:
+            # source == "local" — existing per-provider logic
+            try:
+                if instance.get("is_ovh"):
+                    host = instance.get("public_ip") or instance.get("private_ip")
+                    provider_type = instance.get("provider_type", "")
+                    instance_id = instance.get("id", "")
+                    config = self.app.config_manager.get()
+
+                    username = (
+                        config.ovh.default_username
+                        or self._ovh_default_username(provider_type)
+                    )
+                    key_path = (
+                        config.instance_keys.get(instance_id)
+                        or config.ovh.default_ssh_key
+                        or config.default_key
+                        or resolved.local_key_path
+                        or None
+                    )
+                    proxy_args: list = []
+                    extra_options = self.app.connection_service.get_extra_options(instance, None)
+                    ssh_cmd = self.app.ssh_service.build_ssh_command(
+                        host=host, username=username, key_path=key_path,
+                        proxy_args=proxy_args, port=None, extra_options=extra_options,
+                    )
+                    logger.info(
+                        "SSH connect (OVH %s): host=%s, user=%s, key=%s",
+                        provider_type, host, username, key_path,
+                    )
+
+                elif instance.get("is_custom"):
+                    host = instance.get("public_ip") or instance.get("private_ip")
+                    username = instance.get("username") or "root"
+                    port = instance.get("port", 22)
+                    key_path = resolved.local_key_path or instance.get("ssh_key") or None
+                    proxy_args = []
+                    extra_options = self.app.connection_service.get_extra_options(instance, None)
+                    ssh_cmd = self.app.ssh_service.build_ssh_command(
+                        host=host, username=username, key_path=key_path,
+                        proxy_args=proxy_args, port=port, extra_options=extra_options,
+                    )
+                    logger.info(
+                        "SSH connect (custom): host=%s, user=%s, port=%s", host, username, port,
+                    )
+
+                elif instance.get("is_hetzner"):
+                    host = instance.get("public_ip") or instance.get("private_ip")
+                    username = instance.get("username") or "root"
+                    config = self.app.config_manager.get()
+                    key_path = (
+                        resolved.local_key_path
+                        or instance.get("ssh_key")
+                        or config.default_key
+                        or None
+                    )
+                    proxy_args = []
+                    extra_options = self.app.connection_service.get_extra_options(instance, None)
+                    ssh_cmd = self.app.ssh_service.build_ssh_command(
+                        host=host, username=username, key_path=key_path,
+                        proxy_args=proxy_args, port=None, extra_options=extra_options,
+                    )
+                    logger.info(
+                        "SSH connect (hetzner): host=%s, user=%s, key=%s",
+                        host, username, key_path,
+                    )
+
+                else:
+                    # AWS / generic — resolve bastion profile
+                    profile = self.app.connection_service.resolve_profile(instance)
+                    host = self.app.connection_service.get_target_host(instance, profile)
+
+                    if not host:
+                        self.app.notify(
+                            "No IP address available for this instance.", severity="error",
+                        )
+                        return
+
+                    proxy_args = []
+                    if profile:
+                        proxy_args = self.app.connection_service.get_proxy_args(profile)
+
+                    username = (
+                        (profile.username if profile else None)
+                        or self.app.config_manager.get().default_username
+                    )
+                    key_path = resolved.local_key_path
+
+                    extra_options = self.app.connection_service.get_extra_options(instance, profile)
+                    ssh_cmd = self.app.ssh_service.build_ssh_command(
+                        host=host, username=username, key_path=key_path,
+                        proxy_args=proxy_args, extra_options=extra_options,
+                    )
+                    via = f" via {profile.bastion_host}" if profile and profile.bastion_host else ""
+                    logger.info(
+                        "SSH connect: host=%s, user=%s, key=%s, proxy=%s, profile=%s",
+                        host, username, key_path,
+                        "yes" if proxy_args else "no",
+                        profile.name if profile else "direct",
+                    )
+
+                if self.app.terminal_service.launch_ssh_in_terminal(ssh_cmd):
+                    if (instance.get("is_ovh")
+                            or instance.get("is_custom")
+                            or instance.get("is_hetzner")):
+                        self.app.notify(
+                            f"Connected via local ~/.ssh: {rich_escape(name)}",
+                            markup=True,
+                        )
+                    else:
+                        via_str = via if not instance.get("is_ovh") and not instance.get("is_custom") and not instance.get("is_hetzner") else ""  # noqa: E501
+                        self.app.notify(
+                            f"Connected via local ~/.ssh: {rich_escape(name)}{via_str}",
+                            markup=True,
+                        )
+                else:
+                    self.app.notify(
+                        "Could not detect terminal emulator. Set 'terminal_emulator' in settings.",
+                        severity="error",
+                        markup=False,
+                    )
+
+            except Exception as exc:
+                logger.error("Error launching SSH terminal: %s", exc, exc_info=True)
+                self.app.notify(
+                    f"Error launching SSH: {rich_escape(str(exc))}",
+                    markup=True,
+                    severity="error",
+                )
 
     def action_action_4(self) -> None:
         """SCP Transfer."""
@@ -621,6 +806,47 @@ class ServerActionsScreen(Screen):
         from servonaut.screens.memory import MemoryScreen
         self.app.push_screen(MemoryScreen(self._instance))
 
+    def action_manage_ssh_ref(self) -> None:
+        """Push SshRefEditorModal directly to add/edit/delete the BW SSH ref."""
+        self.run_worker(
+            self._manage_ssh_ref_flow(),
+            group="ssh_verify",
+            exclusive=True,
+        )
+
+    async def _manage_ssh_ref_flow(self) -> None:
+        """Fetch existing ref then open SshRefEditorModal in add or edit mode."""
+        if not getattr(self.app, "bw_ssh_config_service", None):
+            self.app.notify(
+                "BW SSH service not available (sign in required)",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        provider = self._instance.get("provider", "aws").lower()
+        instance_id = self._instance.get("id")
+
+        try:
+            existing = await self.app.bw_ssh_config_service.get_personal_instance_ref(
+                provider, instance_id
+            )
+        except Exception as exc:
+            logger.debug("Failed to load existing SSH ref: %s", exc)
+            existing = None
+
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        saved = await self.app.push_screen_wait(
+            SshRefEditorModal(self._instance, existing_ref=existing)
+        )
+        if saved:
+            # Refresh SSH verify column in instance list if possible.
+            if hasattr(self.app, "_refresh_ssh_verify_status"):
+                self.app.run_worker(
+                    self.app._refresh_ssh_verify_status(),
+                    group="memory_io",
+                )
+
     def action_verify_ssh(self) -> None:
         """Launch the Verify SSH flow: show confirm modal, then run worker."""
         self.run_worker(
@@ -664,12 +890,11 @@ class ServerActionsScreen(Screen):
         if not confirmed:
             return
 
-        # No ref stored → stub "Add SSH ref" path (UI not yet implemented).
+        # No ref stored → open SshRefEditorModal so the user can add one.
         if not has_ref:
-            self.app.notify(
-                "Add SSH ref UI not yet implemented.",
-                severity="information",
-                markup=False,
+            from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+            await self.app.push_screen_wait(
+                SshRefEditorModal(self._instance, existing_ref=None)
             )
             return
 
@@ -831,3 +1056,32 @@ class ServerActionsScreen(Screen):
     def action_back(self) -> None:
         """Navigate back to instance list."""
         self.app.pop_screen()
+
+
+# ---------------------------------------------------------------------------
+# Null-object stubs used by _ssh_connect_flow when API services are absent
+# ---------------------------------------------------------------------------
+
+class _NullBwService:
+    """Drop-in for BwSshConfigService when the user is not logged in.
+
+    Every method the resolver calls returns ``None`` immediately so the
+    personal tier silently passes through to the local fallback.
+    """
+
+    async def get_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> None:
+        return None
+
+
+class _NullTeamService:
+    """Drop-in for TeamService when the user is not logged in."""
+
+    async def get_team_server_ssh_ref(
+        self, slug: str, server_id: str
+    ) -> None:
+        return None
+
+    async def list_teams(self) -> list:
+        return []

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -1,12 +1,16 @@
 """Server actions screen for Servonaut v2.0."""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING
 
+import logging
+import subprocess
+from typing import TYPE_CHECKING, Optional
+
+from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.widgets import Static, Button, Header, Footer
 
 from servonaut.widgets.sidebar import Sidebar
@@ -14,6 +18,75 @@ from servonaut.widgets.sidebar import Sidebar
 if TYPE_CHECKING:
     from servonaut.screens.file_browser import FileBrowserScreen
     from servonaut.screens.command_overlay import CommandOverlay
+
+logger = logging.getLogger(__name__)
+
+
+class ConfirmSshVerifyModal(ModalScreen[bool]):
+    """Brief blocking confirmation for the SSH probe action.
+
+    Returns True on Confirm, False on Cancel (including Escape).
+    Per CLAUDE.md: ModalScreen for brief blocking prompts.
+    Per style constraints: round $accent border, fixed height, Cancel button.
+    """
+
+    BINDINGS = [
+        Binding("escape", "action_cancel", "Cancel", show=False),
+    ]
+
+    def __init__(self, host: str, has_ref: bool) -> None:
+        """Initialize the modal.
+
+        Args:
+            host: Target host name / IP (cloud-origin — must be escaped).
+            has_ref: True if a BW SSH ref is stored for this instance. When
+                False the modal offers "Add SSH ref" instead of the probe prompt.
+        """
+        super().__init__()
+        self._host = host
+        self._has_ref = has_ref
+
+    def compose(self) -> ComposeResult:
+        """Compose the confirm modal."""
+        safe_host = escape(self._host)
+        if self._has_ref:
+            body_text = (
+                f"About to run a local SSH probe against [bold]{safe_host}[/bold].\n\n"
+                "This will:\n"
+                "  (1) resolve the Bitwarden item ref\n"
+                "  (2) run ssh -o BatchMode=yes to test connectivity\n"
+                "  (3) report the result to the server audit log"
+            )
+            confirm_label = "Verify"
+        else:
+            body_text = (
+                f"No SSH ref is stored for [bold]{safe_host}[/bold].\n\n"
+                "Would you like to add one so Servonaut can verify "
+                "SSH connectivity via Bitwarden?"
+            )
+            confirm_label = "Add SSH Ref"
+
+        yield Container(
+            Static("[bold]Verify SSH[/bold]", id="ssh_verify_modal_title"),
+            Static(body_text, id="ssh_verify_modal_body"),
+            Horizontal(
+                Button("Cancel", variant="default", id="btn_ssh_verify_cancel"),
+                Button(confirm_label, variant="primary", id="btn_ssh_verify_confirm"),
+                classes="ssh_verify_actions_row",
+            ),
+            id="ssh_verify_modal_container",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss with the appropriate result."""
+        if event.button.id == "btn_ssh_verify_confirm":
+            self.dismiss(True)
+        else:
+            self.dismiss(False)
+
+    def action_action_cancel(self) -> None:
+        """Escape — dismiss False."""
+        self.dismiss(False)
 
 
 class ServerActionsScreen(Screen):
@@ -41,6 +114,7 @@ class ServerActionsScreen(Screen):
         Binding("7", "action_7", "AI Analysis", show=True),
         Binding("8", "action_8", "Ban IP", show=True),
         Binding("m", "open_memory", "Memory", show=True),
+        Binding("v", "verify_ssh", "Verify SSH", show=True),
         Binding("9", "back", "Back", show=True),
         Binding("escape", "back", "Back", show=False),
     ]
@@ -136,6 +210,8 @@ class ServerActionsScreen(Screen):
                     Static("[dim]  Analyze log text with AI (OpenAI, Anthropic, or Ollama)[/dim]", classes="help_text"),
                     Button("8. Ban IP", id="btn_ban_ip"),
                     Static("[dim]  Ban this server's public IP via WAF, Security Group, or NACL[/dim]", classes="help_text"),
+                    Button("V. Verify SSH", id="btn_verify_ssh"),
+                    Static("[dim]  Run a local BW SSH probe and report the result[/dim]", classes="help_text"),
                     Button("9. Back", id="btn_back", variant="error"),
                     id="action_buttons"
                 ),
@@ -297,6 +373,8 @@ class ServerActionsScreen(Screen):
         elif button_id == "btn_ovh_firewall":
             from servonaut.screens.ovh_firewall import OVHFirewallScreen
             self.app.push_screen(OVHFirewallScreen(self._instance))
+        elif button_id == "btn_verify_ssh":
+            self.action_verify_ssh()
         elif button_id == "btn_back":
             self.action_back()
 
@@ -542,6 +620,213 @@ class ServerActionsScreen(Screen):
         """Open MemoryScreen for this instance."""
         from servonaut.screens.memory import MemoryScreen
         self.app.push_screen(MemoryScreen(self._instance))
+
+    def action_verify_ssh(self) -> None:
+        """Launch the Verify SSH flow: show confirm modal, then run worker."""
+        self.run_worker(
+            self._verify_ssh_flow(),
+            group="ssh_verify",
+            exclusive=True,
+        )
+
+    async def _verify_ssh_flow(self) -> None:
+        """Async flow: modal → BW resolve → probe → report → refresh."""
+        bw_service = getattr(self.app, "bw_ssh_config_service", None)
+        if bw_service is None:
+            self.app.notify(
+                "SSH verify requires a Servonaut account. Sign in via Settings → Login.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        provider = self._instance.get("provider", "aws").lower()
+        instance_id = self._instance.get("id", "")
+        host = (
+            self._instance.get("public_ip")
+            or self._instance.get("private_ip")
+            or instance_id
+        )
+
+        # Check if a BW ref is stored for this instance.
+        try:
+            ref_row = await bw_service.get_personal_instance_ref(provider, instance_id)
+        except Exception as exc:
+            logger.debug("SSH verify ref lookup failed: %s", exc)
+            ref_row = None
+
+        has_ref = ref_row is not None
+
+        # Push the confirm modal and await user's choice.
+        confirmed = await self.app.push_screen_wait(
+            ConfirmSshVerifyModal(host=host, has_ref=has_ref)
+        )
+        if not confirmed:
+            return
+
+        # No ref stored → stub "Add SSH ref" path (UI not yet implemented).
+        if not has_ref:
+            self.app.notify(
+                "Add SSH ref UI not yet implemented.",
+                severity="information",
+                markup=False,
+            )
+            return
+
+        # Resolve BW item and run the SSH probe.
+        ssh_credential_ref = ref_row.get("ssh_credential_ref", {})
+        item_id: Optional[str] = ssh_credential_ref.get("item_id") if isinstance(ssh_credential_ref, dict) else None
+
+        status = await self._run_ssh_probe(item_id, host)
+
+        # Report the result to the server.
+        try:
+            import servonaut as _sn_pkg
+            client_version = f"servonaut-cli/{getattr(_sn_pkg, '__version__', 'unknown')}"
+            await bw_service.report_personal_instance_verify(
+                provider=provider,
+                instance_id=instance_id,
+                status=status,
+                checked_by_client=client_version,
+            )
+        except Exception as exc:
+            from servonaut.services.api_client import APIError
+            if isinstance(exc, APIError) and exc.status == 402:
+                self.app.notify(
+                    "SSH verify reporting requires a paid Servonaut plan.",
+                    severity="warning",
+                    markup=False,
+                )
+            else:
+                logger.warning("SSH verify report POST failed: %s", exc)
+            # Don't abort — update local state anyway.
+
+        # Update the instance dict in memory and re-render the table.
+        from datetime import datetime, timezone
+        self._instance["ssh_verify_status"] = status
+        if status == "verified":
+            self._instance["ssh_verified_at"] = (
+                datetime.now(timezone.utc).isoformat()
+            )
+        else:
+            self._instance.pop("ssh_verified_at", None)
+
+        # Propagate into app.instances so the table refresh picks it up.
+        for inst in self.app.instances:
+            if inst.get("id") == instance_id:
+                inst["ssh_verify_status"] = status
+                if status == "verified":
+                    inst["ssh_verified_at"] = self._instance.get("ssh_verified_at")
+                else:
+                    inst.pop("ssh_verified_at", None)
+                break
+
+        # Surface the result.
+        _status_labels = {
+            "verified": "SSH verified successfully.",
+            "not_found": "SSH probe: host not found or unreachable.",
+            "auth_failed": "SSH probe: authentication failed.",
+        }
+        label = _status_labels.get(status, f"SSH probe status: {status}")
+        self.app.notify(label, markup=False)
+
+        # Refresh the instance list table if it's behind this screen.
+        try:
+            from servonaut.screens.instance_list import InstanceListScreen
+            for screen in self.app.screen_stack:
+                if isinstance(screen, InstanceListScreen):
+                    screen._update_table()
+                    break
+        except Exception:
+            pass
+
+    async def _run_ssh_probe(self, item_id: Optional[str], host: str) -> str:
+        """Resolve BW item and run BatchMode SSH probe. Returns status string."""
+        import asyncio
+
+        # Resolve the private key from Bitwarden (synchronous CLI call — run in thread).
+        private_key_body: Optional[str] = None
+        if item_id:
+            try:
+                from servonaut.services.bw_resolver import (
+                    BwResolver,
+                    BwResolverError,
+                )
+                resolver = BwResolver()
+                private_key_body = await asyncio.to_thread(
+                    resolver.resolve_ssh_key, item_id
+                )
+            except Exception as exc:
+                logger.debug("BW item resolution failed for %s: %s", item_id, exc)
+                return "not_found"
+
+        # Write the key to a temp file so ssh can use it.
+        import tempfile, os, stat
+        if private_key_body:
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="w",
+                    suffix=".pem",
+                    delete=False,
+                    prefix="servonaut_sshverify_",
+                ) as tf:
+                    tf.write(private_key_body)
+                    tmp_key_path: Optional[str] = tf.name
+                os.chmod(tmp_key_path, stat.S_IRUSR | stat.S_IWUSR)
+            except Exception as exc:
+                logger.debug("Temp key write failed: %s", exc)
+                return "not_found"
+        else:
+            tmp_key_path = None
+
+        try:
+            cmd = [
+                "ssh",
+                "-o", "BatchMode=yes",
+                "-o", "ConnectTimeout=5",
+                "-o", "StrictHostKeyChecking=no",
+            ]
+            if tmp_key_path:
+                cmd += ["-i", tmp_key_path, "-o", "IdentitiesOnly=yes"]
+            # Use the configured username or default.
+            username = (
+                self._instance.get("username")
+                or self.app.config_manager.get().default_username
+                or "root"
+            )
+            cmd += [f"{username}@{host}", "true"]
+
+            proc = await asyncio.to_thread(
+                subprocess.run,
+                cmd,
+                capture_output=True,
+                timeout=15,
+            )
+            rc = proc.returncode
+            if rc == 0:
+                return "verified"
+            # Exit code 255: SSH layer failure (host unreachable, key mismatch)
+            # Exit code 1–254: auth issues or remote command failure
+            return "auth_failed" if rc != 255 else "not_found"
+        except subprocess.TimeoutExpired:
+            return "not_found"
+        except FileNotFoundError:
+            # ssh binary not on PATH
+            self.app.notify(
+                "ssh binary not found on PATH — cannot run probe.",
+                severity="error",
+                markup=False,
+            )
+            return "not_found"
+        except Exception as exc:
+            logger.debug("SSH probe subprocess error: %s", exc)
+            return "not_found"
+        finally:
+            if tmp_key_path:
+                try:
+                    os.unlink(tmp_key_path)
+                except OSError:
+                    pass
 
     def action_back(self) -> None:
         """Navigate back to instance list."""

--- a/src/servonaut/screens/settings.py
+++ b/src/servonaut/screens/settings.py
@@ -11,6 +11,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical, Horizontal, ScrollableContainer
 
+from servonaut.services.bw_ssh_config_service import BITWARDEN_PM_PROVIDER
 from servonaut.utils.formatting import format_tokens_remaining
 from servonaut.widgets.sidebar import Sidebar
 from textual.screen import Screen
@@ -56,6 +57,8 @@ class SettingsScreen(Screen):
         self._discovered_ip_sets: List[dict] = []
         self._discovered_sgs: List[dict] = []
         self._discovered_nacls: List[dict] = []
+        # BW SSH vault: cached server response, or None if not configured yet.
+        self._bw_ssh_config: Optional[Dict[str, Any]] = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -410,6 +413,45 @@ class SettingsScreen(Screen):
                 classes="settings_section",
             ),
 
+            # Section 7b: Bitwarden SSH Vault (personal vault wiring)
+            # This section configures which BW vault the CLI queries when
+            # resolving per-instance SSH credential refs. The config is stored
+            # server-side at /api/v1/me/ssh-config — separate from config.json.
+            Container(
+                Static("[b]Bitwarden SSH Vault[/b]", id="bw_ssh_vault_title"),
+                Static(
+                    "[dim]Not configured. Set up vault wiring to resolve per-instance SSH keys.[/dim]",
+                    id="bw_ssh_vault_status",
+                ),
+                Horizontal(
+                    Button("Edit", id="btn_bw_ssh_edit", variant="default"),
+                    classes="form_actions_row",
+                    id="bw_ssh_vault_actions",
+                ),
+                # Inline edit form — hidden until the user clicks Edit.
+                Container(
+                    Static("[bold]Edit Vault Wiring[/bold]", classes="section_header"),
+                    Static("Vault URL", classes="label"),
+                    Input(
+                        id="bw_ssh_vault_url",
+                        placeholder="https://vault.bitwarden.com",
+                    ),
+                    Static("Default Collection ID (optional)", classes="label"),
+                    Input(
+                        id="bw_ssh_default_collection_id",
+                        placeholder="",
+                    ),
+                    Horizontal(
+                        Button("Save", id="btn_bw_ssh_save", variant="primary"),
+                        Button("Cancel", id="btn_bw_ssh_cancel", variant="default"),
+                        classes="form_actions_row",
+                    ),
+                    id="bw_ssh_vault_form",
+                ),
+                id="bw_ssh_vault_section",
+                classes="settings_section",
+            ),
+
             # Section 8: IP Lookup
             Container(
                 Static("[bold]IP Lookup[/bold]", classes="section_header"),
@@ -552,6 +594,9 @@ class SettingsScreen(Screen):
         self.query_one("#ipban_waf_fields").display = False
         self.query_one("#ipban_sg_fields").display = False
         self.query_one("#ipban_nacl_fields").display = False
+        # BW SSH Vault: hide inline form on load, then fetch current config.
+        self.query_one("#bw_ssh_vault_form").display = False
+        self._load_bw_ssh_config()
         # Memory Sync section: hidden unless entitled AND configured.
         self._init_memory_sync_section()
         # T4.5 — refresh the Servonaut AI status row + active preference.
@@ -928,6 +973,157 @@ class SettingsScreen(Screen):
                 f"Validation error [{escape(key)}]: {escape(message)}",
                 severity="error",
             )
+
+    # ------------------------------------------------------------------
+    # Bitwarden SSH Vault
+    # ------------------------------------------------------------------
+
+    def _load_bw_ssh_config(self) -> None:
+        """Kick off a background fetch of the personal BW SSH config."""
+        svc = getattr(self.app, "bw_ssh_config_service", None)
+        if svc is None:
+            return
+        self.run_worker(
+            self._do_load_bw_ssh_config(),
+            group="settings_bw_ssh",
+            name="bw_ssh_load",
+            exclusive=True,
+        )
+
+    async def _do_load_bw_ssh_config(self) -> None:
+        from servonaut.services.api_client import APIError
+
+        svc = getattr(self.app, "bw_ssh_config_service", None)
+        if svc is None:
+            return
+        try:
+            config = await svc.get_personal_config()
+        except APIError as exc:
+            logger.warning("BW SSH config load failed: %s", exc)
+            return
+        except Exception as exc:
+            logger.warning("BW SSH config load failed: %s", exc)
+            return
+        self._bw_ssh_config = config
+        self._refresh_bw_ssh_status()
+
+    def _refresh_bw_ssh_status(self) -> None:
+        """Update the status line from ``self._bw_ssh_config``."""
+        try:
+            status = self.query_one("#bw_ssh_vault_status", Static)
+        except Exception:
+            return
+
+        cfg = self._bw_ssh_config
+        if cfg is None:
+            status.update(
+                "[dim]Not configured. Set up vault wiring to resolve per-instance SSH keys.[/dim]"
+            )
+            return
+
+        inner = cfg.get("config") or {}
+        vault_url = inner.get("vault_url", "")
+        updated_at = cfg.get("updated_at", "")
+
+        # Demo-mode: redact vault_url (may reveal self-hosted infra endpoint).
+        if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None):
+            vault_url = "[redacted]"
+
+        if updated_at:
+            ts_display = escape(str(updated_at))
+        else:
+            ts_display = ""
+
+        url_display = escape(vault_url) if vault_url else "[dim]unknown[/dim]"
+        if ts_display:
+            status.update(
+                f"[green]Configured.[/green] Vault: {url_display} · Updated {ts_display}"
+            )
+        else:
+            status.update(
+                f"[green]Configured.[/green] Vault: {url_display}"
+            )
+
+    def _show_bw_ssh_form(self) -> None:
+        """Reveal the inline form, populate from current config (or blank)."""
+        cfg = self._bw_ssh_config
+        inner = cfg.get("config") or {} if cfg else {}
+
+        vault_url_input = self.query_one("#bw_ssh_vault_url", Input)
+        collection_input = self.query_one("#bw_ssh_default_collection_id", Input)
+
+        vault_url_input.value = inner.get("vault_url", "") if inner else ""
+        collection_input.value = inner.get("default_collection_id", "") if inner else ""
+
+        self.query_one("#bw_ssh_vault_form").display = True
+        vault_url_input.focus()
+
+    def _hide_bw_ssh_form(self) -> None:
+        """Collapse the inline form without making an API call."""
+        self.query_one("#bw_ssh_vault_form").display = False
+
+    def _save_bw_ssh_config(self) -> None:
+        """Validate inputs then kick off the PUT worker."""
+        vault_url = self.query_one("#bw_ssh_vault_url", Input).value.strip()
+        if not vault_url:
+            self.app.notify("Vault URL is required.", severity="error")
+            self.query_one("#bw_ssh_vault_url", Input).focus()
+            return
+        if not (vault_url.startswith("http://") or vault_url.startswith("https://")):
+            self.app.notify(
+                "Vault URL must start with http:// or https://",
+                severity="error",
+            )
+            self.query_one("#bw_ssh_vault_url", Input).focus()
+            return
+        self.run_worker(
+            self._do_save_bw_ssh_config(vault_url),
+            group="settings_bw_ssh",
+            exclusive=True,
+        )
+
+    async def _do_save_bw_ssh_config(self, vault_url: str) -> None:
+        from servonaut.services.api_client import APIError
+
+        collection_id = self.query_one(
+            "#bw_ssh_default_collection_id", Input
+        ).value.strip() or None
+
+        svc = getattr(self.app, "bw_ssh_config_service", None)
+        if svc is None:
+            self.app.notify("BW SSH config service unavailable.", severity="error")
+            return
+        try:
+            result = await svc.put_personal_config(
+                vault_url=vault_url,
+                default_collection_id=collection_id,
+                provider=BITWARDEN_PM_PROVIDER,
+            )
+        except APIError as exc:
+            if exc.status == 402:
+                self.app.notify(
+                    "Personal SSH vault config requires a paid plan. "
+                    "Upgrade at https://servonaut.dev/pricing",
+                    severity="warning",
+                )
+                # Keep form open so user can copy input.
+                return
+            logger.error("BW SSH config save failed: %s", exc)
+            self.app.notify(str(exc), severity="error", markup=False)
+            return
+        except Exception as exc:
+            logger.error("BW SSH config save failed: %s", exc)
+            self.app.notify(str(exc), severity="error", markup=False)
+            return
+
+        self._bw_ssh_config = result
+        self._hide_bw_ssh_form()
+        self._refresh_bw_ssh_status()
+        self.app.notify("Bitwarden SSH vault config saved.", severity="information")
+
+    # ------------------------------------------------------------------
+    # /Bitwarden SSH Vault
+    # ------------------------------------------------------------------
 
     def _load_settings(self) -> None:
         config = self.app.config_manager.get()
@@ -1456,6 +1652,12 @@ class SettingsScreen(Screen):
             self._handle_ai_provider_reset()
         elif button_id == "btn_ai_servonaut_upgrade":
             self._handle_ai_servonaut_upgrade()
+        elif button_id == "btn_bw_ssh_edit":
+            self._show_bw_ssh_form()
+        elif button_id == "btn_bw_ssh_save":
+            self._save_bw_ssh_config()
+        elif button_id == "btn_bw_ssh_cancel":
+            self._hide_bw_ssh_form()
 
     def _add_scan_path(self) -> None:
         input_field = self.query_one("#input_new_path", Input)

--- a/src/servonaut/screens/ssh_ref_editor.py
+++ b/src/servonaut/screens/ssh_ref_editor.py
@@ -1,0 +1,241 @@
+"""Per-instance Bitwarden SSH ref manager modal."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from rich.markup import escape
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Static
+
+from servonaut.services.bw_ssh_config_service import BITWARDEN_PM_PROVIDER
+from servonaut.utils.validation import validate_instance_id, ValidationError
+
+logger = logging.getLogger(__name__)
+
+_HELP_TEXT = (
+    "Stores a Bitwarden Password Manager item reference for SSH key resolution. "
+    "The item must be a native SSH item (BW 2023.10+) with the private key in the "
+    "standard sshKey field."
+)
+
+
+class SshRefEditorModal(ModalScreen[bool]):
+    """Per-instance BW SSH ref manager.
+
+    Returns True if a ref was saved or deleted (so the caller can refresh
+    the instance table). Returns False if the user cancelled.
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    DEFAULT_CSS = ""  # all styling lives in app.css
+
+    def __init__(
+        self,
+        instance: dict,
+        existing_ref: Optional[dict] = None,
+    ) -> None:
+        """
+        Args:
+            instance: Servonaut instance dict (must have 'id', 'provider',
+                'name'). Used to render context + scope the PUT call.
+            existing_ref: If set, the modal is in EDIT mode (Delete + Save
+                buttons enabled, fields pre-populated from
+                existing_ref['ssh_credential_ref']). If None, ADD mode
+                (only Save + Cancel, no Delete).
+        """
+        super().__init__()
+        self._instance = instance
+        self._existing_ref = existing_ref
+        self._edit_mode = existing_ref is not None
+
+    def compose(self) -> ComposeResult:
+        """Compose the SSH ref editor modal."""
+        ref = (
+            self._existing_ref.get("ssh_credential_ref", {})
+            if self._existing_ref
+            else {}
+        )
+        safe_name = escape(self._instance.get("name") or self._instance.get("id", ""))
+
+        mode_label = "Edit" if self._edit_mode else "Add"
+        title = f"[bold]{mode_label} BW SSH Ref — {safe_name}[/bold]"
+
+        existing_item_id = ref.get("item_id", "") if isinstance(ref, dict) else ""
+        existing_collection_id = ref.get("collection_id", "") if isinstance(ref, dict) else ""
+        existing_vault_url = ref.get("vault_url", "") if isinstance(ref, dict) else ""
+
+        buttons: list = [
+            Button("Cancel", variant="default", id="cancel_btn"),
+        ]
+        if self._edit_mode:
+            buttons.append(Button("Delete", variant="error", id="delete_btn"))
+        buttons.append(Button("Save", variant="primary", id="save_btn"))
+
+        yield Container(
+            Static(title, id="ssh_ref_editor_title"),
+            Static(_HELP_TEXT, id="ssh_ref_editor_help"),
+            Vertical(
+                Label("Item ID (required)"),
+                Input(
+                    value=existing_item_id,
+                    id="item_id",
+                    placeholder="Bitwarden item UUID",
+                ),
+                Label("Collection ID (optional)"),
+                Input(
+                    value=existing_collection_id,
+                    id="collection_id",
+                    placeholder="(optional) collection UUID",
+                ),
+                Label("Vault URL (optional)"),
+                Input(
+                    value=existing_vault_url,
+                    id="vault_url",
+                    placeholder="(optional) https://vault.bitwarden.com",
+                ),
+                id="ssh_ref_fields",
+            ),
+            Horizontal(*buttons, classes="ssh_ref_actions_row"),
+            id="ssh_ref_editor_container",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Route button presses."""
+        btn_id = event.button.id
+        if btn_id == "cancel_btn":
+            self.dismiss(False)
+        elif btn_id == "save_btn":
+            self.run_worker(self._do_save(), group="ssh_ref_io", exclusive=True)
+        elif btn_id == "delete_btn":
+            self.run_worker(self._do_delete(), group="ssh_ref_io", exclusive=True)
+
+    def action_cancel(self) -> None:
+        """Escape binding — dismiss False."""
+        self.dismiss(False)
+
+    async def _do_save(self) -> None:
+        """Validate inputs and call PUT API."""
+        from servonaut.services.api_client import APIError
+
+        item_id_input = self.query_one("#item_id", Input)
+        collection_id_input = self.query_one("#collection_id", Input)
+        vault_url_input = self.query_one("#vault_url", Input)
+
+        item_id_value = item_id_input.value.strip()
+        collection_id_value = collection_id_input.value.strip()
+        vault_url_value = vault_url_input.value.strip()
+
+        # Validate item_id is non-empty and UUID-ish (reuse instance_id regex:
+        # [A-Za-z0-9_\-]{1,64} — covers hyphenated UUID format).
+        if not item_id_value:
+            self.app.notify(
+                "Item ID is required.",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        try:
+            validate_instance_id(item_id_value.replace("-", "X"))  # dashes are UUID-legal
+        except ValidationError:
+            self.app.notify(
+                "Item ID looks invalid — expected a Bitwarden UUID (alphanumeric + hyphens).",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        bw_service = getattr(self.app, "bw_ssh_config_service", None)
+        if bw_service is None:
+            self.app.notify(
+                "BW SSH service not available (sign in required).",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        provider = self._instance.get("provider", "aws").lower()
+        instance_id = self._instance.get("id", "")
+
+        ssh_credential_ref: dict = {"item_id": item_id_value}
+        if collection_id_value:
+            ssh_credential_ref["collection_id"] = collection_id_value
+        if vault_url_value:
+            ssh_credential_ref["vault_url"] = vault_url_value
+
+        try:
+            await bw_service.put_personal_instance_ref(
+                provider=provider,
+                instance_id=instance_id,
+                ssh_credential_ref=ssh_credential_ref,
+                ssh_credential_provider=BITWARDEN_PM_PROVIDER,
+            )
+        except APIError as exc:
+            if exc.status == 402:
+                self.app.notify(
+                    "Personal SSH refs require a paid plan. Upgrade at /pricing.",
+                    severity="warning",
+                    markup=False,
+                )
+            elif exc.status == 422:
+                self.app.notify(exc.message, severity="error", markup=False)
+            else:
+                self.app.notify(
+                    f"Failed to save SSH ref: {exc.message}",
+                    severity="error",
+                    markup=False,
+                )
+            return
+        except Exception as exc:
+            self.app.notify(
+                f"Failed to save SSH ref: {exc}",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        self.dismiss(True)
+
+    async def _do_delete(self) -> None:
+        """Call DELETE API and dismiss."""
+        from servonaut.services.api_client import APIError
+
+        bw_service = getattr(self.app, "bw_ssh_config_service", None)
+        if bw_service is None:
+            self.app.notify(
+                "BW SSH service not available (sign in required).",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        provider = self._instance.get("provider", "aws").lower()
+        instance_id = self._instance.get("id", "")
+
+        try:
+            await bw_service.delete_personal_instance_ref(
+                provider=provider,
+                instance_id=instance_id,
+            )
+        except APIError as exc:
+            self.app.notify(
+                f"Failed to delete SSH ref: {exc.message}",
+                severity="error",
+                markup=False,
+            )
+            return
+        except Exception as exc:
+            self.app.notify(
+                f"Failed to delete SSH ref: {exc}",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        self.dismiss(True)

--- a/src/servonaut/services/bw_resolver.py
+++ b/src/servonaut/services/bw_resolver.py
@@ -1,0 +1,133 @@
+"""Bitwarden CLI resolver for SSH private keys stored as native BW SSH items.
+
+Wire contract (locked 2026-05-24):
+- Requires Bitwarden CLI 2023.10+ which introduced native SSH item type.
+- ``bw get item <uuid>`` returns JSON with path ``.sshKey.privateKey`` containing
+  the OpenSSH private key body.
+- The server does NOT store a ``key_field`` pointer — we default to
+  ``sshKey.privateKey`` and surface a clear error if absent.
+
+No fallback shapes (no notes blob, no attachment lookup) — this is intentional.
+The single-path contract keeps the implementation auditable and the error messages
+actionable. A ``key_field`` parameter can be added if a real user reports a
+non-default vault item shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+
+from servonaut.utils.validation import validate_instance_id
+
+logger = logging.getLogger(__name__)
+
+_BW_TIMEOUT_SECONDS: int = 15
+_LOCKED_STDERR_PHRASES: tuple[str, ...] = (
+    "You are not logged in",
+    "Vault is locked",
+    "Mac failed",
+)
+_NOT_FOUND_PHRASE: str = "Not found."
+
+
+class BwResolverError(Exception):
+    """Base for all BW resolution failures — friendly user-facing message in .message."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class BwCliMissingError(BwResolverError):
+    """bw command not found on PATH."""
+
+
+class BwSessionMissingError(BwResolverError):
+    """bw exists but BW_SESSION env var not set or vault locked — user must run ``bw unlock``."""
+
+
+class BwItemNotFoundError(BwResolverError):
+    """bw get item returned 404 / item does not exist."""
+
+
+class BwItemShapeError(BwResolverError):
+    """Item exists but has no .sshKey.privateKey field — likely a non-native SSH item."""
+
+
+class BwResolver:
+    """Resolve a Bitwarden Password Manager item id to an OpenSSH private key.
+
+    Uses the ``bw`` CLI via subprocess. Requires an active BW session
+    (``BW_SESSION`` env var set via ``bw unlock``).
+    """
+
+    def __init__(self, bw_binary: str = "bw") -> None:
+        self._bw_binary = bw_binary
+
+    def resolve_ssh_key(self, item_id: str) -> str:
+        """Resolve a BW item id to its OpenSSH private key body.
+
+        Returns the raw key text (suitable for writing to a 0600 tmpfile).
+        Raises specific BwResolverError subclasses for each failure mode.
+        """
+        validate_instance_id(item_id)  # rejects path traversal and non-UUID-ish ids
+
+        if shutil.which(self._bw_binary) is None:
+            raise BwCliMissingError(
+                f"Bitwarden CLI ({self._bw_binary!r}) not found on PATH. "
+                "Install it from https://bitwarden.com/help/cli/ and ensure it is on your PATH."
+            )
+
+        logger.debug(
+            "Resolving BW item %s via sshKey.privateKey (BW 2023.10+ native shape)",
+            item_id,
+        )
+
+        result = subprocess.run(
+            [self._bw_binary, "get", "item", item_id],
+            capture_output=True,
+            text=True,
+            timeout=_BW_TIMEOUT_SECONDS,
+        )
+
+        stderr = result.stderr or ""
+
+        if any(phrase in stderr for phrase in _LOCKED_STDERR_PHRASES):
+            raise BwSessionMissingError(
+                "Bitwarden vault is locked or you are not logged in. "
+                "Run `bw unlock` and export BW_SESSION, then retry."
+            )
+
+        if _NOT_FOUND_PHRASE in stderr:
+            raise BwItemNotFoundError(
+                f"Bitwarden item {item_id!r} was not found. "
+                "Verify the item UUID in your Bitwarden vault."
+            )
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise BwItemShapeError(
+                f"BW item {item_id} returned non-JSON output. "
+                "Expected a BW 2023.10+ native SSH item. "
+                f"Raw error: {exc}"
+            ) from exc
+
+        try:
+            private_key = data["sshKey"]["privateKey"]
+        except (KeyError, TypeError):
+            raise BwItemShapeError(
+                f"BW item {item_id} has no SSH key field "
+                "(expected BW 2023.10+ native SSH item with .sshKey.privateKey)."
+            )
+
+        if not isinstance(private_key, str) or not private_key:
+            raise BwItemShapeError(
+                f"BW item {item_id} has no SSH key field "
+                "(expected BW 2023.10+ native SSH item with .sshKey.privateKey)."
+            )
+
+        return private_key

--- a/src/servonaut/services/bw_ssh_config_service.py
+++ b/src/servonaut/services/bw_ssh_config_service.py
@@ -166,6 +166,27 @@ class BwSshConfigService(BwSshConfigServiceInterface):
             raise
         return bool(result.get("deleted", True)) if isinstance(result, dict) else True
 
+    async def get_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """GET /api/v1/me/instances/{provider}/{instance_id}/ssh-ref.
+
+        Returns ``{"ssh_credential_provider": ..., "ssh_credential_ref": {...}}``
+        on 200, or ``None`` on 404 (no ref stored yet).
+
+        Used by :class:`SshRefResolver` as the first tier of the resolution
+        chain — if the user has stored a BW item ref for this instance, this
+        method returns it; otherwise falls through to team and local tiers.
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        path = f"/api/v1/me/instances/{provider}/{instance_id}/ssh-ref"
+        try:
+            return await self._api.get(path)
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
     async def get_personal_instance_verify_status(
         self, provider: str, instance_id: str
     ) -> Optional[Dict[str, Any]]:

--- a/src/servonaut/services/bw_ssh_config_service.py
+++ b/src/servonaut/services/bw_ssh_config_service.py
@@ -1,0 +1,211 @@
+"""Bitwarden Password Manager SSH config + per-instance ref client.
+
+Wire contract locked with servonaut.dev on 2026-05-24. Two address spaces:
+
+- Personal (Solo + Teams tiers): ``/api/v1/me/...`` — applies to instances the
+  user owns directly via list_instances (AWS / OVH / Hetzner).
+- Team (Teams tier, admin/owner role for writes): ``/api/v1/teams/{slug}/...``
+  — applies to instances explicitly shared by an owner as ``SharedServer`` rows.
+
+Resolution order (callers walk in this exact priority):
+
+    1. Personal — :meth:`get_personal_instance_ref`
+    2. Team    — :meth:`get_team_server_ref` (added in C2, see ``team_service``)
+    3. Local ``~/.ssh`` fallback
+
+Locked field names (additive-evolution from here, never renamed):
+
+- Body field is **``ssh_credential_ref``** (NOT ``ref``). The server accepts
+  ``ref`` as a backward-compat alias for one release; we never use it.
+- ``ssh_verified_at`` is **NULL whenever ``ssh_verify_status`` ≠ ``"verified"``**.
+  Callers must render it as "—" / "never" for non-verified statuses to avoid
+  showing a stale timestamp next to a failed status.
+
+Tier gates surfaced by the server:
+
+- Free tier on any ``/me/{ssh,secrets}-config`` or ``/me/instances/...`` → 402
+- Member-not-admin on team-side writes → 403 (see ``team_service``)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from .interfaces import BwSshConfigServiceInterface
+
+if TYPE_CHECKING:
+    from servonaut.services.api_client import APIClient
+
+logger = logging.getLogger(__name__)
+
+# Provider identifier in the locked wire contract.
+BITWARDEN_PM_PROVIDER = "bitwarden_pm"
+
+# Verify-report status enum. Server NULLs ``ssh_verified_at`` on anything
+# other than ``verified``.
+STATUS_VERIFIED = "verified"
+STATUS_NOT_FOUND = "not_found"
+STATUS_AUTH_FAILED = "auth_failed"
+VALID_VERIFY_STATUSES = frozenset({STATUS_VERIFIED, STATUS_NOT_FOUND, STATUS_AUTH_FAILED})
+
+
+class BwSshConfigService(BwSshConfigServiceInterface):
+    """Client for personal SSH config + per-instance ref endpoints.
+
+    Team-side equivalents live on :class:`TeamService` because they share the
+    team-slug routing concern; this service is personal-scope only.
+    """
+
+    def __init__(self, api_client: "APIClient") -> None:
+        self._api = api_client
+
+    # ------------------------------------------------------------------
+    # Personal SSH config (vault wiring)
+    # ------------------------------------------------------------------
+
+    async def get_personal_config(self) -> Optional[Dict[str, Any]]:
+        """Return the user's personal BW SSH config, or ``None`` if not configured.
+
+        Shape on 200::
+
+            {"provider": "bitwarden_pm",
+             "config": {"vault_url": "...", "default_collection_id": "..."?},
+             "updated_at": "..."}
+
+        404 → user has not configured personal BW yet — caller should treat
+        this as "fall back to local ``~/.ssh``".
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            return await self._api.get("/api/v1/me/ssh-config")
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    async def put_personal_config(
+        self,
+        vault_url: str,
+        default_collection_id: Optional[str] = None,
+        provider: str = BITWARDEN_PM_PROVIDER,
+    ) -> Dict[str, Any]:
+        config: Dict[str, Any] = {"vault_url": vault_url}
+        if default_collection_id:
+            config["default_collection_id"] = default_collection_id
+        return await self._api.put(
+            "/api/v1/me/ssh-config",
+            json={"provider": provider, "config": config},
+        )
+
+    # ------------------------------------------------------------------
+    # Personal per-instance SSH refs
+    # ------------------------------------------------------------------
+
+    async def list_personal_instances(self) -> List[Dict[str, Any]]:
+        """Roll-up of every personal instance with a stored SSH ref.
+
+        Shape on 200::
+
+            {"instances": [
+                {"provider", "instance_id", "ssh_credential_provider",
+                 "ssh_verify_status", "ssh_verified_at", "updated_at"},
+                ...
+            ]}
+
+        Returns the unwrapped list. Tolerates a bare-array fallback shape
+        for forward-compat.
+        """
+        result = await self._api.get("/api/v1/me/instances")
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            return result.get("instances", [])
+        return []
+
+    async def put_personal_instance_ref(
+        self,
+        provider: str,
+        instance_id: str,
+        ssh_credential_ref: Dict[str, Any],
+        ssh_credential_provider: str = BITWARDEN_PM_PROVIDER,
+    ) -> Dict[str, Any]:
+        """Store/replace the SSH credential ref for a personal instance.
+
+        ``ssh_credential_ref`` shape::
+
+            {"item_id": "uuid",
+             "collection_id": "uuid"?,
+             "vault_url": "https://..."?}
+
+        Callers must validate ``provider`` and ``instance_id`` via
+        :mod:`servonaut.utils.validation` BEFORE calling this — server-side
+        regexes return 404 / 400 which are slower to surface as user-facing
+        errors than a local ``ValidationError``.
+        """
+        path = f"/api/v1/me/instances/{provider}/{instance_id}/ssh-ref"
+        return await self._api.put(
+            path,
+            json={
+                "ssh_credential_provider": ssh_credential_provider,
+                "ssh_credential_ref": ssh_credential_ref,
+            },
+        )
+
+    async def delete_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> bool:
+        """Remove the stored SSH ref. Returns True on delete, False if absent."""
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        path = f"/api/v1/me/instances/{provider}/{instance_id}/ssh-ref"
+        try:
+            result = await self._api.delete(path)
+        except APIError as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return bool(result.get("deleted", True)) if isinstance(result, dict) else True
+
+    async def get_personal_instance_verify_status(
+        self, provider: str, instance_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get the last verify status for a personal instance, or None if no ref.
+
+        Shape on 200::
+
+            {"provider", "instance_id", "ssh_verify_status",
+             "ssh_verified_at", "checked_by_client", "updated_at"}
+
+        ``ssh_verified_at`` is NULL whenever ``ssh_verify_status`` ≠ ``verified``
+        (server-enforced contract).
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        path = f"/api/v1/me/instances/{provider}/{instance_id}/ssh-verify-status"
+        try:
+            return await self._api.get(path)
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    async def report_personal_instance_verify(
+        self,
+        provider: str,
+        instance_id: str,
+        status: str,
+        checked_by_client: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Submit a verify probe result for a personal instance.
+
+        ``status`` must be one of :data:`VALID_VERIFY_STATUSES`.
+        ``checked_by_client`` should be ``"servonaut-cli/<version>"`` so the
+        audit row tells future-us which CLI version did the probe.
+        """
+        if status not in VALID_VERIFY_STATUSES:
+            allowed = ", ".join(sorted(VALID_VERIFY_STATUSES))
+            raise ValueError(f"status must be one of {{{allowed}}}, got {status!r}")
+        body: Dict[str, Any] = {"status": status}
+        if checked_by_client:
+            body["checked_by_client"] = checked_by_client
+        path = f"/api/v1/me/instances/{provider}/{instance_id}/ssh-verify-report"
+        return await self._api.post(path, json=body)

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -1019,6 +1019,54 @@ class TeamServiceInterface(ABC):
     ) -> dict:
         pass
 
+    @abstractmethod
+    async def get_team_ssh_config(self, slug: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    async def put_team_ssh_config(
+        self,
+        slug: str,
+        vault_url: str,
+        default_collection_id: Optional[str] = None,
+        provider: str = "bitwarden_pm",
+    ) -> dict:
+        pass
+
+    @abstractmethod
+    async def get_team_server_ssh_ref(self, slug: str, server_id: str) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    async def put_team_server_ssh_ref(
+        self,
+        slug: str,
+        server_id: str,
+        ssh_credential_ref: dict,
+        ssh_credential_provider: str = "bitwarden_pm",
+    ) -> dict:
+        pass
+
+    @abstractmethod
+    async def delete_team_server_ssh_ref(self, slug: str, server_id: str) -> bool:
+        pass
+
+    @abstractmethod
+    async def get_team_server_ssh_verify_status(
+        self, slug: str, server_id: str
+    ) -> Optional[dict]:
+        pass
+
+    @abstractmethod
+    async def report_team_server_ssh_verify(
+        self,
+        slug: str,
+        server_id: str,
+        status: str,
+        checked_by_client: Optional[str] = None,
+    ) -> dict:
+        pass
+
 
 class RemoteAuditServiceInterface(ABC):
     """Interface for remote audit trail."""

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -1174,6 +1174,17 @@ class BwSshConfigServiceInterface(ABC):
         pass
 
     @abstractmethod
+    async def get_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """GET /api/v1/me/instances/{provider}/{instance_id}/ssh-ref.
+
+        Returns ``{"ssh_credential_provider": ..., "ssh_credential_ref": {...}}``
+        on 200, or ``None`` on 404 (no ref stored).
+        """
+        pass
+
+    @abstractmethod
     async def get_personal_instance_verify_status(
         self, provider: str, instance_id: str
     ) -> Optional[Dict[str, Any]]:

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional, TYPE_CHECKING
+from typing import Any, List, Dict, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from servonaut.config.schema import AIProviderConfig, ConnectionProfile, CustomServer, IPBanConfig
@@ -1083,6 +1083,63 @@ def _validate_secret_value(value: str) -> str:
             f"got {len(value)}"
         )
     return value
+
+
+class BwSshConfigServiceInterface(ABC):
+    """Interface for personal SSH config + per-instance ref endpoints.
+
+    See :mod:`servonaut.services.bw_ssh_config_service` for the locked wire
+    contract (2026-05-24 with servonaut.dev).
+    """
+
+    @abstractmethod
+    async def get_personal_config(self) -> Optional[Dict[str, Any]]:
+        pass
+
+    @abstractmethod
+    async def put_personal_config(
+        self,
+        vault_url: str,
+        default_collection_id: Optional[str] = None,
+        provider: str = "bitwarden_pm",
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def list_personal_instances(self) -> List[Dict[str, Any]]:
+        pass
+
+    @abstractmethod
+    async def put_personal_instance_ref(
+        self,
+        provider: str,
+        instance_id: str,
+        ssh_credential_ref: Dict[str, Any],
+        ssh_credential_provider: str = "bitwarden_pm",
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
+    async def delete_personal_instance_ref(
+        self, provider: str, instance_id: str
+    ) -> bool:
+        pass
+
+    @abstractmethod
+    async def get_personal_instance_verify_status(
+        self, provider: str, instance_id: str
+    ) -> Optional[Dict[str, Any]]:
+        pass
+
+    @abstractmethod
+    async def report_personal_instance_verify(
+        self,
+        provider: str,
+        instance_id: str,
+        status: str,
+        checked_by_client: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        pass
 
 
 class SecretProviderInterface(ABC):

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -8,6 +8,7 @@ import re
 import secrets
 import socket
 import time
+from collections import OrderedDict
 from dataclasses import asdict, replace
 from typing import Any, Awaitable, Callable, Optional, Union
 
@@ -39,6 +40,27 @@ class RelayListener:
     # Refresh the Mercure subscriber JWT a bit before the 1h backend TTL.
     _MERCURE_JWT_REFRESH_SECONDS = 3000
 
+    # Topic suffixes we subscribe to. The Mercure hub accepts repeated
+    # ``topic`` query params, so we subscribe to both in a single SSE
+    # connection.
+    #
+    # Dual-publish contract (servonaut.dev 2026-05-24, PR #74):
+    # the server publishes the SAME payload to BOTH topics during the
+    # transition window. We dedup by ``tool_call_id`` (preferred — the
+    # load-bearing idempotency key for AI tool calls) falling back to
+    # the top-level ``id`` (CommandRequest events). Two separate
+    # ``hub->publish()`` calls server-side generate distinct Mercure
+    # event ids, so event.id-based dedup would NOT work — domain-level
+    # dedup is the only reliable path.
+    _TOPIC_SUFFIXES = ("commands", "ai-tool-calls")
+
+    # Bounded LRU dedup. 256 entries × ~50 bytes ≈ 13 KB worst-case.
+    # TTL of 5 minutes is wildly more than enough for the microsecond
+    # gap between two dual-publish arrivals; the bound + TTL together
+    # ensure a long-lived listener can't accumulate memory.
+    _DEDUP_MAX_ENTRIES = 256
+    _DEDUP_TTL_SECONDS = 300
+
     def __init__(self, executors, base_url: str, mercure_url: str,
                  auth_token: TokenSource, user_id: str,
                  heartbeat_interval: int = 30,
@@ -65,6 +87,10 @@ class RelayListener:
         self._heartbeat_interval = heartbeat_interval
         self._last_event_id: str | None = None
         self._running = False
+        # Bounded LRU of idempotency keys we've already processed; entries
+        # carry a monotonic "first seen" timestamp so the TTL sweep can
+        # evict stale rows even if the size bound never kicks in.
+        self._seen_event_keys: "OrderedDict[str, float]" = OrderedDict()
         self._client: httpx.AsyncClient | None = None
         self._mercure_jwt: str | None = None
         self._mercure_jwt_fetched_at: float = 0.0
@@ -221,11 +247,17 @@ class RelayListener:
             return await self._fetch_mercure_jwt()
         return self._mercure_jwt
 
+    def _topic_urls(self) -> list[str]:
+        """Return every Mercure topic URL this listener subscribes to."""
+        return [
+            f"/cli/{self._user_id}/{suffix}" for suffix in self._TOPIC_SUFFIXES
+        ]
+
     async def _listen_forever(self) -> None:
         """SSE subscribe loop with exponential backoff on failure."""
         backoff = 1
         max_backoff = 30
-        topic = f"/cli/{self._user_id}/commands"
+        topics = self._topic_urls()
 
         while self._running:
             try:
@@ -235,7 +267,13 @@ class RelayListener:
                 # query parameter (not HTTP Bearer). Caddy's Mercure module
                 # redacts this parameter in access logs (see Caddyfile log
                 # filter) so it does not leak to disk.
-                params = {"topic": topic, "authorization": mercure_jwt}
+                # Repeated ``topic`` params subscribe to multiple topics on
+                # one connection — list-of-tuples form lets httpx emit two
+                # ``topic=...`` query params per the Mercure spec.
+                params: list[tuple[str, str]] = [
+                    ("topic", topic) for topic in topics
+                ]
+                params.append(("authorization", mercure_jwt))
                 headers = {}
                 if self._last_event_id:
                     headers["Last-Event-ID"] = self._last_event_id
@@ -246,7 +284,7 @@ class RelayListener:
                     headers=headers,
                 ) as event_source:
                     backoff = 1  # Reset on successful connection
-                    logger.info("Connected to Mercure hub, topic: %s", topic)
+                    logger.info("Connected to Mercure hub, topics: %s", topics)
                     print("Connected to relay. Waiting for commands...")  # noqa: foreground only
 
                     async for event in event_source.aiter_sse():
@@ -277,10 +315,76 @@ class RelayListener:
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, max_backoff)
 
+    @staticmethod
+    def _extract_dedup_key(raw: dict) -> Optional[str]:
+        """Return a stable idempotency key for an inbound event, or None.
+
+        Preference order:
+        1. ``tool_call_id`` (top-level or nested in ``payload``) — the
+           load-bearing key for AI tool calls.
+        2. Top-level ``id`` — the request id for CommandRequest events.
+
+        Returning None means "no idempotency basis" — caller should process
+        the event without dedup (better one execution than zero).
+        """
+        tcid = raw.get("tool_call_id")
+        if not isinstance(tcid, str) or not tcid:
+            payload = raw.get("payload")
+            if isinstance(payload, dict):
+                nested = payload.get("tool_call_id")
+                if isinstance(nested, str) and nested:
+                    tcid = nested
+        if isinstance(tcid, str) and tcid:
+            return f"tcid:{tcid}"
+        rid = raw.get("id")
+        if isinstance(rid, str) and rid:
+            return f"id:{rid}"
+        return None
+
+    def _dedup_should_process(self, key: Optional[str]) -> bool:
+        """Bounded-LRU dedup check. True if the event is new.
+
+        Side effects:
+        - Evicts TTL-expired entries on every call (O(n) scan, n ≤ 256).
+        - On hit: returns False; entry stays in the LRU (so a 3rd or
+          4th republish during the same window also skips).
+        - On miss: records the key, evicts oldest if over the size bound.
+        """
+        if key is None:
+            return True  # Cannot dedup an event with no idempotency key.
+        now = time.monotonic()
+        # Drop anything past TTL — cheap because OrderedDict iterates in
+        # insertion order so we can stop at the first non-expired entry.
+        expired_cutoff = now - self._DEDUP_TTL_SECONDS
+        while self._seen_event_keys:
+            oldest_key, first_seen = next(iter(self._seen_event_keys.items()))
+            if first_seen >= expired_cutoff:
+                break
+            self._seen_event_keys.popitem(last=False)
+        if key in self._seen_event_keys:
+            return False
+        self._seen_event_keys[key] = now
+        # Enforce hard cap regardless of TTL — protects against a flood of
+        # unique-id events from filling memory between TTL sweeps.
+        while len(self._seen_event_keys) > self._DEDUP_MAX_ENTRIES:
+            self._seen_event_keys.popitem(last=False)
+        return True
+
     async def _handle_event(self, data: str) -> None:
         """Parse an SSE event payload and dispatch to executor."""
         try:
             raw = json.loads(data)
+
+            # Dual-publish dedup. The server publishes the same payload to
+            # /commands AND /ai-tool-calls during the transition window;
+            # without this guard a single logical event would dispatch twice.
+            dedup_key = self._extract_dedup_key(raw)
+            if not self._dedup_should_process(dedup_key):
+                logger.debug(
+                    "Skipping duplicate event (dedup_key=%s) — dual-publish "
+                    "transition window", dedup_key,
+                )
+                return
 
             # Validate user_id matches the authenticated identity (mandatory).
             # The server publishes user_id as a JSON int (User::getId() in PHP)

--- a/src/servonaut/services/ssh_ref_resolver.py
+++ b/src/servonaut/services/ssh_ref_resolver.py
@@ -1,0 +1,299 @@
+"""SSH ref resolution chain: personal BW ref → team BW ref → local ~/.ssh.
+
+Resolution order (matches the locked wire contract in bw_ssh_config_service):
+
+    1. Personal — ``BwSshConfigService.get_personal_instance_ref()``
+    2. Team     — ``TeamService.get_team_server_ssh_ref()`` (only when
+                  ``teams_supplier`` is set and the instance is a shared server)
+    3. Local    — ``SSHService.get_key_path()`` / ``discover_key()``
+    4. None     — if nothing matched
+
+Any tier that raises an ``APIError`` (e.g. 403 Forbidden) is logged at
+WARNING and skipped; the chain continues to the next tier.  A 404 from a
+tier means "no ref stored" (not a failure) and also advances the chain.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+ResolutionSource = Literal["personal", "team", "local"]
+
+_KNOWN_PROVIDERS = frozenset({"aws", "ovh", "hetzner"})
+
+
+@dataclass(frozen=True)
+class ResolvedSshRef:
+    """Result of :meth:`SshRefResolver.resolve`.
+
+    Exactly one of (``item_id`` / ``local_key_path``) is populated,
+    depending on ``source``.
+    """
+
+    source: ResolutionSource
+    """Which tier produced this ref."""
+
+    item_id: Optional[str]
+    """Bitwarden item UUID.  Set when ``source`` is ``'personal'`` or ``'team'``."""
+
+    vault_url: Optional[str]
+    """Bitwarden vault URL from the ref payload.  May be ``None`` even for BW
+    sources when the personal/global default is used."""
+
+    collection_id: Optional[str]
+    """Bitwarden collection UUID from the ref payload.  Optional."""
+
+    local_key_path: Optional[str]
+    """Absolute path to an ``~/.ssh`` key file.  Set only when ``source`` is
+    ``'local'``."""
+
+    team_slug: Optional[str]
+    """Team slug.  Set only when ``source`` is ``'team'``."""
+
+    server_id: Optional[str]
+    """SharedServer row id used to fetch the team ref.  Set only when
+    ``source`` is ``'team'``."""
+
+
+class SshRefResolver:
+    """Walk personal → team → local to resolve an SSH credential for an instance.
+
+    The resolver is *defensive by design*: API errors from any tier are caught,
+    logged at WARNING, and the chain continues.  Only a 404 (no ref stored) is
+    treated as "tier has nothing" and silently advances to the next.
+
+    Args:
+        bw_ssh_config_service: :class:`BwSshConfigService` instance (personal tier).
+        team_service: :class:`TeamService` instance (team tier).
+        ssh_service: :class:`SSHService` instance (local fallback).
+        teams_supplier: Zero-arg callable that returns the list of teams the
+            caller belongs to (used to iterate the team tier).  When ``None``
+            the team tier is entirely skipped.
+    """
+
+    def __init__(
+        self,
+        bw_ssh_config_service: object,
+        team_service: object,
+        ssh_service: object,
+        teams_supplier: Optional[Callable[[], List[dict]]] = None,
+    ) -> None:
+        self._bw = bw_ssh_config_service
+        self._team_svc = team_service
+        self._ssh_svc = ssh_service
+        self._teams_supplier = teams_supplier
+
+    async def resolve(self, instance: dict) -> Optional[ResolvedSshRef]:
+        """Resolve an SSH credential for *instance*.
+
+        Args:
+            instance: Servonaut instance dict with at minimum ``'id'``.  The
+                ``'provider'`` key is used for the personal tier and may be
+                absent for custom-server entries — in that case the personal
+                tier is skipped gracefully.
+
+        Returns:
+            :class:`ResolvedSshRef` from the first tier that matches, or
+            ``None`` if no tier could resolve a credential.
+        """
+        # --- Tier 1: personal BW ref ---
+        ref = await self._try_personal(instance)
+        if ref is not None:
+            return ref
+
+        # --- Tier 2: team BW ref ---
+        ref = await self._try_team(instance)
+        if ref is not None:
+            return ref
+
+        # --- Tier 3: local ~/.ssh fallback ---
+        ref = self._try_local(instance)
+        if ref is not None:
+            return ref
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _try_personal(self, instance: dict) -> Optional[ResolvedSshRef]:
+        """Attempt resolution via the personal BW ref endpoint.
+
+        Skips silently when:
+        - ``instance`` has no ``'provider'`` key.
+        - ``provider`` is not in the set ``{aws, ovh, hetzner}`` (custom servers).
+        - ``provider`` or ``instance_id`` fail client-side validation.
+        - The API returns 404 (no ref stored).
+
+        Logs a WARNING and skips when the API returns any other error.
+        """
+        from servonaut.utils.validation import (
+            validate_provider,
+            validate_instance_id,
+            ValidationError,
+        )
+        from servonaut.services.api_client import APIError
+
+        provider = instance.get("provider")
+        instance_id = instance.get("id") or instance.get("instance_id")
+
+        # Custom servers or unknown providers don't have personal BW refs.
+        if not provider or provider not in _KNOWN_PROVIDERS:
+            return None
+
+        # Client-side validation mirrors server-side regexes — invalid values
+        # would silently 404 at the server; fail fast and skip the tier.
+        try:
+            validate_provider(provider)
+            validate_instance_id(str(instance_id or ""))
+        except ValidationError as exc:
+            logger.debug(
+                "Personal tier skipped for %r/%r: %s", provider, instance_id, exc
+            )
+            return None
+
+        try:
+            payload = await self._bw.get_personal_instance_ref(provider, str(instance_id))
+        except APIError as exc:
+            logger.warning(
+                "Personal BW ref lookup failed for %s/%s (status=%s): %s",
+                provider,
+                instance_id,
+                exc.status,
+                exc.message,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Unexpected error in personal BW ref lookup for %s/%s: %s",
+                provider,
+                instance_id,
+                exc,
+            )
+            return None
+
+        if payload is None:
+            # 404 → no ref stored; advance to next tier
+            return None
+
+        cred_ref = payload.get("ssh_credential_ref") or {}
+        return ResolvedSshRef(
+            source="personal",
+            item_id=cred_ref.get("item_id"),
+            vault_url=cred_ref.get("vault_url"),
+            collection_id=cred_ref.get("collection_id"),
+            local_key_path=None,
+            team_slug=None,
+            server_id=None,
+        )
+
+    async def _try_team(self, instance: dict) -> Optional[ResolvedSshRef]:
+        """Attempt resolution via team BW ref endpoints.
+
+        Only attempted when ``teams_supplier`` is set and the instance carries
+        ``is_shared=True`` plus ``team_slug``.  Iterates all teams and returns
+        the first hit.
+        """
+        from servonaut.services.api_client import APIError
+
+        if self._teams_supplier is None:
+            return None
+
+        is_shared = instance.get("is_shared") is True
+        if not is_shared:
+            return None
+
+        team_slug = instance.get("team_slug")
+        if not team_slug:
+            return None
+
+        server_id = instance.get("shared_server_id") or instance.get("id")
+        if not server_id:
+            return None
+
+        try:
+            teams: List[dict] = self._teams_supplier()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("teams_supplier() raised: %s", exc)
+            return None
+
+        for team in teams:
+            slug = team.get("slug") or team.get("name")
+            if slug != team_slug:
+                continue
+            try:
+                payload = await self._team_svc.get_team_server_ssh_ref(slug, str(server_id))
+            except APIError as exc:
+                logger.warning(
+                    "Team BW ref lookup failed for %s/servers/%s (status=%s): %s",
+                    slug,
+                    server_id,
+                    exc.status,
+                    exc.message,
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Unexpected error in team BW ref lookup for %s/%s: %s",
+                    slug,
+                    server_id,
+                    exc,
+                )
+                continue
+
+            if payload is None:
+                continue
+
+            cred_ref = payload.get("ssh_credential_ref") or {}
+            return ResolvedSshRef(
+                source="team",
+                item_id=cred_ref.get("item_id"),
+                vault_url=cred_ref.get("vault_url"),
+                collection_id=cred_ref.get("collection_id"),
+                local_key_path=None,
+                team_slug=slug,
+                server_id=str(server_id),
+            )
+
+        return None
+
+    def _try_local(self, instance: dict) -> Optional[ResolvedSshRef]:
+        """Attempt resolution via local ``~/.ssh`` discovery.
+
+        Tries ``get_key_path(instance_id)`` first, then
+        ``discover_key(key_name)`` when ``key_name`` is present.
+        """
+        instance_id = str(instance.get("id") or "")
+        key_path: Optional[str] = None
+
+        if instance_id:
+            try:
+                key_path = self._ssh_svc.get_key_path(instance_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("get_key_path(%r) raised: %s", instance_id, exc)
+
+        if not key_path:
+            key_name = instance.get("key_name")
+            if key_name:
+                try:
+                    key_path = self._ssh_svc.discover_key(key_name)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("discover_key(%r) raised: %s", key_name, exc)
+
+        if not key_path:
+            return None
+
+        return ResolvedSshRef(
+            source="local",
+            item_id=None,
+            vault_url=None,
+            collection_id=None,
+            local_key_path=key_path,
+            team_slug=None,
+            server_id=None,
+        )

--- a/src/servonaut/services/team_service.py
+++ b/src/servonaut/services/team_service.py
@@ -5,6 +5,10 @@ import logging
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 from .interfaces import TeamServiceInterface
+from servonaut.services.bw_ssh_config_service import (
+    BITWARDEN_PM_PROVIDER,
+    VALID_VERIFY_STATUSES,
+)
 
 if TYPE_CHECKING:
     from servonaut.services.api_client import APIClient
@@ -186,6 +190,155 @@ class TeamService(TeamServiceInterface):
         """Get team MCP policy."""
         result = await self._api.get(f"/api/v1/teams/{slug}/policy")
         return result
+
+    # ------------------------------------------------------------------
+    # Team-side SSH config (vault wiring, admin/owner only for writes)
+    # ------------------------------------------------------------------
+
+    async def get_team_ssh_config(self, slug: str) -> Optional[dict]:
+        """GET /teams/{slug}/ssh-config. Returns None on 404.
+
+        Shape on 200::
+
+            {"provider": "bitwarden_pm",
+             "config": {"vault_url": "...", "default_collection_id": "..."?},
+             "team_slug": "...", "updated_at": "..."}
+
+        404 → team has not configured BW yet — caller should treat as
+        "fall back to local ``~/.ssh``".
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            return await self._api.get(f"/api/v1/teams/{slug}/ssh-config")
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    async def put_team_ssh_config(
+        self,
+        slug: str,
+        vault_url: str,
+        default_collection_id: Optional[str] = None,
+        provider: str = BITWARDEN_PM_PROVIDER,
+    ) -> dict:
+        """PUT /teams/{slug}/ssh-config (admin/owner only — 403 otherwise).
+
+        Caller is responsible for catching 403 (member-not-admin) and surfacing
+        an appropriate error message; this method propagates it as ``APIError``.
+        """
+        config: Dict = {"vault_url": vault_url}
+        if default_collection_id:
+            config["default_collection_id"] = default_collection_id
+        return await self._api.put(
+            f"/api/v1/teams/{slug}/ssh-config",
+            json={"provider": provider, "config": config},
+        )
+
+    # ------------------------------------------------------------------
+    # Team-side per-server SSH refs
+    # ------------------------------------------------------------------
+
+    async def get_team_server_ssh_ref(self, slug: str, server_id: str) -> Optional[dict]:
+        """GET /teams/{slug}/servers/{server_id}/ssh-ref. Returns None on 404."""
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            return await self._api.get(f"/api/v1/teams/{slug}/servers/{server_id}/ssh-ref")
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    async def put_team_server_ssh_ref(
+        self,
+        slug: str,
+        server_id: str,
+        ssh_credential_ref: dict,
+        ssh_credential_provider: str = BITWARDEN_PM_PROVIDER,
+    ) -> dict:
+        """PUT /teams/{slug}/servers/{server_id}/ssh-ref. Admin/owner only.
+
+        Body field is ``ssh_credential_ref`` (NOT ``ref`` — the deprecated alias
+        must never appear in new code even though the server accepts it for one
+        release). Caller is responsible for catching 403 (member-not-admin).
+
+        ``ssh_credential_ref`` shape::
+
+            {"item_id": "uuid",
+             "collection_id": "uuid"?,
+             "vault_url": "https://..."?}
+        """
+        return await self._api.put(
+            f"/api/v1/teams/{slug}/servers/{server_id}/ssh-ref",
+            json={
+                "ssh_credential_provider": ssh_credential_provider,
+                "ssh_credential_ref": ssh_credential_ref,
+            },
+        )
+
+    async def delete_team_server_ssh_ref(self, slug: str, server_id: str) -> bool:
+        """DELETE the SSH ref. Returns True on delete, False on 404."""
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            result = await self._api.delete(
+                f"/api/v1/teams/{slug}/servers/{server_id}/ssh-ref"
+            )
+        except APIError as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return bool(result.get("deleted", True)) if isinstance(result, dict) else True
+
+    async def get_team_server_ssh_verify_status(
+        self, slug: str, server_id: str
+    ) -> Optional[dict]:
+        """GET /teams/{slug}/servers/{server_id}/ssh-verify-status.
+
+        Any team member may read. Returns None when no ref is stored (404).
+
+        Shape on 200::
+
+            {"server_id": "...", "ssh_verify_status": "...",
+             "ssh_verified_at": "..."?,  <- NULL unless status == "verified"
+             "checked_by_client": "...", "updated_at": "..."}
+        """
+        from servonaut.services.api_client import APIError  # local import — avoid cycle
+        try:
+            return await self._api.get(
+                f"/api/v1/teams/{slug}/servers/{server_id}/ssh-verify-status"
+            )
+        except APIError as exc:
+            if exc.status == 404:
+                return None
+            raise
+
+    async def report_team_server_ssh_verify(
+        self,
+        slug: str,
+        server_id: str,
+        status: str,
+        checked_by_client: Optional[str] = None,
+    ) -> dict:
+        """POST /teams/{slug}/servers/{server_id}/ssh-verify-report.
+
+        ``status`` must be one of :data:`VALID_VERIFY_STATUSES`
+        (``verified``, ``not_found``, ``auth_failed``). Local validation is
+        performed BEFORE any round-trip so the caller gets a ``ValueError``
+        immediately rather than a remote 422.
+
+        ``checked_by_client`` should be ``"servonaut-cli/<version>"`` so the
+        audit row identifies which CLI version ran the probe.
+        """
+        if status not in VALID_VERIFY_STATUSES:
+            allowed = ", ".join(sorted(VALID_VERIFY_STATUSES))
+            raise ValueError(f"status must be one of {{{allowed}}}, got {status!r}")
+        body: Dict = {"status": status}
+        if checked_by_client:
+            body["checked_by_client"] = checked_by_client
+        return await self._api.post(
+            f"/api/v1/teams/{slug}/servers/{server_id}/ssh-verify-report",
+            json=body,
+        )
 
     def check_permission(self, role: str, permission: str) -> bool:
         """Check if a role has a specific permission."""

--- a/src/servonaut/utils/ephemeral_key.py
+++ b/src/servonaut/utils/ephemeral_key.py
@@ -10,14 +10,135 @@ unlink so that user-space filesystem cache tools cannot recover it after exit.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
+import secrets
 import tempfile
+import time
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Iterator
 
 logger = logging.getLogger(__name__)
+
+# Runtime dir used by both ephemeral and persistent helpers.
+_RUNTIME_SUBDIR = Path(".servonaut") / "tmp"
+
+# Prefix for persistent BW key files so cleanup_stale_bw_keys can target them
+# safely without risk of removing unrelated files.
+_BW_KEY_PREFIX = "bw-"
+
+
+def persistent_bw_ssh_key(key_body: str, *, prefix: str = _BW_KEY_PREFIX) -> str:
+    """Write *key_body* to a long-lived 0600 tmpfile and return its path.
+
+    Unlike :func:`ephemeral_ssh_key` (a context-manager that wipes the file
+    when the ``with``-block exits), this helper returns immediately so the
+    caller can pass the path to a detached child process (e.g. an SSH session
+    launched in an external terminal window) that outlives the Python process.
+
+    Tradeoff vs ephemeral_ssh_key
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    The key stays on disk until either:
+
+    * The ``atexit`` callback registered here fires at normal program exit
+      (covers the common case — user opens SSH, then quits TUI later), or
+    * :func:`cleanup_stale_bw_keys` is called on next startup and the file
+      is older than *max_age_seconds* (covers abnormal exit / crash).
+
+    The file is placed in ``~/.servonaut/tmp/`` (mode 0700) rather than
+    ``/tmp`` to prevent other users on multi-user hosts from reading it.
+
+    Args:
+        key_body: Full OpenSSH private key text (BEGIN/END markers included).
+        prefix: File name prefix.  Defaults to ``"bw-"`` so stale-key sweeper
+            can identify them without touching other servonaut tmpfiles.
+
+    Returns:
+        Absolute path (str) to the written key file.
+
+    Raises:
+        OSError: If the runtime root cannot be created or written to.
+    """
+    runtime_dir = Path.home() / _RUNTIME_SUBDIR
+    os.makedirs(str(runtime_dir), mode=0o700, exist_ok=True)
+    os.chmod(str(runtime_dir), 0o700)
+
+    body = key_body if key_body.endswith("\n") else key_body + "\n"
+
+    # Use a random suffix so concurrent BW launches for the same instance
+    # don't collide.
+    rand_suffix = secrets.token_hex(8)
+    filename = f"{prefix}{rand_suffix}"
+    tmp_path = str(runtime_dir / filename)
+
+    # O_CREAT | O_EXCL ensures no TOCTOU race when creating the file.
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, body.encode())
+    finally:
+        os.close(fd)
+
+    logger.debug(
+        "Created persistent BW SSH key tmpfile at %s (size=%d bytes)",
+        tmp_path,
+        len(body),
+    )
+
+    # Register a best-effort cleanup so normal TUI exit removes the key.
+    def _cleanup() -> None:
+        with suppress(OSError):
+            _zero_and_unlink(tmp_path)
+
+    atexit.register(_cleanup)
+
+    return tmp_path
+
+
+def cleanup_stale_bw_keys(max_age_seconds: int = 86400) -> None:
+    """Remove ``bw-*`` key files older than *max_age_seconds* from the tmp dir.
+
+    Intended to be called once at app startup.  Silently does nothing when
+    the tmp dir does not exist yet (first-run scenario).
+
+    Args:
+        max_age_seconds: Age threshold in seconds.  Files older than this
+            are considered stale and removed.  Defaults to 86400 (24 h).
+    """
+    runtime_dir = Path.home() / _RUNTIME_SUBDIR
+    if not runtime_dir.exists():
+        return
+
+    cutoff = time.time() - max_age_seconds
+    for entry in runtime_dir.iterdir():
+        if not entry.name.startswith(_BW_KEY_PREFIX):
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff:
+            with suppress(OSError):
+                _zero_and_unlink(str(entry))
+                logger.debug("Removed stale BW SSH key: %s", entry)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _zero_and_unlink(path: str) -> None:
+    """Best-effort zero-overwrite then unlink *path*."""
+    with suppress(OSError):
+        file_size = os.path.getsize(path)
+        with open(path, "r+b") as fh:
+            fh.seek(0)
+            fh.write(b"\x00" * file_size)
+            fh.flush()
+            os.fsync(fh.fileno())
+    with suppress(OSError):
+        os.unlink(path)
 
 
 @contextmanager
@@ -79,13 +200,4 @@ def ephemeral_ssh_key(key_body: str, *, prefix: str = "servonaut-ssh-") -> Itera
         yield tmp_path
     finally:
         # Best-effort zero-overwrite before unlink.
-        with suppress(OSError):
-            file_size = os.path.getsize(tmp_path)
-            with open(tmp_path, "r+b") as wipe_fh:
-                wipe_fh.seek(0)
-                wipe_fh.write(b"\x00" * file_size)
-                wipe_fh.flush()
-                os.fsync(wipe_fh.fileno())
-
-        with suppress(OSError):
-            os.unlink(tmp_path)
+        _zero_and_unlink(tmp_path)

--- a/src/servonaut/utils/ephemeral_key.py
+++ b/src/servonaut/utils/ephemeral_key.py
@@ -1,0 +1,91 @@
+"""Ephemeral SSH key file management.
+
+Guards against the secrets-on-disk window between writing a private key
+(retrieved from a secrets provider like Bitwarden) and handing it to the
+``ssh -i`` process. The key lives in a private directory (``~/.servonaut/tmp/``,
+mode 0700) rather than the world-readable ``/tmp``, is chmod'd to 0600 before
+any bytes are written, and is best-effort overwritten with zero bytes before
+unlink so that user-space filesystem cache tools cannot recover it after exit.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def ephemeral_ssh_key(key_body: str, *, prefix: str = "servonaut-ssh-") -> Iterator[str]:
+    """Yield a 0600-permission tmpfile path containing the given SSH key body.
+
+    The file is created in a private directory (mode 0700) inside the user's
+    runtime root (~/.servonaut/tmp/) so even an errant /tmp readability bug
+    can't expose it. Both the file and its containing directory are removed
+    on context exit, even when an exception propagates out of the with-block.
+
+    On exit, the file contents are best-effort overwritten with zero bytes
+    before unlink. This is NOT a guaranteed secure wipe on modern SSDs (which
+    may keep prior copies via wear leveling), but it removes the key from the
+    filesystem cache that user-space tools can reach.
+
+    Args:
+        key_body: The OpenSSH private key text (the full PEM/OpenSSH block,
+            including the BEGIN/END markers and trailing newline).
+        prefix: Tmpfile name prefix for human-greppable cleanup if a crash
+            leaves something behind. Defaults to ``"servonaut-ssh-"``.
+
+    Yields:
+        Absolute path to the tmpfile (str). SSH's ``-i`` accepts this path
+        as-is.
+
+    Raises:
+        OSError: If the runtime root cannot be created (rare — disk full,
+            permission issue on $HOME).
+    """
+    runtime_dir = Path.home() / ".servonaut" / "tmp"
+    os.makedirs(str(runtime_dir), mode=0o700, exist_ok=True)
+    # Defensively re-apply 0700 in case dir pre-existed with looser perms.
+    os.chmod(str(runtime_dir), 0o700)
+
+    # Ensure the key body ends with a newline — SSH parsers can be picky.
+    body = key_body if key_body.endswith("\n") else key_body + "\n"
+
+    tmp_file = tempfile.NamedTemporaryFile(
+        prefix=prefix,
+        dir=str(runtime_dir),
+        delete=False,
+        mode="w",
+    )
+    tmp_path = tmp_file.name
+    try:
+        # Set 0600 BEFORE writing so the key is never readable by others even
+        # transiently.
+        os.fchmod(tmp_file.fileno(), 0o600)
+        tmp_file.write(body)
+        tmp_file.flush()
+        tmp_file.close()
+
+        logger.debug(
+            "Created ephemeral SSH key tmpfile at %s (size=%d bytes)",
+            tmp_path,
+            len(body),
+        )
+        yield tmp_path
+    finally:
+        # Best-effort zero-overwrite before unlink.
+        with suppress(OSError):
+            file_size = os.path.getsize(tmp_path)
+            with open(tmp_path, "r+b") as wipe_fh:
+                wipe_fh.seek(0)
+                wipe_fh.write(b"\x00" * file_size)
+                wipe_fh.flush()
+                os.fsync(wipe_fh.fileno())
+
+        with suppress(OSError):
+            os.unlink(tmp_path)

--- a/src/servonaut/utils/formatting.py
+++ b/src/servonaut/utils/formatting.py
@@ -244,3 +244,71 @@ def _parse_iso(iso_str: str) -> Optional[datetime]:
         return datetime.fromisoformat(s)
     except (TypeError, ValueError):
         return None
+
+
+def _format_age(seconds: float) -> str:
+    """Compact human-readable age — '5m', '2h', '3d'. Floors to the unit."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{int(minutes)}m"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{int(hours)}h"
+    days = hours / 24
+    return f"{int(days)}d"
+
+
+def format_ssh_verify_state(
+    status: Optional[str],
+    verified_at: Optional[str],
+    *,
+    now_utc: Optional[datetime] = None,
+) -> str:
+    """Render the SSH verify state as a Rich-markup string for the TUI.
+
+    Locked contract with servonaut.dev (2026-05-24): the server NULLs
+    ``ssh_verified_at`` whenever ``ssh_verify_status`` is anything other
+    than ``"verified"``. This helper enforces the same invariant
+    client-side — even if a buggy server response includes a timestamp
+    alongside a non-verified status, we IGNORE it so the UI never shows
+    a stale "last verified 3h ago" next to a red "auth failed" badge.
+
+    Args:
+        status: One of ``"verified"``, ``"not_found"``, ``"auth_failed"``
+            from :mod:`servonaut.services.bw_ssh_config_service`. Anything
+            else (None, unknown enum, non-string) renders as "no data".
+        verified_at: ISO-8601 timestamp from the server. Only consulted
+            when ``status == "verified"``.
+        now_utc: Override for testing; defaults to current UTC time.
+
+    Returns:
+        Rich-markup string suitable for ``DataTable.add_row`` /
+        ``Static.update``. Never raises.
+    """
+    if not isinstance(status, str) or not status:
+        return "[dim]—[/dim]"
+    s = status.strip().lower()
+    if s == "verified":
+        if not verified_at or not isinstance(verified_at, str):
+            # Server contract says this shouldn't happen, but degrade
+            # gracefully if it does — show verified without an age.
+            return "[green]✓ verified[/green]"
+        parsed = _parse_iso(verified_at)
+        if parsed is None:
+            return "[green]✓ verified[/green]"
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        now = now_utc or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        age_seconds = max(0.0, (now - parsed).total_seconds())
+        return f"[green]✓ verified[/green] ({_format_age(age_seconds)} ago)"
+    if s == "not_found":
+        return "[red]✗ not found[/red]"
+    if s == "auth_failed":
+        return "[red]✗ auth failed[/red]"
+    # Defensive: unknown status enum value — degrade to "no data" rather
+    # than render literal text the user can't interpret.
+    return "[dim]—[/dim]"

--- a/src/servonaut/utils/validation.py
+++ b/src/servonaut/utils/validation.py
@@ -1,0 +1,49 @@
+"""Client-side validators for wire-format fields shared with servonaut.dev.
+
+These mirror server-side route requirements so that obviously-malformed input
+fails locally with a friendly message instead of round-tripping to the API
+and coming back as a 404 (provider whitelist) or 400 (instance id regex).
+
+Server-side regexes (locked contract — do not loosen without coordinating):
+- provider: ``aws|ovh|hetzner``
+- instance_id: ``[A-Za-z0-9_\\-]{1,64}``
+"""
+
+from __future__ import annotations
+
+import re
+
+ALLOWED_PROVIDERS: frozenset[str] = frozenset({"aws", "ovh", "hetzner"})
+
+_INSTANCE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+class ValidationError(ValueError):
+    """Raised when a wire-format field fails client-side validation."""
+
+
+def validate_provider(provider: str) -> str:
+    if not isinstance(provider, str):
+        raise ValidationError(
+            f"Provider must be a string, got {type(provider).__name__}."
+        )
+    normalized = provider.strip().lower()
+    if normalized not in ALLOWED_PROVIDERS:
+        allowed = ", ".join(sorted(ALLOWED_PROVIDERS))
+        raise ValidationError(
+            f"Unknown provider {provider!r}. Allowed: {allowed}."
+        )
+    return normalized
+
+
+def validate_instance_id(instance_id: str) -> str:
+    if not isinstance(instance_id, str):
+        raise ValidationError(
+            f"Instance id must be a string, got {type(instance_id).__name__}."
+        )
+    if not _INSTANCE_ID_RE.match(instance_id):
+        raise ValidationError(
+            f"Instance id {instance_id!r} must match "
+            "[A-Za-z0-9_-] (1-64 chars)."
+        )
+    return instance_id

--- a/src/servonaut/widgets/instance_table.py
+++ b/src/servonaut/widgets/instance_table.py
@@ -30,6 +30,8 @@ class InstanceTable(DataTable):
         self.add_column("Region", width=14, key="region")
         self.add_column("Provider", width=14, key="provider")
         self.add_column("Key", key="key")
+        # SSH verify status — at-a-glance BW probe result badge.
+        self.add_column("SSH", width=14, key="ssh")
         # Memory discoverability — at-a-glance status so users learn the
         # feature exists without needing to drill into a server.
         self.add_column("Mem", width=6, key="memory")
@@ -112,8 +114,21 @@ class InstanceTable(DataTable):
                 instance.get('region', ''),
                 instance.get('provider', 'AWS'),
                 instance.get('key_name', '') or '-',
+                self._ssh_verify_cell(instance),
                 self._memory_icon(instance, memory_service),
             )
+
+    def _ssh_verify_cell(self, instance: dict) -> str:
+        """Return Rich-markup badge for the SSH verify status column.
+
+        Delegates to :func:`format_ssh_verify_state` so the formatter is the
+        single source of truth for badge text / colour.
+        """
+        from servonaut.utils.formatting import format_ssh_verify_state
+        return format_ssh_verify_state(
+            instance.get("ssh_verify_status"),
+            instance.get("ssh_verified_at"),
+        )
 
     def _memory_icon(self, instance: dict, memory_service) -> str:
         """Return a compact Rich-markup icon for the memory column.

--- a/tests/test_bw_resolver.py
+++ b/tests/test_bw_resolver.py
@@ -1,0 +1,158 @@
+"""Tests for BwResolver — Bitwarden CLI SSH key resolution."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.services.bw_resolver import (
+    BwCliMissingError,
+    BwItemNotFoundError,
+    BwItemShapeError,
+    BwResolver,
+    BwSessionMissingError,
+)
+from servonaut.utils.validation import ValidationError
+
+VALID_ITEM_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+VALID_ITEM_ID_SHORT = "abc123"
+SAMPLE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nfakekey\n-----END OPENSSH PRIVATE KEY-----"
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> CompletedProcess:  # type: ignore[type-arg]
+    return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _bw_item_json(private_key: object) -> str:
+    return json.dumps({"sshKey": {"privateKey": private_key}})
+
+
+class TestHappyPath:
+    def test_returns_key_body(self, caplog):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout=_bw_item_json(SAMPLE_KEY))):
+            resolver = BwResolver()
+            key = resolver.resolve_ssh_key(VALID_ITEM_ID)
+        assert key == SAMPLE_KEY
+
+    def test_debug_breadcrumb_emitted(self, caplog):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout=_bw_item_json(SAMPLE_KEY))):
+            with caplog.at_level("DEBUG", logger="servonaut.services.bw_resolver"):
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert any("sshKey.privateKey" in r.message for r in caplog.records)
+        assert any("BW 2023.10+" in r.message for r in caplog.records)
+
+
+class TestBwNotOnPath:
+    def test_raises_bw_cli_missing(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(BwCliMissingError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert exc_info.value.message
+        assert "PATH" in exc_info.value.message
+
+    def test_does_not_call_subprocess_when_binary_missing(self):
+        with patch("shutil.which", return_value=None), \
+             patch("subprocess.run") as mock_run:
+            with pytest.raises(BwCliMissingError):
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        mock_run.assert_not_called()
+
+
+class TestVaultLocked:
+    def test_not_logged_in_stderr(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stderr="You are not logged in")):
+            with pytest.raises(BwSessionMissingError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert exc_info.value.message
+
+    def test_vault_is_locked_stderr(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stderr="Vault is locked")):
+            with pytest.raises(BwSessionMissingError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert "unlock" in exc_info.value.message.lower()
+
+    def test_mac_failed_stderr(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stderr="Mac failed. Invalid key.")):
+            with pytest.raises(BwSessionMissingError):
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+
+
+class TestItemNotFound:
+    def test_not_found_phrase_in_stderr(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stderr="Not found.")):
+            with pytest.raises(BwItemNotFoundError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert VALID_ITEM_ID in exc_info.value.message
+
+
+class TestItemShapeErrors:
+    def test_missing_ssh_key_field(self):
+        payload = json.dumps({"type": 5, "name": "My Server Key"})
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout=payload)):
+            with pytest.raises(BwItemShapeError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert "sshKey.privateKey" in exc_info.value.message
+
+    def test_private_key_is_null(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout=_bw_item_json(None))):
+            with pytest.raises(BwItemShapeError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert "sshKey.privateKey" in exc_info.value.message
+
+    def test_private_key_is_empty_string(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout=_bw_item_json(""))):
+            with pytest.raises(BwItemShapeError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert "sshKey.privateKey" in exc_info.value.message
+
+    def test_stdout_not_valid_json(self):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run", return_value=_completed(stdout="not-json-at-all")):
+            with pytest.raises(BwItemShapeError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert exc_info.value.message
+
+
+class TestInvalidItemId:
+    @pytest.mark.parametrize("bad_id", [
+        "../../etc/passwd",
+        "../relative",
+        "",
+        "a" * 65,
+        "has space",
+        "has/slash",
+    ])
+    def test_raises_validation_error_before_shelling_out(self, bad_id: str):
+        with patch("shutil.which", return_value="/usr/bin/bw"), \
+             patch("subprocess.run") as mock_run:
+            with pytest.raises(ValidationError):
+                BwResolver().resolve_ssh_key(bad_id)
+        mock_run.assert_not_called()
+
+
+class TestCustomBwBinary:
+    def test_uses_custom_binary_path(self):
+        with patch("shutil.which", return_value="/opt/bw/bw") as mock_which, \
+             patch("subprocess.run", return_value=_completed(stdout=_bw_item_json(SAMPLE_KEY))) as mock_run:
+            BwResolver(bw_binary="/opt/bw/bw").resolve_ssh_key(VALID_ITEM_ID_SHORT)
+        mock_which.assert_called_once_with("/opt/bw/bw")
+        args = mock_run.call_args[0][0]
+        assert args[0] == "/opt/bw/bw"
+
+    def test_missing_custom_binary_raises_bw_cli_missing(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(BwCliMissingError) as exc_info:
+                BwResolver(bw_binary="/opt/bw/bw").resolve_ssh_key(VALID_ITEM_ID_SHORT)
+        assert "/opt/bw/bw" in exc_info.value.message

--- a/tests/test_bw_ssh_config_service.py
+++ b/tests/test_bw_ssh_config_service.py
@@ -1,0 +1,235 @@
+"""Tests for BwSshConfigService — locked wire contract with servonaut.dev."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.services.api_client import APIClient, APIError
+from servonaut.services.bw_ssh_config_service import (
+    BITWARDEN_PM_PROVIDER,
+    BwSshConfigService,
+    STATUS_AUTH_FAILED,
+    STATUS_NOT_FOUND,
+    STATUS_VERIFIED,
+    VALID_VERIFY_STATUSES,
+)
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    return asyncio.run(coro)
+
+
+def _api_error(status: int, code: str = "not_found") -> APIError:
+    return APIError(code=code, message="boom", status=status)
+
+
+@pytest.fixture
+def mock_api():
+    """APIClient mock with spec so positional ``json`` payloads fail loudly."""
+    api = MagicMock(spec=APIClient)
+    api.get = AsyncMock(return_value={})
+    api.put = AsyncMock(return_value={})
+    api.post = AsyncMock(return_value={})
+    api.delete = AsyncMock(return_value={})
+    return api
+
+
+@pytest.fixture
+def service(mock_api):
+    return BwSshConfigService(mock_api)
+
+
+class TestPersonalConfig:
+    def test_get_personal_config_returns_payload(self, service, mock_api):
+        mock_api.get.return_value = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.bitwarden.com"},
+            "updated_at": "2026-05-24T10:00:00Z",
+        }
+        result = _run(service.get_personal_config())
+        assert result is not None
+        assert result["provider"] == "bitwarden_pm"
+        mock_api.get.assert_awaited_once_with("/api/v1/me/ssh-config")
+
+    def test_get_personal_config_returns_none_on_404(self, service, mock_api):
+        mock_api.get.side_effect = _api_error(404)
+        assert _run(service.get_personal_config()) is None
+
+    def test_get_personal_config_raises_on_other_errors(self, service, mock_api):
+        mock_api.get.side_effect = _api_error(500, "internal_error")
+        with pytest.raises(APIError):
+            _run(service.get_personal_config())
+
+    def test_put_personal_config_minimal_body(self, service, mock_api):
+        mock_api.put.return_value = {"ok": True}
+        _run(service.put_personal_config(vault_url="https://vault.example.com"))
+        mock_api.put.assert_awaited_once_with(
+            "/api/v1/me/ssh-config",
+            json={
+                "provider": BITWARDEN_PM_PROVIDER,
+                "config": {"vault_url": "https://vault.example.com"},
+            },
+        )
+
+    def test_put_personal_config_with_collection_id(self, service, mock_api):
+        _run(
+            service.put_personal_config(
+                vault_url="https://vault.example.com",
+                default_collection_id="col-uuid",
+            )
+        )
+        _, kwargs = mock_api.put.call_args
+        assert kwargs["json"]["config"]["default_collection_id"] == "col-uuid"
+
+
+class TestListPersonalInstances:
+    def test_unwraps_instances_envelope(self, service, mock_api):
+        mock_api.get.return_value = {
+            "instances": [
+                {"provider": "aws", "instance_id": "i-1"},
+                {"provider": "ovh", "instance_id": "srv-2"},
+            ]
+        }
+        result = _run(service.list_personal_instances())
+        assert len(result) == 2
+        assert result[0]["instance_id"] == "i-1"
+        mock_api.get.assert_awaited_once_with("/api/v1/me/instances")
+
+    def test_tolerates_bare_array(self, service, mock_api):
+        mock_api.get.return_value = [{"provider": "aws", "instance_id": "i-1"}]
+        result = _run(service.list_personal_instances())
+        assert len(result) == 1
+
+    def test_returns_empty_on_unknown_shape(self, service, mock_api):
+        mock_api.get.return_value = "weird"  # type: ignore[arg-type]
+        assert _run(service.list_personal_instances()) == []
+
+    def test_missing_instances_key_returns_empty(self, service, mock_api):
+        mock_api.get.return_value = {"foo": "bar"}
+        assert _run(service.list_personal_instances()) == []
+
+
+class TestPutPersonalInstanceRef:
+    def test_body_uses_ssh_credential_ref_not_ref(self, service, mock_api):
+        """The body field is ssh_credential_ref — NEVER ``ref``.
+
+        PR #77 on the server side fixed a discovered mismatch where
+        C-solo-2 originally accepted ``ref``. We code against the canonical
+        field name from day one so we never depend on the back-compat alias.
+        """
+        _run(
+            service.put_personal_instance_ref(
+                provider="aws",
+                instance_id="i-0abc",
+                ssh_credential_ref={"item_id": "uuid-1"},
+            )
+        )
+        path, kwargs = mock_api.put.call_args
+        assert path[0] == "/api/v1/me/instances/aws/i-0abc/ssh-ref"
+        body = kwargs["json"]
+        assert "ref" not in body
+        assert body["ssh_credential_ref"] == {"item_id": "uuid-1"}
+        assert body["ssh_credential_provider"] == BITWARDEN_PM_PROVIDER
+
+    def test_full_ref_shape_round_trips(self, service, mock_api):
+        ref = {
+            "item_id": "uuid-1",
+            "collection_id": "col-1",
+            "vault_url": "https://vault.example.com",
+        }
+        _run(
+            service.put_personal_instance_ref(
+                provider="hetzner",
+                instance_id="hetzner-001",
+                ssh_credential_ref=ref,
+            )
+        )
+        _, kwargs = mock_api.put.call_args
+        assert kwargs["json"]["ssh_credential_ref"] == ref
+
+
+class TestDeletePersonalInstanceRef:
+    def test_returns_true_on_success(self, service, mock_api):
+        mock_api.delete.return_value = {"deleted": True}
+        assert _run(service.delete_personal_instance_ref("aws", "i-1")) is True
+        mock_api.delete.assert_awaited_once_with(
+            "/api/v1/me/instances/aws/i-1/ssh-ref"
+        )
+
+    def test_returns_false_on_404(self, service, mock_api):
+        mock_api.delete.side_effect = _api_error(404)
+        assert _run(service.delete_personal_instance_ref("aws", "i-1")) is False
+
+    def test_raises_on_other_errors(self, service, mock_api):
+        mock_api.delete.side_effect = _api_error(500, "internal_error")
+        with pytest.raises(APIError):
+            _run(service.delete_personal_instance_ref("aws", "i-1"))
+
+
+class TestVerifyStatusGet:
+    def test_returns_payload(self, service, mock_api):
+        payload = {
+            "provider": "aws",
+            "instance_id": "i-1",
+            "ssh_verify_status": "verified",
+            "ssh_verified_at": "2026-05-24T10:00:00Z",
+            "checked_by_client": "servonaut-cli/2.12.0",
+            "updated_at": "2026-05-24T10:00:00Z",
+        }
+        mock_api.get.return_value = payload
+        result = _run(service.get_personal_instance_verify_status("aws", "i-1"))
+        assert result == payload
+        mock_api.get.assert_awaited_once_with(
+            "/api/v1/me/instances/aws/i-1/ssh-verify-status"
+        )
+
+    def test_returns_none_on_404(self, service, mock_api):
+        mock_api.get.side_effect = _api_error(404)
+        assert _run(service.get_personal_instance_verify_status("aws", "i-1")) is None
+
+
+class TestVerifyReport:
+    @pytest.mark.parametrize(
+        "status", [STATUS_VERIFIED, STATUS_NOT_FOUND, STATUS_AUTH_FAILED]
+    )
+    def test_accepts_all_valid_statuses(self, service, mock_api, status: str):
+        _run(
+            service.report_personal_instance_verify(
+                provider="aws",
+                instance_id="i-1",
+                status=status,
+                checked_by_client="servonaut-cli/2.12.0",
+            )
+        )
+        path, kwargs = mock_api.post.call_args
+        assert path[0] == "/api/v1/me/instances/aws/i-1/ssh-verify-report"
+        assert kwargs["json"]["status"] == status
+        assert kwargs["json"]["checked_by_client"] == "servonaut-cli/2.12.0"
+
+    def test_omits_checked_by_client_when_none(self, service, mock_api):
+        _run(
+            service.report_personal_instance_verify(
+                provider="aws", instance_id="i-1", status=STATUS_VERIFIED
+            )
+        )
+        _, kwargs = mock_api.post.call_args
+        assert "checked_by_client" not in kwargs["json"]
+
+    def test_rejects_invalid_status_locally(self, service, mock_api):
+        with pytest.raises(ValueError, match="status must be one of"):
+            _run(
+                service.report_personal_instance_verify(
+                    provider="aws", instance_id="i-1", status="bogus"
+                )
+            )
+        # Never round-tripped to the server
+        mock_api.post.assert_not_called()
+
+    def test_valid_status_set_is_locked(self):
+        # Locked contract — any change requires coordination with servonaut.dev.
+        assert VALID_VERIFY_STATUSES == frozenset(
+            {"verified", "not_found", "auth_failed"}
+        )

--- a/tests/test_bw_ssh_config_service_ref.py
+++ b/tests/test_bw_ssh_config_service_ref.py
@@ -1,0 +1,91 @@
+"""Tests for BwSshConfigService.get_personal_instance_ref (new method).
+
+Separate file to keep the locked-contract tests in test_bw_ssh_config_service.py
+untouched while adding the new-method coverage cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.services.api_client import APIClient, APIError
+from servonaut.services.bw_ssh_config_service import BwSshConfigService
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    return asyncio.run(coro)
+
+
+def _api_error(status: int, code: str = "not_found") -> APIError:
+    return APIError(code=code, message="boom", status=status)
+
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock(spec=APIClient)
+    api.get = AsyncMock(return_value={})
+    api.put = AsyncMock(return_value={})
+    api.post = AsyncMock(return_value={})
+    api.delete = AsyncMock(return_value={})
+    return api
+
+
+@pytest.fixture
+def service(mock_api):
+    return BwSshConfigService(mock_api)
+
+
+class TestGetPersonalInstanceRef:
+    def test_returns_payload_on_200(self, service, mock_api):
+        """200 response is returned as-is."""
+        payload = {
+            "ssh_credential_provider": "bitwarden_pm",
+            "ssh_credential_ref": {
+                "item_id": "uuid-abc",
+                "vault_url": "https://vault.bitwarden.com",
+                "collection_id": "col-xyz",
+            },
+        }
+        mock_api.get.return_value = payload
+        result = _run(service.get_personal_instance_ref("aws", "i-0abc"))
+        assert result is not None
+        assert result["ssh_credential_ref"]["item_id"] == "uuid-abc"
+        mock_api.get.assert_awaited_once_with(
+            "/api/v1/me/instances/aws/i-0abc/ssh-ref"
+        )
+
+    def test_returns_none_on_404(self, service, mock_api):
+        """404 → None (no ref stored, not an error)."""
+        mock_api.get.side_effect = _api_error(404)
+        result = _run(service.get_personal_instance_ref("aws", "i-0abc"))
+        assert result is None
+
+    def test_raises_on_non_404_errors(self, service, mock_api):
+        """Non-404 API errors (e.g. 403, 500) propagate to the caller."""
+        mock_api.get.side_effect = _api_error(403, "forbidden")
+        with pytest.raises(APIError) as exc_info:
+            _run(service.get_personal_instance_ref("aws", "i-0abc"))
+        assert exc_info.value.status == 403
+
+    def test_builds_correct_path_for_ovh(self, service, mock_api):
+        mock_api.get.return_value = {
+            "ssh_credential_provider": "bitwarden_pm",
+            "ssh_credential_ref": {"item_id": "uuid-1"},
+        }
+        _run(service.get_personal_instance_ref("ovh", "server-001"))
+        mock_api.get.assert_awaited_once_with(
+            "/api/v1/me/instances/ovh/server-001/ssh-ref"
+        )
+
+    def test_payload_without_collection_id_is_valid(self, service, mock_api):
+        """collection_id is optional — payload without it must not crash."""
+        mock_api.get.return_value = {
+            "ssh_credential_provider": "bitwarden_pm",
+            "ssh_credential_ref": {"item_id": "uuid-only"},
+        }
+        result = _run(service.get_personal_instance_ref("hetzner", "htz-999"))
+        assert result["ssh_credential_ref"]["item_id"] == "uuid-only"
+        assert "collection_id" not in result["ssh_credential_ref"]

--- a/tests/test_cli_servers.py
+++ b/tests/test_cli_servers.py
@@ -1,0 +1,522 @@
+"""Tests for ``servonaut servers`` CLI subcommand (``servers verify``).
+
+All network I/O, subprocess calls, and BW resolver invocations are mocked.
+The headless init function is patched so that no real filesystem / AWS / API
+access occurs during the test run.
+
+Exit-code contract:
+    0  — STATUS_VERIFIED
+    1  — STATUS_NOT_FOUND or STATUS_AUTH_FAILED (probe ran, key didn't work)
+    2  — Fatal: no ref stored, BW CLI missing, session locked, not logged in
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from servonaut.cli import servers as cli_servers
+from servonaut.cli.servers import (
+    _EXIT_FATAL,
+    _EXIT_SUCCESS,
+    _EXIT_VERIFY_FAILED,
+    add_servers_parser,
+    handle_servers_command,
+)
+from servonaut.services.bw_ssh_config_service import (
+    STATUS_AUTH_FAILED,
+    STATUS_NOT_FOUND,
+    STATUS_VERIFIED,
+    VALID_VERIFY_STATUSES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_argv(argv: list[str]) -> argparse.Namespace:
+    """Parse *argv* through a minimal parser that only has servers registered."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    add_servers_parser(subparsers)
+    return parser.parse_args(argv)
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build an :class:`argparse.Namespace` for the ``servers verify`` command."""
+    defaults = dict(
+        subcommand="servers",
+        servers_command="verify",
+        instance="i-abc123",
+        host=None,
+        user=None,
+        port=None,
+        timeout=5,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _make_services(
+    *,
+    authenticated: bool = True,
+    personal_ref: Optional[dict] = None,
+    team_ref: Optional[dict] = None,
+    teams: Optional[list] = None,
+    report_result: Optional[dict] = None,
+):
+    """Build the 6-tuple returned by ``_init_headless_services``."""
+    config_manager = MagicMock()
+    config = MagicMock()
+    config.cache_ttl_seconds = 3600
+    config_manager.get.return_value = config
+
+    auth_service = MagicMock()
+    auth_service.is_authenticated = authenticated
+
+    api_client = MagicMock()
+    api_client.get = AsyncMock()
+    api_client.post = AsyncMock()
+
+    bw_ssh_cfg = MagicMock()
+    bw_ssh_cfg.get_personal_instance_ref = AsyncMock(return_value=personal_ref)
+    bw_ssh_cfg.report_personal_instance_verify = AsyncMock(
+        return_value=report_result or {"ok": True}
+    )
+
+    team_svc = MagicMock()
+    team_svc.list_teams = AsyncMock(return_value=teams or [])
+    team_svc.get_team_server_ssh_ref = AsyncMock(return_value=team_ref)
+    team_svc.report_team_server_ssh_verify = AsyncMock(
+        return_value=report_result or {"ok": True}
+    )
+
+    custom_server_service = MagicMock()
+    custom_server_service.list_as_instances.return_value = []
+
+    return (
+        config_manager,
+        auth_service,
+        api_client,
+        bw_ssh_cfg,
+        team_svc,
+        custom_server_service,
+    )
+
+
+def _patch_init(monkeypatch, services):
+    monkeypatch.setattr(cli_servers, "_init_headless_services", lambda: services)
+
+
+def _make_aws_mock(instances=None):
+    """Return a mock AWSService instance whose cache returns *instances*."""
+    cache = MagicMock()
+    cache.load_any.return_value = instances or []
+    aws_mock = MagicMock()
+    aws_mock._cache = cache
+    return aws_mock
+
+
+# ---------------------------------------------------------------------------
+# Status enum smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestStatusEnum:
+    def test_valid_statuses_are_present(self):
+        assert STATUS_VERIFIED in VALID_VERIFY_STATUSES
+        assert STATUS_NOT_FOUND in VALID_VERIFY_STATUSES
+        assert STATUS_AUTH_FAILED in VALID_VERIFY_STATUSES
+
+    def test_status_values(self):
+        assert STATUS_VERIFIED == "verified"
+        assert STATUS_NOT_FOUND == "not_found"
+        assert STATUS_AUTH_FAILED == "auth_failed"
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+
+class TestParserWiring:
+    def test_servers_verify_minimal(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123"])
+        assert ns.subcommand == "servers"
+        assert ns.servers_command == "verify"
+        assert ns.instance == "i-abc123"
+
+    def test_default_timeout_is_5(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123"])
+        assert ns.timeout == 5
+
+    def test_host_override(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123", "--host", "10.0.0.1"])
+        assert ns.host == "10.0.0.1"
+
+    def test_user_short_flag(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123", "-u", "ubuntu"])
+        assert ns.user == "ubuntu"
+
+    def test_port_short_flag(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123", "-p", "2222"])
+        assert ns.port == 2222
+
+    def test_timeout_flag(self):
+        ns = _parse_argv(["servers", "verify", "i-abc123", "--timeout", "10"])
+        assert ns.timeout == 10
+
+    def test_missing_instance_raises_systemexit(self):
+        with pytest.raises(SystemExit):
+            _parse_argv(["servers", "verify"])
+
+    def test_no_subcommand_dispatches_to_fatal(self, capsys):
+        ns = argparse.Namespace(subcommand="servers", servers_command=None)
+        rc = handle_servers_command(ns)
+        assert rc == _EXIT_FATAL
+
+    def test_unknown_subcommand_returns_fatal(self, capsys):
+        ns = argparse.Namespace(subcommand="servers", servers_command="frobnicate")
+        rc = handle_servers_command(ns)
+        assert rc == _EXIT_FATAL
+
+
+# ---------------------------------------------------------------------------
+# Not logged in
+# ---------------------------------------------------------------------------
+
+
+class TestNotLoggedIn:
+    def test_not_authenticated_exits_fatal(self, monkeypatch, capsys):
+        svc = _make_services(authenticated=False)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService"), \
+             patch("servonaut.cli.servers.CacheService"):
+            rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_FATAL
+        out = capsys.readouterr()
+        assert "servonaut --login" in out.err
+
+
+# ---------------------------------------------------------------------------
+# Personal probe — happy paths
+# ---------------------------------------------------------------------------
+
+
+_PERSONAL_INSTANCE = {
+    "id": "i-abc123",
+    "name": "web-01",
+    "provider": "aws",
+    "public_ip": "1.2.3.4",
+    "private_ip": "10.0.0.1",
+}
+
+_PERSONAL_REF = {
+    "ssh_credential_provider": "bitwarden_pm",
+    "ssh_credential_ref": {"item_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+}
+
+
+class TestPersonalProbeVerified:
+    def test_verified_exits_0_and_posts(self, monkeypatch, capsys):
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"), \
+             patch("servonaut.cli.servers.BwResolver") as MockBwR, \
+             patch("servonaut.cli.servers.ephemeral_ssh_key") as mock_ek, \
+             patch("servonaut.cli.servers._run_ssh_probe", return_value=0):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            MockBwR.return_value.resolve_ssh_key.return_value = "PRIVATE_KEY"
+            # ephemeral_ssh_key is a context manager — make it yield a fake path.
+            mock_ek.return_value.__enter__ = MagicMock(return_value="/tmp/fake.pem")
+            mock_ek.return_value.__exit__ = MagicMock(return_value=False)
+
+            rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_SUCCESS
+        out = capsys.readouterr()
+        assert "[OK] Verified:" in out.out
+        # Report was POSTed with STATUS_VERIFIED
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_awaited_once()
+        args = bw_cfg.report_personal_instance_verify.call_args.args
+        assert args[2] == STATUS_VERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Personal probe — BwItemNotFoundError → status=not_found POSTed
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalProbeNotFound:
+    def test_bw_item_not_found_posts_not_found(self, monkeypatch, capsys):
+        from servonaut.services.bw_resolver import BwItemNotFoundError
+
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            with patch("servonaut.cli.servers.BwResolver") as MockBwR:
+                MockBwR.return_value.resolve_ssh_key.side_effect = BwItemNotFoundError(
+                    "Not found."
+                )
+
+                rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_VERIFY_FAILED
+        out = capsys.readouterr()
+        assert "[FAIL] not_found:" in out.out
+        # Report was POSTed with not_found
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_awaited_once()
+        args = bw_cfg.report_personal_instance_verify.call_args.args
+        assert args[2] == STATUS_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Personal probe — SSH exits non-zero → auth_failed
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalProbeAuthFailed:
+    def test_ssh_returncode_255_posts_auth_failed(self, monkeypatch, capsys):
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            with patch("servonaut.cli.servers.BwResolver") as MockBwR, \
+                 patch("servonaut.cli.servers._run_ssh_probe", return_value=255):
+                MockBwR.return_value.resolve_ssh_key.return_value = "PRIVATE_KEY"
+
+                rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_VERIFY_FAILED
+        out = capsys.readouterr()
+        assert "[FAIL] auth_failed:" in out.out
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_awaited_once()
+        args = bw_cfg.report_personal_instance_verify.call_args.args
+        assert args[2] == STATUS_AUTH_FAILED
+
+
+# ---------------------------------------------------------------------------
+# Personal probe — subprocess.TimeoutExpired → auth_failed (no crash)
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalProbeTimeout:
+    def test_ssh_timeout_returns_255(self):
+        """_run_ssh_probe catches TimeoutExpired and returns 255."""
+        with patch("servonaut.cli.servers.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="ssh", timeout=5)):
+            rc = cli_servers._run_ssh_probe(
+                "/tmp/key.pem", "ubuntu", "1.2.3.4", None, 5
+            )
+        assert rc == 255
+
+
+# ---------------------------------------------------------------------------
+# BwCliMissingError → fatal, no POST
+# ---------------------------------------------------------------------------
+
+
+class TestBwCliMissing:
+    def test_bw_cli_missing_exits_fatal_no_post(self, monkeypatch, capsys):
+        from servonaut.services.bw_resolver import BwCliMissingError
+
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            with patch("servonaut.cli.servers.BwResolver") as MockBwR:
+                MockBwR.return_value.resolve_ssh_key.side_effect = BwCliMissingError(
+                    "bw not found"
+                )
+
+                rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_FATAL
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_not_awaited()
+        err = capsys.readouterr().err
+        assert "bw" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# BwSessionMissingError → fatal, message about bw unlock, no POST
+# ---------------------------------------------------------------------------
+
+
+class TestBwSessionMissing:
+    def test_bw_session_missing_exits_fatal_no_post(self, monkeypatch, capsys):
+        from servonaut.services.bw_resolver import BwSessionMissingError
+
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            with patch("servonaut.cli.servers.BwResolver") as MockBwR:
+                MockBwR.return_value.resolve_ssh_key.side_effect = BwSessionMissingError(
+                    "Vault is locked. Run `bw unlock`."
+                )
+
+                rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_FATAL
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_not_awaited()
+        err = capsys.readouterr().err
+        assert "bw unlock" in err
+
+
+# ---------------------------------------------------------------------------
+# No ref stored anywhere → friendly message, no POST, exit 2
+# ---------------------------------------------------------------------------
+
+
+class TestNoRefStored:
+    def test_no_ref_anywhere_exits_fatal_no_post(self, monkeypatch, capsys):
+        # personal_ref=None means get_personal_instance_ref returns None
+        svc = _make_services(personal_ref=None)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"), \
+             patch("servonaut.cli.servers.BwResolver"):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            rc = handle_servers_command(_ns())
+
+        assert rc == _EXIT_FATAL
+        _, _, _, bw_cfg, _, _ = svc
+        bw_cfg.report_personal_instance_verify.assert_not_awaited()
+        err = capsys.readouterr().err
+        assert "No SSH ref" in err
+
+
+# ---------------------------------------------------------------------------
+# Team probe: UUID not in personal cache but team ref exists
+# ---------------------------------------------------------------------------
+
+_TEAM_UUID = "550e8400-e29b-41d4-a716-446655440000"
+_TEAM_REF = {
+    "ssh_credential_provider": "bitwarden_pm",
+    "ssh_credential_ref": {"item_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+}
+
+
+class TestTeamProbe:
+    def test_team_path_when_personal_misses(self, monkeypatch, capsys):
+        teams_list = [{"slug": "my-team"}]
+        svc = _make_services(
+            personal_ref=None,
+            team_ref=_TEAM_REF,
+            teams=teams_list,
+        )
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"):
+            # No instance in cache matching the UUID
+            MockAws.return_value._cache.load_any.return_value = []
+            with patch("servonaut.cli.servers.BwResolver") as MockBwR, \
+                 patch("servonaut.cli.servers._run_ssh_probe", return_value=0):
+                MockBwR.return_value.resolve_ssh_key.return_value = "PRIVATE_KEY"
+
+                rc = handle_servers_command(_ns(
+                    instance=_TEAM_UUID,
+                    host="1.2.3.4",
+                    user="ubuntu",
+                ))
+
+        assert rc == _EXIT_SUCCESS
+        _, _, _, _, team_svc, _ = svc
+        team_svc.report_team_server_ssh_verify.assert_awaited_once()
+        args = team_svc.report_team_server_ssh_verify.call_args.args
+        assert args[2] == STATUS_VERIFIED
+
+
+# ---------------------------------------------------------------------------
+# SSH command construction — BatchMode, ConnectTimeout, -i path, user@host
+# ---------------------------------------------------------------------------
+
+
+class TestSshCommandConstruction:
+    def test_standard_command_shape(self):
+        with patch("servonaut.cli.servers.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0)
+            cli_servers._run_ssh_probe("/tmp/key.pem", "ubuntu", "1.2.3.4", None, 7)
+
+        cmd = run_mock.call_args.args[0]
+        assert "ssh" == cmd[0]
+        assert "-o" in cmd
+        assert "BatchMode=yes" in cmd
+        assert "ConnectTimeout=7" in cmd
+        assert "-i" in cmd
+        assert "/tmp/key.pem" in cmd
+        assert "ubuntu@1.2.3.4" in cmd
+        assert "true" in cmd
+
+    def test_custom_port_adds_p_flag(self):
+        with patch("servonaut.cli.servers.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0)
+            cli_servers._run_ssh_probe("/tmp/key.pem", "ubuntu", "1.2.3.4", 2222, 5)
+
+        cmd = run_mock.call_args.args[0]
+        assert "-p" in cmd
+        p_idx = cmd.index("-p")
+        assert cmd[p_idx + 1] == "2222"
+
+    def test_port_22_not_added(self):
+        with patch("servonaut.cli.servers.subprocess.run") as run_mock:
+            run_mock.return_value = MagicMock(returncode=0)
+            cli_servers._run_ssh_probe("/tmp/key.pem", "ubuntu", "1.2.3.4", 22, 5)
+
+        cmd = run_mock.call_args.args[0]
+        assert "-p" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# checked_by_client includes version string
+# ---------------------------------------------------------------------------
+
+
+class TestCheckedByClient:
+    def test_checked_by_client_includes_version(self, monkeypatch, capsys):
+        from servonaut import __version__
+
+        svc = _make_services(personal_ref=_PERSONAL_REF)
+        _patch_init(monkeypatch, svc)
+
+        with patch("servonaut.cli.servers.AWSService") as MockAws, \
+             patch("servonaut.cli.servers.CacheService"), \
+             patch("servonaut.cli.servers.BwResolver") as MockBwR, \
+             patch("servonaut.cli.servers._run_ssh_probe", return_value=0):
+            MockAws.return_value._cache.load_any.return_value = [_PERSONAL_INSTANCE]
+            MockBwR.return_value.resolve_ssh_key.return_value = "PRIVATE_KEY"
+            handle_servers_command(_ns())
+
+        _, _, _, bw_cfg, _, _ = svc
+        call_kwargs = bw_cfg.report_personal_instance_verify.call_args
+        checked = call_kwargs.kwargs.get("checked_by_client") or (
+            call_kwargs.args[3] if len(call_kwargs.args) > 3 else None
+        )
+        expected = f"servonaut-cli/{__version__}"
+        assert checked == expected, f"Got {checked!r}, expected {expected!r}"

--- a/tests/test_cli_ssh.py
+++ b/tests/test_cli_ssh.py
@@ -1,0 +1,502 @@
+"""Tests for cli/ssh.py — parser registration, instance lookup, SSH dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from servonaut.cli.ssh import (
+    add_ssh_parser,
+    _find_instance,
+    _resolve_username,
+    _EXIT_NOT_FOUND,
+    _EXIT_AMBIGUOUS,
+    _EXIT_NO_CREDENTIAL,
+    _EXIT_BW_ERROR,
+    _EXIT_SUCCESS,
+)
+from servonaut.services.bw_resolver import (
+    BwCliMissingError,
+    BwSessionMissingError,
+    BwItemNotFoundError,
+    BwItemShapeError,
+)
+from servonaut.services.ssh_ref_resolver import ResolvedSshRef
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_args(
+    instance: str = "i-abc",
+    user: Optional[str] = None,
+    port: Optional[int] = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(instance=instance, user=user, port=port)
+
+
+def _make_instance(
+    iid: str = "i-abc",
+    name: str = "prod",
+    provider: str = "aws",
+    username: Optional[str] = None,
+    public_ip: str = "1.2.3.4",
+    port: Optional[int] = None,
+) -> Dict[str, Any]:
+    inst: Dict[str, Any] = {
+        "id": iid,
+        "name": name,
+        "provider": provider,
+        "public_ip": public_ip,
+    }
+    if username:
+        inst["username"] = username
+    if port:
+        inst["port"] = port
+    return inst
+
+
+def _make_config(default_username: str = "ec2-user") -> Any:
+    cfg = MagicMock()
+    cfg.default_username = default_username
+    return cfg
+
+
+def _resolved_local(path: str = "/ssh/id_rsa") -> ResolvedSshRef:
+    return ResolvedSshRef(
+        source="local",
+        item_id=None,
+        vault_url=None,
+        collection_id=None,
+        local_key_path=path,
+        team_slug=None,
+        server_id=None,
+    )
+
+
+def _resolved_personal(item_id: str = "uuid-bw") -> ResolvedSshRef:
+    return ResolvedSshRef(
+        source="personal",
+        item_id=item_id,
+        vault_url="https://vault.bitwarden.com",
+        collection_id=None,
+        local_key_path=None,
+        team_slug=None,
+        server_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parser registration
+# ---------------------------------------------------------------------------
+
+class TestAddSshParser:
+    def test_registers_ssh_subcommand(self):
+        """add_ssh_parser registers 'ssh' with a required 'instance' argument."""
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        args = top.parse_args(["ssh", "i-abc123"])
+        assert args.subcommand == "ssh"
+        assert args.instance == "i-abc123"
+
+    def test_user_flag(self):
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        args = top.parse_args(["ssh", "i-abc", "--user", "ubuntu"])
+        assert args.user == "ubuntu"
+
+    def test_port_flag(self):
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        args = top.parse_args(["ssh", "i-abc", "--port", "2222"])
+        assert args.port == 2222
+
+    def test_user_short_flag(self):
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        args = top.parse_args(["ssh", "i-abc", "-u", "root"])
+        assert args.user == "root"
+
+    def test_instance_is_required(self):
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        with pytest.raises(SystemExit):
+            top.parse_args(["ssh"])
+
+    def test_defaults_are_none(self):
+        top = argparse.ArgumentParser()
+        subparsers = top.add_subparsers(dest="subcommand")
+        add_ssh_parser(subparsers)
+
+        args = top.parse_args(["ssh", "i-abc"])
+        assert args.user is None
+        assert args.port is None
+
+
+# ---------------------------------------------------------------------------
+# Instance lookup
+# ---------------------------------------------------------------------------
+
+class TestFindInstance:
+    def test_exact_id_match(self):
+        instances = [_make_instance("i-abc", "prod"), _make_instance("i-def", "dev")]
+        result = _find_instance(instances, "i-abc")
+        assert len(result) == 1
+        assert result[0]["id"] == "i-abc"
+
+    def test_case_insensitive_name_match(self):
+        instances = [_make_instance("i-abc", "MyServer"), _make_instance("i-def", "other")]
+        result = _find_instance(instances, "myserver")
+        assert len(result) == 1
+        assert result[0]["id"] == "i-abc"
+
+    def test_no_match_returns_empty_list(self):
+        instances = [_make_instance("i-abc", "prod")]
+        result = _find_instance(instances, "i-xyz")
+        assert result == []
+
+    def test_multiple_matches_returns_all(self):
+        """Same name on two instances → both returned."""
+        instances = [
+            _make_instance("i-abc", "prod"),
+            _make_instance("i-def", "prod"),
+        ]
+        result = _find_instance(instances, "prod")
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Username resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveUsername:
+    def test_args_user_takes_priority(self):
+        args = _make_args(user="ec2-user")
+        inst = _make_instance(username="ubuntu")
+        cfg = _make_config(default_username="root")
+        assert _resolve_username(args, inst, cfg) == "ec2-user"
+
+    def test_instance_username_second_priority(self):
+        args = _make_args(user=None)
+        inst = _make_instance(username="ubuntu")
+        cfg = _make_config(default_username="root")
+        assert _resolve_username(args, inst, cfg) == "ubuntu"
+
+    def test_config_default_third_priority(self):
+        args = _make_args(user=None)
+        inst = _make_instance()  # no username key
+        cfg = _make_config(default_username="centos")
+        assert _resolve_username(args, inst, cfg) == "centos"
+
+    def test_final_fallback_is_ubuntu(self):
+        args = _make_args(user=None)
+        inst = _make_instance()
+        cfg = _make_config(default_username="")
+        assert _resolve_username(args, inst, cfg) == "ubuntu"
+
+
+# ---------------------------------------------------------------------------
+# handle_ssh_command integration (mocked subprocess + resolver)
+# ---------------------------------------------------------------------------
+
+def _patch_headless(
+    config=None,
+    auth_authenticated=True,
+    instances=None,
+    resolved=None,
+):
+    """Context manager factory that patches the main moving parts."""
+    if config is None:
+        config = _make_config()
+    if instances is None:
+        instances = [_make_instance()]
+
+    ssh_svc = MagicMock()
+    ssh_svc.build_ssh_command.return_value = ["ssh", "-i", "/key", "ubuntu@1.2.3.4"]
+
+    auth_svc = MagicMock()
+    auth_svc.is_authenticated = auth_authenticated
+
+    # The headless services tuple
+    headless_return = (
+        config,        # config
+        auth_svc,      # auth_service
+        MagicMock(),   # api_client
+        MagicMock(),   # bw_ssh_config_service
+        MagicMock(),   # team_service
+        ssh_svc,       # ssh_service
+        MagicMock(),   # custom_server_service
+    )
+
+    return headless_return, ssh_svc, instances
+
+
+class TestHandleSshCommand:
+    def _run(self, args, headless_return, instances, resolved):
+        """Run handle_ssh_command with patched internals."""
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless_return),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+            from servonaut.cli.ssh import handle_ssh_command
+            return handle_ssh_command(args)
+
+    def test_no_match_returns_not_found(self):
+        args = _make_args(instance="i-missing")
+        headless, ssh_svc, _ = _patch_headless()
+        result = self._run(args, headless, [], _resolved_local())
+        assert result == _EXIT_NOT_FOUND
+
+    def test_multiple_matches_returns_ambiguous(self):
+        args = _make_args(instance="prod")
+        instances = [
+            _make_instance("i-abc", "prod"),
+            _make_instance("i-def", "prod"),
+        ]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        result = self._run(args, headless, instances, _resolved_local())
+        assert result == _EXIT_AMBIGUOUS
+
+    def test_none_resolved_returns_no_credential(self):
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        result = self._run(args, headless, instances, None)
+        assert result == _EXIT_NO_CREDENTIAL
+
+    def test_local_source_calls_subprocess_with_local_key(self):
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        resolved = _resolved_local("/home/user/.ssh/id_rsa")
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("subprocess.run") as mock_subproc,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+            mock_subproc.return_value = MagicMock(returncode=0)
+
+            # ssh_service is the one inside headless_return
+            ssh_svc = headless[5]
+            ssh_svc.build_ssh_command.return_value = ["ssh", "ubuntu@1.2.3.4"]
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        assert rc == 0
+        # ssh_service.build_ssh_command was called with local key path
+        ssh_svc.build_ssh_command.assert_called_once()
+        call_kwargs = ssh_svc.build_ssh_command.call_args
+        assert call_kwargs.kwargs.get("key_path") == "/home/user/.ssh/id_rsa"
+        mock_subproc.assert_called_once()
+
+    def test_personal_source_calls_bw_resolver_and_ephemeral_key(self):
+        """BW source: BwResolver.resolve_ssh_key called, subprocess called with tmpfile."""
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        resolved = _resolved_personal("uuid-bw-item")
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("servonaut.services.bw_resolver.BwResolver") as MockBwResolver,
+            patch("servonaut.utils.ephemeral_key.ephemeral_ssh_key") as mock_eph,
+            patch("subprocess.run") as mock_subproc,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+
+            bw_instance = MagicMock()
+            bw_instance.resolve_ssh_key.return_value = "-----BEGIN OPENSSH PRIVATE KEY-----\n..."
+            MockBwResolver.return_value = bw_instance
+
+            # ephemeral_ssh_key context manager
+            mock_eph.return_value.__enter__ = MagicMock(return_value="/tmp/servonaut-ssh-abc")
+            mock_eph.return_value.__exit__ = MagicMock(return_value=False)
+            mock_subproc.return_value = MagicMock(returncode=0)
+
+            ssh_svc_inner = headless[5]
+            ssh_svc_inner.build_ssh_command.return_value = ["ssh", "ubuntu@1.2.3.4"]
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        bw_instance.resolve_ssh_key.assert_called_once_with("uuid-bw-item")
+        mock_eph.assert_called_once()
+        mock_subproc.assert_called_once()
+
+    def test_bw_cli_missing_prints_friendly_message_and_exits_nonzero(self, capsys):
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        resolved = _resolved_personal("uuid-bw-item")
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("servonaut.services.bw_resolver.BwResolver") as MockBwResolver,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+
+            bw_instance = MagicMock()
+            bw_instance.resolve_ssh_key.side_effect = BwCliMissingError("bw not found")
+            MockBwResolver.return_value = bw_instance
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        assert rc == _EXIT_BW_ERROR
+        captured = capsys.readouterr()
+        assert "Bitwarden CLI not found" in captured.err or "not found" in captured.err.lower()
+
+    def test_bw_session_missing_prints_unlock_hint(self, capsys):
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, ssh_svc, _ = _patch_headless(instances=instances)
+        resolved = _resolved_personal("uuid-bw")
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("servonaut.services.bw_resolver.BwResolver") as MockBwResolver,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+
+            bw_instance = MagicMock()
+            bw_instance.resolve_ssh_key.side_effect = BwSessionMissingError("vault locked")
+            MockBwResolver.return_value = bw_instance
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        assert rc == _EXIT_BW_ERROR
+        captured = capsys.readouterr()
+        assert "bw unlock" in captured.err
+
+    def test_bw_item_not_found_friendly_message(self, capsys):
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, _, _ = _patch_headless(instances=instances)
+        resolved = _resolved_personal("uuid-bw")
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("servonaut.services.bw_resolver.BwResolver") as MockBwResolver,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+
+            bw_instance = MagicMock()
+            bw_instance.resolve_ssh_key.side_effect = BwItemNotFoundError("not found")
+            MockBwResolver.return_value = bw_instance
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        assert rc == _EXIT_BW_ERROR
+
+    def test_port_override_via_flag(self):
+        """--port flag is forwarded to build_ssh_command."""
+        args = _make_args(instance="i-abc", port=2222)
+        instances = [_make_instance("i-abc")]
+        headless, _, _ = _patch_headless(instances=instances)
+        resolved = _resolved_local()
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("subprocess.run") as mock_subproc,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+            mock_subproc.return_value = MagicMock(returncode=0)
+
+            ssh_svc_inner = headless[5]
+            ssh_svc_inner.build_ssh_command.return_value = ["ssh", "-p", "2222", "u@h"]
+
+            from servonaut.cli.ssh import handle_ssh_command
+            handle_ssh_command(args)
+
+        call_kwargs = ssh_svc_inner.build_ssh_command.call_args
+        assert call_kwargs.kwargs.get("port") == 2222
+
+    def test_subprocess_return_code_propagated(self):
+        """SSH exit code is forwarded as the CLI exit code."""
+        args = _make_args(instance="i-abc")
+        instances = [_make_instance("i-abc")]
+        headless, _, _ = _patch_headless(instances=instances)
+        resolved = _resolved_local()
+
+        from servonaut.cli import ssh as ssh_mod
+
+        with (
+            patch.object(ssh_mod, "_init_headless_services", return_value=headless),
+            patch.object(ssh_mod, "_load_instances", return_value=instances),
+            patch("servonaut.services.ssh_ref_resolver.SshRefResolver") as MockResolver,
+            patch("subprocess.run") as mock_subproc,
+        ):
+            resolver_instance = MagicMock()
+            resolver_instance.resolve = AsyncMock(return_value=resolved)
+            MockResolver.return_value = resolver_instance
+            mock_subproc.return_value = MagicMock(returncode=255)
+
+            ssh_svc_inner = headless[5]
+            ssh_svc_inner.build_ssh_command.return_value = ["ssh", "ubuntu@h"]
+
+            from servonaut.cli.ssh import handle_ssh_command
+            rc = handle_ssh_command(args)
+
+        assert rc == 255

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -705,6 +705,14 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes relay backend connection state, heartbeat timestamps, "
                    "and client_ids — internal relay metadata, not user PII."),
 
+    # server_actions.py — _run_ssh_probe writes a private key to a tmpfile
+    # (tempfile.NamedTemporaryFile). `tf.write(private_key_body)` is a filesystem
+    # write, not a widget write — no user-visible UI widget is involved, and the
+    # key material comes from the local Bitwarden vault (not streamed server data).
+    AllowlistEntry("screens/server_actions.py", "_run_ssh_probe", "write",
+                   "tf.write() is a tempfile filesystem write of the BW private key "
+                   "— not a widget write. No user-visible UI surface involved."),
+
     # ---------------------------------------------------------------------------
     # load_text — TextArea content (added to _GUARDED_ATTRS in iteration-4)
     # ---------------------------------------------------------------------------

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -668,6 +668,16 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes '[dim]Saved.[/dim]' after saving settings "
                    "— hard-coded confirmation string."),
 
+    # settings.py — _refresh_bw_ssh_status writes a status line that may embed
+    # the vault_url from the server response.  When demo_mode is True the vault_url
+    # is replaced with the literal string "[redacted]" BEFORE the update() call,
+    # so the actual server value never reaches the widget.  The guard is an
+    # explicit if-branch at the top of _refresh_bw_ssh_status.
+    AllowlistEntry("screens/settings.py", "_refresh_bw_ssh_status", "update",
+                   "vault_url is replaced with '[redacted]' before update() when "
+                   "demo_mode=True and redaction_service is set — guard is an "
+                   "explicit if-branch inside _refresh_bw_ssh_status."),
+
     # snapshot_manager.py — _submit writes static validation error strings;
     # _set_status writes hard-coded count/result strings.
     AllowlistEntry("screens/snapshot_manager.py", "_submit", "update",

--- a/tests/test_ephemeral_key.py
+++ b/tests/test_ephemeral_key.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import os
 import stat
+import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from servonaut.utils.ephemeral_key import ephemeral_ssh_key
+from servonaut.utils.ephemeral_key import (
+    cleanup_stale_bw_keys,
+    ephemeral_ssh_key,
+    persistent_bw_ssh_key,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -150,3 +156,99 @@ class TestZeroWipe:
         assert wiped == b"\x00" * key_size, (
             f"Expected all-zero bytes of length {key_size}, got {wiped_preview}..."
         )
+
+
+# ---------------------------------------------------------------------------
+# persistent_bw_ssh_key tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentBwSshKey:
+    def test_file_written_with_0600_perms(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        mode = os.stat(path).st_mode & 0o777
+        assert mode == 0o600
+
+    def test_file_contains_key_body(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        content = Path(path).read_text()
+        assert content == SAMPLE_KEY
+
+    def test_file_under_servonaut_tmp(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        parent = Path(path).parent
+        assert parent == tmp_path / ".servonaut" / "tmp"
+
+    def test_dir_permissions_0700(self, tmp_path: Path) -> None:
+        persistent_bw_ssh_key(SAMPLE_KEY)
+        runtime_dir = tmp_path / ".servonaut" / "tmp"
+        mode = os.stat(runtime_dir).st_mode & 0o777
+        assert mode == 0o700
+
+    def test_atexit_callback_registered(self, tmp_path: Path) -> None:
+        """atexit.register must be called once per persistent_bw_ssh_key call."""
+        with patch("atexit.register") as mock_register:
+            persistent_bw_ssh_key(SAMPLE_KEY)
+        mock_register.assert_called_once()
+
+    def test_file_has_bw_prefix(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        assert Path(path).name.startswith("bw-")
+
+    def test_custom_prefix_used(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY, prefix="myprefix-")
+        assert Path(path).name.startswith("myprefix-")
+
+    def test_trailing_newline_appended(self, tmp_path: Path) -> None:
+        path = persistent_bw_ssh_key(SAMPLE_KEY_NO_NEWLINE)
+        content = Path(path).read_text()
+        assert content.endswith("\n")
+
+    def test_two_calls_produce_different_files(self, tmp_path: Path) -> None:
+        path1 = persistent_bw_ssh_key(SAMPLE_KEY)
+        path2 = persistent_bw_ssh_key(SAMPLE_KEY)
+        assert path1 != path2
+
+
+# ---------------------------------------------------------------------------
+# cleanup_stale_bw_keys tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupStaleBwKeys:
+    def test_silent_when_tmp_dir_missing(self, tmp_path: Path) -> None:
+        """cleanup_stale_bw_keys must not raise when the tmp dir doesn't exist."""
+        # tmp_path is home; ~/.servonaut/tmp does NOT exist yet
+        cleanup_stale_bw_keys(max_age_seconds=3600)  # should not raise
+
+    def test_removes_old_bw_key(self, tmp_path: Path) -> None:
+        """Files older than max_age_seconds with bw- prefix are deleted."""
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        # Back-date the file by 2 days
+        old_ts = time.time() - 172800
+        os.utime(path, (old_ts, old_ts))
+
+        cleanup_stale_bw_keys(max_age_seconds=86400)
+
+        assert not Path(path).exists()
+
+    def test_leaves_recent_bw_key(self, tmp_path: Path) -> None:
+        """Recent files (within max_age_seconds) are left alone."""
+        path = persistent_bw_ssh_key(SAMPLE_KEY)
+        # File is freshly created — well within 24 h
+        cleanup_stale_bw_keys(max_age_seconds=86400)
+        assert Path(path).exists()
+
+    def test_does_not_touch_non_bw_files(self, tmp_path: Path) -> None:
+        """Files without the bw- prefix are not removed even when stale."""
+        runtime_dir = tmp_path / ".servonaut" / "tmp"
+        os.makedirs(str(runtime_dir), mode=0o700, exist_ok=True)
+        other_file = runtime_dir / "servonaut-ssh-somefile"
+        other_file.write_text("not a bw key")
+        # Back-date
+        old_ts = time.time() - 172800
+        os.utime(str(other_file), (old_ts, old_ts))
+
+        cleanup_stale_bw_keys(max_age_seconds=86400)
+
+        assert other_file.exists()

--- a/tests/test_ephemeral_key.py
+++ b/tests/test_ephemeral_key.py
@@ -1,0 +1,152 @@
+"""Tests for servonaut.utils.ephemeral_key."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from servonaut.utils.ephemeral_key import ephemeral_ssh_key
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_KEY = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    "AAAA...fake...key...body==\n"
+    "-----END OPENSSH PRIVATE KEY-----\n"
+)
+
+SAMPLE_KEY_NO_NEWLINE = SAMPLE_KEY.rstrip("\n")
+
+
+@pytest.fixture(autouse=True)
+def redirect_runtime_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect Path.home() into tmp_path so tests don't touch ~/.servonaut."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_file_contains_key_body(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            content = Path(path).read_text()
+        assert content == SAMPLE_KEY
+
+    def test_file_permissions_are_0600(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            mode = os.stat(path).st_mode & 0o777
+        assert mode == 0o600
+
+    def test_directory_permissions_are_0700_or_stricter(self, tmp_path: Path) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            parent = Path(path).parent
+            dir_mode = os.stat(parent).st_mode & 0o777
+        assert dir_mode <= 0o700, f"Expected <= 0700, got {oct(dir_mode)}"
+
+    def test_directory_is_under_servonaut_tmp(self, tmp_path: Path) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            parent = Path(path).parent
+        assert parent == tmp_path / ".servonaut" / "tmp"
+
+    def test_file_deleted_after_normal_exit(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            pass
+        assert not Path(path).exists()
+
+    def test_containing_directory_persists_after_exit(self, tmp_path: Path) -> None:
+        """The runtime dir is NOT removed — other servonaut processes may use it."""
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            parent = Path(path).parent
+        assert parent.exists()
+
+    def test_tmpfile_name_carries_default_prefix(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            name = Path(path).name
+        assert name.startswith("servonaut-ssh-")
+
+    def test_tmpfile_name_carries_custom_prefix(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY, prefix="bw-key-") as path:
+            name = Path(path).name
+        assert name.startswith("bw-key-")
+
+
+class TestNewlineHandling:
+    def test_trailing_newline_appended_when_missing(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY_NO_NEWLINE) as path:
+            content = Path(path).read_text()
+        assert content.endswith("\n")
+
+    def test_trailing_newline_not_doubled_when_present(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            content = Path(path).read_text()
+        assert not content.endswith("\n\n")
+
+    def test_body_content_preserved_with_newline_appended(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY_NO_NEWLINE) as path:
+            content = Path(path).read_text()
+        assert content == SAMPLE_KEY_NO_NEWLINE + "\n"
+
+
+class TestCleanupOnException:
+    def test_file_deleted_even_on_exception(self) -> None:
+        captured_path: list[str] = []
+        with pytest.raises(RuntimeError, match="boom"):
+            with ephemeral_ssh_key(SAMPLE_KEY) as path:
+                captured_path.append(path)
+                raise RuntimeError("boom")
+        assert captured_path, "with-block body should have executed"
+        assert not Path(captured_path[0]).exists()
+
+    def test_exception_propagates_unchanged(self) -> None:
+        with pytest.raises(ValueError, match="test-signal"):
+            with ephemeral_ssh_key(SAMPLE_KEY):
+                raise ValueError("test-signal")
+
+
+class TestConcurrency:
+    def test_two_concurrent_managers_yield_different_paths(self) -> None:
+        with ephemeral_ssh_key(SAMPLE_KEY, prefix="key-a-") as path_a:
+            with ephemeral_ssh_key(SAMPLE_KEY, prefix="key-b-") as path_b:
+                assert path_a != path_b
+                assert Path(path_a).exists()
+                assert Path(path_b).exists()
+
+
+class TestZeroWipe:
+    def test_file_overwritten_with_zeros_before_unlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Capture file contents just before unlink to verify zero-wipe."""
+        captured_bytes: list[bytes] = []
+        original_unlink = os.unlink
+
+        def spy_unlink(p: str) -> None:
+            # Read file bytes (if still present) before delegating to real unlink.
+            try:
+                with open(p, "rb") as fh:
+                    captured_bytes.append(fh.read())
+            except OSError:
+                pass
+            original_unlink(p)
+
+        monkeypatch.setattr(os, "unlink", spy_unlink)
+
+        with ephemeral_ssh_key(SAMPLE_KEY) as path:
+            key_size = len(SAMPLE_KEY)
+
+        assert captured_bytes, "spy_unlink was never called"
+        wiped = captured_bytes[0]
+        wiped_preview = repr(wiped[:40])
+        assert wiped == b"\x00" * key_size, (
+            f"Expected all-zero bytes of length {key_size}, got {wiped_preview}..."
+        )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,8 +1,9 @@
 """Tests for formatting utilities."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from servonaut.utils.formatting import (
+    format_ssh_verify_state,
     format_timedelta,
     truncate_string,
     format_file_size,
@@ -74,3 +75,101 @@ class TestFormatFileSize:
 
     def test_gigabytes(self):
         assert format_file_size(1073741824) == '1.0 GB'
+
+
+class TestFormatSshVerifyState:
+    NOW = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_no_status_renders_dash(self):
+        assert format_ssh_verify_state(None, None) == "[dim]—[/dim]"
+
+    def test_empty_status_renders_dash(self):
+        assert format_ssh_verify_state("", "2026-05-24T10:00:00Z") == "[dim]—[/dim]"
+
+    def test_non_string_status_renders_dash(self):
+        assert format_ssh_verify_state(123, None) == "[dim]—[/dim]"
+
+    def test_unknown_status_renders_dash(self):
+        # Future enum values from the server must NOT render as raw text.
+        assert format_ssh_verify_state("partial", None) == "[dim]—[/dim]"
+
+    def test_verified_with_timestamp_includes_age(self):
+        result = format_ssh_verify_state(
+            "verified", "2026-05-24T10:00:00Z", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (2h ago)"
+
+    def test_verified_handles_seconds_age(self):
+        result = format_ssh_verify_state(
+            "verified", "2026-05-24T11:59:30Z", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (30s ago)"
+
+    def test_verified_handles_minutes_age(self):
+        result = format_ssh_verify_state(
+            "verified", "2026-05-24T11:55:00Z", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (5m ago)"
+
+    def test_verified_handles_days_age(self):
+        result = format_ssh_verify_state(
+            "verified", "2026-05-21T12:00:00Z", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (3d ago)"
+
+    def test_verified_without_timestamp_degrades_gracefully(self):
+        # Server contract says verified always carries verified_at, but if it
+        # somehow doesn't we render the badge without an age rather than crashing.
+        result = format_ssh_verify_state("verified", None, now_utc=self.NOW)
+        assert result == "[green]✓ verified[/green]"
+
+    def test_verified_with_invalid_timestamp_degrades_gracefully(self):
+        result = format_ssh_verify_state(
+            "verified", "not-an-iso-date", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green]"
+
+    def test_not_found_never_shows_timestamp(self):
+        # CONTRACT GUARD: server NULLs ssh_verified_at on non-verified statuses.
+        # Even if a buggy server response passes one in, we must IGNORE it —
+        # showing "last verified 3h ago" next to "not found" is misleading.
+        result = format_ssh_verify_state(
+            "not_found", "2026-05-24T10:00:00Z", now_utc=self.NOW
+        )
+        assert result == "[red]✗ not found[/red]"
+        assert "ago" not in result
+
+    def test_auth_failed_never_shows_timestamp(self):
+        # Same contract guard for auth_failed.
+        result = format_ssh_verify_state(
+            "auth_failed", "2026-05-24T10:00:00Z", now_utc=self.NOW
+        )
+        assert result == "[red]✗ auth failed[/red]"
+        assert "ago" not in result
+
+    def test_case_insensitive_status_match(self):
+        assert format_ssh_verify_state(
+            "VERIFIED", "2026-05-24T10:00:00Z", now_utc=self.NOW
+        ).startswith("[green]✓ verified[/green]")
+        assert format_ssh_verify_state("Not_Found", None) == "[red]✗ not found[/red]"
+
+    def test_whitespace_in_status_is_trimmed(self):
+        assert format_ssh_verify_state("  auth_failed  ", None) == (
+            "[red]✗ auth failed[/red]"
+        )
+
+    def test_future_timestamp_clamps_to_zero_age(self):
+        # Clock skew between server and client could put verified_at in the
+        # future. Render as "0s ago" rather than a negative number.
+        result = format_ssh_verify_state(
+            "verified", "2026-05-24T13:00:00Z", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (0s ago)"
+
+    def test_naive_timestamp_assumed_utc(self):
+        # If the server somehow strips the tz suffix, treat as UTC rather than
+        # crashing on naive-vs-aware arithmetic.
+        result = format_ssh_verify_state(
+            "verified", "2026-05-24T10:00:00", now_utc=self.NOW
+        )
+        assert result == "[green]✓ verified[/green] (2h ago)"

--- a/tests/test_instance_table.py
+++ b/tests/test_instance_table.py
@@ -1,0 +1,141 @@
+"""Tests for InstanceTable widget — SSH verify column additions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.widgets.instance_table import InstanceTable
+from servonaut.utils.formatting import format_ssh_verify_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_table() -> InstanceTable:
+    """Construct an InstanceTable without a real Textual app."""
+    # Patch DataTable.__init__ so we can instantiate without a running app.
+    with patch("textual.widgets.DataTable.__init__", return_value=None), \
+         patch.object(InstanceTable, "add_column", MagicMock()):
+        table = InstanceTable.__new__(InstanceTable)
+        table._all_instances = []
+        table._filtered_instances = []
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Column presence
+# ---------------------------------------------------------------------------
+
+class TestSetupColumns:
+    def test_ssh_column_added(self):
+        """_setup_columns must add a column with key='ssh'."""
+        calls = []
+
+        class FakeTable:
+            def add_column(self, label, **kwargs):
+                calls.append((label, kwargs))
+
+        ft = FakeTable()
+        # Borrow the method and bind it to the fake table.
+        InstanceTable._setup_columns(ft)
+
+        keys = [kw.get("key") for _, kw in calls]
+        assert "ssh" in keys, f"Expected 'ssh' key in columns; got {keys}"
+
+    def test_ssh_column_between_key_and_mem(self):
+        """'SSH' column must be inserted between 'Key' and 'Mem'."""
+        calls = []
+
+        class FakeTable:
+            def add_column(self, label, **kwargs):
+                calls.append((label, kwargs))
+
+        ft = FakeTable()
+        InstanceTable._setup_columns(ft)
+
+        labels = [label for label, _ in calls]
+        assert "Key" in labels and "SSH" in labels and "Mem" in labels
+        key_idx = labels.index("Key")
+        ssh_idx = labels.index("SSH")
+        mem_idx = labels.index("Mem")
+        assert key_idx < ssh_idx < mem_idx, (
+            f"Expected Key < SSH < Mem in column order; got indices "
+            f"Key={key_idx}, SSH={ssh_idx}, Mem={mem_idx}"
+        )
+
+    def test_ssh_column_width(self):
+        """SSH column should have width=14."""
+        calls = []
+
+        class FakeTable:
+            def add_column(self, label, **kwargs):
+                calls.append((label, kwargs))
+
+        ft = FakeTable()
+        InstanceTable._setup_columns(ft)
+
+        ssh_entry = next(
+            (kw for label, kw in calls if kw.get("key") == "ssh"),
+            None,
+        )
+        assert ssh_entry is not None, "SSH column not found"
+        assert ssh_entry.get("width") == 14
+
+
+# ---------------------------------------------------------------------------
+# _ssh_verify_cell
+# ---------------------------------------------------------------------------
+
+class TestSshVerifyCell:
+    def _cell(self, instance: dict) -> str:
+        table = _make_table()
+        return InstanceTable._ssh_verify_cell(table, instance)
+
+    def test_missing_status_returns_dash(self):
+        """Instance without ssh_verify_status keys renders the dim dash."""
+        result = self._cell({})
+        assert result == "[dim]—[/dim]"
+
+    def test_none_status_returns_dash(self):
+        result = self._cell({"ssh_verify_status": None})
+        assert result == "[dim]—[/dim]"
+
+    def test_verified_status_shows_green_tick(self):
+        result = self._cell({
+            "ssh_verify_status": "verified",
+            "ssh_verified_at": "2026-05-24T10:00:00+00:00",
+        })
+        assert "[green]" in result
+        assert "verified" in result
+
+    def test_not_found_status_shows_red(self):
+        result = self._cell({"ssh_verify_status": "not_found"})
+        assert "[red]" in result
+        assert "not found" in result
+
+    def test_auth_failed_status_shows_red(self):
+        result = self._cell({"ssh_verify_status": "auth_failed"})
+        assert "[red]" in result
+        assert "auth failed" in result
+
+    def test_delegates_to_format_ssh_verify_state(self):
+        """_ssh_verify_cell must produce same output as format_ssh_verify_state."""
+        inst = {
+            "ssh_verify_status": "verified",
+            "ssh_verified_at": "2026-05-20T12:00:00+00:00",
+        }
+        table_result = self._cell(inst)
+        formatter_result = format_ssh_verify_state(
+            inst["ssh_verify_status"],
+            inst["ssh_verified_at"],
+        )
+        # Both should start with the same green prefix
+        assert table_result.startswith("[green]") == formatter_result.startswith("[green]")
+
+    def test_unknown_status_returns_dash(self):
+        """Unrecognised status values degrade to the dim dash."""
+        result = self._cell({"ssh_verify_status": "something_new"})
+        assert result == "[dim]—[/dim]"

--- a/tests/test_relay_listener.py
+++ b/tests/test_relay_listener.py
@@ -691,3 +691,160 @@ class TestHandleEventUnknownCommandType:
         data = make_event_payload(cmd_type="future_unknown_verb", payload={"foo": "bar"})
         run(listener._handle_event(data))
         listener._executors.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dual-topic subscription + dedup (PR #74 — servonaut.dev 2026-05-24)
+# ---------------------------------------------------------------------------
+
+
+class TestDualTopicSubscription:
+    def test_topic_urls_includes_both_legacy_and_new(self):
+        listener = make_listener(user_id="user-123")
+        urls = listener._topic_urls()
+        assert urls == [
+            "/cli/user-123/commands",
+            "/cli/user-123/ai-tool-calls",
+        ]
+
+    def test_topic_suffixes_are_locked(self):
+        # Locked dual-publish contract — any reorder/rename here breaks
+        # cross-team alignment with servonaut.dev's ToolDispatcher.
+        from servonaut.services.relay_listener import RelayListener
+        assert RelayListener._TOPIC_SUFFIXES == ("commands", "ai-tool-calls")
+
+
+class TestExtractDedupKey:
+    def test_prefers_top_level_tool_call_id(self):
+        from servonaut.services.relay_listener import RelayListener
+        key = RelayListener._extract_dedup_key(
+            {"tool_call_id": "tc-1", "id": "req-1"}
+        )
+        assert key == "tcid:tc-1"
+
+    def test_falls_back_to_payload_tool_call_id(self):
+        from servonaut.services.relay_listener import RelayListener
+        key = RelayListener._extract_dedup_key(
+            {"id": "req-1", "payload": {"tool_call_id": "tc-2"}}
+        )
+        assert key == "tcid:tc-2"
+
+    def test_falls_back_to_top_level_id_when_no_tool_call_id(self):
+        from servonaut.services.relay_listener import RelayListener
+        key = RelayListener._extract_dedup_key(
+            {"id": "req-1", "type": "run_command"}
+        )
+        assert key == "id:req-1"
+
+    def test_returns_none_when_no_idempotency_basis(self):
+        from servonaut.services.relay_listener import RelayListener
+        assert RelayListener._extract_dedup_key({"foo": "bar"}) is None
+
+    def test_ignores_non_string_keys(self):
+        from servonaut.services.relay_listener import RelayListener
+        # tool_call_id wrapped in dict accidentally, id present
+        assert (
+            RelayListener._extract_dedup_key({"tool_call_id": 42, "id": "r-1"})
+            == "id:r-1"
+        )
+
+    def test_ignores_empty_strings(self):
+        from servonaut.services.relay_listener import RelayListener
+        assert RelayListener._extract_dedup_key({"tool_call_id": "", "id": ""}) is None
+
+
+class TestDedupShouldProcess:
+    def test_new_key_is_processed(self):
+        listener = make_listener()
+        assert listener._dedup_should_process("tcid:fresh") is True
+
+    def test_repeat_key_is_skipped(self):
+        listener = make_listener()
+        assert listener._dedup_should_process("tcid:x") is True
+        assert listener._dedup_should_process("tcid:x") is False
+        # Still skipped on a 3rd attempt (dual-publish + a rogue retry).
+        assert listener._dedup_should_process("tcid:x") is False
+
+    def test_none_key_always_processes(self):
+        listener = make_listener()
+        # No idempotency basis → better to execute once than zero times.
+        assert listener._dedup_should_process(None) is True
+        assert listener._dedup_should_process(None) is True
+
+    def test_distinct_keys_dont_collide(self):
+        listener = make_listener()
+        assert listener._dedup_should_process("tcid:a") is True
+        assert listener._dedup_should_process("tcid:b") is True
+        assert listener._dedup_should_process("id:a") is True  # prefix matters
+
+    def test_lru_evicts_oldest_when_over_cap(self):
+        listener = make_listener()
+        listener._DEDUP_MAX_ENTRIES = 3  # shrink for test
+        listener._dedup_should_process("k1")
+        listener._dedup_should_process("k2")
+        listener._dedup_should_process("k3")
+        listener._dedup_should_process("k4")  # evicts k1
+        # k1 has been forgotten — would be processed again
+        assert listener._dedup_should_process("k1") is True
+        # k4 still in the set
+        assert listener._dedup_should_process("k4") is False
+
+    def test_ttl_eviction_forgets_old_entries(self):
+        listener = make_listener()
+        listener._DEDUP_TTL_SECONDS = 0  # immediate expiry
+        listener._dedup_should_process("k1")
+        # Force a non-zero monotonic delta before the next call so the
+        # cutoff (= now - 0) strictly exceeds the recorded "first seen".
+        import time as _t
+        _t.sleep(0.001)
+        # On the next call the TTL sweep drops k1, so it processes again.
+        assert listener._dedup_should_process("k1") is True
+
+
+class TestHandleEventDedup:
+    def test_duplicate_event_executes_once(self):
+        listener = make_listener(user_id="user-123")
+        data = make_event_payload(req_id="req-dup")
+        run(listener._handle_event(data))
+        run(listener._handle_event(data))  # second arrival on the other topic
+        assert listener._executors.execute.call_count == 1
+
+    def test_distinct_events_both_execute(self):
+        listener = make_listener(user_id="user-123")
+        run(listener._handle_event(make_event_payload(req_id="req-1")))
+        run(listener._handle_event(make_event_payload(req_id="req-2")))
+        assert listener._executors.execute.call_count == 2
+
+    def test_ai_tool_call_dedup_uses_tool_call_id(self):
+        listener = make_listener(user_id="user-123")
+        # An AI tool call event mirrored onto BOTH topics. The CommandType
+        # is unknown so the executor is never called; the dedup record is
+        # what we care about — second arrival must NOT log a second skip.
+        ai_payload = json.dumps({
+            "id": "req-mirror-1",
+            "user_id": "user-123",
+            "type": "ssh_exec_readonly",
+            "target_server_id": "i-1",
+            "tool_call_id": "tc-shared",
+            "payload": {"command": "ls"},
+        })
+        run(listener._handle_event(ai_payload))
+        # Second event with SAME tool_call_id but DIFFERENT top-level id —
+        # demonstrates that tool_call_id is the idempotency anchor, not id.
+        ai_payload_2 = json.dumps({
+            "id": "req-mirror-2",  # different request id
+            "user_id": "user-123",
+            "type": "ssh_exec_readonly",
+            "target_server_id": "i-1",
+            "tool_call_id": "tc-shared",  # same tool call
+            "payload": {"command": "ls"},
+        })
+        # The dedup gate fires on the second call (returns from
+        # _dedup_should_process without proceeding to the
+        # CommandType-skip path), but neither path invokes the executor
+        # for an AI tool call anyway. The behaviour-under-test is that
+        # the second event takes the "duplicate" code path, not the
+        # "unknown command type" path.
+        assert listener._dedup_should_process("tcid:tc-shared") is False
+        run(listener._handle_event(ai_payload_2))
+        listener._executors.execute.assert_not_called()

--- a/tests/test_server_actions_screen.py
+++ b/tests/test_server_actions_screen.py
@@ -1,0 +1,304 @@
+"""Tests for ServerActionsScreen — Verify SSH feature."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from servonaut.screens.server_actions import ConfirmSshVerifyModal, ServerActionsScreen
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_instance(
+    instance_id: str = "i-abc123",
+    provider: str = "aws",
+    public_ip: str = "1.2.3.4",
+    name: str = "test-server",
+) -> dict:
+    return {
+        "id": instance_id,
+        "provider": provider,
+        "public_ip": public_ip,
+        "name": name,
+        "state": "running",
+        "type": "t3.micro",
+        "region": "us-east-1",
+        "key_name": "my-key",
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# ConfirmSshVerifyModal — unit tests (no Textual pilot needed)
+# ---------------------------------------------------------------------------
+
+class TestConfirmSshVerifyModal:
+    def test_instantiates_with_ref(self):
+        modal = ConfirmSshVerifyModal(host="1.2.3.4", has_ref=True)
+        assert modal._host == "1.2.3.4"
+        assert modal._has_ref is True
+
+    def test_instantiates_without_ref(self):
+        modal = ConfirmSshVerifyModal(host="10.0.0.1", has_ref=False)
+        assert modal._has_ref is False
+
+    def test_inherits_from_modal_screen(self):
+        from textual.screen import ModalScreen
+        assert issubclass(ConfirmSshVerifyModal, ModalScreen)
+
+    def test_generic_param_is_bool(self):
+        """ConfirmSshVerifyModal[bool] — check via __orig_bases__ or mro."""
+        import inspect
+        # The class must be declared as ModalScreen[bool]
+        bases = getattr(ConfirmSshVerifyModal, "__orig_bases__", [])
+        base_strs = [str(b) for b in bases]
+        assert any("bool" in s for s in base_strs), (
+            f"Expected ModalScreen[bool] in bases; got {base_strs}"
+        )
+
+    def test_escape_binding_exists(self):
+        bindings = ConfirmSshVerifyModal.BINDINGS
+        keys = [b.key for b in bindings]
+        assert "escape" in keys
+
+
+# ---------------------------------------------------------------------------
+# ServerActionsScreen — compose includes Verify SSH button
+# ---------------------------------------------------------------------------
+
+class TestServerActionsScreenCompose:
+    """Lightweight checks on ServerActionsScreen without a running pilot."""
+
+    def test_verify_ssh_binding_registered(self):
+        """'v' binding for action_verify_ssh must be in BINDINGS."""
+        keys = [b.key for b in ServerActionsScreen.BINDINGS]
+        assert "v" in keys, f"Expected 'v' in BINDINGS; got {keys}"
+
+    def test_action_verify_ssh_method_exists(self):
+        assert hasattr(ServerActionsScreen, "action_verify_ssh")
+        assert callable(ServerActionsScreen.action_verify_ssh)
+
+    def test_run_ssh_probe_method_exists(self):
+        assert hasattr(ServerActionsScreen, "_run_ssh_probe")
+
+    def test_verify_ssh_flow_method_exists(self):
+        assert hasattr(ServerActionsScreen, "_verify_ssh_flow")
+
+
+# ---------------------------------------------------------------------------
+# _verify_ssh_flow — worker logic
+# ---------------------------------------------------------------------------
+
+class _FakeApp:
+    """Minimal app double for testing ServerActionsScreen flow without Textual."""
+
+    def __init__(self, bw_service=None, instances=None):
+        self.bw_ssh_config_service = bw_service
+        self.instances = instances or []
+        self._notifications = []
+        self._pushed_screens = []
+        self._push_screen_wait_result = True
+        self.demo_mode = False
+        self.redaction_service = None
+
+        # Minimal config manager double
+        cfg = MagicMock()
+        cfg.default_username = "root"
+        cm = MagicMock()
+        cm.get.return_value = cfg
+        self.config_manager = cm
+
+    def notify(self, message, *, severity="information", markup=True, timeout=None):
+        self._notifications.append({"message": message, "severity": severity})
+
+    async def push_screen_wait(self, modal):
+        self._pushed_screens.append(modal)
+        return self._push_screen_wait_result
+
+    @property
+    def screen_stack(self):
+        return []
+
+
+def _make_screen(instance=None, app=None) -> ServerActionsScreen:
+    """Build ServerActionsScreen without mounting it in a Textual app."""
+    inst = instance or _make_instance()
+    screen = ServerActionsScreen.__new__(ServerActionsScreen)
+    screen._instance = inst
+    if app is not None:
+        screen._app = app  # bypass the Textual descriptor
+    # Patch self.app to return the fake
+    if app is not None:
+        screen.__class__ = type(
+            "PatchedServerActionsScreen",
+            (ServerActionsScreen,),
+            {"app": property(lambda self: app)},
+        )
+    return screen
+
+
+class TestVerifySshFlowNoService:
+    def test_no_bw_service_shows_warning(self):
+        fake_app = _FakeApp(bw_service=None)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "warning" in sevs
+
+    def test_no_bw_service_does_not_push_modal(self):
+        fake_app = _FakeApp(bw_service=None)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        assert fake_app._pushed_screens == []
+
+
+class TestVerifySshFlowNoRef:
+    def test_no_ref_modal_pushed(self):
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        assert len(fake_app._pushed_screens) == 1
+        assert isinstance(fake_app._pushed_screens[0], ConfirmSshVerifyModal)
+        assert not fake_app._pushed_screens[0]._has_ref
+
+    def test_no_ref_confirmed_shows_stub_notify(self):
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert any("not yet implemented" in m for m in msgs)
+
+    def test_cancel_on_no_ref_no_stub_notify(self):
+        """If user cancels on the no-ref modal, no stub notify is shown."""
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        fake_app._push_screen_wait_result = False
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert not any("not yet implemented" in m for m in msgs)
+
+
+class TestVerifySshFlowWithRef:
+    def _make_bw(self, report_result=None, report_exc=None):
+        bw = MagicMock()
+        ref_row = {
+            "ssh_credential_ref": {"item_id": "bw-item-uuid"},
+        }
+        bw.get_personal_instance_ref = AsyncMock(return_value=ref_row)
+        if report_exc:
+            bw.report_personal_instance_verify = AsyncMock(side_effect=report_exc)
+        else:
+            bw.report_personal_instance_verify = AsyncMock(
+                return_value=report_result or {}
+            )
+        return bw
+
+    def test_has_ref_modal_is_has_ref_true(self):
+        bw = self._make_bw()
+        fake_app = _FakeApp(bw_service=bw)
+        # Patch _run_ssh_probe so it returns 'verified' quickly
+        async def _fast_probe(item_id, host):
+            return "verified"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        assert fake_app._pushed_screens[0]._has_ref is True
+
+    def test_verified_status_posts_verified(self):
+        bw = self._make_bw()
+        fake_app = _FakeApp(bw_service=bw)
+        async def _fast_probe(item_id, host):
+            return "verified"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        bw.report_personal_instance_verify.assert_awaited_once()
+        call_kwargs = bw.report_personal_instance_verify.call_args
+        assert call_kwargs.kwargs["status"] == "verified"
+
+    def test_not_found_status_posts_not_found(self):
+        bw = self._make_bw()
+        fake_app = _FakeApp(bw_service=bw)
+        async def _fast_probe(item_id, host):
+            return "not_found"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        call_kwargs = bw.report_personal_instance_verify.call_args
+        assert call_kwargs.kwargs["status"] == "not_found"
+
+    def test_auth_failed_status_posts_auth_failed(self):
+        bw = self._make_bw()
+        fake_app = _FakeApp(bw_service=bw)
+        async def _fast_probe(item_id, host):
+            return "auth_failed"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        call_kwargs = bw.report_personal_instance_verify.call_args
+        assert call_kwargs.kwargs["status"] == "auth_failed"
+
+    def test_tier_gate_402_shows_friendly_notify(self):
+        from servonaut.services.api_client import APIError
+        exc = APIError(code="payment_required", message="Upgrade required", status=402)
+        bw = self._make_bw(report_exc=exc)
+        fake_app = _FakeApp(bw_service=bw)
+        async def _fast_probe(item_id, host):
+            return "verified"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        # Should NOT raise — 402 is handled gracefully
+        _run(screen._verify_ssh_flow())
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "warning" in sevs
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert any("paid" in m.lower() or "plan" in m.lower() for m in msgs)
+
+    def test_instance_dict_updated_after_probe(self):
+        bw = self._make_bw()
+        inst = _make_instance()
+        fake_app = _FakeApp(bw_service=bw, instances=[inst])
+        async def _fast_probe(item_id, host):
+            return "verified"
+        screen = _make_screen(instance=inst, app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        assert inst["ssh_verify_status"] == "verified"
+        assert "ssh_verified_at" in inst
+
+    def test_not_found_clears_verified_at(self):
+        bw = self._make_bw()
+        inst = _make_instance()
+        inst["ssh_verified_at"] = "2026-05-20T00:00:00+00:00"
+        fake_app = _FakeApp(bw_service=bw, instances=[inst])
+        async def _fast_probe(item_id, host):
+            return "not_found"
+        screen = _make_screen(instance=inst, app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        assert inst.get("ssh_verified_at") is None
+
+    def test_user_cancel_aborts_flow(self):
+        bw = self._make_bw()
+        fake_app = _FakeApp(bw_service=bw)
+        fake_app._push_screen_wait_result = False  # user cancels
+        async def _fast_probe(item_id, host):
+            return "verified"
+        screen = _make_screen(app=fake_app)
+        screen._run_ssh_probe = _fast_probe
+        _run(screen._verify_ssh_flow())
+        bw.report_personal_instance_verify.assert_not_awaited()

--- a/tests/test_server_actions_screen.py
+++ b/tests/test_server_actions_screen.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import pytest
 
 from servonaut.screens.server_actions import ConfirmSshVerifyModal, ServerActionsScreen
+from servonaut.services.ssh_ref_resolver import ResolvedSshRef
 
 
 # ---------------------------------------------------------------------------
@@ -167,18 +168,25 @@ class TestVerifySshFlowNoRef:
         fake_app = _FakeApp(bw_service=bw)
         screen = _make_screen(app=fake_app)
         _run(screen._verify_ssh_flow())
-        assert len(fake_app._pushed_screens) == 1
+        # First modal: ConfirmSshVerifyModal; second: SshRefEditorModal (new)
+        assert len(fake_app._pushed_screens) >= 1
         assert isinstance(fake_app._pushed_screens[0], ConfirmSshVerifyModal)
         assert not fake_app._pushed_screens[0]._has_ref
 
-    def test_no_ref_confirmed_shows_stub_notify(self):
+    def test_no_ref_confirmed_pushes_editor_modal(self):
+        """Confirm on no-ref now opens SshRefEditorModal instead of stub notify."""
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
         bw = MagicMock()
         bw.get_personal_instance_ref = AsyncMock(return_value=None)
         fake_app = _FakeApp(bw_service=bw)
         screen = _make_screen(app=fake_app)
         _run(screen._verify_ssh_flow())
+        # ConfirmSshVerifyModal + SshRefEditorModal
+        assert len(fake_app._pushed_screens) == 2
+        assert isinstance(fake_app._pushed_screens[1], SshRefEditorModal)
+        # No stub "not yet implemented" notify should appear
         msgs = [n["message"] for n in fake_app._notifications]
-        assert any("not yet implemented" in m for m in msgs)
+        assert not any("not yet implemented" in m for m in msgs)
 
     def test_cancel_on_no_ref_no_stub_notify(self):
         """If user cancels on the no-ref modal, no stub notify is shown."""
@@ -302,3 +310,642 @@ class TestVerifySshFlowWithRef:
         screen._run_ssh_probe = _fast_probe
         _run(screen._verify_ssh_flow())
         bw.report_personal_instance_verify.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for SshRefResolver chain tests
+# ---------------------------------------------------------------------------
+
+def _make_connect_app(
+    *,
+    resolved: object = None,
+    resolver_raises: Exception = None,
+    bw_key_body: str = "FAKE_KEY",
+    bw_resolver_raises: Exception = None,
+    launch_result: bool = True,
+    team_service=None,
+    bw_service=None,
+) -> "_FakeConnectApp":
+    """Build a fake app pre-wired for _ssh_connect_flow tests."""
+
+    class _FakeConnectApp:
+        def __init__(self):
+            self._notifications = []
+            self.demo_mode = False
+            self.redaction_service = None
+            self.instances = []
+
+            cfg = MagicMock()
+            cfg.default_username = "ubuntu"
+            cm = MagicMock()
+            cm.get.return_value = cfg
+            self.config_manager = cm
+
+            self.ssh_service = MagicMock()
+            self.ssh_service.build_ssh_command.return_value = ["ssh", "host"]
+            self.ssh_service.get_key_path.return_value = "/home/user/.ssh/id_rsa"
+            self.ssh_service.discover_key.return_value = "/home/user/.ssh/id_rsa"
+
+            self.connection_service = MagicMock()
+            self.connection_service.resolve_profile.return_value = None
+            self.connection_service.get_target_host.return_value = "1.2.3.4"
+            self.connection_service.get_proxy_args.return_value = []
+            self.connection_service.get_extra_options.return_value = {}
+
+            self.terminal_service = MagicMock()
+            self.terminal_service.launch_ssh_in_terminal.return_value = launch_result
+
+            self.bw_ssh_config_service = bw_service
+            self.team_service = team_service
+
+        def notify(self, message, *, severity="information", markup=True, timeout=None):
+            self._notifications.append({"message": message, "severity": severity})
+
+        @property
+        def screen_stack(self):
+            return []
+
+    return _FakeConnectApp()
+
+
+def _make_connect_screen(
+    instance: dict = None,
+    app=None,
+) -> ServerActionsScreen:
+    """Build a ServerActionsScreen for _ssh_connect_flow tests."""
+    inst = instance or _make_instance()
+    screen = ServerActionsScreen.__new__(ServerActionsScreen)
+    screen._instance = inst
+    if app is not None:
+        screen.__class__ = type(
+            "ConnectScreen",
+            (ServerActionsScreen,),
+            {"app": property(lambda self: app)},
+        )
+    return screen
+
+
+# ---------------------------------------------------------------------------
+# TestSshConnectResolverChain
+# ---------------------------------------------------------------------------
+
+_PERSONAL_RESOLVED = ResolvedSshRef(
+    source="personal",
+    item_id="bw-uuid-personal",
+    vault_url=None,
+    collection_id=None,
+    local_key_path=None,
+    team_slug=None,
+    server_id=None,
+)
+
+_TEAM_RESOLVED = ResolvedSshRef(
+    source="team",
+    item_id="bw-uuid-team",
+    vault_url=None,
+    collection_id=None,
+    local_key_path=None,
+    team_slug="acme",
+    server_id="srv-1",
+)
+
+_LOCAL_RESOLVED = ResolvedSshRef(
+    source="local",
+    item_id=None,
+    vault_url=None,
+    collection_id=None,
+    local_key_path="/home/user/.ssh/id_rsa",
+    team_slug=None,
+    server_id=None,
+)
+
+
+class TestSshConnectResolverChain:
+    """SSH Connect walks SshRefResolver before falling back to local.
+
+    Strategy: patch at source-module paths because all imports in
+    _ssh_connect_flow are local (inside the function body).  The source
+    module is the correct patch target for locally-imported names.
+    """
+
+    # Source-module patch targets (all imports in _ssh_connect_flow are local).
+    _P_RESOLVE = "servonaut.services.ssh_ref_resolver.SshRefResolver.resolve"
+    _P_BW_KEY = "servonaut.services.bw_resolver.BwResolver.resolve_ssh_key"
+    _P_PERSIST = "servonaut.utils.ephemeral_key.persistent_bw_ssh_key"
+
+    def _run_flow(self, screen):
+        return asyncio.run(screen._ssh_connect_flow())
+
+    def test_personal_match_uses_bw_resolver(self):
+        """When resolver returns personal source, BwResolver is called and terminal launched."""
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_PERSONAL_RESOLVED),
+            patch(self._P_BW_KEY, return_value="FAKE_KEY"),
+            patch(self._P_PERSIST, return_value="/tmp/bw-fake.key") as mock_persistent,
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        mock_persistent.assert_called_once_with("FAKE_KEY")
+        app.terminal_service.launch_ssh_in_terminal.assert_called_once()
+
+    def test_team_match_uses_bw_resolver(self):
+        """When resolver returns team source, BwResolver is called and terminal launched."""
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_TEAM_RESOLVED),
+            patch(self._P_BW_KEY, return_value="FAKE_TEAM_KEY"),
+            patch(self._P_PERSIST, return_value="/tmp/bw-team.key") as mock_persistent,
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        mock_persistent.assert_called_once_with("FAKE_TEAM_KEY")
+        app.terminal_service.launch_ssh_in_terminal.assert_called_once()
+
+    def test_local_match_uses_existing_ssh_service_path(self):
+        """When resolver returns local source, BW is not involved and terminal launched."""
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_LOCAL_RESOLVED),
+            patch(self._P_PERSIST) as mock_persistent,
+            patch(self._P_BW_KEY) as mock_bw,
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        mock_persistent.assert_not_called()
+        mock_bw.assert_not_called()
+        app.terminal_service.launch_ssh_in_terminal.assert_called_once()
+
+    def test_no_match_notifies_user(self):
+        """When resolver returns None, user gets a warning and terminal is not launched."""
+        app = _make_connect_app()
+
+        with patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=None):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        app.terminal_service.launch_ssh_in_terminal.assert_not_called()
+        sevs = [n["severity"] for n in app._notifications]
+        assert "warning" in sevs
+
+    def test_bw_cli_missing_surfaces_friendly_error(self):
+        """BwCliMissingError from BwResolver -> notify error, no terminal launch."""
+        from servonaut.services.bw_resolver import BwCliMissingError
+
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_PERSONAL_RESOLVED),
+            patch(self._P_BW_KEY, side_effect=BwCliMissingError("bw not found")),
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        app.terminal_service.launch_ssh_in_terminal.assert_not_called()
+        sevs = [n["severity"] for n in app._notifications]
+        assert "error" in sevs
+        msgs = [n["message"] for n in app._notifications]
+        assert any("Bitwarden CLI" in m for m in msgs)
+
+    def test_bw_session_locked_surfaces_friendly_error(self):
+        """BwSessionMissingError -> notify error mentioning 'bw unlock'."""
+        from servonaut.services.bw_resolver import BwSessionMissingError
+
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_PERSONAL_RESOLVED),
+            patch(self._P_BW_KEY, side_effect=BwSessionMissingError("vault locked")),
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        app.terminal_service.launch_ssh_in_terminal.assert_not_called()
+        msgs = [n["message"] for n in app._notifications]
+        assert any("bw unlock" in m for m in msgs)
+
+    def test_bw_item_not_found_surfaces_friendly_error(self):
+        """BwItemNotFoundError -> notify error mentioning item UUID."""
+        from servonaut.services.bw_resolver import BwItemNotFoundError
+
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_PERSONAL_RESOLVED),
+            patch(self._P_BW_KEY, side_effect=BwItemNotFoundError("not found")),
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        app.terminal_service.launch_ssh_in_terminal.assert_not_called()
+        msgs = [n["message"] for n in app._notifications]
+        assert any("item" in m.lower() for m in msgs)
+
+    def test_resolver_called_only_once_per_action(self):
+        """SshRefResolver.resolve is invoked exactly once per connect action."""
+        app = _make_connect_app()
+
+        with patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=None) as mock_resolve:
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        mock_resolve.assert_awaited_once()
+
+    def test_tier_notification_includes_source_name(self):
+        """Notification message names the tier that resolved the credential."""
+        app = _make_connect_app()
+
+        with patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_LOCAL_RESOLVED):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        msgs = [n["message"] for n in app._notifications]
+        assert any("local" in m.lower() for m in msgs)
+
+    def test_personal_notification_names_personal_tier(self):
+        """Notification says 'personal' when BW personal ref was used."""
+        app = _make_connect_app()
+
+        with (
+            patch(self._P_RESOLVE, new_callable=AsyncMock, return_value=_PERSONAL_RESOLVED),
+            patch(self._P_BW_KEY, return_value="KEY"),
+            patch(self._P_PERSIST, return_value="/tmp/bw-fake.key"),
+        ):
+            screen = _make_connect_screen(app=app)
+            self._run_flow(screen)
+
+        msgs = [n["message"] for n in app._notifications]
+        assert any("personal" in m.lower() for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# SshRefEditorModal — unit tests
+# ---------------------------------------------------------------------------
+
+class _FakeModalApp:
+    """Minimal app double for SshRefEditorModal tests."""
+
+    def __init__(self, bw_service=None):
+        self.bw_ssh_config_service = bw_service
+        self._notifications = []
+
+    def notify(self, message, *, severity="information", markup=True, timeout=None):
+        self._notifications.append({"message": message, "severity": severity})
+
+    def run_worker(self, *args, **kwargs):
+        pass
+
+
+def _make_modal(instance=None, existing_ref=None, app=None):
+    """Build SshRefEditorModal without mounting."""
+    from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+    inst = instance or _make_instance()
+    modal = SshRefEditorModal.__new__(SshRefEditorModal)
+    modal._instance = inst
+    modal._existing_ref = existing_ref
+    modal._edit_mode = existing_ref is not None
+    modal._dismissed_with = None
+    if app is not None:
+        modal.__class__ = type(
+            "PatchedSshRefEditorModal",
+            (SshRefEditorModal,),
+            {"app": property(lambda self: app)},
+        )
+    return modal
+
+
+class TestSshRefEditorModal:
+    """Unit tests for SshRefEditorModal — no Textual pilot required."""
+
+    def test_inherits_from_modal_screen(self):
+        from textual.screen import ModalScreen
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        assert issubclass(SshRefEditorModal, ModalScreen)
+
+    def test_generic_param_is_bool(self):
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        bases = getattr(SshRefEditorModal, "__orig_bases__", [])
+        base_strs = [str(b) for b in bases]
+        assert any("bool" in s for s in base_strs), (
+            f"Expected ModalScreen[bool] in bases; got {base_strs}"
+        )
+
+    def test_add_mode_no_existing_ref(self):
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        inst = _make_instance()
+        modal = SshRefEditorModal(inst, existing_ref=None)
+        assert modal._edit_mode is False
+
+    def test_edit_mode_with_existing_ref(self):
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        inst = _make_instance()
+        existing = {"ssh_credential_ref": {"item_id": "bw-uuid-123"}}
+        modal = SshRefEditorModal(inst, existing_ref=existing)
+        assert modal._edit_mode is True
+
+    def test_escape_binding_exists(self):
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        keys = [b.key for b in SshRefEditorModal.BINDINGS]
+        assert "escape" in keys
+
+    def test_save_empty_item_id_notifies_error_no_api_call(self):
+        """Save with empty item_id → error notify, no API call."""
+        bw = MagicMock()
+        bw.put_personal_instance_ref = AsyncMock()
+        fake_app = _FakeModalApp(bw_service=bw)
+        modal = _make_modal(app=fake_app)
+
+        # Patch Input query
+        item_input = MagicMock()
+        item_input.value = ""
+        collection_input = MagicMock()
+        collection_input.value = ""
+        vault_input = MagicMock()
+        vault_input.value = ""
+
+        def _query_one(selector, widget_type=None):
+            if "#item_id" in selector:
+                return item_input
+            if "#collection_id" in selector:
+                return collection_input
+            if "#vault_url" in selector:
+                return vault_input
+            raise ValueError(selector)
+
+        modal.query_one = _query_one
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_save())
+
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "error" in sevs
+        bw.put_personal_instance_ref.assert_not_awaited()
+        modal.dismiss.assert_not_called()
+
+    def test_save_success_calls_put_with_correct_body(self):
+        """Save with valid item_id → PUT called with ssh_credential_ref body."""
+        bw = MagicMock()
+        bw.put_personal_instance_ref = AsyncMock(return_value={})
+        fake_app = _FakeModalApp(bw_service=bw)
+        inst = _make_instance(instance_id="i-abc123", provider="aws")
+        modal = _make_modal(instance=inst, app=fake_app)
+
+        item_input = MagicMock()
+        item_input.value = "11111111-2222-3333-4444-555555555555"
+        collection_input = MagicMock()
+        collection_input.value = ""
+        vault_input = MagicMock()
+        vault_input.value = ""
+
+        def _query_one(selector, widget_type=None):
+            if "#item_id" in selector:
+                return item_input
+            if "#collection_id" in selector:
+                return collection_input
+            if "#vault_url" in selector:
+                return vault_input
+            raise ValueError(selector)
+
+        modal.query_one = _query_one
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_save())
+
+        bw.put_personal_instance_ref.assert_awaited_once()
+        call_kwargs = bw.put_personal_instance_ref.call_args
+        assert call_kwargs.kwargs["ssh_credential_ref"]["item_id"] == "11111111-2222-3333-4444-555555555555"
+        assert "ref" not in call_kwargs.kwargs  # never use 'ref' field directly
+        modal.dismiss.assert_called_once_with(True)
+
+    def test_save_optional_fields_included_when_set(self):
+        """Collection ID and vault URL are included in ssh_credential_ref when set."""
+        bw = MagicMock()
+        bw.put_personal_instance_ref = AsyncMock(return_value={})
+        fake_app = _FakeModalApp(bw_service=bw)
+        modal = _make_modal(app=fake_app)
+
+        item_input = MagicMock()
+        item_input.value = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        collection_input = MagicMock()
+        collection_input.value = "col-abc"
+        vault_input = MagicMock()
+        vault_input.value = "https://vault.example.com"
+
+        def _query_one(selector, widget_type=None):
+            if "#item_id" in selector:
+                return item_input
+            if "#collection_id" in selector:
+                return collection_input
+            if "#vault_url" in selector:
+                return vault_input
+            raise ValueError(selector)
+
+        modal.query_one = _query_one
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_save())
+
+        call_kwargs = bw.put_personal_instance_ref.call_args
+        ref = call_kwargs.kwargs["ssh_credential_ref"]
+        assert ref["collection_id"] == "col-abc"
+        assert ref["vault_url"] == "https://vault.example.com"
+
+    def test_save_402_notifies_warning_modal_stays_open(self):
+        """402 → warning notify, dismiss NOT called (modal stays open)."""
+        from servonaut.services.api_client import APIError
+        exc = APIError(code="payment_required", message="Upgrade required", status=402)
+        bw = MagicMock()
+        bw.put_personal_instance_ref = AsyncMock(side_effect=exc)
+        fake_app = _FakeModalApp(bw_service=bw)
+        modal = _make_modal(app=fake_app)
+
+        item_input = MagicMock()
+        item_input.value = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        collection_input = MagicMock()
+        collection_input.value = ""
+        vault_input = MagicMock()
+        vault_input.value = ""
+
+        def _query_one(selector, widget_type=None):
+            if "#item_id" in selector:
+                return item_input
+            if "#collection_id" in selector:
+                return collection_input
+            if "#vault_url" in selector:
+                return vault_input
+            raise ValueError(selector)
+
+        modal.query_one = _query_one
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_save())
+
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "warning" in sevs
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert any("/pricing" in m for m in msgs)
+        modal.dismiss.assert_not_called()
+
+    def test_save_422_notifies_server_message_verbatim(self):
+        """422 → server error message notified verbatim."""
+        from servonaut.services.api_client import APIError
+        server_msg = "item_id must be a valid UUID"
+        exc = APIError(code="unprocessable", message=server_msg, status=422)
+        bw = MagicMock()
+        bw.put_personal_instance_ref = AsyncMock(side_effect=exc)
+        fake_app = _FakeModalApp(bw_service=bw)
+        modal = _make_modal(app=fake_app)
+
+        item_input = MagicMock()
+        item_input.value = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        collection_input = MagicMock()
+        collection_input.value = ""
+        vault_input = MagicMock()
+        vault_input.value = ""
+
+        def _query_one(selector, widget_type=None):
+            if "#item_id" in selector:
+                return item_input
+            if "#collection_id" in selector:
+                return collection_input
+            if "#vault_url" in selector:
+                return vault_input
+            raise ValueError(selector)
+
+        modal.query_one = _query_one
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_save())
+
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert server_msg in msgs
+
+    def test_delete_calls_delete_api_and_dismisses_true(self):
+        """Delete → calls delete_personal_instance_ref, dismisses True."""
+        bw = MagicMock()
+        bw.delete_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeModalApp(bw_service=bw)
+        inst = _make_instance(instance_id="i-abc123", provider="aws")
+        existing = {"ssh_credential_ref": {"item_id": "bw-uuid"}}
+        modal = _make_modal(instance=inst, existing_ref=existing, app=fake_app)
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_delete())
+
+        bw.delete_personal_instance_ref.assert_awaited_once_with(
+            provider="aws",
+            instance_id="i-abc123",
+        )
+        modal.dismiss.assert_called_once_with(True)
+
+    def test_delete_api_error_notifies_and_stays_open(self):
+        """Delete API error → notify error, dismiss not called."""
+        from servonaut.services.api_client import APIError
+        exc = APIError(code="not_found", message="Ref not found", status=404)
+        bw = MagicMock()
+        bw.delete_personal_instance_ref = AsyncMock(side_effect=exc)
+        fake_app = _FakeModalApp(bw_service=bw)
+        modal = _make_modal(app=fake_app)
+        modal.dismiss = MagicMock()
+
+        _run(modal._do_delete())
+
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "error" in sevs
+        modal.dismiss.assert_not_called()
+
+    def test_cancel_action_dismisses_false(self):
+        """action_cancel (ESC binding) dismisses with False."""
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        modal = SshRefEditorModal(_make_instance())
+        modal.dismiss = MagicMock()
+        modal.action_cancel()
+        modal.dismiss.assert_called_once_with(False)
+
+
+# ---------------------------------------------------------------------------
+# ServerActionsScreen.action_manage_ssh_ref — integration
+# ---------------------------------------------------------------------------
+
+class TestManageSshRefAction:
+    def test_manage_ssh_ref_binding_registered(self):
+        """'r' binding for action_manage_ssh_ref must be in BINDINGS."""
+        keys = [b.key for b in ServerActionsScreen.BINDINGS]
+        assert "r" in keys, f"Expected 'r' in BINDINGS; got {keys}"
+
+    def test_action_manage_ssh_ref_method_exists(self):
+        assert hasattr(ServerActionsScreen, "action_manage_ssh_ref")
+        assert callable(ServerActionsScreen.action_manage_ssh_ref)
+
+    def test_manage_ssh_ref_flow_method_exists(self):
+        assert hasattr(ServerActionsScreen, "_manage_ssh_ref_flow")
+
+    def test_no_bw_service_shows_warning(self):
+        """When bw_ssh_config_service is absent, shows warning."""
+        fake_app = _FakeApp(bw_service=None)
+        screen = _make_screen(app=fake_app)
+        _run(screen._manage_ssh_ref_flow())
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "warning" in sevs
+
+    def test_pushes_modal_in_add_mode_when_no_existing_ref(self):
+        """When no ref exists, SshRefEditorModal pushed in add mode."""
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._manage_ssh_ref_flow())
+        assert len(fake_app._pushed_screens) == 1
+        modal = fake_app._pushed_screens[0]
+        assert isinstance(modal, SshRefEditorModal)
+        assert modal._edit_mode is False
+
+    def test_pushes_modal_in_edit_mode_when_ref_exists(self):
+        """When ref exists, SshRefEditorModal pushed in edit mode."""
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        ref_row = {"ssh_credential_ref": {"item_id": "bw-existing"}}
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=ref_row)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._manage_ssh_ref_flow())
+        assert len(fake_app._pushed_screens) == 1
+        modal = fake_app._pushed_screens[0]
+        assert isinstance(modal, SshRefEditorModal)
+        assert modal._edit_mode is True
+
+
+# ---------------------------------------------------------------------------
+# ConfirmSshVerifyModal no-ref path now pushes SshRefEditorModal
+# ---------------------------------------------------------------------------
+
+class TestVerifySshNoRefPathPushesEditorModal:
+    def test_no_ref_confirmed_pushes_ssh_ref_editor(self):
+        """When has_ref=False and user confirms, SshRefEditorModal is pushed."""
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        # Two pushes: ConfirmSshVerifyModal first, then SshRefEditorModal
+        assert len(fake_app._pushed_screens) == 2
+        assert isinstance(fake_app._pushed_screens[0], ConfirmSshVerifyModal)
+        assert isinstance(fake_app._pushed_screens[1], SshRefEditorModal)
+
+    def test_no_ref_confirmed_does_not_show_stub_notify(self):
+        """The old 'not yet implemented' stub notify must NOT appear."""
+        bw = MagicMock()
+        bw.get_personal_instance_ref = AsyncMock(return_value=None)
+        fake_app = _FakeApp(bw_service=bw)
+        screen = _make_screen(app=fake_app)
+        _run(screen._verify_ssh_flow())
+        msgs = [n["message"] for n in fake_app._notifications]
+        assert not any("not yet implemented" in m for m in msgs)

--- a/tests/test_settings_screen_bw_ssh.py
+++ b/tests/test_settings_screen_bw_ssh.py
@@ -1,0 +1,529 @@
+"""Tests for the Bitwarden SSH Vault section in SettingsScreen.
+
+Covers:
+- Status line renders "Not configured" when get_personal_config returns None
+- Status line renders "Configured" when a config is returned
+- Edit button reveals the form
+- Cancel button hides the form without an API call
+- Save with empty vault_url: notify error, no API call
+- Save with invalid URL (no http/https prefix): notify error, no API call
+- Save success: calls put_personal_config with correct body, hides form
+- Save 402: notify warning, form stays open
+- Save generic error: notify verbatim (markup=False)
+- Provider is locked to BITWARDEN_PM_PROVIDER in the PUT body
+- Re-rendering after save shows the new vault_url in the status line
+- Demo-mode: vault_url is redacted in the status line when demo_mode=True
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.screens.settings import SettingsScreen
+from servonaut.services.api_client import APIError
+from servonaut.services.bw_ssh_config_service import BITWARDEN_PM_PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeWidget:
+    """Minimal stand-in for a Textual Static / Input / Button widget."""
+
+    def __init__(self, value: str = "", display: bool = True) -> None:
+        self.value = value
+        self.display = display
+        self._updates: list[str] = []
+        self.disabled = False
+
+    def update(self, markup: str) -> None:
+        self._updates.append(markup)
+
+    def focus(self) -> None:
+        pass
+
+    @property
+    def last_update(self) -> str:
+        return self._updates[-1] if self._updates else ""
+
+
+class _FakeScreen:
+    """Duck-typed stand-in for SettingsScreen targeting BW SSH vault methods.
+
+    All BW SSH vault methods from SettingsScreen are called via
+    ``SettingsScreen.<method>(self_fake, ...)`` so they receive the right
+    ``self`` without relying on MRO binding.
+    """
+
+    def __init__(
+        self,
+        *,
+        bw_config: Optional[Dict[str, Any]] = None,
+        put_result: Optional[Dict[str, Any]] = None,
+        put_exc: Optional[Exception] = None,
+        demo_mode: bool = False,
+        vault_url_input_value: str = "",
+        collection_input_value: str = "",
+    ) -> None:
+        self._bw_ssh_config: Optional[Dict[str, Any]] = bw_config
+
+        # Fake widgets
+        self._status_widget = _FakeWidget()
+        self._form_container = _FakeWidget(display=False)
+        self._vault_url_input = _FakeWidget(value=vault_url_input_value)
+        self._collection_input = _FakeWidget(value=collection_input_value)
+
+        # Capture notify calls
+        self._notifications: list[dict] = []
+
+        # Build service mock
+        svc = MagicMock()
+        svc.get_personal_config = AsyncMock(return_value=bw_config)
+        if put_exc is not None:
+            svc.put_personal_config = AsyncMock(side_effect=put_exc)
+        else:
+            svc.put_personal_config = AsyncMock(return_value=put_result or {})
+
+        # Build app mock
+        app = MagicMock()
+        app.bw_ssh_config_service = svc
+        app.demo_mode = demo_mode
+        app.redaction_service = MagicMock() if demo_mode else None
+        app.notify = self._capture_notify
+        self.app = app
+
+    def _capture_notify(
+        self,
+        message: str,
+        *,
+        severity: str = "information",
+        markup: bool = True,
+    ) -> None:
+        self._notifications.append(
+            {"message": message, "severity": severity, "markup": markup}
+        )
+
+    def query_one(self, selector: str, widget_type: type = None) -> Any:
+        mapping = {
+            "#bw_ssh_vault_status": self._status_widget,
+            "#bw_ssh_vault_form": self._form_container,
+            "#bw_ssh_vault_url": self._vault_url_input,
+            "#bw_ssh_default_collection_id": self._collection_input,
+        }
+        widget = mapping.get(selector)
+        if widget is None:
+            raise LookupError(f"No fake widget for selector {selector!r}")
+        return widget
+
+    def run_worker(
+        self, coro, *, group: str = "", name: str = "", exclusive: bool = False
+    ) -> None:
+        """Run the coroutine synchronously in tests (no Textual event loop).
+
+        Uses ``asyncio.run`` rather than ``get_event_loop().run_until_complete``
+        so each invocation gets a fresh loop — prior tests in the suite that
+        close/exhaust the default loop don't pollute this one.
+        """
+        asyncio.run(coro)
+
+    # Wire in the real async worker method so _save_bw_ssh_config can
+    # call self._do_save_bw_ssh_config(...) correctly.
+    _do_save_bw_ssh_config = SettingsScreen._do_save_bw_ssh_config
+    _refresh_bw_ssh_status = SettingsScreen._refresh_bw_ssh_status
+    _hide_bw_ssh_form = SettingsScreen._hide_bw_ssh_form
+
+
+# Shortcuts so tests can call the real method with the fake self.
+
+def _refresh_status(fake: _FakeScreen) -> None:
+    SettingsScreen._refresh_bw_ssh_status(fake)  # type: ignore[arg-type]
+
+
+def _show_form(fake: _FakeScreen) -> None:
+    SettingsScreen._show_bw_ssh_form(fake)  # type: ignore[arg-type]
+
+
+def _hide_form(fake: _FakeScreen) -> None:
+    SettingsScreen._hide_bw_ssh_form(fake)  # type: ignore[arg-type]
+
+
+def _save(fake: _FakeScreen) -> None:
+    SettingsScreen._save_bw_ssh_config(fake)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Status line rendering
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultStatusLine:
+    def test_not_configured_when_none(self) -> None:
+        fake = _FakeScreen(bw_config=None)
+        _refresh_status(fake)
+        assert "Not configured" in fake._status_widget.last_update
+
+    def test_configured_shows_vault_url(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {"vault_url": "https://vault.example.com"},
+                "updated_at": "2026-05-01T12:00:00Z",
+            }
+        )
+        _refresh_status(fake)
+        assert "Configured" in fake._status_widget.last_update
+        assert "https://vault.example.com" in fake._status_widget.last_update
+
+    def test_configured_shows_updated_at(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {"vault_url": "https://vault.example.com"},
+                "updated_at": "2026-05-01T12:00:00Z",
+            }
+        )
+        _refresh_status(fake)
+        assert "2026-05-01T12:00:00Z" in fake._status_widget.last_update
+
+    def test_configured_without_updated_at_still_shows_configured(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {"vault_url": "https://vault.example.com"},
+            }
+        )
+        _refresh_status(fake)
+        assert "Configured" in fake._status_widget.last_update
+        assert "https://vault.example.com" in fake._status_widget.last_update
+
+
+# ---------------------------------------------------------------------------
+# Demo-mode redaction
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultDemoMode:
+    def test_vault_url_redacted_in_demo_mode(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {"vault_url": "https://internal-vault.corp.example.com"},
+                "updated_at": "2026-05-01T12:00:00Z",
+            },
+            demo_mode=True,
+        )
+        _refresh_status(fake)
+        last = fake._status_widget.last_update
+        assert "internal-vault.corp.example.com" not in last
+        assert "[redacted]" in last
+
+    def test_vault_url_shown_when_demo_mode_false(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {"vault_url": "https://vault.example.com"},
+                "updated_at": "2026-05-01T12:00:00Z",
+            },
+            demo_mode=False,
+        )
+        _refresh_status(fake)
+        last = fake._status_widget.last_update
+        assert "vault.example.com" in last
+        assert "[redacted]" not in last
+
+
+# ---------------------------------------------------------------------------
+# Form visibility
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultFormVisibility:
+    def test_edit_reveals_form(self) -> None:
+        fake = _FakeScreen(bw_config=None)
+        assert fake._form_container.display is False
+        _show_form(fake)
+        assert fake._form_container.display is True
+
+    def test_edit_populates_vault_url_from_config(self) -> None:
+        fake = _FakeScreen(
+            bw_config={
+                "provider": "bitwarden_pm",
+                "config": {
+                    "vault_url": "https://vault.example.com",
+                    "default_collection_id": "col-abc",
+                },
+            }
+        )
+        _show_form(fake)
+        assert fake._vault_url_input.value == "https://vault.example.com"
+        assert fake._collection_input.value == "col-abc"
+
+    def test_edit_blank_inputs_when_not_configured(self) -> None:
+        fake = _FakeScreen(bw_config=None)
+        _show_form(fake)
+        assert fake._vault_url_input.value == ""
+        assert fake._collection_input.value == ""
+
+    def test_cancel_hides_form(self) -> None:
+        fake = _FakeScreen(bw_config=None)
+        fake._form_container.display = True
+        _hide_form(fake)
+        assert fake._form_container.display is False
+
+    def test_cancel_makes_no_api_call(self) -> None:
+        fake = _FakeScreen(bw_config=None)
+        fake._form_container.display = True
+        _hide_form(fake)
+        fake.app.bw_ssh_config_service.put_personal_config.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultValidation:
+    def test_empty_vault_url_triggers_error_notify(self) -> None:
+        fake = _FakeScreen(vault_url_input_value="")
+        fake._form_container.display = True
+        _save(fake)
+        assert any(n["severity"] == "error" for n in fake._notifications)
+
+    def test_empty_vault_url_keeps_form_open(self) -> None:
+        fake = _FakeScreen(vault_url_input_value="")
+        fake._form_container.display = True
+        _save(fake)
+        assert fake._form_container.display is True
+
+    def test_empty_vault_url_no_api_call(self) -> None:
+        fake = _FakeScreen(vault_url_input_value="")
+        _save(fake)
+        fake.app.bw_ssh_config_service.put_personal_config.assert_not_called()
+
+    def test_url_without_http_prefix_triggers_error(self) -> None:
+        fake = _FakeScreen(vault_url_input_value="vault.example.com")
+        _save(fake)
+        assert any(n["severity"] == "error" for n in fake._notifications)
+        fake.app.bw_ssh_config_service.put_personal_config.assert_not_called()
+
+    def test_http_prefix_is_accepted(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "http://local.vault"},
+        }
+        fake = _FakeScreen(put_result=result, vault_url_input_value="http://local.vault")
+        fake._form_container.display = True
+        _save(fake)
+        fake.app.bw_ssh_config_service.put_personal_config.assert_called_once()
+
+    def test_https_prefix_is_accepted(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+        }
+        fake = _FakeScreen(
+            put_result=result, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        fake.app.bw_ssh_config_service.put_personal_config.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Save success
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultSaveSuccess:
+    def test_save_success_hides_form(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+            "updated_at": "2026-05-01T12:00:00Z",
+        }
+        fake = _FakeScreen(
+            put_result=result, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert fake._form_container.display is False
+
+    def test_save_success_status_shows_configured(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+            "updated_at": "2026-05-01T12:00:00Z",
+        }
+        fake = _FakeScreen(
+            put_result=result, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        last = fake._status_widget.last_update
+        assert "Configured" in last
+        assert "https://vault.example.com" in last
+
+    def test_save_uses_bitwarden_pm_provider(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+        }
+        fake = _FakeScreen(
+            put_result=result, vault_url_input_value="https://vault.example.com"
+        )
+        _save(fake)
+        kwargs = fake.app.bw_ssh_config_service.put_personal_config.call_args.kwargs
+        assert kwargs.get("provider") == BITWARDEN_PM_PROVIDER
+
+    def test_save_passes_vault_url(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+        }
+        fake = _FakeScreen(
+            put_result=result, vault_url_input_value="https://vault.example.com"
+        )
+        _save(fake)
+        kwargs = fake.app.bw_ssh_config_service.put_personal_config.call_args.kwargs
+        assert kwargs.get("vault_url") == "https://vault.example.com"
+
+    def test_save_passes_none_for_empty_collection_id(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+        }
+        fake = _FakeScreen(
+            put_result=result,
+            vault_url_input_value="https://vault.example.com",
+            collection_input_value="",
+        )
+        _save(fake)
+        kwargs = fake.app.bw_ssh_config_service.put_personal_config.call_args.kwargs
+        assert kwargs.get("default_collection_id") is None
+
+    def test_save_passes_collection_id_when_provided(self) -> None:
+        result = {
+            "provider": "bitwarden_pm",
+            "config": {
+                "vault_url": "https://vault.example.com",
+                "default_collection_id": "col-123",
+            },
+        }
+        fake = _FakeScreen(
+            put_result=result,
+            vault_url_input_value="https://vault.example.com",
+            collection_input_value="col-123",
+        )
+        _save(fake)
+        kwargs = fake.app.bw_ssh_config_service.put_personal_config.call_args.kwargs
+        assert kwargs.get("default_collection_id") == "col-123"
+
+
+# ---------------------------------------------------------------------------
+# 402 gate
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultSave402:
+    def test_402_notifies_warning(self) -> None:
+        exc = APIError(
+            code="payment_required",
+            message="Payment required",
+            status=402,
+        )
+        fake = _FakeScreen(
+            put_exc=exc, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert any(n["severity"] == "warning" for n in fake._notifications)
+
+    def test_402_form_stays_open(self) -> None:
+        exc = APIError(
+            code="payment_required",
+            message="Payment required",
+            status=402,
+        )
+        fake = _FakeScreen(
+            put_exc=exc, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert fake._form_container.display is True
+
+    def test_402_message_mentions_paid_plan(self) -> None:
+        exc = APIError(
+            code="payment_required",
+            message="Payment required",
+            status=402,
+        )
+        fake = _FakeScreen(
+            put_exc=exc, vault_url_input_value="https://vault.example.com"
+        )
+        _save(fake)
+        warning_msgs = [
+            n["message"]
+            for n in fake._notifications
+            if n["severity"] == "warning"
+        ]
+        assert any("paid plan" in m or "Upgrade" in m for m in warning_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Generic / network errors
+# ---------------------------------------------------------------------------
+
+
+class TestBwSshVaultSaveGenericError:
+    def test_generic_api_error_notifies_error(self) -> None:
+        exc = APIError(
+            code="internal_error",
+            message="Internal Server Error",
+            status=500,
+        )
+        fake = _FakeScreen(
+            put_exc=exc, vault_url_input_value="https://vault.example.com"
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert any(n["severity"] == "error" for n in fake._notifications)
+
+    def test_generic_api_error_markup_false(self) -> None:
+        exc = APIError(
+            code="internal_error",
+            message="Internal Server Error",
+            status=500,
+        )
+        fake = _FakeScreen(
+            put_exc=exc, vault_url_input_value="https://vault.example.com"
+        )
+        _save(fake)
+        for n in fake._notifications:
+            if n["severity"] == "error":
+                assert n["markup"] is False, (
+                    f"Expected markup=False on error notify, got {n!r}"
+                )
+
+    def test_network_error_notifies_error(self) -> None:
+        fake = _FakeScreen(
+            put_exc=OSError("Network unreachable"),
+            vault_url_input_value="https://vault.example.com",
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert any(n["severity"] == "error" for n in fake._notifications)
+
+    def test_network_error_form_stays_open(self) -> None:
+        fake = _FakeScreen(
+            put_exc=OSError("Network unreachable"),
+            vault_url_input_value="https://vault.example.com",
+        )
+        fake._form_container.display = True
+        _save(fake)
+        assert fake._form_container.display is True

--- a/tests/test_ssh_ref_resolver.py
+++ b/tests/test_ssh_ref_resolver.py
@@ -1,0 +1,342 @@
+"""Tests for SshRefResolver — three-tier SSH credential resolution chain."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.services.api_client import APIClient, APIError
+from servonaut.services.bw_ssh_config_service import BwSshConfigService
+from servonaut.services.team_service import TeamService
+from servonaut.services.ssh_ref_resolver import ResolvedSshRef, SshRefResolver
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    return asyncio.run(coro)
+
+
+def _api_error(status: int, code: str = "not_found") -> APIError:
+    return APIError(code=code, message="boom", status=status)
+
+
+def _aws_instance(iid: str = "i-0abc", key_name: str = "my-key") -> dict:
+    return {
+        "id": iid,
+        "name": "prod-server",
+        "provider": "aws",
+        "key_name": key_name,
+        "public_ip": "1.2.3.4",
+    }
+
+
+def _shared_instance(
+    iid: str = "srv-1",
+    slug: str = "my-team",
+    server_id: str = "srv-1",
+) -> dict:
+    return {
+        "id": iid,
+        "name": "shared-server",
+        "provider": "aws",
+        "is_shared": True,
+        "team_slug": slug,
+        "shared_server_id": server_id,
+        "public_ip": "2.3.4.5",
+    }
+
+
+def _make_resolver(
+    bw_get_ref=None,
+    team_get_ref=None,
+    ssh_key_path: Optional[str] = None,
+    ssh_discover: Optional[str] = None,
+    teams: Optional[List[dict]] = None,
+) -> SshRefResolver:
+    """Build a SshRefResolver with mocked sub-services."""
+    bw_svc = MagicMock(spec=BwSshConfigService)
+    bw_svc.get_personal_instance_ref = AsyncMock(
+        return_value=bw_get_ref if bw_get_ref is not None else None
+    )
+
+    team_svc = MagicMock(spec=TeamService)
+    team_svc.get_team_server_ssh_ref = AsyncMock(
+        return_value=team_get_ref if team_get_ref is not None else None
+    )
+
+    ssh_svc = MagicMock()
+    ssh_svc.get_key_path = MagicMock(return_value=ssh_key_path)
+    ssh_svc.discover_key = MagicMock(return_value=ssh_discover)
+
+    teams_supplier = (lambda: teams) if teams is not None else None
+
+    return SshRefResolver(
+        bw_ssh_config_service=bw_svc,
+        team_service=team_svc,
+        ssh_service=ssh_svc,
+        teams_supplier=teams_supplier,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — personal
+# ---------------------------------------------------------------------------
+
+class TestPersonalTier:
+    def test_personal_hit_returns_resolved_ref_with_item_id(self):
+        """Personal tier hit → ResolvedSshRef(source='personal', item_id=…)."""
+        payload = {
+            "ssh_credential_provider": "bitwarden_pm",
+            "ssh_credential_ref": {
+                "item_id": "uuid-personal",
+                "vault_url": "https://vault.bitwarden.com",
+                "collection_id": "col-1",
+            },
+        }
+        resolver = _make_resolver(bw_get_ref=payload)
+        result = _run(resolver.resolve(_aws_instance()))
+        assert result is not None
+        assert result.source == "personal"
+        assert result.item_id == "uuid-personal"
+        assert result.vault_url == "https://vault.bitwarden.com"
+        assert result.collection_id == "col-1"
+        assert result.local_key_path is None
+        assert result.team_slug is None
+
+    def test_personal_404_cascades_to_next_tier(self):
+        """Personal tier returning None (404) → falls through to local tier."""
+        resolver = _make_resolver(
+            bw_get_ref=None,  # simulates 404
+            ssh_key_path="/home/user/.ssh/my-key.pem",
+        )
+        result = _run(resolver.resolve(_aws_instance()))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == "/home/user/.ssh/my-key.pem"
+
+    def test_personal_api_error_logs_warning_and_cascades(self, caplog):
+        """403/5xx from personal tier: logs WARNING, chain continues."""
+        bw_svc = MagicMock(spec=BwSshConfigService)
+        bw_svc.get_personal_instance_ref = AsyncMock(
+            side_effect=_api_error(403, "forbidden")
+        )
+        ssh_svc = MagicMock()
+        ssh_svc.get_key_path = MagicMock(return_value="/ssh/fallback-key")
+        ssh_svc.discover_key = MagicMock(return_value=None)
+
+        resolver = SshRefResolver(
+            bw_ssh_config_service=bw_svc,
+            team_service=MagicMock(spec=TeamService),
+            ssh_service=ssh_svc,
+            teams_supplier=None,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="servonaut.services.ssh_ref_resolver"):
+            result = _run(resolver.resolve(_aws_instance()))
+
+        assert result is not None
+        assert result.source == "local"
+        # A WARNING must have been emitted for the 403
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("403" in r.message or "personal" in r.message.lower() for r in warning_records), \
+            f"Expected a warning about the 403; got: {[r.message for r in warning_records]}"
+
+    def test_custom_server_no_provider_skips_personal_tier(self):
+        """Custom servers (no 'provider' key) silently skip personal tier."""
+        custom_inst = {
+            "id": "my-vps",
+            "name": "vps-1",
+            "is_custom": True,
+            "public_ip": "3.4.5.6",
+        }
+        resolver = _make_resolver(
+            bw_get_ref={"ssh_credential_ref": {"item_id": "should-not-be-used"}},
+            ssh_key_path="/ssh/vps-key",
+        )
+        # bw service should NOT be called for custom instance
+        result = _run(resolver.resolve(custom_inst))
+        assert result is not None
+        assert result.source == "local"
+        resolver._bw.get_personal_instance_ref.assert_not_awaited()
+
+    def test_invalid_provider_skips_personal_tier_no_propagation(self):
+        """Unknown provider (e.g. 'gcp') → validation silently skips tier."""
+        gcp_inst = {
+            "id": "gcp-1234",
+            "name": "gcp-instance",
+            "provider": "gcp",  # not in {aws, ovh, hetzner}
+            "public_ip": "5.6.7.8",
+        }
+        resolver = _make_resolver(ssh_key_path="/ssh/gcp-key")
+        result = _run(resolver.resolve(gcp_inst))
+        assert result is not None
+        assert result.source == "local"
+        resolver._bw.get_personal_instance_ref.assert_not_awaited()
+
+    def test_invalid_instance_id_skips_personal_tier_no_propagation(self):
+        """Invalid instance_id (path-traversal chars) → validation skips tier."""
+        bad_inst = {
+            "id": "../../etc/passwd",
+            "name": "bad-instance",
+            "provider": "aws",
+            "public_ip": "1.2.3.4",
+        }
+        resolver = _make_resolver(ssh_key_path="/ssh/local-key")
+        result = _run(resolver.resolve(bad_inst))
+        # Should not crash, should fall through to local
+        assert result is not None
+        assert result.source == "local"
+        resolver._bw.get_personal_instance_ref.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — team
+# ---------------------------------------------------------------------------
+
+class TestTeamTier:
+    def test_team_hit_when_instance_is_shared(self):
+        """Shared instance with team BW ref → ResolvedSshRef(source='team')."""
+        payload = {
+            "ssh_credential_ref": {
+                "item_id": "uuid-team",
+                "vault_url": "https://vault.bitwarden.com",
+            }
+        }
+        inst = _shared_instance(slug="my-team", server_id="srv-1")
+        teams = [{"slug": "my-team"}]
+        resolver = _make_resolver(
+            bw_get_ref=None,  # personal 404
+            team_get_ref=payload,
+            teams=teams,
+        )
+        result = _run(resolver.resolve(inst))
+        assert result is not None
+        assert result.source == "team"
+        assert result.item_id == "uuid-team"
+        assert result.team_slug == "my-team"
+        assert result.server_id == "srv-1"
+
+    def test_team_tier_skipped_when_teams_supplier_is_none(self):
+        """No teams_supplier → team tier entirely skipped."""
+        inst = _shared_instance()
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            team_get_ref={"ssh_credential_ref": {"item_id": "uuid-team"}},
+            ssh_key_path="/local/key",
+            teams=None,  # no supplier
+        )
+        result = _run(resolver.resolve(inst))
+        # Should skip team, fall through to local
+        assert result is not None
+        assert result.source == "local"
+        resolver._team_svc.get_team_server_ssh_ref.assert_not_awaited()
+
+    def test_team_tier_walks_multiple_teams_first_match_wins(self):
+        """Multiple teams: first team with a hit wins; others not consulted."""
+        payload = {
+            "ssh_credential_ref": {"item_id": "uuid-team-b"}
+        }
+        inst = _shared_instance(slug="team-b", server_id="s-99")
+        teams = [{"slug": "team-a"}, {"slug": "team-b"}, {"slug": "team-c"}]
+
+        # Only team-b has a ref
+        team_svc = MagicMock(spec=TeamService)
+        team_svc.get_team_server_ssh_ref = AsyncMock(
+            side_effect=lambda slug, sid: (
+                payload if slug == "team-b" else None
+            )
+        )
+
+        bw_svc = MagicMock(spec=BwSshConfigService)
+        bw_svc.get_personal_instance_ref = AsyncMock(return_value=None)
+
+        ssh_svc = MagicMock()
+        ssh_svc.get_key_path = MagicMock(return_value=None)
+        ssh_svc.discover_key = MagicMock(return_value=None)
+
+        resolver = SshRefResolver(
+            bw_ssh_config_service=bw_svc,
+            team_service=team_svc,
+            ssh_service=ssh_svc,
+            teams_supplier=lambda: teams,
+        )
+        result = _run(resolver.resolve(inst))
+        assert result is not None
+        assert result.source == "team"
+        assert result.item_id == "uuid-team-b"
+        assert result.team_slug == "team-b"
+
+    def test_team_tier_not_attempted_for_non_shared_instance(self):
+        """Non-shared instances skip the team tier entirely."""
+        inst = _aws_instance()  # not shared
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            team_get_ref={"ssh_credential_ref": {"item_id": "should-not-be-called"}},
+            ssh_key_path="/local/key",
+            teams=[{"slug": "some-team"}],
+        )
+        result = _run(resolver.resolve(inst))
+        assert result is not None
+        assert result.source == "local"
+        resolver._team_svc.get_team_server_ssh_ref.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — local
+# ---------------------------------------------------------------------------
+
+class TestLocalTier:
+    def test_local_fallback_when_both_api_tiers_return_none(self):
+        """When personal and team return None, local tier is used."""
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path="/home/user/.ssh/id_rsa",
+        )
+        result = _run(resolver.resolve(_aws_instance()))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == "/home/user/.ssh/id_rsa"
+        assert result.item_id is None
+
+    def test_local_discover_key_used_when_get_key_path_is_none(self):
+        """discover_key() is tried when get_key_path() returns None."""
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path=None,
+            ssh_discover="/home/user/.ssh/my-key.pem",
+        )
+        inst = _aws_instance(key_name="my-key")
+        result = _run(resolver.resolve(inst))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == "/home/user/.ssh/my-key.pem"
+
+    def test_returns_none_when_no_tier_resolves(self):
+        """All tiers return None → resolve() returns None."""
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path=None,
+            ssh_discover=None,
+        )
+        result = _run(resolver.resolve(_aws_instance()))
+        assert result is None
+
+    def test_custom_server_may_match_local_tier(self):
+        """Custom server without provider skips personal, but local still works."""
+        custom_inst = {
+            "id": "my-vps",
+            "name": "vps-1",
+            "is_custom": True,
+            "public_ip": "3.4.5.6",
+        }
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path="/ssh/vps-key",
+        )
+        result = _run(resolver.resolve(custom_inst))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == "/ssh/vps-key"

--- a/tests/test_team_service.py
+++ b/tests/test_team_service.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from servonaut.services.api_client import APIClient, APIError
 from servonaut.services.team_service import TeamService, ROLE_PERMISSIONS
 
 
@@ -16,7 +17,8 @@ def run(coro):
 
 @pytest.fixture
 def mock_api():
-    api = MagicMock()
+    # spec=APIClient catches positional json= misuse (APIClient.post/put require json= kwarg)
+    api = MagicMock(spec=APIClient)
     api.get = AsyncMock()
     api.post = AsyncMock()
     api.put = AsyncMock()
@@ -154,6 +156,248 @@ class TestTeamService:
             "/api/v1/teams/team-a/servers",
             json={"name": "web-1", "host": "10.0.0.1"},
         )
+
+
+class TestTeamSshConfig:
+    """Tests for team-side SSH config methods."""
+
+    # --- get_team_ssh_config ---
+
+    def test_get_team_ssh_config_happy_path(self, team_service, mock_api):
+        payload = {
+            "provider": "bitwarden_pm",
+            "config": {"vault_url": "https://vault.example.com"},
+            "team_slug": "team-a",
+            "updated_at": "2026-05-24T00:00:00+00:00",
+        }
+        mock_api.get.return_value = payload
+        result = run(team_service.get_team_ssh_config("team-a"))
+        assert result == payload
+        mock_api.get.assert_called_with("/api/v1/teams/team-a/ssh-config")
+
+    def test_get_team_ssh_config_returns_none_on_404(self, team_service, mock_api):
+        mock_api.get.side_effect = APIError(
+            code="not_found", message="Not configured", status=404
+        )
+        result = run(team_service.get_team_ssh_config("team-a"))
+        assert result is None
+
+    def test_get_team_ssh_config_propagates_non_404(self, team_service, mock_api):
+        mock_api.get.side_effect = APIError(
+            code="server_error", message="Unexpected", status=500
+        )
+        with pytest.raises(APIError) as exc_info:
+            run(team_service.get_team_ssh_config("team-a"))
+        assert exc_info.value.status == 500
+
+    # --- put_team_ssh_config ---
+
+    def test_put_team_ssh_config_body_shape(self, team_service, mock_api):
+        mock_api.put.return_value = {"provider": "bitwarden_pm"}
+        run(team_service.put_team_ssh_config(
+            "team-a", "https://vault.example.com", "col-uuid-123"
+        ))
+        mock_api.put.assert_called_with(
+            "/api/v1/teams/team-a/ssh-config",
+            json={
+                "provider": "bitwarden_pm",
+                "config": {
+                    "vault_url": "https://vault.example.com",
+                    "default_collection_id": "col-uuid-123",
+                },
+            },
+        )
+
+    def test_put_team_ssh_config_omits_collection_id_when_none(self, team_service, mock_api):
+        mock_api.put.return_value = {"provider": "bitwarden_pm"}
+        run(team_service.put_team_ssh_config("team-a", "https://vault.example.com"))
+        sent_body = mock_api.put.call_args.kwargs["json"]
+        assert "default_collection_id" not in sent_body["config"]
+
+    def test_put_team_ssh_config_uses_bitwarden_pm_provider_default(
+        self, team_service, mock_api
+    ):
+        mock_api.put.return_value = {}
+        run(team_service.put_team_ssh_config("team-a", "https://vault.example.com"))
+        sent_body = mock_api.put.call_args.kwargs["json"]
+        assert sent_body["provider"] == "bitwarden_pm"
+
+    def test_put_team_ssh_config_propagates_403(self, team_service, mock_api):
+        # Member-not-admin — must NOT be swallowed; caller handles it.
+        mock_api.put.side_effect = APIError(
+            code="forbidden", message="Admin required", status=403
+        )
+        with pytest.raises(APIError) as exc_info:
+            run(team_service.put_team_ssh_config("team-a", "https://vault.example.com"))
+        assert exc_info.value.status == 403
+
+
+class TestTeamServerSshRef:
+    """Tests for team-side per-server SSH ref methods."""
+
+    # --- get_team_server_ssh_ref ---
+
+    def test_get_team_server_ssh_ref_happy_path(self, team_service, mock_api):
+        payload = {
+            "ssh_credential_provider": "bitwarden_pm",
+            "ssh_credential_ref": {"item_id": "item-uuid"},
+        }
+        mock_api.get.return_value = payload
+        result = run(team_service.get_team_server_ssh_ref("team-a", "srv-001"))
+        assert result == payload
+        mock_api.get.assert_called_with(
+            "/api/v1/teams/team-a/servers/srv-001/ssh-ref"
+        )
+
+    def test_get_team_server_ssh_ref_returns_none_on_404(self, team_service, mock_api):
+        mock_api.get.side_effect = APIError(
+            code="not_found", message="No ref", status=404
+        )
+        result = run(team_service.get_team_server_ssh_ref("team-a", "srv-001"))
+        assert result is None
+
+    # --- put_team_server_ssh_ref ---
+
+    def test_put_team_server_ssh_ref_uses_ssh_credential_ref_field_name(
+        self, team_service, mock_api
+    ):
+        # Critical: body field is ssh_credential_ref, NOT the deprecated ref alias.
+        mock_api.put.return_value = {"ssh_credential_ref": {"item_id": "item-uuid"}}
+        ref = {"item_id": "item-uuid", "collection_id": "col-uuid"}
+        run(team_service.put_team_server_ssh_ref("team-a", "srv-001", ref))
+        sent_body = mock_api.put.call_args.kwargs["json"]
+        assert "ssh_credential_ref" in sent_body
+        assert "ref" not in sent_body
+        assert sent_body["ssh_credential_ref"] == ref
+
+    def test_put_team_server_ssh_ref_uses_bitwarden_pm_provider_default(
+        self, team_service, mock_api
+    ):
+        mock_api.put.return_value = {}
+        run(team_service.put_team_server_ssh_ref("team-a", "srv-001", {"item_id": "x"}))
+        sent_body = mock_api.put.call_args.kwargs["json"]
+        assert sent_body["ssh_credential_provider"] == "bitwarden_pm"
+
+    def test_put_team_server_ssh_ref_correct_url(self, team_service, mock_api):
+        mock_api.put.return_value = {}
+        run(team_service.put_team_server_ssh_ref("team-a", "srv-001", {"item_id": "x"}))
+        mock_api.put.assert_called_with(
+            "/api/v1/teams/team-a/servers/srv-001/ssh-ref",
+            json={
+                "ssh_credential_provider": "bitwarden_pm",
+                "ssh_credential_ref": {"item_id": "x"},
+            },
+        )
+
+    def test_put_team_server_ssh_ref_propagates_403(self, team_service, mock_api):
+        mock_api.put.side_effect = APIError(
+            code="forbidden", message="Admin required", status=403
+        )
+        with pytest.raises(APIError) as exc_info:
+            run(team_service.put_team_server_ssh_ref("team-a", "srv-001", {"item_id": "x"}))
+        assert exc_info.value.status == 403
+
+    # --- delete_team_server_ssh_ref ---
+
+    def test_delete_team_server_ssh_ref_returns_true_on_success(
+        self, team_service, mock_api
+    ):
+        mock_api.delete.return_value = {"deleted": True}
+        result = run(team_service.delete_team_server_ssh_ref("team-a", "srv-001"))
+        assert result is True
+        mock_api.delete.assert_called_with(
+            "/api/v1/teams/team-a/servers/srv-001/ssh-ref"
+        )
+
+    def test_delete_team_server_ssh_ref_returns_false_on_404(
+        self, team_service, mock_api
+    ):
+        mock_api.delete.side_effect = APIError(
+            code="not_found", message="No ref", status=404
+        )
+        result = run(team_service.delete_team_server_ssh_ref("team-a", "srv-001"))
+        assert result is False
+
+
+class TestTeamServerSshVerify:
+    """Tests for team-side SSH verify-status and verify-report methods."""
+
+    # --- get_team_server_ssh_verify_status ---
+
+    def test_get_team_server_ssh_verify_status_happy_path(self, team_service, mock_api):
+        payload = {
+            "server_id": "srv-001",
+            "ssh_verify_status": "verified",
+            "ssh_verified_at": "2026-05-24T00:00:00+00:00",
+            "checked_by_client": "servonaut-cli/2.10.2",
+            "updated_at": "2026-05-24T00:00:00+00:00",
+        }
+        mock_api.get.return_value = payload
+        result = run(team_service.get_team_server_ssh_verify_status("team-a", "srv-001"))
+        assert result == payload
+        mock_api.get.assert_called_with(
+            "/api/v1/teams/team-a/servers/srv-001/ssh-verify-status"
+        )
+
+    def test_get_team_server_ssh_verify_status_returns_none_on_404(
+        self, team_service, mock_api
+    ):
+        mock_api.get.side_effect = APIError(
+            code="not_found", message="No ref stored", status=404
+        )
+        result = run(team_service.get_team_server_ssh_verify_status("team-a", "srv-001"))
+        assert result is None
+
+    # --- report_team_server_ssh_verify ---
+
+    def test_report_verified_status(self, team_service, mock_api):
+        mock_api.post.return_value = {"ok": True}
+        run(team_service.report_team_server_ssh_verify("team-a", "srv-001", "verified"))
+        mock_api.post.assert_called_with(
+            "/api/v1/teams/team-a/servers/srv-001/ssh-verify-report",
+            json={"status": "verified"},
+        )
+
+    def test_report_not_found_status(self, team_service, mock_api):
+        mock_api.post.return_value = {"ok": True}
+        run(team_service.report_team_server_ssh_verify("team-a", "srv-001", "not_found"))
+        sent_body = mock_api.post.call_args.kwargs["json"]
+        assert sent_body["status"] == "not_found"
+
+    def test_report_auth_failed_status(self, team_service, mock_api):
+        mock_api.post.return_value = {"ok": True}
+        run(team_service.report_team_server_ssh_verify("team-a", "srv-001", "auth_failed"))
+        sent_body = mock_api.post.call_args.kwargs["json"]
+        assert sent_body["status"] == "auth_failed"
+
+    def test_report_with_checked_by_client(self, team_service, mock_api):
+        mock_api.post.return_value = {"ok": True}
+        run(team_service.report_team_server_ssh_verify(
+            "team-a", "srv-001", "verified", checked_by_client="servonaut-cli/2.10.2"
+        ))
+        sent_body = mock_api.post.call_args.kwargs["json"]
+        assert sent_body["checked_by_client"] == "servonaut-cli/2.10.2"
+
+    def test_report_omits_checked_by_client_when_none(self, team_service, mock_api):
+        mock_api.post.return_value = {"ok": True}
+        run(team_service.report_team_server_ssh_verify("team-a", "srv-001", "verified"))
+        sent_body = mock_api.post.call_args.kwargs["json"]
+        assert "checked_by_client" not in sent_body
+
+    def test_report_rejects_invalid_status_locally_no_round_trip(
+        self, team_service, mock_api
+    ):
+        # Local validation MUST raise ValueError before any API call.
+        with pytest.raises(ValueError, match="status must be one of"):
+            run(team_service.report_team_server_ssh_verify(
+                "team-a", "srv-001", "invalid_status"
+            ))
+        mock_api.post.assert_not_called()
+
+    def test_report_rejects_empty_status(self, team_service, mock_api):
+        with pytest.raises(ValueError):
+            run(team_service.report_team_server_ssh_verify("team-a", "srv-001", ""))
+        mock_api.post.assert_not_called()
 
 
 class TestRBAC:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,77 @@
+"""Tests for client-side wire-format validators."""
+
+from __future__ import annotations
+
+import pytest
+
+from servonaut.utils.validation import (
+    ALLOWED_PROVIDERS,
+    ValidationError,
+    validate_instance_id,
+    validate_provider,
+)
+
+
+class TestValidateProvider:
+    @pytest.mark.parametrize("provider", ["aws", "ovh", "hetzner"])
+    def test_accepts_allowed(self, provider: str) -> None:
+        assert validate_provider(provider) == provider
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [("AWS", "aws"), ("  ovh ", "ovh"), ("Hetzner", "hetzner")],
+    )
+    def test_normalizes_case_and_whitespace(self, raw: str, expected: str) -> None:
+        assert validate_provider(raw) == expected
+
+    @pytest.mark.parametrize("provider", ["gcp", "digitalocean", "azure", "", " "])
+    def test_rejects_unknown(self, provider: str) -> None:
+        with pytest.raises(ValidationError, match="Unknown provider"):
+            validate_provider(provider)
+
+    def test_rejects_non_string(self) -> None:
+        with pytest.raises(ValidationError, match="must be a string"):
+            validate_provider(None)  # type: ignore[arg-type]
+
+    def test_allowed_set_is_locked(self) -> None:
+        # Locked contract with servonaut.dev — any change requires coordination.
+        assert ALLOWED_PROVIDERS == frozenset({"aws", "ovh", "hetzner"})
+
+
+class TestValidateInstanceId:
+    @pytest.mark.parametrize(
+        "instance_id",
+        [
+            "i-0abc1234def567890",
+            "hetzner-server-001",
+            "my_instance",
+            "X",
+            "a" * 64,
+            "_-_-",
+            "ovh-srv_12-AB",
+        ],
+    )
+    def test_accepts_valid(self, instance_id: str) -> None:
+        assert validate_instance_id(instance_id) == instance_id
+
+    @pytest.mark.parametrize(
+        "instance_id",
+        [
+            "",
+            "a" * 65,
+            "with space",
+            "with/slash",
+            "with.dot",
+            "with:colon",
+            "with$dollar",
+            "with;semi",
+            "naïve",
+        ],
+    )
+    def test_rejects_invalid(self, instance_id: str) -> None:
+        with pytest.raises(ValidationError, match="must match"):
+            validate_instance_id(instance_id)
+
+    def test_rejects_non_string(self) -> None:
+        with pytest.raises(ValidationError, match="must be a string"):
+            validate_instance_id(12345)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Prepares the CLI surface for the upcoming `servonaut ssh <instance-id>` and `servonaut servers verify <id>` commands (servonaut.dev epic #59 — Bitwarden Password Manager SSH integration). Everything in this PR is zero-network-dependency so it can land before the prod cut of `/api/v1/me/instances/...` and `/api/v1/me/ssh-config`.

**Draft**: held until the implementation commands (#29, #30) and InstanceTable column wiring (deferred portion of #31) land in a follow-up PR after prod deploys.

## What's in the box

### 1. `BwSshConfigService` (services/bw_ssh_config_service.py)

Covers personal vault config + per-instance SSH ref CRUD + verify status/report. **Body field locked to `ssh_credential_ref` from day one** — never the deprecated `ref` alias that servonaut-dev had to fix in PR #77. 404 on GET → returns `None` so callers can fall back to local `~/.ssh`. Status enum validated locally before round-trip.

### 2. Wire-format validators (utils/validation.py)

`validate_provider(p)` matches `^(aws|ovh|hetzner)$` and `validate_instance_id(s)` matches `^[A-Za-z0-9_\-]{1,64}$` — mirroring the server-side route requirements so obviously-malformed input fails locally with a friendly message instead of round-tripping to a 404. `ALLOWED_PROVIDERS` frozenset has a lock-test against accidental drift.

### 3. Mercure relay listener: dual-topic subscription (services/relay_listener.py)

Now subscribes to BOTH `/cli/{uid}/commands` (legacy) AND `/cli/{uid}/ai-tool-calls` (new, PR #74 server-side) in one SSE connection via repeated `topic=` query params.

**Bounded LRU dedup** (256 entries, 5min TTL) keyed by `tool_call_id` (preferred — the load-bearing idempotency key for AI tool calls) with top-level `id` fallback for CommandRequest events. Domain-level dedup is required because the dual `hub->publish()` calls server-side generate distinct Mercure event ids — `event.id`-based dedup would NOT work.

### 4. SSH verify state formatter (utils/formatting.py)

`format_ssh_verify_state(status, verified_at, *, now_utc=)` renders the upcoming TUI badge.

**Contract guard**: enforces the server's NULL-when-not-verified invariant client-side too. Even if a buggy server response includes `ssh_verified_at` alongside a non-verified status, we IGNORE it — never show "last verified 3h ago" next to a red "auth failed" badge. Defense-in-depth.

## Test coverage

+85 tests across four new/extended files:

| File | Tests | Highlights |
|---|---|---|
| `test_validation.py` | 30 | Locked-set assertion, case normalization, non-ASCII rejection |
| `test_bw_ssh_config_service.py` | 22 | `ssh_credential_ref` regression test, status enum lock-test, 404-fallback |
| `test_relay_listener.py` (+17) | 54 total | Dedup TTL eviction, LRU cap eviction, `tool_call_id` precedence |
| `test_formatting.py` (+16) | 34 total | Contract guard (timestamp ignored on non-verified), clock-skew clamp |

Full suite: **3753 passing, 5 skipped, 0 regressions.**

## Wire contract source

Locked with servonaut.dev on agent-bus thread `43f065e6-a2c2-4d2a-b3db-0de7f141b0a1` on 2026-05-24. Decisions captured:

- **Mercure dedup**: option A (`tool_call_id`-based, no server change needed) — recommendation B (server-pinned event id) explicitly declined.
- **BW item shape**: assume native 2023.10+ `sshKey.privateKey` field with clear error if absent — no `key_field?` ref field until a real user reports a non-default shape.
- **`checked_by_client` audit persistence**: confirmed on both personal (`admin_audit_logs`) and team (`audit_logs`) sides, including round-trip surfacing via `ssh-verify-status` GET.

## Test plan

- [x] `pytest tests/test_validation.py` — 30 passed
- [x] `pytest tests/test_bw_ssh_config_service.py` — 22 passed
- [x] `pytest tests/test_relay_listener.py` — 54 passed
- [x] `pytest tests/test_formatting.py` — 34 passed
- [x] Full suite (excluding pre-existing hcloud-env-issue file): 3753 passed
- [x] Read-only staging smoke: `BwSshConfigService.list_personal_instances()` against `staging.servonaut.dev` (cleared by servonaut-dev for early read-only GETs)
- [x] Follow-up PR will add: `servonaut ssh` + `servonaut servers verify` commands, `InstanceTable` column wiring, "Verify SSH" action on `ServerActionsScreen`

