### PR TITLE
fix(config-sync): prompt "Enter" not "Set" passphrase on restore / new machine

### DIFF
--- a/src/servonaut/screens/snapshot_manager.py
+++ b/src/servonaut/screens/snapshot_manager.py
@@ -399,10 +399,14 @@ class SnapshotManagerScreen(Screen):
     def _push_after_label(self, label: Optional[str]) -> None:
         if not label:
             return
+        # Only the very first push (account has no snapshots yet) lets the user
+        # choose a brand-new passphrase. Subsequent pushes must reuse the
+        # existing account passphrase so all snapshots share one key.
         self._prompt_passphrase_then(
             lambda pp: self.run_worker(
                 self._do_push(label, pp), exclusive=True, name="push_snapshot"
-            )
+            ),
+            allow_set=not self._snapshots,
         )
 
     async def _do_push(self, label: str, passphrase: str) -> None:
@@ -448,10 +452,22 @@ class SnapshotManagerScreen(Screen):
         except Exception:
             pass
 
-    def _prompt_passphrase_then(self, then) -> None:
+    def _prompt_passphrase_then(self, then, *, allow_set: bool = False) -> None:
         """Prompt the user for the sync passphrase, then run `then(passphrase)`.
 
         If the passphrase is cached on the service, uses it without prompting.
+
+        The "Set Sync Passphrase" (type-it-twice) mode is ONLY correct when the
+        user is choosing the passphrase for the very first time — i.e. an
+        initial push to an account that has zero snapshots. In every other case
+        the passphrase is account-global and must EXACTLY match the key the
+        target snapshot was encrypted with, so we prompt to *enter* it.
+
+        Keying this off the local probe file (as the old code did) was wrong: a
+        brand-new machine restoring an existing snapshot has no probe yet, so it
+        was mis-prompted to "Set" a new passphrase — which then could never
+        decrypt the existing snapshot. ``allow_set`` is passed True only by the
+        first-push path; restores always pass False.
         """
         sync = self._sync_service()
         if sync is None:
@@ -462,10 +478,12 @@ class SnapshotManagerScreen(Screen):
             return
         # Lazy import to avoid circular imports with login.py
         from servonaut.screens.login import PassphraseModal
-        is_first = not sync.has_probe()
-        title = "Set Sync Passphrase" if is_first else "Enter Sync Passphrase"
+        # A local probe means a passphrase was already established on this
+        # device, so never offer "Set" even if the caller allows it.
+        is_set = allow_set and not sync.has_probe()
+        title = "Set Sync Passphrase" if is_set else "Enter Sync Passphrase"
         self.app.push_screen(
-            PassphraseModal(confirm=is_first, title=title),
+            PassphraseModal(confirm=is_set, title=title),
             callback=lambda pp: then(pp) if pp else None,
         )
 

