### PR TITLE
feat(chat): catalog consumer + dangerous-floor escalation (PR5')

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servonaut"
-version = "2.14.0"
+version = "2.15.0"
 description = "Manage AWS, Hetzner, OVH, and custom servers from one TUI — with a built-in AI assistant and MCP server"
 readme = "README.md"
 license = "MIT"

--- a/src/servonaut/__init__.py
+++ b/src/servonaut/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 """Servonaut — Interactive TUI for managing AWS EC2 SSH connections."""
-__version__ = '2.14.0'
+__version__ = '2.15.0'

--- a/src/servonaut/services/ai_providers/servonaut_provider.py
+++ b/src/servonaut/services/ai_providers/servonaut_provider.py
@@ -387,11 +387,66 @@ class ServonautProvider(AIProviderInterface):
         )
 
         async for event in self._api_client.stream_sse(_CHAT_PATH, body):
+            if event.get("event") == "tool_catalog":
+                # PR5' audit-only consumer. The static _LOCAL_TOOL_HANDLERS map
+                # in ai_tool_bridge.py is source of truth for dispatch; the
+                # received catalog is logged but not used for routing yet.
+                # PR6'+ will build the live-catalog consumer on this wire.
+                self._handle_tool_catalog_event(event.get("data") or {})
+                continue
             yield event
 
         # Synthesise a terminal ``done`` event so callers can distinguish
         # graceful stream-close from an exception-raising terminal event.
         yield {"event": "done", "data": {}}
