### PR TITLE
feat(server-actions): per-instance dashboard with live stats, memory snapshot, and inline browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ All screenshots and the launch video were recorded with `--demo` active, which r
 - **List and search** instances across all AWS regions with OVH and Hetzner instances merged into the same view
 - **SSH into instances** — launches in new terminal window with auto-detected emulator
 - **Run remote commands** via overlay panel with real-time streaming output, persistent history, and saved command favorites
-- **Browse remote file systems** — interactive file tree navigation
+- **Per-instance dashboard** — clicking an instance opens a Server Actions view with a sectioned action rail plus a detail pane showing an at-a-glance **server-memory snapshot** (OS, disk, web stack, databases, runtimes, containers) and an opt-in **live resource monitor** (CPU / RAM / load / disk / uptime, press `L` to start — polled over SSH only while open, never in the background)
+- **Browse remote file systems** — interactive file tree navigation, available inline in the dashboard or as a full screen
 - **SCP file transfer** — upload/download files and directories
 - **Real-time log viewer** — stream remote logs via `tail -f` with pause, search, and log switching
 - **Keyword-based server scanning** — search file contents across instances
@@ -147,6 +148,9 @@ account](#servonaut-cloud-account) below.
 | Instance List | `C` | Run command overlay |
 | Instance List | `T` | SCP transfer |
 | Instance List | `Y` | Copy IP to clipboard |
+| Server Actions | `L` | Toggle the live resource monitor |
+| Server Actions | `1`–`8` | Run the numbered action (Browse, Command, SSH, …) |
+| Server Actions | `Esc` | Close inline view, or go back |
 | Global | `F2` | Toggle AI chat panel |
 | Anywhere | Mouse drag | Select text (auto-copies to clipboard) |
 | Anywhere | `Ctrl+C` | Copy selected text |
@@ -191,7 +195,7 @@ The TUI opens to a unified instance list (AWS + OVH + Hetzner + custom servers i
 **Account**
 - Login · Teams · Bug Reports
 
-**Server Actions** (clicking any instance row): Browse Files, Run Command, SSH Connect, SCP Transfer, View Scan Results, View Logs (tail -f), AI Analysis, Ban IP
+**Server Actions** (clicking any instance row): a per-instance dashboard — the detail pane shows the server's identity, a memory snapshot, and an opt-in live resource monitor (`L`), while the action rail covers Browse Files (opens inline in the dashboard), Run Command, SSH Connect, SCP Transfer, View Scan Results, View Logs (tail -f), AI Analysis, Ban IP, and Manage/Verify SSH Ref
 
 Command history persists across sessions — use `Ctrl+R` to search history and saved commands, `Ctrl+S` to save favorites.
 

--- a/src/servonaut/app.css
+++ b/src/servonaut/app.css
@@ -337,30 +337,99 @@ FleetMemoryScreen #memory-actions Button {
    SERVER ACTIONS SCREEN
    =================================================================== */
 
-#actions_container {
+#sa-body {
     width: 1fr;
     height: 100%;
     background: $surface;
-    padding: 2 4;
-    overflow-y: auto;
 }
 
-#server_info {
-    text-align: left;
-    padding: 2;
-    margin-bottom: 2;
-    border: round $primary;
-    background: $boost;
-}
-
+/* Left: narrow, sectioned action rail */
 #action_buttons {
-    width: 100%;
-    height: auto;
+    width: 36;
+    height: 100%;
+    padding: 1 2;
+    overflow-y: auto;
+    border-right: round $primary;
 }
 
 #action_buttons Button {
     width: 100%;
     margin: 0 0 1 0;
