### PR TITLE
fix(update): sidebar update button never appears on authenticated machines

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -201,8 +201,16 @@ class ServonautApp(App):
         # Push optional initial screen (e.g., OVH setup wizard launched via --setup-ovh)
         if self._initial_screen is not None:
             self.push_screen(self._initial_screen)
-        # Check for updates in background
-        self.run_worker(self._check_for_update(), name="version_check", exclusive=True)
+        # Check for updates in background. Own group is REQUIRED: other
+        # on_mount workers (relay_autostart) run exclusive=True in the
+        # default group and would otherwise cancel this in-flight network
+        # call before it resolves, so the update button never appears.
+        self.run_worker(
+            self._check_for_update(),
+            name="version_check",
+            group="version_check",
+            exclusive=True,
+        )
         # Decorate instances with SSH verify sidecar data (no-op if not logged in)
         self.run_worker(
             self._refresh_ssh_verify_status(),


### PR DESCRIPTION
## Summary

The "Update available" button in the sidebar silently never appears on machines that are logged in with the relay entitlement (reported on a laptop stuck on v2.16.0 while 2.16.2 was live).

## Root cause

The startup version check is an app-level worker started in `on_mount`:

```python
self.run_worker(self._check_for_update(), name="version_check", exclusive=True)  # default group
...
self.run_worker(self._start_relay_with_toast(), name="relay_autostart", exclusive=True)  # default group
```

Both ran in the **default** worker group with `exclusive=True`. Textual's `exclusive=True` cancels every other running worker in the same group when it starts. `relay_autostart` starts immediately *after* `version_check`, so it cancels the in-flight PyPI request before it resolves — `_latest_version` stays `None`, and neither the button nor the notification ever fires.

**Machine-specific** because `relay_autostart` only runs when authenticated *and* relay-entitled (`app.py` ~217-219). Unauthenticated machines never start it, so their version check completes and the button shows — which made it look intermittent.

## Regression origin

Introduced by the sidebar restyle (`f4a7503`, "replace main menu with persistent sidebar navigation"), whose commit message notes it *"moved the update check to app level."* On the old `MainMenuScreen` the check was a screen-owned worker with no competing default-group worker, so it always survived.

## Fix

Give the version check its own worker group:

```python
self.run_worker(
    self._check_for_update(),
    name="version_check",
    group="version_check",
    exclusive=True,
)
```

Now no default-group `exclusive=True` worker (`relay_autostart`, `global_scan`, `update`, relay login/logout) can cancel it.

## Verification
- `python -m py_compile src/servonaut/app.py` clean.
- AST audit of all `run_worker` calls confirms `version_check` is now the sole member of group `version_check`; the only other `on_mount` default-group exclusive worker (`relay_autostart`) can no longer reach it.
- The reveal path itself (`_show_update_button` → `self.screen.query_one("#nav_update")`) is sound once the check completes — the sidebar is mounted well before the PyPI call returns.

## Notes
Patch release 2.16.3 to follow after merge. The CLI `servonaut --update` path is unaffected (no workers) and already works as a manual fallback.