+
+    def _handle_tool_catalog_event(self, event_data: Dict[str, Any]) -> None:
+        """Audit-only handler for the ``tool_catalog`` SSE event (PR5').
+
+        Receives the catalog envelope emitted by the server at chat-stream
+        open. In PR5' we log the receipt to ``~/.servonaut/mcp_audit.jsonl``
+        as evidence the wire works, but we do NOT update dispatch state —
+        the static ``_LOCAL_TOOL_HANDLERS`` map in ``ai_tool_bridge.py``
+        remains the source of truth. PR6'+ will build the live-catalog
+        consumer on this wire.
+
+        Degrades gracefully if no audit logger is wired: falls back to a
+        standard ``logger.info`` so the event is never silently dropped.
+        """
+        from datetime import datetime, timezone
+
+        catalog_version = event_data.get("catalog_version")
+        surface = event_data.get("surface")
+        tools = event_data.get("tools") or []
+        tool_count = len(tools)
+        # Sample first 5 names only — avoids PII-adjacent info in audit row
+        # and keeps the row compact for the audit viewer.
+        tool_names_sample = [t.get("name") for t in tools[:5] if isinstance(t, dict)]
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        logger.info(
+            "tool_catalog SSE event received: version=%s surface=%s tool_count=%d",
+            catalog_version, surface, tool_count,
+        )
+
+        audit = getattr(self, "_audit", None)
+        if audit is not None and callable(getattr(audit, "log", None)):
+            try:
+                audit.log(
+                    "tool_catalog_received",
+                    {},
+                    "",
+                    True,
+                    "tool_catalog_received",
+                    catalog_version=catalog_version,
+                    surface=surface,
+                    tool_count=tool_count,
+                    tool_names_sample=tool_names_sample,
+                    timestamp=ts,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to audit tool_catalog SSE event")
+        # If no audit logger: the logger.info above already captured the event.
 
     @staticmethod
     def _unmarshal_buffered_response(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import (
     Any,
     Awaitable,
@@ -145,6 +146,97 @@ _RELAY_TOOL_TO_TYPE: Dict[str, CommandType] = {
 _LOCAL_TOOL_HANDLERS: Dict[str, str] = {
     "list_instances":    "list_instances",
     "describe_instance": "get_server_info",
+
+    # -----------------------------------------------------------------------
+    # PR5': 57 catalog-advertised tools routed to ServonautTools.
+    # Each tool name maps to the exact ServonautTools async method name.
+    # All tools below exist on ServonautTools (verified against tools.py).
+    # -----------------------------------------------------------------------
+
+    # --- AWS describe (readonly) ---
+    "aws_list_regions":           "aws_list_regions",
+    "aws_list_amis":              "aws_list_amis",
+    "aws_list_instance_types":    "aws_list_instance_types",
+    "aws_list_key_pairs":         "aws_list_key_pairs",
+    "aws_list_subnets":           "aws_list_subnets",
+    "aws_list_security_groups":   "aws_list_security_groups",
+
+    # --- AWS lifecycle (standard tier) ---
+    "aws_start_instance":         "aws_start_instance",
+    "aws_stop_instance":          "aws_stop_instance",
+    "aws_reboot_instance":        "aws_reboot_instance",
+
+    # --- AWS lifecycle (dangerous tier) ---
+    "aws_run_instances":          "aws_run_instances",
+    "aws_terminate_instance":     "aws_terminate_instance",
+
+    # --- S3 read (readonly) ---
+    "s3_list_buckets":            "s3_list_buckets",
+    "s3_list_objects":            "s3_list_objects",
+
+    # --- S3 mutations (dangerous tier) ---
+    "s3_create_bucket":           "s3_create_bucket",
+    "s3_delete_bucket":           "s3_delete_bucket",
+    "s3_upload_object":           "s3_upload_object",
+    "s3_delete_object":           "s3_delete_object",
+    "s3_copy_object":             "s3_copy_object",
+    "s3_move_object":             "s3_move_object",
+    "s3_generate_presigned_url":  "s3_generate_presigned_url",
+    # s3_download_object: FS-hazard carve-out but still routes locally so
+    # the bridge doesn't synthesise "tool unavailable" for a legitimate call.
+    "s3_download_object":         "s3_download_object",
+
+    # --- AWS observability (readonly) ---
+    "cloudwatch_list_log_groups": "cloudwatch_list_log_groups",
+    "cloudwatch_get_log_events":  "cloudwatch_get_log_events",
+    "cloudwatch_top_ips":         "cloudwatch_top_ips",
+    "cloudtrail_lookup_events":   "cloudtrail_lookup_events",
+    "ip_ban_list_configs":        "ip_ban_list_configs",
+    "ip_ban_list_banned":         "ip_ban_list_banned",
+    "ip_ban_set":                 "ip_ban_set",
+
+    # --- Log fetch (standard tier via relay for managed servers,
+    #     but the tool name 'get_logs' resolves locally on ServonautTools
+    #     for standalone MCP / chat-panel use-cases) ---
+    "get_logs":                   "get_logs",
+
+    # --- Hetzner read + power management ---
+    "hetzner_list_servers":       "hetzner_list_servers",
+    "hetzner_list_server_types":  "hetzner_list_server_types",
+    "hetzner_list_ssh_keys":      "hetzner_list_ssh_keys",
+    "hetzner_power_on":           "hetzner_power_on",
+    "hetzner_power_off":          "hetzner_power_off",
+    "hetzner_shutdown":           "hetzner_shutdown",
+    "hetzner_reboot":             "hetzner_reboot",
+    "hetzner_create_ssh_key":     "hetzner_create_ssh_key",
+
+    # --- Hetzner lifecycle (dangerous tier) ---
+    "hetzner_create_server":      "hetzner_create_server",
+    "hetzner_delete_server":      "hetzner_delete_server",
+    "hetzner_delete_ssh_key":     "hetzner_delete_ssh_key",
+
+    # --- OVH read + lifecycle ---
+    "ovh_monitoring":             "ovh_monitoring",
+    "ovh_list_ips":               "ovh_list_ips",
+    "ovh_firewall_rules":         "ovh_firewall_rules",
+    "ovh_ssh_keys":               "ovh_ssh_keys",
+    "ovh_snapshots":              "ovh_snapshots",
+    "ovh_dns_records":            "ovh_dns_records",
+    "ovh_billing":                "ovh_billing",
+    "ovh_invoices":               "ovh_invoices",
+    "ovh_start_instance":         "ovh_start_instance",
+    "ovh_stop_instance":          "ovh_stop_instance",
+    "ovh_reboot_instance":        "ovh_reboot_instance",
+
+    # --- OVH lifecycle (dangerous tier) ---
+    "ovh_create_instance":        "ovh_create_instance",
+    "ovh_delete_instance":        "ovh_delete_instance",
+
+    # --- Memory (read + build/refresh) ---
+    "get_server_memory":          "get_server_memory",
+    "list_server_memories":       "list_server_memories",
+    "build_server_memory":        "build_server_memory",
+    "refresh_server_memory":      "refresh_server_memory",
 }
 
 # Tools the catalog advertises but that aren't dispatchable on this
@@ -480,6 +572,41 @@ class AIToolBridge(_FloorDangerousMixin):
                 call.guard_level, call.tool, client_guard, effective_guard,
             )
             call.guard_level = effective_guard
+
+        # 0b. PR5' dangerous-tool name-pattern floor (defense-in-depth).
+        # Chat tool_calls arrive without explicit tier info from the server
+        # catalog; we default server_tier to call.guard_level so the floor
+        # uses whatever guard was resolved above. Any tool whose NAME matches
+        # a known-destructive pattern is escalated to dangerous regardless.
+        server_tier = call.guard_level  # default: use already-resolved guard
+        effective_tier, was_escalated = self._floor_dangerous(call.tool, server_tier)
+        if was_escalated:
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            logger.warning(
+                "Dangerous-floor escalation: tool %r arrived with tier %r — "
+                "escalated to 'dangerous' by pattern floor (PR5')",
+                call.tool, server_tier,
+            )
+            try:
+                self._audit.log(
+                    call.tool,
+                    dict(call.args),
+                    "",
+                    False,
+                    "dangerous_floor_escalation",
+                    source="ai_chat",
+                    conversation_id=call.conversation_id,
+                    tool_call_id=call.tool_call_id,
+                    server_tier=server_tier,
+                    effective_tier=effective_tier,
+                    timestamp=ts,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to audit dangerous-floor escalation for tool %s",
+                    call.tool,
+                )
+            call.guard_level = effective_tier  # type: ignore[assignment]
 
         # 1. Dangerous-tool entitlement gate (defense-in-depth — server
         # already checks ``allow_dangerous_ai_tools``, this just spares

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -220,7 +220,10 @@ class RelayListener:
             "version": getattr(servonaut, "__version__", "unknown"),
             "cli_release_channel": self._release_channel,
             "providers_configured": list(self._providers_configured),
-            "capabilities": {"supports_dynamic_catalog": False},
+            # v2.15.0: capability bit flipped True — CLI now consumes the
+            # tool_catalog SSE event and routes all 60 catalog tools via
+            # _LOCAL_TOOL_HANDLERS / _RELAY_TOOL_TO_TYPE (PR5').
+            "capabilities": {"supports_dynamic_catalog": True},
             "client_id": self._client_id,
         }
 

--- a/tests/test_ai_tool_bridge.py
+++ b/tests/test_ai_tool_bridge.py
@@ -318,7 +318,10 @@ def test_bytes_count_for_denied_is_utf8_length_of_message():
 def test_audit_row_written_with_source_ai_chat(tmp_path):
     audit = AuditTrail(str(tmp_path / "ai_audit.jsonl"))
     bridge, _, _, _, _ = _make_bridge(audit_trail=audit)
-    call = _call(tool="run_command", guard_level="standard")
+    # PR5': run_command is in the dangerous-floor pattern set, so sending it
+    # at 'standard' triggers escalation to 'dangerous'. Use 'dangerous' here
+    # to test the ok_local audit row without the escalation prefix row.
+    call = _call(tool="run_command", guard_level="dangerous")
     run(bridge.handle_tool_call(call))
 
     # Read the JSONL and verify a row exists with source="ai_chat" and
@@ -330,7 +333,7 @@ def test_audit_row_written_with_source_ai_chat(tmp_path):
     assert entry["source"] == "ai_chat"
     assert entry["conversation_id"] == call.conversation_id
     assert entry["tool_call_id"] == call.tool_call_id
-    assert entry["guard_level"] == "standard"
+    assert entry["guard_level"] == "dangerous"
     assert entry["status"] == "ok"
 
 

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -1,0 +1,213 @@
+"""Tests for PR5' _LOCAL_TOOL_HANDLERS dispatch routing.
+
+Verifies that every tool added in PR5' resolves to the expected
+ServonautTools method name and that the bridge's _execute_local path
+invokes the right handler.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.services.ai_tool_bridge import (
+    AIToolBridge,
+    ToolCall,
+    _LOCAL_TOOL_HANDLERS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _make_bridge_with_tools(tool_methods: dict) -> tuple:
+    """Return (bridge, servonaut_tools_mock) with all external deps mocked.
+
+    ``tool_methods`` maps method_name -> return value (str).
+    """
+    api = MagicMock()
+    api.post = AsyncMock(return_value={})
+
+    relay = MagicMock()
+    relay.execute = AsyncMock(return_value=MagicMock(status="success", output="ok"))
+
+    audit = MagicMock()
+    audit.log = MagicMock()
+
+    confirm = AsyncMock(return_value=True)
+    auth = MagicMock()
+    auth.has_dangerous_ai_tools = True
+
+    tools = MagicMock()
+    for method_name, ret_val in tool_methods.items():
+        setattr(tools, method_name, AsyncMock(return_value=ret_val))
+
+    bridge = AIToolBridge(
+        api_client=api,
+        relay_executors=relay,
+        mcp_audit=audit,
+        confirm_callback=confirm,
+        auth_service=auth,
+        servonaut_tools=tools,
+    )
+    return bridge, tools
+
+
+# ---------------------------------------------------------------------------
+# Map-level assertion: every new tool in _LOCAL_TOOL_HANDLERS points to a
+# real ServonautTools method.
+# ---------------------------------------------------------------------------
+
+_ORIGINAL_TOOLS = {"list_instances", "describe_instance"}
+
+
+class TestLocalToolHandlerMapCompleteness:
+    def test_all_new_handlers_have_servonaut_tools_method(self):
+        """Every tool added in PR5' must have a matching ServonautTools method."""
+        from servonaut.mcp.tools import ServonautTools
+
+        st_methods = {
+            m for m in dir(ServonautTools)
+            if not m.startswith("_") and callable(getattr(ServonautTools, m))
+        }
+        missing = []
+        for tool_name, method_name in _LOCAL_TOOL_HANDLERS.items():
+            if tool_name in _ORIGINAL_TOOLS:
+                continue
+            if method_name not in st_methods:
+                missing.append((tool_name, method_name))
+
+        assert not missing, (
+            f"Tools in _LOCAL_TOOL_HANDLERS whose target method is missing "
+            f"from ServonautTools: {missing}"
+        )
+
+    def test_new_entries_count_is_57(self):
+        """PR5' adds exactly 57 entries on top of the 2 original ones."""
+        new_entries = {k for k in _LOCAL_TOOL_HANDLERS if k not in _ORIGINAL_TOOLS}
+        assert len(new_entries) == 57, (
+            f"Expected 57 new entries, got {len(new_entries)}: {sorted(new_entries)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parametrised dispatch tests -- sample across the full set
+# ---------------------------------------------------------------------------
+
+# fmt: off
+_DISPATCH_CASES = [
+    # (tool_name, expected_method, mock_return)
+    # --- AWS describe ---
+    ("aws_list_regions",           "aws_list_regions",           "us-east-1\nus-west-2"),
+    ("aws_list_amis",              "aws_list_amis",              "ami-abc"),
+    ("aws_list_instance_types",    "aws_list_instance_types",    "t3.micro"),
+    ("aws_list_key_pairs",         "aws_list_key_pairs",         "mykey"),
+    ("aws_list_subnets",           "aws_list_subnets",           "subnet-123"),
+    ("aws_list_security_groups",   "aws_list_security_groups",   "sg-456"),
+    # --- AWS lifecycle ---
+    ("aws_start_instance",         "aws_start_instance",         "started"),
+    ("aws_stop_instance",          "aws_stop_instance",          "stopped"),
+    ("aws_reboot_instance",        "aws_reboot_instance",        "rebooted"),
+    ("aws_run_instances",          "aws_run_instances",          "launched"),
+    ("aws_terminate_instance",     "aws_terminate_instance",     "terminated"),
+    # --- S3 read ---
+    ("s3_list_buckets",            "s3_list_buckets",            "my-bucket"),
+    ("s3_list_objects",            "s3_list_objects",            "object.txt"),
+    # --- S3 mutations ---
+    ("s3_create_bucket",           "s3_create_bucket",           "created"),
+    ("s3_delete_bucket",           "s3_delete_bucket",           "deleted"),
+    ("s3_upload_object",           "s3_upload_object",           "uploaded"),
+    ("s3_delete_object",           "s3_delete_object",           "deleted"),
+    ("s3_copy_object",             "s3_copy_object",             "copied"),
+    ("s3_move_object",             "s3_move_object",             "moved"),
+    ("s3_generate_presigned_url",  "s3_generate_presigned_url",  "https://example.com/presigned"),
+    ("s3_download_object",         "s3_download_object",         "downloaded"),
+    # --- AWS observability ---
+    ("cloudwatch_list_log_groups", "cloudwatch_list_log_groups", "/aws/lambda/fn"),
+    ("cloudwatch_get_log_events",  "cloudwatch_get_log_events",  "log event"),
+    ("cloudwatch_top_ips",         "cloudwatch_top_ips",         "1.2.3.4"),
+    ("cloudtrail_lookup_events",   "cloudtrail_lookup_events",   "event"),
+    ("ip_ban_list_configs",        "ip_ban_list_configs",        "config"),
+    ("ip_ban_list_banned",         "ip_ban_list_banned",         "banned ip"),
+    ("ip_ban_set",                 "ip_ban_set",                 "banned"),
+    # --- Log fetch ---
+    ("get_logs",                   "get_logs",                   "log output"),
+    # --- Hetzner read + power management ---
+    ("hetzner_list_servers",       "hetzner_list_servers",       "server1"),
+    ("hetzner_list_server_types",  "hetzner_list_server_types",  "cx11"),
+    ("hetzner_list_ssh_keys",      "hetzner_list_ssh_keys",      "key1"),
+    ("hetzner_power_on",           "hetzner_power_on",           "on"),
+    ("hetzner_power_off",          "hetzner_power_off",          "off"),
+    ("hetzner_shutdown",           "hetzner_shutdown",           "shutdown"),
+    ("hetzner_reboot",             "hetzner_reboot",             "rebooted"),
+    ("hetzner_create_ssh_key",     "hetzner_create_ssh_key",     "created"),
+    # --- Hetzner lifecycle (dangerous) ---
+    ("hetzner_create_server",      "hetzner_create_server",      "created"),
+    ("hetzner_delete_server",      "hetzner_delete_server",      "deleted"),
+    ("hetzner_delete_ssh_key",     "hetzner_delete_ssh_key",     "deleted"),
+    # --- OVH read + lifecycle ---
+    ("ovh_monitoring",             "ovh_monitoring",             "metrics"),
+    ("ovh_list_ips",               "ovh_list_ips",               "1.2.3.4"),
+    ("ovh_firewall_rules",         "ovh_firewall_rules",         "rules"),
+    ("ovh_ssh_keys",               "ovh_ssh_keys",               "key"),
+    ("ovh_snapshots",              "ovh_snapshots",              "snap"),
+    ("ovh_dns_records",            "ovh_dns_records",            "records"),
+    ("ovh_billing",                "ovh_billing",                "billing"),
+    ("ovh_invoices",               "ovh_invoices",               "invoice"),
+    ("ovh_start_instance",         "ovh_start_instance",         "started"),
+    ("ovh_stop_instance",          "ovh_stop_instance",          "stopped"),
+    ("ovh_reboot_instance",        "ovh_reboot_instance",        "rebooted"),
+    # --- OVH lifecycle (dangerous) ---
+    ("ovh_create_instance",        "ovh_create_instance",        "created"),
+    ("ovh_delete_instance",        "ovh_delete_instance",        "deleted"),
+    # --- Memory ---
+    ("get_server_memory",          "get_server_memory",          "memory data"),
+    ("list_server_memories",       "list_server_memories",       "memories"),
+    ("build_server_memory",        "build_server_memory",        "built"),
+    ("refresh_server_memory",      "refresh_server_memory",      "refreshed"),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize("tool_name,expected_method,mock_return", _DISPATCH_CASES)
+def test_dispatch_routes_to_correct_method(tool_name, expected_method, mock_return):
+    """Bridge dispatches each tool name to the right ServonautTools method."""
+    bridge, tools_mock = _make_bridge_with_tools({expected_method: mock_return})
+    call = ToolCall(
+        tool_call_id="tc-1",
+        tool=tool_name,
+        args={},
+        # Use dangerous for tests so entitlement gate does not block
+        guard_level="dangerous",
+        conversation_id="conv-1",
+    )
+    result = run(bridge.handle_tool_call(call))
+
+    # Method was called
+    getattr(tools_mock, expected_method).assert_called_once()
+    # Result status is ok and content matches
+    assert result.status == "ok"
+    assert result.result == mock_return
+
+
+def test_unknown_tool_returns_error():
+    """A tool not in any dispatch map returns status='error' with skipped=True."""
+    bridge, _ = _make_bridge_with_tools({})
+    call = ToolCall(
+        tool_call_id="tc-unknown",
+        tool="completely_unknown_tool_xyz",
+        args={},
+        guard_level="readonly",
+        conversation_id="conv-1",
+    )
+    result = run(bridge.handle_tool_call(call))
+    assert result.status == "error"
+    assert result.skipped is True

--- a/tests/test_dangerous_floor_escalation.py
+++ b/tests/test_dangerous_floor_escalation.py
@@ -1,0 +1,189 @@
+"""Tests for PR5' dangerous-tool name-pattern floor escalation.
+
+Verifies that handle_tool_call escalates any tool matching
+DANGEROUS_FLOOR_PATTERNS to the 'dangerous' tier and writes an
+audit row with reason 'dangerous_floor_escalation', regardless of
+what guard_level the server asserts.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from servonaut.services.ai_tool_bridge import (
+    AIToolBridge,
+    ToolCall,
+    _FloorDangerousMixin,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _FloorDangerousMixin._floor_dangerous in isolation
+# ---------------------------------------------------------------------------
+
+
+class TestFloorDangerousMixinUnit:
+    def setup_method(self):
+        self.mixin = _FloorDangerousMixin()
+
+    def test_aws_terminate_escalated_from_standard(self):
+        tier, escalated = self.mixin._floor_dangerous("aws_terminate_instance", "standard")
+        assert tier == "dangerous"
+        assert escalated is True
+
+    def test_aws_run_instances_escalated_from_readonly(self):
+        tier, escalated = self.mixin._floor_dangerous("aws_run_instances", "readonly")
+        assert tier == "dangerous"
+        assert escalated is True
+
+    def test_s3_delete_object_escalated(self):
+        tier, escalated = self.mixin._floor_dangerous("s3_delete_object", "standard")
+        assert tier == "dangerous"
+        assert escalated is True
+
+    def test_hetzner_create_server_escalated(self):
+        tier, escalated = self.mixin._floor_dangerous("hetzner_create_server", "standard")
+        assert tier == "dangerous"
+        assert escalated is True
+
+    def test_safe_tool_not_escalated(self):
+        tier, escalated = self.mixin._floor_dangerous("aws_list_regions", "readonly")
+        assert tier == "readonly"
+        assert escalated is False
+
+    def test_cloudwatch_not_escalated(self):
+        tier, escalated = self.mixin._floor_dangerous("cloudwatch_top_ips", "readonly")
+        assert tier == "readonly"
+        assert escalated is False
+
+    def test_already_dangerous_not_re_escalated(self):
+        """A tool that IS dangerous tier already produces escalated=False."""
+        tier, escalated = self.mixin._floor_dangerous("aws_run_instances", "dangerous")
+        assert tier == "dangerous"
+        assert escalated is False  # server already said dangerous
+
+
+# ---------------------------------------------------------------------------
+# Integration: escalation inside handle_tool_call writes audit row
+# ---------------------------------------------------------------------------
+
+
+def _make_bridge(*, has_dangerous: bool = True) -> tuple:
+    """Return (bridge, audit_mock) with all external deps mocked."""
+    api = MagicMock()
+    api.post = AsyncMock(return_value={})
+
+    relay = MagicMock()
+    relay.execute = AsyncMock(return_value=MagicMock(status="success", output="ok"))
+
+    audit = MagicMock()
+    audit.log = MagicMock()
+
+    confirm = AsyncMock(return_value=True)
+    auth = MagicMock()
+    auth.has_dangerous_ai_tools = has_dangerous
+
+    # ServonautTools mock that handles any tool call
+    tools = MagicMock()
+    tools.aws_terminate_instance = AsyncMock(return_value="terminated")
+    tools.aws_list_regions = AsyncMock(return_value="us-east-1")
+
+    bridge = AIToolBridge(
+        api_client=api,
+        relay_executors=relay,
+        mcp_audit=audit,
+        confirm_callback=confirm,
+        auth_service=auth,
+        servonaut_tools=tools,
+    )
+    return bridge, audit
+
+
+class TestDangerousFloorEscalationIntegration:
+    def test_escalation_audit_row_written_for_destructive_tool(self):
+        """aws_terminate_instance arriving as 'standard' triggers audit row."""
+        bridge, audit = _make_bridge()
+        call_ = ToolCall(
+            tool_call_id="tc-floor-1",
+            tool="aws_terminate_instance",
+            args={},
+            guard_level="standard",  # server under-classified
+            conversation_id="conv-floor",
+        )
+        result = run(bridge.handle_tool_call(call_))
+
+        # Should succeed (dangerous entitlement granted + confirm accepted)
+        assert result.status == "ok"
+
+        # Audit must have been called with reason 'dangerous_floor_escalation'
+        audit_calls = audit.log.call_args_list
+        reasons = [
+            c.args[4] if len(c.args) > 4 else c.kwargs.get("reason", "")
+            for c in audit_calls
+        ]
+        assert "dangerous_floor_escalation" in reasons, (
+            f"Expected 'dangerous_floor_escalation' in audit reasons but got: {reasons}"
+        )
+
+    def test_escalation_sets_guard_to_dangerous(self):
+        """After floor escalation the effective call.guard_level is 'dangerous'."""
+        bridge, audit = _make_bridge()
+        call_ = ToolCall(
+            tool_call_id="tc-floor-2",
+            tool="aws_run_instances",
+            args={},
+            guard_level="standard",
+            conversation_id="conv-floor",
+        )
+        # Capture guard_level at audit-log time via side_effect
+        captured_guard = {}
+
+        def capture_audit(*args, **kwargs):
+            captured_guard["last"] = kwargs.get("guard_level")
+
+        audit.log.side_effect = capture_audit
+        bridge._servonaut_tools.aws_run_instances = AsyncMock(return_value="launched")
+        run(bridge.handle_tool_call(call_))
+
+        # The final ok_local audit row must carry guard_level='dangerous'
+        assert captured_guard.get("last") == "dangerous"
+
+    def test_safe_tool_no_floor_escalation_audit_row(self):
+        """aws_list_regions at readonly does NOT trigger floor escalation row."""
+        bridge, audit = _make_bridge()
+        call_ = ToolCall(
+            tool_call_id="tc-floor-safe",
+            tool="aws_list_regions",
+            args={},
+            guard_level="readonly",
+            conversation_id="conv-floor",
+        )
+        run(bridge.handle_tool_call(call_))
+
+        audit_calls = audit.log.call_args_list
+        reasons = [
+            c.args[4] if len(c.args) > 4 else c.kwargs.get("reason", "")
+            for c in audit_calls
+        ]
+        assert "dangerous_floor_escalation" not in reasons, (
+            f"Unexpected floor escalation audit row for safe tool: {reasons}"
+        )
+
+    def test_floor_escalation_denied_without_dangerous_entitlement(self):
+        """Floor-escalated tool is denied if auth.has_dangerous_ai_tools is False."""
+        bridge, audit = _make_bridge(has_dangerous=False)
+        call_ = ToolCall(
+            tool_call_id="tc-floor-deny",
+            tool="aws_terminate_instance",
+            args={},
+            guard_level="standard",
+            conversation_id="conv-floor",
+        )
+        result = run(bridge.handle_tool_call(call_))
+        assert result.status == "denied"

--- a/tests/test_relay_handshake.py
+++ b/tests/test_relay_handshake.py
@@ -168,10 +168,11 @@ class TestBuildHandshake:
         hs = listener._build_handshake()
         assert hs["providers_configured"] == []
 
-    def test_handshake_capabilities_supports_dynamic_catalog_false(self):
+    def test_handshake_capabilities_supports_dynamic_catalog_true(self):
+        # v2.15.0 — capability bit flipped True when PR5' landed.
         listener = _make_listener()
         hs = listener._build_handshake()
-        assert hs["capabilities"] == {"supports_dynamic_catalog": False}
+        assert hs["capabilities"] == {"supports_dynamic_catalog": True}
 
     def test_handshake_cli_release_channel_present(self):
         listener = _make_listener()
@@ -267,7 +268,7 @@ class TestHeartbeatLoopPayloads:
         assert len(posted_bodies) >= 2
         # First payload must be the handshake
         assert posted_bodies[0]["type"] == "cli.handshake"
-        assert posted_bodies[0]["capabilities"] == {"supports_dynamic_catalog": False}
+        assert posted_bodies[0]["capabilities"] == {"supports_dynamic_catalog": True}
         # Second payload must be the minimal heartbeat
         assert posted_bodies[1]["type"] == "cli.heartbeat"
         assert "capabilities" not in posted_bodies[1]

--- a/tests/test_tool_catalog_sse_event.py
+++ b/tests/test_tool_catalog_sse_event.py
@@ -1,0 +1,207 @@
+"""Tests for PR5' tool_catalog SSE event handler in ServonautProvider.
+
+Verifies that:
+1. A ``tool_catalog`` SSE event is consumed (not forwarded to the caller).
+2. An audit row is written (when _audit is wired) with reason
+   ``tool_catalog_received`` and the correct fields.
+3. Subsequent non-catalog events still yield to the caller.
+4. _LOCAL_TOOL_HANDLERS dispatch state is NOT mutated (audit-only).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Dict, Any
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+from servonaut.services.ai_providers.servonaut_provider import ServonautProvider
+from servonaut.services.ai_tool_bridge import _LOCAL_TOOL_HANDLERS
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+async def _fake_sse_stream(events: list) -> AsyncIterator[Dict[str, Any]]:
+    """Async generator that yields the given event dicts."""
+    for event in events:
+        yield event
+
+
+def _make_provider(audit=None) -> ServonautProvider:
+    """Return a ServonautProvider with all external deps mocked."""
+    api = MagicMock()
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.has_feature = MagicMock(return_value=True)
+    provider = ServonautProvider(api_client=api, auth_service=auth)
+    if audit is not None:
+        provider._audit = audit
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# _handle_tool_catalog_event unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleToolCatalogEvent:
+    def test_audit_log_written_with_correct_reason(self):
+        """_handle_tool_catalog_event writes audit row with reason=tool_catalog_received."""
+        audit = MagicMock()
+        audit.log = MagicMock()
+        provider = _make_provider(audit=audit)
+
+        provider._handle_tool_catalog_event({
+            "catalog_version": "2026-05-26.2",
+            "surface": "chat",
+            "tools": [
+                {"name": "aws_list_regions"},
+                {"name": "s3_list_buckets"},
+            ],
+        })
+
+        audit.log.assert_called_once()
+        call_args = audit.log.call_args
+        # Positional arg[4] is the reason
+        if len(call_args.args) > 4:
+            reason = call_args.args[4]
+        else:
+            reason = call_args.kwargs.get("reason", "")
+        assert reason == "tool_catalog_received"
+
+    def test_audit_log_includes_catalog_version_and_count(self):
+        """Audit row carries catalog_version and tool_count kwargs."""
+        audit = MagicMock()
+        audit.log = MagicMock()
+        provider = _make_provider(audit=audit)
+
+        provider._handle_tool_catalog_event({
+            "catalog_version": "2026-05-26.2",
+            "surface": "chat",
+            "tools": [{"name": f"tool_{i}"} for i in range(10)],
+        })
+
+        call_kwargs = audit.log.call_args.kwargs
+        assert call_kwargs.get("catalog_version") == "2026-05-26.2"
+        assert call_kwargs.get("tool_count") == 10
+
+    def test_tool_names_sample_limited_to_5(self):
+        """tool_names_sample carries at most 5 names."""
+        audit = MagicMock()
+        audit.log = MagicMock()
+        provider = _make_provider(audit=audit)
+
+        provider._handle_tool_catalog_event({
+            "catalog_version": "v-test",
+            "surface": "chat",
+            "tools": [{"name": f"tool_{i}"} for i in range(20)],
+        })
+
+        sample = audit.log.call_args.kwargs.get("tool_names_sample", [])
+        assert len(sample) <= 5
+
+    def test_no_audit_degrades_to_logger_info(self):
+        """When _audit is absent, the handler logs via standard logger and does not raise."""
+        provider = _make_provider(audit=None)
+        # Remove _audit if somehow present
+        if hasattr(provider, "_audit"):
+            del provider._audit
+
+        # Should not raise
+        provider._handle_tool_catalog_event({
+            "catalog_version": "v-test",
+            "surface": "chat",
+            "tools": [{"name": "aws_list_regions"}],
+        })
+
+
+# ---------------------------------------------------------------------------
+# stream_chat integration: tool_catalog event consumed, not forwarded
+# ---------------------------------------------------------------------------
+
+
+class TestStreamChatToolCatalogConsumption:
+    def test_tool_catalog_event_not_yielded_to_caller(self):
+        """stream_chat absorbs tool_catalog events; they don't reach the caller."""
+        provider = _make_provider()
+
+        # Mock api_client.stream_sse to yield a tool_catalog then a token event
+        sse_events = [
+            {
+                "event": "tool_catalog",
+                "data": {
+                    "catalog_version": "2026-05-26.2",
+                    "surface": "chat",
+                    "tools": [{"name": "aws_list_regions"}],
+                },
+            },
+            {"event": "token", "data": {"text": "Hello"}},
+        ]
+
+        async def fake_stream(*args, **kwargs):
+            for ev in sse_events:
+                yield ev
+
+        provider._api_client.stream_sse = fake_stream
+
+        async def collect():
+            events = []
+            async for ev in provider.stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                system_prompt="",
+                config=MagicMock(),
+            ):
+                events.append(ev)
+            return events
+
+        yielded = run(collect())
+
+        # tool_catalog must NOT be in yielded events
+        yielded_types = [e.get("event") for e in yielded]
+        assert "tool_catalog" not in yielded_types
+        # token must be yielded
+        assert "token" in yielded_types
+        # done sentinel must be yielded
+        assert "done" in yielded_types
+
+    def test_dispatch_state_not_mutated(self):
+        """tool_catalog SSE event does not modify _LOCAL_TOOL_HANDLERS."""
+        provider = _make_provider()
+        handler_before = dict(_LOCAL_TOOL_HANDLERS)
+
+        sse_events = [
+            {
+                "event": "tool_catalog",
+                "data": {
+                    "catalog_version": "2026-05-26.2",
+                    "surface": "chat",
+                    "tools": [
+                        {"name": "aws_list_regions"},
+                        {"name": "new_future_tool"},
+                    ],
+                },
+            },
+        ]
+
+        async def fake_stream(*args, **kwargs):
+            for ev in sse_events:
+                yield ev
+
+        provider._api_client.stream_sse = fake_stream
+
+        async def collect():
+            async for _ in provider.stream_chat(
+                messages=[{"role": "user", "content": "hi"}],
+                system_prompt="",
+                config=MagicMock(),
+            ):
+                pass
+
+        run(collect())
+
+        # _LOCAL_TOOL_HANDLERS must be identical to before
+        assert dict(_LOCAL_TOOL_HANDLERS) == handler_before, (
+            "tool_catalog SSE event must not mutate _LOCAL_TOOL_HANDLERS in PR5'"
+        )


### PR DESCRIPTION
## Summary

- Extends `_LOCAL_TOOL_HANDLERS` in `services/ai_tool_bridge.py` with **57 new entries** routing all catalog-advertised, non-relay tools to their `ServonautTools` method names (AWS describe/lifecycle, S3, CloudWatch/Trail, Hetzner/OVH, IP ban, memory).
- Flips `capabilities.supports_dynamic_catalog: True` in `_build_handshake()` — this is the v2.15.0 signal the server gates `CHAT_CATALOG_EXPANSION_ENABLED` staging flag-flip on.
- Wires `_FloorDangerousMixin._floor_dangerous` into `handle_tool_call`: any tool matching the 18 dangerous-floor patterns arriving below `'dangerous'` tier is escalated and audit-logged with `reason='dangerous_floor_escalation'`.
- Adds `_handle_tool_catalog_event` to `ServonautProvider`: absorbs the `tool_catalog` SSE event at stream open, writes an audit row (`reason='tool_catalog_received'`, `catalog_version`, `surface`, `tool_count`, `tool_names_sample`), and does **not** mutate dispatch state (static map remains authoritative for PR5').
- Version bump `2.14.0 → 2.15.0`.

## Agent-bus thread

`d59dd956-8c7a-4cd1-bde1-f127ce005dc4`

## Wire format spec

v1.0 — `dispatch_hint: 'local'` for all chat-surface entries per PR4' shipment. All 57 new handlers use the `_LOCAL_TOOL_HANDLERS` local-dispatch path.

## Staging-flip protocol

After this PR merges and v2.15.0 is on PyPI:
1. Confirm `capabilities.supports_dynamic_catalog=true` visible in the server's `cli.handshake` log.
2. Flip `CHAT_CATALOG_EXPANSION_ENABLED=true` on staging.
3. Run E2E: chat panel should surface the ~40 newly-advertised tools to the LLM.

## Test plan

- [ ] `tests/test_relay_handshake.py` — `test_handshake_capabilities_supports_dynamic_catalog_true` flipped from `False`.
- [ ] `tests/test_ai_tool_bridge_dispatch.py` — 60 parametrised dispatch cases + map-completeness assertions (57 new entries, all pointing to real ServonautTools methods).
- [ ] `tests/test_dangerous_floor_escalation.py` — 11 unit + integration cases for floor escalation; verifies audit row with `reason='dangerous_floor_escalation'`; denied path without entitlement.
- [ ] `tests/test_tool_catalog_sse_event.py` — 6 tests: audit row shape, sample cap, graceful-no-audit degradation, stream absorbs event (not forwarded), dispatch state unchanged.
- [ ] `tests/test_catalog_drift.py` — still 60 entries, drift gate unchanged.
- [ ] `tests/test_ai_tool_bridge.py::test_audit_row_written_with_source_ai_chat` — updated to send `guard_level='dangerous'` for `run_command` (now floor-escalated from `standard`).
- [ ] Full suite: **4889 passed, 5 skipped** (one pre-existing failure resolved).