+}
+
+#action_buttons .section_label {
+    color: $accent;
+    text-style: bold;
+    padding: 1 0 0 0;
+    margin: 0;
+}
+
+/* Right: detail pane (identity + live + memory + focus help) */
+#sa-detail {
+    width: 1fr;
+    height: 100%;
+    padding: 1 3;
+    overflow-y: auto;
+}
+
+#server_info {
+    text-align: left;
+    padding: 1 2;
+    margin-bottom: 1;
+    border: round $primary;
+    background: $boost;
+}
+
+#live_stats {
+    padding: 1 2;
+    margin-bottom: 1;
+    border: round $accent;
+    background: $boost;
+}
+
+#memory_panel {
+    padding: 1 2;
+    margin-bottom: 1;
+    border: round $primary;
+    background: $boost;
+}
+
+#action_help {
+    padding: 0 2;
+    height: auto;
+}
+
+/* Inline read-only views (Browse / Logs) mounted below the dashboard panels */
+#sa-inline {
+    width: 100%;
+    height: auto;
+    display: none;
+}
+
+#sa-inline.visible {
+    display: block;
+    height: 1fr;
+    min-height: 14;
+    margin-top: 1;
+    border: round $accent;
+}
+
+#sa-inline .inline_title {
+    padding: 0 1;
+    background: $boost;
+    color: $accent;
+    text-style: bold;
+}
+
+#sa-inline .inline_note {
+    height: auto;
+    padding: 0 1;
+    border-top: round $surface-lighten-1;
+}
+
+#sa-inline RemoteTree,
+#sa-inline RichLog {
+    height: 1fr;
 }
 
 /* ===================================================================

--- a/src/servonaut/screens/file_browser.py
+++ b/src/servonaut/screens/file_browser.py
@@ -18,6 +18,49 @@ if TYPE_CHECKING:
     from servonaut.services.scan_service import ScanService
 
 
+def get_scan_paths_for_instance(config, instance: dict) -> List[str]:
+    """Resolve the scan paths to show for *instance*.
+
+    Combines ``default_scan_paths`` with any matching ``scan_rules`` paths,
+    de-duplicates, ensures trailing slashes, and defaults to ``['~']``.
+
+    Shared by :class:`FileBrowserScreen` and the inline browser on
+    ``ServerActionsScreen`` so the two never drift.
+    """
+    paths = config.default_scan_paths.copy()
+    for rule in config.scan_rules:
+        if matches_conditions(instance, rule.match_conditions):
+            paths.extend(rule.scan_paths)
+    unique_paths = list(set(paths))
+    normalized = [p if p.endswith('/') else p + '/' for p in unique_paths]
+    return normalized or ['~']
+
+
+def build_remote_tree(app, instance: dict, tree_id: str = "remote_tree") -> RemoteTree:
+    """Build a :class:`RemoteTree` for *instance* using *app*'s services.
+
+    Username resolution: custom servers use their own ``username``; everything
+    else uses the connection profile's username, falling back to the configured
+    default. Mirrors the original inline logic so behaviour is identical whether
+    the tree is shown full-screen or embedded.
+    """
+    config = app.config_manager.get()
+    scan_paths = get_scan_paths_for_instance(config, instance)
+    if instance.get('is_custom'):
+        username = instance.get('username') or 'root'
+    else:
+        profile = app.connection_service.resolve_profile(instance)
+        username = (profile.username if profile else None) or config.default_username
+    return RemoteTree(
+        instance=instance,
+        ssh_service=app.ssh_service,
+        connection_service=app.connection_service,
+        username=username,
+        scan_paths=scan_paths,
+        id=tree_id,
+    )
+
+
 class FileBrowserScreen(Screen):
     """Screen for browsing remote server filesystem via SSH.
 
@@ -77,57 +120,8 @@ class FileBrowserScreen(Screen):
         Returns:
             RemoteTree widget instance.
         """
-        # Get scan paths for this instance
-        config = self.app.config_manager.get()
-        scan_paths = self._get_scan_paths_for_instance()
-
-        # Resolve username: custom > profile > default
-        if self._instance.get('is_custom'):
-            username = self._instance.get('username') or 'root'
-        else:
-            profile = self.app.connection_service.resolve_profile(self._instance)
-            username = (
-                (profile.username if profile else None)
-                or config.default_username
-            )
-        self._remote_tree = RemoteTree(
-            instance=self._instance,
-            ssh_service=self.app.ssh_service,
-            connection_service=self.app.connection_service,
-            username=username,
-            scan_paths=scan_paths,
-            id="remote_tree"
-        )
+        self._remote_tree = build_remote_tree(self.app, self._instance)
         return self._remote_tree
-
-    def _get_scan_paths_for_instance(self) -> List[str]:
-        """Get scan paths for the current instance from configuration.
-
-        Combines default_scan_paths with any matching scan_rules paths.
-
-        Returns:
-            List of paths to scan.
-        """
-        config = self.app.config_manager.get()
-        paths = config.default_scan_paths.copy()
-
-        # Check scan_rules for additional paths
-        for rule in config.scan_rules:
-            if matches_conditions(self._instance, rule.match_conditions):
-                paths.extend(rule.scan_paths)
-
-        # Remove duplicates and ensure trailing slashes
-        unique_paths = list(set(paths))
-        normalized_paths = [
-            path if path.endswith('/') else path + '/'
-            for path in unique_paths
-        ]
-
-        # Default to home directory if no paths configured
-        if not normalized_paths:
-            normalized_paths = ['~']
-
-        return normalized_paths
 
     def action_back(self) -> None:
         """Navigate back to server actions screen."""

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -438,7 +438,13 @@ class ServerActionsScreen(Screen):
             logger.debug("get_all_modules failed for %s: %s", instance_id, exc)
             modules = {}
 
-        panel.update(render_memory_panel(modules))
+        text = render_memory_panel(modules)
+        # Demo mode: the snapshot can embed paths / hostnames / versions from
+        # the probed server — scrub before rendering, same posture as the
+        # Memory screen and log viewer.
+        if self.app.demo_mode and getattr(self.app, "redaction_service", None):
+            text = self.app.redaction_service.scrub_stream(text)
+        panel.update(text)
 
     # ------------------------------------------------------------------
     # Inline read-only views (Browse / Logs) — mounted in #sa-inline

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -2,18 +2,46 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import subprocess
 from typing import TYPE_CHECKING, Optional
 
 from rich.markup import escape
+from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.screen import ModalScreen, Screen
 from textual.widgets import Static, Button, Header, Footer
 
+from servonaut.utils.live_stats import LIVE_STATS_COMMAND, LiveStats, parse_live_stats
+from servonaut.utils.memory_panel import render_memory_panel
 from servonaut.widgets.sidebar import Sidebar
+
+#: Seconds between live-stats polls while the panel is active.
+_LIVE_STATS_INTERVAL = 3.0
+
+#: Per-action one-line help shown in the detail pane on focus.
+_ACTION_HELP: dict[str, str] = {
+    "btn_browse": "Browse the remote filesystem in a tree view (over SSH).",
+    "btn_command": "Run a one-off command on this server in an overlay panel.",
+    "btn_ssh": "Open a full SSH session in a new terminal window.",
+    "btn_memory": "Build / view the AI-queryable fact cache for this server.",
+    "btn_logs": "Stream live log files via SSH (tail -f).",
+    "btn_scan": "View keyword scan results collected from this server.",
+    "btn_ai_analysis": "Analyze log text with AI (OpenAI, Anthropic, or Ollama).",
+    "btn_scp": "Upload or download files via SCP.",
+    "btn_ban_ip": "Ban this server's public IP via WAF, Security Group, or NACL.",
+    "btn_manage_ssh_ref": "Add, edit, or remove the Bitwarden SSH item ref.",
+    "btn_verify_ssh": "Run a local SSH probe and report the result.",
+    "btn_ovh_reinstall": "Reinstall this OVH server with a new OS image.",
+    "btn_ovh_resize": "Change the VPS model or Cloud flavor.",
+    "btn_ovh_monitoring": "View CPU, RAM, and network metrics.",
+    "btn_ovh_snapshots": "Create, restore, or delete snapshots.",
+    "btn_ovh_firewall": "Manage VPS firewall rules.",
+    "btn_back": "Return to the instance list.",
+}
 
 if TYPE_CHECKING:
     from servonaut.screens.file_browser import FileBrowserScreen
@@ -114,6 +142,7 @@ class ServerActionsScreen(Screen):
         Binding("7", "action_7", "AI Analysis", show=True),
         Binding("8", "action_8", "Ban IP", show=True),
         Binding("m", "open_memory", "Memory", show=True),
+        Binding("l", "toggle_live", "Live", show=True),
         Binding("r", "manage_ssh_ref", "SSH Ref", show=True),
         Binding("v", "verify_ssh", "Verify SSH", show=True),
         Binding("9", "back", "Back", show=True),
@@ -128,9 +157,16 @@ class ServerActionsScreen(Screen):
         """
         super().__init__()
         self._instance = instance
+        self._live_on = False
+        # Id of the action button the focus-help line currently describes, so a
+        # click on that (otherwise passive) line can re-dispatch to the button.
+        self._focused_action_id: Optional[str] = None
+        # Which read-only view is mounted inline in the detail pane, if any:
+        # None | "browse" | "logs".
+        self._inline_view: Optional[str] = None
 
     def on_mount(self) -> None:
-        """Focus the first action button on mount."""
+        """Focus the first action button and populate the detail pane."""
         self.query_one("#btn_browse", Button).focus()
         # Fetch reverse DNS for OVH VPS instances
         if self._instance.get('is_ovh') and self._instance.get('provider_type') == 'vps':
@@ -141,18 +177,16 @@ class ServerActionsScreen(Screen):
         if self._instance.get('is_ovh'):
             action_buttons = self.query_one("#action_buttons")
             action_buttons.mount(
+                Static("OVH", classes="section_label"),
                 Button("Reinstall OS", id="btn_ovh_reinstall", variant="error"),
-                Static("[dim]  Reinstall with a new OS image[/dim]", classes="help_text"),
                 Button("Resize / Upgrade", id="btn_ovh_resize"),
-                Static("[dim]  Change VPS model or Cloud flavor[/dim]", classes="help_text"),
                 Button("Monitoring", id="btn_ovh_monitoring"),
-                Static("[dim]  View CPU, RAM, and network metrics[/dim]", classes="help_text"),
                 Button("Snapshots", id="btn_ovh_snapshots"),
-                Static("[dim]  Create, restore, or delete snapshots[/dim]", classes="help_text"),
                 Button("Firewall", id="btn_ovh_firewall"),
-                Static("[dim]  Manage VPS firewall rules[/dim]", classes="help_text"),
                 before=self.query_one("#btn_back"),
             )
+        # Populate the cached-memory snapshot pane.
+        self._render_memory_panel()
 
     def on_key(self, event) -> None:
         """Handle arrow key navigation between buttons.
@@ -161,13 +195,14 @@ class ServerActionsScreen(Screen):
             event: Key event.
         """
         if event.key in ("up", "down"):
-            buttons = list(self.query("Button"))
+            # Only cycle the action rail when a rail button already has focus.
+            # When focus is inside the inline view (file tree) or elsewhere,
+            # leave arrow keys alone so that widget can handle them.
+            buttons = list(self.query("#action_buttons Button"))
             if not buttons:
                 return
-            # Find currently focused button
             focused = self.focused
             if focused not in buttons:
-                buttons[0].focus()
                 return
             idx = buttons.index(focused)
             if event.key == "down":
@@ -177,49 +212,44 @@ class ServerActionsScreen(Screen):
             buttons[next_idx].focus()
 
     def compose(self) -> ComposeResult:
-        """Compose the server actions UI."""
+        """Compose the server actions UI (narrow action rail + detail pane)."""
         yield Header()
         with Horizontal(id="main-layout"):
             yield Sidebar()
-            yield Container(
-                Static(self._build_server_info(), id="server_info"),
-                Vertical(
+            with Horizontal(id="sa-body"):
+                # --- Left: narrow, sectioned action rail ---
+                yield Vertical(
+                    Static("CONNECT", classes="section_label"),
                     Button("1. Browse Files", id="btn_browse", variant="primary"),
-                    Static("[dim]  Browse remote filesystem via SSH (tree view)[/dim]", classes="help_text"),
                     Button("2. Run Command", id="btn_command"),
-                    Static("[dim]  Execute commands on this server in an overlay panel[/dim]", classes="help_text"),
                     Button("3. SSH Connect", id="btn_ssh"),
-                    Static("[dim]  Open a new terminal window with SSH session[/dim]", classes="help_text"),
-                    # Promoted above SCP — memory is the highest-leverage
-                    # feature on this screen for AI / MCP workflows, so it
-                    # earns a prominent slot in the action stack.
+                    Static("INSPECT", classes="section_label"),
+                    # Memory promoted to the top of INSPECT — highest-leverage
+                    # feature for AI / MCP workflows.
                     Button("M. Memory", id="btn_memory"),
-                    Static(
-                        "[dim]  🧠 Build an AI-queryable fact cache (OS, "
-                        "runtimes, services, web stack, logs) so the chat "
-                        "panel and MCP agents answer instantly — no SSH "
-                        "round-trip needed.[/dim]",
-                        classes="help_text",
-                    ),
-                    Button("4. SCP Transfer", id="btn_scp"),
-                    Static("[dim]  Upload or download files via SCP[/dim]", classes="help_text"),
-                    Button("5. View Scan Results", id="btn_scan"),
-                    Static("[dim]  View keyword scan data collected from this server[/dim]", classes="help_text"),
                     Button("6. View Logs", id="btn_logs"),
-                    Static("[dim]  Stream live log files via SSH tail -f[/dim]", classes="help_text"),
+                    Button("5. Scan Results", id="btn_scan"),
                     Button("7. AI Analysis", id="btn_ai_analysis"),
-                    Static("[dim]  Analyze log text with AI (OpenAI, Anthropic, or Ollama)[/dim]", classes="help_text"),
+                    Static("OPERATE", classes="section_label"),
+                    Button("4. SCP Transfer", id="btn_scp"),
                     Button("8. Ban IP", id="btn_ban_ip"),
-                    Static("[dim]  Ban this server's public IP via WAF, Security Group, or NACL[/dim]", classes="help_text"),
+                    Static("MANAGE", classes="section_label"),
                     Button("R. Manage SSH Ref", id="btn_manage_ssh_ref"),
-                    Static("[dim]  Add, edit, or remove the Bitwarden SSH item ref for this server[/dim]", classes="help_text"),
                     Button("V. Verify SSH", id="btn_verify_ssh"),
-                    Static("[dim]  Run a local BW SSH probe and report the result[/dim]", classes="help_text"),
                     Button("9. Back", id="btn_back", variant="error"),
-                    id="action_buttons"
-                ),
-                id="actions_container"
-            )
+                    id="action_buttons",
+                )
+                # --- Right: identity + live + memory + focus help + inline view ---
+                yield Vertical(
+                    Static(self._build_server_info(), id="server_info"),
+                    Static(self._live_stats_idle_text(), id="live_stats"),
+                    Static("", id="memory_panel"),
+                    Static("", id="action_help"),
+                    # Mount target for inline read-only views (Browse / Logs).
+                    # Hidden until an action opens it (see _open_inline).
+                    Vertical(id="sa-inline"),
+                    id="sa-detail",
+                )
         yield Footer()
 
     def _build_server_info(self) -> str:
@@ -335,6 +365,271 @@ class ServerActionsScreen(Screen):
             )
             info_widget.update(current)
 
+    # ------------------------------------------------------------------
+    # Detail pane: focus help, cached memory snapshot, live stats
+    # ------------------------------------------------------------------
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """Update the focus-driven help line when an action button gains focus.
+
+        The line is also a clickable proxy for the focused button (see
+        :meth:`on_click`), so it reads as actionable rather than a dead label.
+        """
+        widget_id = getattr(event.widget, "id", None)
+        if not widget_id:
+            return
+        help_text = _ACTION_HELP.get(widget_id)
+        if help_text is None:
+            return
+        self._focused_action_id = widget_id
+        try:
+            self.query_one("#action_help", Static).update(
+                f"[dim]▸[/dim] [u]{escape(help_text)}[/u]  [dim]· click to run[/dim]"
+            )
+        except Exception:  # noqa: BLE001 — pane may not be mounted yet
+            pass
+
+    def on_click(self, event: events.Click) -> None:
+        """Treat a click on the focus-help line as activating the focused action."""
+        widget = getattr(event, "widget", None)
+        if widget is None or getattr(widget, "id", None) != "action_help":
+            return
+        btn_id = self._focused_action_id
+        if not btn_id:
+            return
+        try:
+            self.query_one(f"#{btn_id}", Button).press()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _provider_for_memory(self) -> str:
+        """Best-effort provider slug for memory lookups.
+
+        Passing an empty string makes ``get_all_modules`` scan every provider
+        sub-directory, so the snapshot is found regardless of which slug it was
+        stored under (custom / aws / ovh / hetzner).
+        """
+        return ""
+
+    def _render_memory_panel(self) -> None:
+        """Render the cached server-memory snapshot into the detail pane."""
+        try:
+            panel = self.query_one("#memory_panel", Static)
+        except Exception:  # noqa: BLE001
+            return
+
+        memory_service = getattr(self.app, "memory_service", None)
+        if memory_service is None:
+            panel.update("[dim]Server memory is unavailable.[/dim]")
+            return
+
+        instance_id = str(self._instance.get("id") or "")
+        instance_name = self._instance.get("name") or ""
+        try:
+            if memory_service.is_memory_disabled(instance_id, instance_name):
+                panel.update("[dim]Memory is disabled for this server.[/dim]")
+                return
+        except Exception:  # noqa: BLE001
+            pass
+
+        try:
+            modules = memory_service.get_all_modules(instance_id, self._provider_for_memory())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("get_all_modules failed for %s: %s", instance_id, exc)
+            modules = {}
+
+        panel.update(render_memory_panel(modules))
+
+    # ------------------------------------------------------------------
+    # Inline read-only views (Browse / Logs) — mounted in #sa-inline
+    # ------------------------------------------------------------------
+
+    def _safe_focus(self, selector: str) -> None:
+        """Focus the widget matching *selector*, swallowing query failures."""
+        try:
+            self.query_one(selector).focus()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _clear_inline(self) -> None:
+        """Tear down whatever is mounted in the inline region and hide it."""
+        try:
+            inline = self.query_one("#sa-inline", Vertical)
+        except Exception:  # noqa: BLE001
+            self._inline_view = None
+            return
+        inline.remove_children()
+        inline.remove_class("visible")
+        self._inline_view = None
+
+    def _open_inline_browse(self) -> None:
+        """Mount the remote file tree inline in the detail pane."""
+        from servonaut.screens.file_browser import build_remote_tree
+
+        if self._inline_view == "browse":
+            self._safe_focus("#remote_tree")
+            return
+        self._clear_inline()
+
+        try:
+            inline = self.query_one("#sa-inline", Vertical)
+        except Exception:  # noqa: BLE001
+            return
+
+        try:
+            tree = build_remote_tree(self.app, self._instance, tree_id="remote_tree")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Could not build inline file tree: %s", exc, exc_info=True)
+            self.app.notify("Could not open file browser.", severity="error", markup=False)
+            return
+
+        self._inline_view = "browse"
+        inline.mount(
+            Static(
+                "[b]📁 Files[/b]  [dim]· Esc to close[/dim]",
+                classes="inline_title",
+            ),
+            tree,
+            Static(
+                "[dim]Root folders come from [b]Settings → Default Scan Paths[/b] "
+                "(plus any matching Scan Rule).[/dim]",
+                classes="inline_note",
+            ),
+        )
+        inline.add_class("visible")
+        self.call_after_refresh(lambda: self._safe_focus("#remote_tree"))
+
+    # ------------------------------------------------------------------
+    # Live stats (opt-in, SSH-polled)
+    # ------------------------------------------------------------------
+
+    def _live_stats_idle_text(self) -> str:
+        """Text shown in the live-stats pane while polling is off."""
+        return "[dim]Live stats: off — press [b]L[/b] to start (SSH-polled).[/dim]"
+
+    def action_toggle_live(self) -> None:
+        """Toggle the live resource-stats poller on/off."""
+        if self._live_on:
+            self._stop_live_stats()
+            return
+
+        if getattr(self.app, "memory_service", None) is None:
+            self.app.notify(
+                "Live stats need the memory service (SSH runner) — unavailable.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        if not self._validate_instance_connection():
+            return
+
+        self._live_on = True
+        try:
+            self.query_one("#live_stats", Static).update("[cyan]Live stats: connecting…[/cyan]")
+        except Exception:  # noqa: BLE001
+            pass
+        self.run_worker(
+            self._live_stats_worker(),
+            group="live_stats",
+            exclusive=True,
+        )
+
+    def _stop_live_stats(self) -> None:
+        """Stop the poller and reset the pane to its idle text."""
+        self._live_on = False
+        self.workers.cancel_group(self, "live_stats")
+        try:
+            self.query_one("#live_stats", Static).update(self._live_stats_idle_text())
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _live_stats_worker(self) -> None:
+        """Poll live resource stats over SSH until toggled off or screen left."""
+        memory_service = getattr(self.app, "memory_service", None)
+        if memory_service is None:
+            return
+        try:
+            runner = memory_service.make_ssh_runner(self._instance)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not build SSH runner for live stats: %s", exc)
+            self._set_live_text("[red]Live stats: SSH unavailable.[/red]")
+            self._live_on = False
+            return
+
+        while self._live_on:
+            try:
+                stdout, _stderr, _rc = await runner(LIVE_STATS_COMMAND)
+                stats = parse_live_stats(stdout)
+                self._set_live_text(self._format_live_stats(stats))
+            except asyncio.CancelledError:
+                raise
+            except asyncio.TimeoutError:
+                self._set_live_text("[yellow]Live stats: timed out — retrying…[/yellow]")
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Live stats poll failed: %s", exc)
+                self._set_live_text("[red]Live stats: poll failed — retrying…[/red]")
+
+            try:
+                await asyncio.sleep(_LIVE_STATS_INTERVAL)
+            except asyncio.CancelledError:
+                raise
+
+    def _set_live_text(self, markup: str) -> None:
+        """Update the live-stats pane defensively (screen may be torn down)."""
+        try:
+            self.query_one("#live_stats", Static).update(markup)
+        except Exception:  # noqa: BLE001
+            pass
+
+    @staticmethod
+    def _bar(pct: Optional[float], width: int = 12) -> str:
+        """Return a simple text gauge for *pct* (0–100), color-coded."""
+        if pct is None:
+            return "[dim]" + "·" * width + "[/dim]"
+        filled = max(0, min(width, round(pct / 100 * width)))
+        color = "green" if pct < 70 else ("yellow" if pct < 90 else "red")
+        return f"[{color}]{'█' * filled}[/{color}][dim]{'░' * (width - filled)}[/dim]"
+
+    def _format_live_stats(self, s: LiveStats) -> str:
+        """Format a :class:`LiveStats` into a compact htop-like panel."""
+        cpu = f"{s.cpu_pct:.0f}%" if s.cpu_pct is not None else "?"
+        if s.mem_pct is not None and s.mem_total_mb:
+            mem = f"{s.mem_pct:.0f}% [dim]({s.mem_used_mb}/{s.mem_total_mb} MB)[/dim]"
+        else:
+            mem = "?"
+        if s.load_1m is not None:
+            load = f"{s.load_1m:.2f} {s.load_5m:.2f} {s.load_15m:.2f}"
+        else:
+            load = "?"
+        if s.disk_pct is not None:
+            disk = f"{s.disk_pct}% [dim]({s.disk_used_gb}/{s.disk_total_gb} GB)[/dim]"
+        else:
+            disk = "?"
+        uptime = escape(s.uptime) if s.uptime else "?"
+
+        return (
+            "[bold]Live[/bold]  [dim]· press [b]L[/b] to stop[/dim]\n\n"
+            f"  [dim]CPU [/dim] {self._bar(s.cpu_pct)} {cpu}\n"
+            f"  [dim]RAM [/dim] {self._bar(s.mem_pct)} {mem}\n"
+            f"  [dim]Load[/dim] {load}    [dim]Disk[/dim] {self._bar(float(s.disk_pct) if s.disk_pct is not None else None)} {disk}\n"
+            f"  [dim]Up  [/dim] {uptime}"
+        )
+
+    def on_screen_suspend(self) -> None:
+        """Stop live polling when navigating away (no background SSH traffic)."""
+        if self._live_on:
+            self._stop_live_stats()
+
+    def on_unmount(self) -> None:
+        """Ensure the poller is cancelled and inline views torn down on teardown."""
+        self._live_on = False
+        try:
+            self.workers.cancel_group(self, "live_stats")
+        except Exception:  # noqa: BLE001
+            pass
+        if self._inline_view is not None:
+            self._clear_inline()
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button press events.
 
@@ -419,11 +714,10 @@ class ServerActionsScreen(Screen):
         return True
 
     def action_action_1(self) -> None:
-        """Navigate to File Browser screen."""
+        """Browse Files — open the remote file tree inline in the detail pane."""
         if not self._validate_instance_connection():
             return
-        from servonaut.screens.file_browser import FileBrowserScreen
-        self.app.push_screen(FileBrowserScreen(self._instance))
+        self._open_inline_browse()
 
     def action_action_2(self) -> None:
         """Open Command Overlay as modal."""
@@ -1054,7 +1348,15 @@ class ServerActionsScreen(Screen):
                     pass
 
     def action_back(self) -> None:
-        """Navigate back to instance list."""
+        """Close an open inline view, or navigate back to the instance list.
+
+        When a file tree / log view is open inline, Esc (and "9") first closes
+        it and returns focus to the rail; a second press leaves the screen.
+        """
+        if self._inline_view is not None:
+            self._clear_inline()
+            self._safe_focus("#btn_browse")
+            return
         self.app.pop_screen()
 
 

--- a/src/servonaut/services/memory/service.py
+++ b/src/servonaut/services/memory/service.py
@@ -643,6 +643,27 @@ class MemoryService(MemoryServiceInterface):
                     instance_id, result.module, exc
                 )
 
+    def make_ssh_runner(self, instance: Dict[str, Any]) -> Any:
+        """Public factory for a one-shot async SSH runner bound to *instance*.
+
+        Returns the same ``(command) -> (stdout, stderr, returncode)`` callable
+        used internally for probing, so consumers outside ``services/memory/``
+        (e.g. the live-stats panel on ``ServerActionsScreen``) get the exact
+        same provider-aware connection resolution — host, username, key path,
+        proxy args, port — without duplicating it.
+
+        The runner is read-only by nature of how callers use it; it imposes no
+        write-guard (that is the prober base class's responsibility), so callers
+        MUST only pass read-only commands.
+
+        Args:
+            instance: Instance dict (same format as ``app.instances``).
+
+        Returns:
+            Async callable ``(command: str) -> (stdout, stderr, returncode)``.
+        """
+        return self._make_ssh_runner(instance)
+
     def _make_ssh_runner(self, instance: Dict[str, Any]) -> Any:
         """Return an async SSH runner callable for *instance*.
 

--- a/src/servonaut/services/ssh_ref_resolver.py
+++ b/src/servonaut/services/ssh_ref_resolver.py
@@ -265,9 +265,38 @@ class SshRefResolver:
     def _try_local(self, instance: dict) -> Optional[ResolvedSshRef]:
         """Attempt resolution via local ``~/.ssh`` discovery.
 
-        Tries ``get_key_path(instance_id)`` first, then
-        ``discover_key(key_name)`` when ``key_name`` is present.
+        Resolution order:
+
+        1. ``instance['ssh_key']`` — when present and pointing at an existing
+           path on disk.  Custom servers (and Hetzner instances) carry the
+           key path directly on the instance dict; the AWS-style
+           ``get_key_path`` / ``discover_key`` lookups can't find these
+           because ``instance['key_name']`` for a custom server is itself
+           the full path, not an AWS key-pair name.
+        2. ``get_key_path(instance_id)`` — checks ``instance_keys`` map then
+           ``config.default_key``.
+        3. ``discover_key(key_name)`` — globs ``~/.ssh`` for AWS key-pair
+           naming patterns.
         """
+        from pathlib import Path
+
+        direct = instance.get("ssh_key")
+        if direct:
+            try:
+                expanded = Path(str(direct)).expanduser()
+                if expanded.exists():
+                    return ResolvedSshRef(
+                        source="local",
+                        item_id=None,
+                        vault_url=None,
+                        collection_id=None,
+                        local_key_path=str(expanded),
+                        team_slug=None,
+                        server_id=None,
+                    )
+            except (OSError, ValueError) as exc:
+                logger.debug("instance['ssh_key']=%r not usable: %s", direct, exc)
+
         instance_id = str(instance.get("id") or "")
         key_path: Optional[str] = None
 

--- a/src/servonaut/utils/live_stats.py
+++ b/src/servonaut/utils/live_stats.py
@@ -1,0 +1,202 @@
+"""Live resource-stats command + parser for the server actions dashboard.
+
+A single read-only SSH command gathers CPU / memory / load / uptime / disk in
+one round-trip; :func:`parse_live_stats` turns its stdout into a
+:class:`LiveStats` dataclass.  Each field is parsed independently and degrades
+to ``None`` on any failure, so a partial/odd remote response never raises.
+
+Portability note: the command reads from ``/proc`` plus ``free``/``df`` only —
+it deliberately avoids ``top`` and ``uptime -p``, which vary across distros
+(``uptime -p`` is unsupported on older Amazon Linux ``procps``, and ``top`` is
+absent from minimal AMIs).  ``/proc/stat``, ``/proc/loadavg``, ``/proc/uptime``,
+``free`` and GNU ``df`` are present on every mainstream Linux (Ubuntu, Amazon
+Linux 2/2023, RHEL, Debian…), so the panel renders consistently everywhere.
+
+The command is run through the public ``MemoryService.make_ssh_runner`` which
+imposes no write-guard, so the read-only contract lives here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Section markers — unlikely to collide with real command output.
+_M_CPU = "SVN_CPU"
+_M_MEM = "SVN_MEM"
+_M_LOAD = "SVN_LOAD"
+_M_UP = "SVN_UP"
+_M_DISK = "SVN_DISK"
+
+#: Read-only command emitted to the remote host.  CPU is sampled twice from
+#: ``/proc/stat`` (0.3s apart) so the parser can compute a busy percentage the
+#: canonical way without ``top``.  ``2>/dev/null`` keeps stderr out of stdout;
+#: every stage tolerates a missing tool by simply producing no parsable line.
+LIVE_STATS_COMMAND = (
+    f"echo {_M_CPU}; grep '^cpu ' /proc/stat 2>/dev/null; "
+    f"sleep 0.3; grep '^cpu ' /proc/stat 2>/dev/null; "
+    f"echo {_M_MEM}; free -m 2>/dev/null | grep -iE '^Mem'; "
+    f"echo {_M_LOAD}; cat /proc/loadavg 2>/dev/null; "
+    f"echo {_M_UP}; cat /proc/uptime 2>/dev/null; "
+    f"echo {_M_DISK}; df -P -BG / 2>/dev/null | tail -1"
+)
+
+_FLOAT_RE = re.compile(r"[\d.]+")
+
+
+@dataclass(frozen=True)
+class LiveStats:
+    """Parsed live resource snapshot.  Any field may be ``None`` if unparsable."""
+
+    cpu_pct: Optional[float] = None
+    mem_used_mb: Optional[int] = None
+    mem_total_mb: Optional[int] = None
+    load_1m: Optional[float] = None
+    load_5m: Optional[float] = None
+    load_15m: Optional[float] = None
+    uptime: Optional[str] = None
+    disk_used_gb: Optional[int] = None
+    disk_total_gb: Optional[int] = None
+    disk_pct: Optional[int] = None
+
+    @property
+    def mem_pct(self) -> Optional[float]:
+        """Used memory as a percentage of total, or ``None``."""
+        if self.mem_total_mb and self.mem_used_mb is not None and self.mem_total_mb > 0:
+            return round(self.mem_used_mb / self.mem_total_mb * 100, 1)
+        return None
+
+
+def _section(text: str, marker: str, next_markers: tuple[str, ...]) -> str:
+    """Return the text between *marker* and the next of *next_markers*."""
+    start = text.find(marker)
+    if start == -1:
+        return ""
+    start += len(marker)
+    end = len(text)
+    for nxt in next_markers:
+        idx = text.find(nxt, start)
+        if idx != -1:
+            end = min(end, idx)
+    return text[start:end].strip()
+
+
+def _cpu_from_proc_stat(cpu_sec: str) -> Optional[float]:
+    """Compute busy CPU% from two ``/proc/stat`` ``cpu`` aggregate lines.
+
+    Each line is ``cpu  user nice system idle iowait irq softirq steal …``.
+    Busy% = 100 * (1 - delta_idle / delta_total) across the two samples.
+    """
+    lines = [ln for ln in cpu_sec.splitlines() if ln.strip().startswith("cpu ")]
+    if len(lines) < 2:
+        return None
+    try:
+        a = [int(x) for x in lines[0].split()[1:]]
+        b = [int(x) for x in lines[-1].split()[1:]]
+    except ValueError:
+        return None
+    if len(a) < 5 or len(b) < 5:
+        return None
+    # idle + iowait (fields index 3 and 4) count as "not busy".
+    idle_a, idle_b = a[3] + a[4], b[3] + b[4]
+    total_a, total_b = sum(a), sum(b)
+    d_total = total_b - total_a
+    d_idle = idle_b - idle_a
+    if d_total <= 0:
+        return None
+    pct = 100.0 * (1.0 - d_idle / d_total)
+    return round(max(0.0, min(100.0, pct)), 1)
+
+
+def _format_uptime(seconds: float) -> str:
+    """Format an uptime in seconds as e.g. ``up 5d 2h 13m``."""
+    secs = int(seconds)
+    days, rem = divmod(secs, 86400)
+    hours, rem = divmod(rem, 3600)
+    mins = rem // 60
+    parts: List[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    parts.append(f"{mins}m")
+    return "up " + " ".join(parts)
+
+
+def parse_live_stats(stdout: str) -> LiveStats:
+    """Parse the stdout of :data:`LIVE_STATS_COMMAND` into a :class:`LiveStats`.
+
+    Defensive by design: each section is parsed in its own ``try`` and any
+    failure leaves that field ``None`` rather than raising.
+    """
+    if not stdout:
+        return LiveStats()
+
+    cpu_sec = _section(stdout, _M_CPU, (_M_MEM, _M_LOAD, _M_UP, _M_DISK))
+    mem_sec = _section(stdout, _M_MEM, (_M_LOAD, _M_UP, _M_DISK))
+    load_sec = _section(stdout, _M_LOAD, (_M_UP, _M_DISK))
+    up_sec = _section(stdout, _M_UP, (_M_DISK,))
+    disk_sec = _section(stdout, _M_DISK, ())
+
+    mem_used_mb: Optional[int] = None
+    mem_total_mb: Optional[int] = None
+    load_1m = load_5m = load_15m = None
+    uptime: Optional[str] = None
+    disk_used_gb: Optional[int] = None
+    disk_total_gb: Optional[int] = None
+    disk_pct: Optional[int] = None
+
+    cpu_pct = _cpu_from_proc_stat(cpu_sec)
+
+    # Memory: `free -m` Mem row → total used free shared buff/cache available.
+    try:
+        nums = [int(n) for n in re.findall(r"\d+", mem_sec)]
+        if len(nums) >= 2:
+            mem_total_mb = nums[0]
+            mem_used_mb = nums[1]
+    except ValueError:
+        mem_used_mb = mem_total_mb = None
+
+    # Load: /proc/loadavg → "0.40 0.55 0.60 1/234 5678".
+    try:
+        floats = _FLOAT_RE.findall(load_sec)
+        if len(floats) >= 3:
+            load_1m, load_5m, load_15m = (
+                float(floats[0]),
+                float(floats[1]),
+                float(floats[2]),
+            )
+    except ValueError:
+        load_1m = load_5m = load_15m = None
+
+    # Uptime: /proc/uptime → "<up_seconds> <idle_seconds>".
+    try:
+        m = _FLOAT_RE.search(up_sec)
+        if m:
+            uptime = _format_uptime(float(m.group(0)))
+    except (ValueError, AttributeError):
+        uptime = None
+
+    # Disk: `df -P -BG /` last row → FS 1G-blocks Used Avail Capacity Mounted.
+    try:
+        parts = disk_sec.split()
+        if len(parts) >= 5:
+            disk_total_gb = int(re.sub(r"\D", "", parts[1]) or 0)
+            disk_used_gb = int(re.sub(r"\D", "", parts[2]) or 0)
+            disk_pct = int(re.sub(r"\D", "", parts[4]) or 0)
+    except (ValueError, IndexError):
+        disk_used_gb = disk_total_gb = disk_pct = None
+
+    return LiveStats(
+        cpu_pct=cpu_pct,
+        mem_used_mb=mem_used_mb,
+        mem_total_mb=mem_total_mb,
+        load_1m=load_1m,
+        load_5m=load_5m,
+        load_15m=load_15m,
+        uptime=uptime,
+        disk_used_gb=disk_used_gb,
+        disk_total_gb=disk_total_gb,
+        disk_pct=disk_pct,
+    )

--- a/src/servonaut/utils/memory_panel.py
+++ b/src/servonaut/utils/memory_panel.py
@@ -1,0 +1,145 @@
+"""Compact renderer for the cached server-memory snapshot.
+
+Turns the ``{module: {observed: {...}, probed_at: ..., partial: ...}}`` dict
+returned by ``MemoryService.get_all_modules`` into a few human-readable Rich
+markup lines for the server actions detail pane.  Pure and side-effect free so
+it can be unit-tested without a live store.
+
+Every observed value interpolated into markup is escaped via
+``rich.markup.escape`` (cloud-supplied strings can contain ``[`` sequences).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from rich.markup import escape
+
+
+def human_age(probed_at_str: str) -> str:
+    """Return a short age string ("5m", "2h", "3d") for an ISO timestamp."""
+    if not probed_at_str:
+        return "?"
+    try:
+        probed_at = datetime.fromisoformat(probed_at_str.rstrip("Z"))
+        if not probed_at.tzinfo:
+            probed_at = probed_at.replace(tzinfo=timezone.utc)
+        secs = (datetime.now(tz=timezone.utc) - probed_at).total_seconds()
+    except (ValueError, TypeError):
+        return "?"
+    if secs < 60:
+        return "just now"
+    if secs < 3600:
+        return f"{int(secs // 60)}m ago"
+    if secs < 86400:
+        return f"{int(secs // 3600)}h ago"
+    return f"{int(secs // 86400)}d ago"
+
+
+def _val(observed: Dict[str, Any], key: str) -> Optional[str]:
+    """Return a stripped string for *key* in *observed*, or ``None`` if empty."""
+    raw = observed.get(key)
+    if raw is None or raw == "" or raw == []:
+        return None
+    return str(raw)
+
+
+def _newest_probed_at(modules: Dict[str, Dict[str, Any]]) -> str:
+    """Return the most recent ``probed_at`` across all modules."""
+    stamps = [
+        str(data.get("probed_at", ""))
+        for data in modules.values()
+        if data.get("probed_at")
+    ]
+    return max(stamps) if stamps else ""
+
+
+def render_memory_panel(modules: Dict[str, Dict[str, Any]]) -> str:
+    """Render the cached-memory snapshot as Rich markup.
+
+    Args:
+        modules: Mapping returned by ``MemoryService.get_all_modules``.
+
+    Returns:
+        Rich markup string.  Empty modules → a build call-to-action.
+    """
+    if not modules:
+        return (
+            "[bold]Server Memory[/bold]\n\n"
+            "[dim]No memory cached yet.[/dim]\n"
+            "[dim]Press [b]M[/b] to build an AI-queryable fact cache "
+            "(OS, disk, services, web stack…).[/dim]"
+        )
+
+    age = human_age(_newest_probed_at(modules))
+    partial = any(data.get("partial") for data in modules.values())
+    header = f"[bold]Server Memory[/bold]  [dim]· {escape(age)}[/dim]"
+    if partial:
+        header += "  [yellow]⚠ partial[/yellow]"
+
+    rows: List[str] = []
+
+    def add(label: str, value: Optional[str]) -> None:
+        if value:
+            rows.append(f"  [dim]{label:<10}[/dim] {escape(value)}")
+
+    def obs(module: str) -> Dict[str, Any]:
+        return modules.get(module, {}).get("observed", {}) or {}
+
+    # OS
+    os_o = obs("os")
+    add("OS", _val(os_o, "pretty_name") or _val(os_o, "id"))
+    add("Kernel", _val(os_o, "kernel"))
+
+    # Disk
+    disk_o = obs("disk")
+    pct = _val(disk_o, "pct_used")
+    mount = _val(disk_o, "mount") or "/"
+    if pct:
+        rows.append(f"  [dim]{'Disk':<10}[/dim] {escape(pct)} used [dim]({escape(mount)})[/dim]")
+
+    # Web stack
+    web_o = obs("web_stack")
+    web_bits = []
+    if _val(web_o, "nginx"):
+        web_bits.append(f"nginx {escape(_val(web_o, 'nginx'))}")
+    if _val(web_o, "apache"):
+        web_bits.append(f"apache {escape(_val(web_o, 'apache'))}")
+    if web_bits:
+        rows.append(f"  [dim]{'Web':<10}[/dim] " + " · ".join(web_bits))
+
+    # Databases
+    db_o = obs("databases")
+    db_bits = []
+    for engine, key in (("postgres", "postgres_version"), ("mysql", "mysql_version"),
+                        ("mariadb", "mariadb_version"), ("redis", "redis_version"),
+                        ("mongodb", "mongodb_version")):
+        v = _val(db_o, key)
+        if v:
+            db_bits.append(f"{engine} {escape(v)}")
+    if db_bits:
+        rows.append(f"  [dim]{'DB':<10}[/dim] " + " · ".join(db_bits))
+
+    # Runtimes
+    rt_o = obs("runtimes")
+    rt_bits = [
+        f"{name} {escape(_val(rt_o, name))}"
+        for name in ("python", "node", "php", "go", "ruby")
+        if _val(rt_o, name)
+    ]
+    if rt_bits:
+        rows.append(f"  [dim]{'Runtime':<10}[/dim] " + " · ".join(rt_bits))
+
+    # Containers
+    ct_o = obs("containers")
+    dv = _val(ct_o, "docker_version")
+    if dv:
+        running = _val(ct_o, "docker_running")
+        suffix = f" [dim]({escape(running)} running)[/dim]" if running else ""
+        rows.append(f"  [dim]{'Docker':<10}[/dim] {escape(dv)}{suffix}")
+
+    if not rows:
+        rows.append("  [dim]No structured facts parsed (modules may be partial).[/dim]")
+
+    return header + "\n\n" + "\n".join(rows)

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -727,6 +727,28 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "tf.write() is a tempfile filesystem write of the BW private key "
                    "— not a widget write. No user-visible UI surface involved."),
 
+    # server_actions.py — dashboard focus-help line writes the description of the
+    # focused action button from the _ACTION_HELP constant dict (hard-coded
+    # strings) plus a code-controlled "click to run" suffix. No server data.
+    AllowlistEntry("screens/server_actions.py", "on_descendant_focus", "update",
+                   "Writes the focused action's description from the _ACTION_HELP "
+                   "constant dict — hard-coded strings, no server-origin data."),
+
+    # server_actions.py — live resource monitor. _set_live_text renders the
+    # formatted CPU/RAM/load/disk/uptime panel: numeric metrics from /proc, free
+    # and df with no hostnames or IPs (same class as ovh_monitoring metrics).
+    # action_toggle_live and _stop_live_stats write hard-coded status/idle strings.
+    AllowlistEntry("screens/server_actions.py", "_set_live_text", "update",
+                   "Renders numeric CPU/RAM/load/disk/uptime metrics from /proc, "
+                   "free and df — structured numbers, no hostnames or IPs "
+                   "(same justification as ovh_monitoring metric panels)."),
+    AllowlistEntry("screens/server_actions.py", "action_toggle_live", "update",
+                   "Writes a hard-coded 'Live stats: connecting…' status string "
+                   "— code-controlled constant, no server data."),
+    AllowlistEntry("screens/server_actions.py", "_stop_live_stats", "update",
+                   "Writes the hard-coded idle text ('Live stats: off — press L…') "
+                   "— code-controlled constant, no server data."),
+
     # ---------------------------------------------------------------------------
     # load_text — TextArea content (added to _GUARDED_ATTRS in iteration-4)
     # ---------------------------------------------------------------------------

--- a/tests/test_live_stats.py
+++ b/tests/test_live_stats.py
@@ -1,0 +1,112 @@
+"""Tests for the live resource-stats parser (utils/live_stats.py)."""
+
+from __future__ import annotations
+
+from servonaut.utils.live_stats import (
+    LIVE_STATS_COMMAND,
+    LiveStats,
+    parse_live_stats,
+)
+
+
+def _sample(
+    cpu1: str = "cpu  1000 0 500 8000 200 0 50 0 0 0",
+    cpu2: str = "cpu  1100 0 520 8700 210 0 55 0 0 0",
+    mem_line: str = "Mem:           15761        3465         512         128        4360        4500",
+    load_line: str = "0.40 0.55 0.60 1/234 5678",
+    up_line: str = "456789.12 3456789.00",
+    disk_line: str = "/dev/xvda1   58G   11G   47G  18% /",
+) -> str:
+    return (
+        f"SVN_CPU\n{cpu1}\n{cpu2}\n"
+        f"SVN_MEM\n{mem_line}\n"
+        f"SVN_LOAD\n{load_line}\n"
+        f"SVN_UP\n{up_line}\n"
+        f"SVN_DISK\n{disk_line}\n"
+    )
+
+
+class TestParseLiveStats:
+    def test_full_parse(self):
+        s = parse_live_stats(_sample())
+        # delta_total = (1100+520+8700+210+55) - (1000+500+8000+200+50) = 10585-9750 = 835
+        # delta_idle  = (8700+210) - (8000+200) = 710 ; busy = 100*(1-710/835) ≈ 15.0
+        assert s.cpu_pct is not None and 14.0 <= s.cpu_pct <= 16.0
+        assert s.mem_total_mb == 15761
+        assert s.mem_used_mb == 3465
+        assert s.load_1m == 0.40
+        assert s.load_5m == 0.55
+        assert s.load_15m == 0.60
+        assert s.uptime is not None and s.uptime.startswith("up ")
+        assert s.disk_total_gb == 58
+        assert s.disk_used_gb == 11
+        assert s.disk_pct == 18
+
+    def test_uptime_formatting(self):
+        # 456789s = 5d 6h 53m
+        s = parse_live_stats(_sample(up_line="456789.12 0"))
+        assert s.uptime == "up 5d 6h 53m"
+
+    def test_uptime_under_a_day(self):
+        s = parse_live_stats(_sample(up_line="3700.0 0"))  # 1h 1m
+        assert s.uptime == "up 1h 1m"
+
+    def test_mem_pct_derived(self):
+        s = parse_live_stats(_sample())
+        assert s.mem_pct == round(3465 / 15761 * 100, 1)
+
+    def test_empty_input_all_none(self):
+        s = parse_live_stats("")
+        assert s == LiveStats()
+        assert s.mem_pct is None
+
+    def test_garbage_input_does_not_raise(self):
+        s = parse_live_stats("totally unrelated\noutput here\n")
+        assert isinstance(s, LiveStats)
+        assert s.cpu_pct is None
+        assert s.load_1m is None
+
+    def test_single_cpu_sample_yields_none(self):
+        # Only one /proc/stat line → cannot compute a delta.
+        text = "SVN_CPU\ncpu  1000 0 500 8000 200 0 50 0 0 0\nSVN_MEM\nMem: 1000 400\n"
+        s = parse_live_stats(text)
+        assert s.cpu_pct is None
+        assert s.mem_used_mb == 400
+
+    def test_cpu_idle_only_is_zero_busy(self):
+        # No movement except idle → 0% busy.
+        text = (
+            "SVN_CPU\ncpu  100 0 100 1000 0 0 0 0 0 0\n"
+            "cpu  100 0 100 1100 0 0 0 0 0 0\nSVN_MEM\n"
+        )
+        s = parse_live_stats(text)
+        assert s.cpu_pct == 0.0
+
+    def test_missing_cpu_section_other_fields_survive(self):
+        text = (
+            "SVN_MEM\nMem:  1000  400  600\n"
+            "SVN_LOAD\n0.10 0.20 0.30\n"
+            "SVN_DISK\n/dev/sda1 10G 2G 8G 20% /\n"
+        )
+        s = parse_live_stats(text)
+        assert s.cpu_pct is None
+        assert s.mem_used_mb == 400
+        assert s.load_1m == 0.10
+        assert s.disk_pct == 20
+
+    def test_command_is_read_only(self):
+        for tok in (" > ", " >> ", " tee ", " rm ", " dd ", " mv "):
+            assert tok not in LIVE_STATS_COMMAND
+
+    def test_command_avoids_nonportable_tools(self):
+        # Regression: must not depend on top / uptime -p (Amazon Linux gaps).
+        assert "top " not in LIVE_STATS_COMMAND
+        assert "uptime -p" not in LIVE_STATS_COMMAND
+        assert "/proc/stat" in LIVE_STATS_COMMAND
+        assert "/proc/uptime" in LIVE_STATS_COMMAND
+
+    def test_disk_with_gigabyte_suffix(self):
+        s = parse_live_stats(_sample(disk_line="/dev/root 40G 12G 28G 30% /"))
+        assert s.disk_total_gb == 40
+        assert s.disk_used_gb == 12
+        assert s.disk_pct == 30

--- a/tests/test_memory_panel.py
+++ b/tests/test_memory_panel.py
@@ -1,0 +1,94 @@
+"""Tests for the cached-memory snapshot renderer (utils/memory_panel.py)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from servonaut.utils.memory_panel import human_age, render_memory_panel
+
+
+def _iso_ago(**kwargs) -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(**kwargs)).isoformat()
+
+
+class TestHumanAge:
+    def test_empty_returns_question(self):
+        assert human_age("") == "?"
+
+    def test_minutes(self):
+        assert human_age(_iso_ago(minutes=5)) == "5m ago"
+
+    def test_hours(self):
+        assert human_age(_iso_ago(hours=2)) == "2h ago"
+
+    def test_days(self):
+        assert human_age(_iso_ago(days=3)) == "3d ago"
+
+    def test_just_now(self):
+        assert human_age(_iso_ago(seconds=5)) == "just now"
+
+    def test_garbage_returns_question(self):
+        assert human_age("not-a-date") == "?"
+
+
+class TestRenderMemoryPanel:
+    def test_empty_shows_build_cta(self):
+        out = render_memory_panel({})
+        assert "No memory cached" in out
+        assert "[b]M[/b]" in out
+
+    def test_renders_os_and_disk(self):
+        modules = {
+            "os": {
+                "observed": {"pretty_name": "Ubuntu 24.04 LTS", "kernel": "6.8.0-31-generic"},
+                "probed_at": _iso_ago(hours=2),
+            },
+            "disk": {
+                "observed": {"pct_used": "61%", "mount": "/"},
+                "probed_at": _iso_ago(hours=2),
+            },
+        }
+        out = render_memory_panel(modules)
+        assert "Ubuntu 24.04 LTS" in out
+        assert "6.8.0-31-generic" in out
+        assert "61%" in out
+        assert "2h ago" in out
+
+    def test_partial_flag_shown(self):
+        modules = {
+            "os": {"observed": {"pretty_name": "Debian 12"}, "probed_at": _iso_ago(minutes=1), "partial": True},
+        }
+        out = render_memory_panel(modules)
+        assert "partial" in out
+
+    def test_web_db_runtime_containers(self):
+        modules = {
+            "web_stack": {"observed": {"nginx": "1.24.0"}, "probed_at": _iso_ago(minutes=10)},
+            "databases": {"observed": {"postgres_version": "16.2"}, "probed_at": _iso_ago(minutes=10)},
+            "runtimes": {"observed": {"python": "3.12.3", "node": "20.11"}, "probed_at": _iso_ago(minutes=10)},
+            "containers": {"observed": {"docker_version": "26.0.0", "docker_running": "6"}, "probed_at": _iso_ago(minutes=10)},
+        }
+        out = render_memory_panel(modules)
+        assert "nginx 1.24.0" in out
+        assert "postgres 16.2" in out
+        assert "python 3.12.3" in out
+        assert "node 20.11" in out
+        assert "26.0.0" in out
+        assert "6 running" in out
+
+    def test_rich_markup_in_observed_value_is_escaped(self):
+        # A server name / value containing markup must not break rendering.
+        modules = {
+            "os": {"observed": {"pretty_name": "Evil [bold]OS[/bold]"}, "probed_at": _iso_ago(minutes=1)},
+        }
+        out = render_memory_panel(modules)
+        # The raw markup should be escaped, not passed through verbatim.
+        assert "Evil \\[bold]OS\\[/bold]" in out
+
+    def test_modules_present_but_no_known_facts(self):
+        modules = {
+            "logs": {"observed": {"some_unknown_key": "x"}, "probed_at": _iso_ago(minutes=1)},
+        }
+        out = render_memory_panel(modules)
+        assert "Server Memory" in out
+        assert "No structured facts" in out

--- a/tests/test_server_actions_screen.py
+++ b/tests/test_server_actions_screen.py
@@ -93,6 +93,185 @@ class TestServerActionsScreenCompose:
     def test_verify_ssh_flow_method_exists(self):
         assert hasattr(ServerActionsScreen, "_verify_ssh_flow")
 
+    def test_live_binding_registered(self):
+        keys = [b.key for b in ServerActionsScreen.BINDINGS]
+        assert "l" in keys, f"Expected 'l' in BINDINGS; got {keys}"
+
+
+# ---------------------------------------------------------------------------
+# Detail pane: live stats formatting + gating
+# ---------------------------------------------------------------------------
+
+class TestLiveStatsPanel:
+    def test_format_live_stats_renders_fields(self):
+        from servonaut.utils.live_stats import LiveStats
+        screen = _make_screen()
+        s = LiveStats(
+            cpu_pct=12.0, mem_used_mb=3104, mem_total_mb=7976,
+            load_1m=0.4, load_5m=0.5, load_15m=0.6, uptime="up 4 days",
+            disk_used_gb=48, disk_total_gb=80, disk_pct=61,
+        )
+        out = screen._format_live_stats(s)
+        assert "12%" in out
+        assert "3104/7976 MB" in out
+        assert "0.40 0.50 0.60" in out
+        assert "61%" in out
+        assert "up 4 days" in out
+
+    def test_format_live_stats_handles_none(self):
+        from servonaut.utils.live_stats import LiveStats
+        screen = _make_screen()
+        out = screen._format_live_stats(LiveStats())
+        # Unparsable fields degrade to '?', never raise.
+        assert out.count("?") >= 4
+
+    def test_bar_thresholds(self):
+        screen = _make_screen()
+        assert "green" in screen._bar(10.0)
+        assert "yellow" in screen._bar(80.0)
+        assert "red" in screen._bar(95.0)
+        assert "dim" in screen._bar(None)
+
+    def test_provider_for_memory_scans_all(self):
+        screen = _make_screen()
+        assert screen._provider_for_memory() == ""
+
+    def test_toggle_live_without_memory_service_warns(self):
+        fake_app = _FakeApp()  # has no memory_service attribute
+        screen = _make_screen(app=fake_app)
+        screen._live_on = False
+        screen.action_toggle_live()
+        sevs = [n["severity"] for n in fake_app._notifications]
+        assert "warning" in sevs
+
+
+# ---------------------------------------------------------------------------
+# Focus-help line: clickable proxy for the focused action button
+# ---------------------------------------------------------------------------
+
+class TestActionHelpClick:
+    def _click_event(self, widget_id):
+        ev = MagicMock()
+        ev.widget = MagicMock()
+        ev.widget.id = widget_id
+        return ev
+
+    def test_click_on_help_line_presses_focused_button(self):
+        screen = _make_screen()
+        screen._focused_action_id = "btn_browse"
+        pressed = []
+        btn = MagicMock()
+        btn.press = lambda: pressed.append("pressed")
+        screen.query_one = lambda sel, *a: btn
+        screen.on_click(self._click_event("action_help"))
+        assert pressed == ["pressed"]
+
+    def test_click_elsewhere_is_ignored(self):
+        screen = _make_screen()
+        screen._focused_action_id = "btn_browse"
+        pressed = []
+        btn = MagicMock()
+        btn.press = lambda: pressed.append("pressed")
+        screen.query_one = lambda sel, *a: btn
+        # A click on some other widget must NOT press the focused button.
+        screen.on_click(self._click_event("server_info"))
+        assert pressed == []
+
+    def test_click_with_no_focused_action_is_noop(self):
+        screen = _make_screen()
+        screen._focused_action_id = None
+        pressed = []
+        btn = MagicMock()
+        btn.press = lambda: pressed.append("pressed")
+        screen.query_one = lambda sel, *a: btn
+        screen.on_click(self._click_event("action_help"))
+        assert pressed == []
+
+
+# ---------------------------------------------------------------------------
+# Inline Browse Files (mounted in the detail pane, no screen push)
+# ---------------------------------------------------------------------------
+
+class TestInlineBrowse:
+    def test_browse_opens_inline_not_a_screen(self):
+        screen = _make_screen()
+        screen._validate_instance_connection = lambda: True
+        called = []
+        screen._open_inline_browse = lambda: called.append("inline")
+        screen.action_action_1()
+        assert called == ["inline"]
+
+    def test_browse_validation_blocks_inline(self):
+        screen = _make_screen()
+        screen._validate_instance_connection = lambda: False
+        called = []
+        screen._open_inline_browse = lambda: called.append("inline")
+        screen.action_action_1()
+        assert called == []  # invalid connection → no inline view
+
+    def test_back_with_inline_open_closes_it_without_popping(self):
+        fake_app = _FakeApp()
+        popped = []
+        fake_app.pop_screen = lambda: popped.append(1)
+        screen = _make_screen(app=fake_app)
+        screen._inline_view = "browse"
+        cleared = []
+        screen._clear_inline = lambda: (cleared.append(1), setattr(screen, "_inline_view", None))
+        screen._safe_focus = lambda sel: None
+        screen.action_back()
+        assert cleared == [1]
+        assert popped == []  # first Esc closes inline, does not leave the screen
+
+    def test_back_without_inline_pops_screen(self):
+        fake_app = _FakeApp()
+        popped = []
+        fake_app.pop_screen = lambda: popped.append(1)
+        screen = _make_screen(app=fake_app)
+        screen._inline_view = None
+        screen.action_back()
+        assert popped == [1]
+
+
+# ---------------------------------------------------------------------------
+# Detail pane: cached memory snapshot rendering
+# ---------------------------------------------------------------------------
+
+class TestMemoryPanelRender:
+    def test_render_calls_get_all_modules_with_scan_all(self):
+        fake_app = _FakeApp()
+        mem = MagicMock()
+        mem.is_memory_disabled.return_value = False
+        mem.get_all_modules.return_value = {}
+        fake_app.memory_service = mem
+        screen = _make_screen(app=fake_app)
+
+        updated = {}
+        panel = MagicMock()
+        panel.update = lambda text: updated.update({"text": text})
+        screen.query_one = lambda sel, *a: panel
+
+        screen._render_memory_panel()
+        # provider "" → store scans every provider directory
+        mem.get_all_modules.assert_called_once()
+        assert mem.get_all_modules.call_args.args[1] == ""
+        assert "No memory cached" in updated["text"]
+
+    def test_render_disabled_shows_disabled_message(self):
+        fake_app = _FakeApp()
+        mem = MagicMock()
+        mem.is_memory_disabled.return_value = True
+        fake_app.memory_service = mem
+        screen = _make_screen(app=fake_app)
+
+        updated = {}
+        panel = MagicMock()
+        panel.update = lambda text: updated.update({"text": text})
+        screen.query_one = lambda sel, *a: panel
+
+        screen._render_memory_panel()
+        assert "disabled" in updated["text"].lower()
+        mem.get_all_modules.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # _verify_ssh_flow — worker logic

--- a/tests/test_ssh_ref_resolver.py
+++ b/tests/test_ssh_ref_resolver.py
@@ -340,3 +340,74 @@ class TestLocalTier:
         assert result is not None
         assert result.source == "local"
         assert result.local_key_path == "/ssh/vps-key"
+
+    def test_instance_ssh_key_used_when_path_exists(self, tmp_path):
+        """Custom-server ``instance['ssh_key']`` resolves directly when on disk.
+
+        Regression: custom servers stash the key path in ``ssh_key`` and
+        ``key_name`` both, but ``key_name`` is the full path — not an AWS
+        key-pair name — so ``discover_key`` can't find it.  The resolver
+        must consult ``instance['ssh_key']`` before falling through.
+        """
+        key_file = tmp_path / "vps.pem"
+        key_file.write_text("FAKE KEY")
+
+        custom_inst = {
+            "id": "custom-vps-1",
+            "name": "vps-1",
+            "provider": "custom",
+            "is_custom": True,
+            "ssh_key": str(key_file),
+            "key_name": str(key_file),
+            "public_ip": "3.4.5.6",
+        }
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path=None,
+            ssh_discover=None,
+        )
+        result = _run(resolver.resolve(custom_inst))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == str(key_file)
+
+    def test_instance_ssh_key_skipped_when_path_missing(self):
+        """Non-existent ``instance['ssh_key']`` falls through to other lookups."""
+        custom_inst = {
+            "id": "custom-vps-1",
+            "name": "vps-1",
+            "provider": "custom",
+            "is_custom": True,
+            "ssh_key": "/nonexistent/path/to/key.pem",
+            "public_ip": "3.4.5.6",
+        }
+        resolver = _make_resolver(
+            bw_get_ref=None,
+            ssh_key_path="/configured/default-key",
+        )
+        result = _run(resolver.resolve(custom_inst))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == "/configured/default-key"
+
+    def test_instance_ssh_key_expands_user(self, tmp_path, monkeypatch):
+        """``~``-prefixed ``ssh_key`` paths are expanded before existence check."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key_file = ssh_dir / "vps.pem"
+        key_file.write_text("FAKE KEY")
+
+        custom_inst = {
+            "id": "custom-vps-1",
+            "name": "vps-1",
+            "provider": "custom",
+            "is_custom": True,
+            "ssh_key": "~/.ssh/vps.pem",
+            "public_ip": "3.4.5.6",
+        }
+        resolver = _make_resolver(bw_get_ref=None, ssh_key_path=None)
+        result = _run(resolver.resolve(custom_inst))
+        assert result is not None
+        assert result.source == "local"
+        assert result.local_key_path == str(key_file)


### PR DESCRIPTION
## Description of Changes

Reworks the **Server Actions** screen (shown when you click an instance) from a stack of full-width buttons into a per-instance dashboard, plus a fix for SSH key resolution on custom servers.

### Server Actions dashboard
- **Sectioned action rail** (Connect / Inspect / Operate / Manage) replaces the full-width button list, beside a detail pane.
- **Server-memory snapshot** in the detail pane — OS, disk, web stack, databases, runtimes, and containers at a glance, straight from the cached fact store (no SSH round-trip). Falls back to a "press M to build" prompt when no memory exists.
- **Live resource monitor** (opt-in, press `L`) — CPU / RAM / load / disk / uptime with text gauges. It polls over SSH **only while the screen is open** and stops on leave, so there's no background traffic. Metrics are read from `/proc`, `free`, and `df` so the panel renders consistently across distributions (Ubuntu, Amazon Linux, RHEL, …).
- **Inline file browser** — Browse Files mounts the remote file tree in the detail pane (split below the panels) instead of opening a separate screen; `Esc` closes it. A note points to where root folders are configured (Settings → Default Scan Paths). The full-screen browser still exists and shares the same tree-building logic.
- The focus-help line under the panels doubles as a clickable shortcut for the focused action.

### Fix: SSH key resolution for custom servers
Custom servers carry their key path directly on the instance record, but the resolver's local tier only did AWS-style key-name discovery, so SSH Connect / `servonaut ssh` reported "No SSH key configured" for custom servers that worked fine from the list view. The local tier now uses the instance's own key path (with `~` expansion) first. AWS behavior is unchanged.

### Notes
- New helpers `utils/live_stats.py` (command + defensive parser) and `utils/memory_panel.py` (snapshot renderer) are pure and unit-tested.
- `MemoryService.make_ssh_runner()` is exposed so the live monitor reuses the same provider-aware connection resolution as memory probing.

## Testing
- New unit tests for the stats parser, memory-panel renderer, inline-browse behavior, focus-help dispatch, and the resolver fix.
- Relevant suites pass (`test_server_actions_screen`, `test_live_stats`, `test_memory_panel`, `test_ssh_ref_resolver`, `test_cli_ssh`): **133 passed**.
- Live behavior verified by mounting the screen and driving the actions.