--- a/tests/test_snapshot_passphrase_prompt.py
+++ b/tests/test_snapshot_passphrase_prompt.py
@@ -1,0 +1,89 @@
+"""Regression tests for the snapshot-manager passphrase prompt mode.
+
+Bug: ``_prompt_passphrase_then`` chose "Set Sync Passphrase" (type-it-twice)
+vs "Enter Sync Passphrase" based on the *local probe file*. A brand-new
+machine restoring an existing snapshot has no probe, so it was mis-prompted to
+SET a brand-new passphrase — which could never decrypt the existing snapshot.
+
+The fix: "Set" mode is gated on ``allow_set`` (True only for a first-ever push
+to an account with zero snapshots) AND the absence of a local probe. Restores
+always prompt to ENTER.
+"""
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from servonaut.screens.snapshot_manager import SnapshotManagerScreen
+
+
+def _make_screen(*, has_probe: bool, cached=None):
+    """Build a screen without running Textual __init__ and stub its deps."""
+    screen = object.__new__(SnapshotManagerScreen)
+    sync = MagicMock()
+    sync._cached_passphrase = cached
+    sync.has_probe.return_value = has_probe
+    # Instance attribute shadows the bound method for our call site.
+    screen._sync_service = lambda: sync
+    return screen
+
+
+def _captured_modal(screen, **kwargs):
+    """Invoke _prompt_passphrase_then and return the PassphraseModal pushed."""
+    mock_app = MagicMock()
+    with patch.object(
+        SnapshotManagerScreen, "app", new_callable=PropertyMock, return_value=mock_app
+    ):
+        screen._prompt_passphrase_then(lambda pp: None, **kwargs)
+    if not mock_app.push_screen.called:
+        return None
+    return mock_app.push_screen.call_args[0][0]
+
+
+def test_restore_always_prompts_enter_on_fresh_machine():
+    """No probe (new machine), restore (allow_set defaults False) -> ENTER."""
+    screen = _make_screen(has_probe=False)
+    modal = _captured_modal(screen)  # restore path: no allow_set
+    assert modal is not None
+    assert modal._confirm is False
+    assert modal._title == "Enter Sync Passphrase"
+
+
+def test_restore_prompts_enter_even_with_probe():
+    screen = _make_screen(has_probe=True)
+    modal = _captured_modal(screen)
+    assert modal._confirm is False
+    assert modal._title == "Enter Sync Passphrase"
+
+
+def test_first_push_no_probe_prompts_set():
+    """First push (account empty -> allow_set=True), no probe -> SET."""
+    screen = _make_screen(has_probe=False)
+    modal = _captured_modal(screen, allow_set=True)
+    assert modal._confirm is True
+    assert modal._title == "Set Sync Passphrase"
+
+
+def test_allow_set_is_overridden_by_existing_probe():
+    """Even on a first push, a local probe means a passphrase already exists."""
+    screen = _make_screen(has_probe=True)
+    modal = _captured_modal(screen, allow_set=True)
+    assert modal._confirm is False
+    assert modal._title == "Enter Sync Passphrase"
+
+
+def test_subsequent_push_prompts_enter():
+    """Account already has snapshots -> allow_set=False -> ENTER."""
+    screen = _make_screen(has_probe=False)
+    modal = _captured_modal(screen, allow_set=False)
+    assert modal._confirm is False
+    assert modal._title == "Enter Sync Passphrase"
+
+
+def test_cached_passphrase_skips_modal():
+    screen = _make_screen(has_probe=False, cached="hunter2hunter2")
+    captured = {}
+    mock_app = MagicMock()
+    with patch.object(
+        SnapshotManagerScreen, "app", new_callable=PropertyMock, return_value=mock_app
+    ):
+        screen._prompt_passphrase_then(lambda pp: captured.setdefault("pp", pp))
+    assert mock_app.push_screen.called is False
+    assert captured["pp"] == "hunter2hunter2"


### PR DESCRIPTION
## Problem

Restoring synced config on a **brand-new machine** (or any machine without a local probe file) prompts **"Set Sync Passphrase"** with a type-it-twice confirm field — as if creating a new passphrase. The config-sync passphrase is **account-global**: it must exactly match the key the snapshot was encrypted with. The misleading "Set" framing pushes users to invent a new password, which then can't decrypt the existing snapshot, surfacing as a confusing *"wrong passphrase / encryption error"* even when the user knows the correct passphrase.

### Root cause

`SnapshotManagerScreen._prompt_passphrase_then` derived "first time" from the presence of `~/.servonaut/sync_key_probe.json`:

```python
is_first = not sync.has_probe()
title = "Set Sync Passphrase" if is_first else "Enter Sync Passphrase"
```

The probe is only a **local fast-path optimization** (offline "is this the right passphrase?" check). Its *absence* on a fresh machine does not mean "no passphrase exists for this account" — it just means this device has never pushed. The old logic conflated *"first time on this device"* with *"first time ever for this account"*.

## Fix

- Gate "Set" (confirm) mode on an explicit `allow_set` flag.
- **Push** passes `allow_set=not self._snapshots` → "Set" only on the genuine first push to an account with zero snapshots.
- A pre-existing local probe still suppresses "Set" (`allow_set and not sync.has_probe()`).
- **Restore** keeps the default `allow_set=False` → always prompts **"Enter Sync Passphrase"** (single field).

`settings.py` needs no change — it delegates to `SnapshotManagerScreen`; this was the only site with the flawed logic (verified by grep for `has_probe` / `PassphraseModal`).

## Tests

New `tests/test_snapshot_passphrase_prompt.py` covers the full decision matrix (6 cases):

| Scenario | probe | allow_set | Result |
|---|---|---|---|
| Restore, fresh machine | no | (default False) | Enter |
| Restore, has probe | yes | False | Enter |
| First push, fresh | no | True | **Set** |
| First push, probe exists | yes | True | Enter |
| Subsequent push | no | False | Enter |
| Cached passphrase | — | — | no modal |

`pytest tests/test_config_sync_service.py tests/test_snapshot_passphrase_prompt.py` → **58 passed**.

## Verification notes

- Pure UI-flow fix; crypto (`config_crypto`) untouched — cross-machine decrypt was always correct given the right passphrase.
- Manual workaround for users on the old build: type the original passphrase into *both* boxes on the "Set" screen (confirm only checks the two entries match).