### PR TITLE
feat: incident-response tooling (traffic/topology/RDS/WAF/DB diagnostics + mitigation)

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -654,6 +654,11 @@ class ServonautApp(App):
                     self.auth_service, self.entitlement_guard,
                 )
                 self.ssh_service.set_secret_provider(provider)
+                # Same provider feeds the DB introspection tools (db_processlist
+                # / db_top_queries) so they resolve passwords from the user's
+                # selected secret store.
+                if getattr(self, "servonaut_tools", None) is not None:
+                    self.servonaut_tools.set_secret_provider(provider)
                 logger.info(
                     "SSHService secret_provider bound: %s",
                     provider.provider_name if provider is not None else "None (legacy ~/.ssh)",
@@ -667,6 +672,8 @@ class ServonautApp(App):
                     "legacy ~/.ssh discovery: %s", e,
                 )
                 self.ssh_service.set_secret_provider(None)
+                if getattr(self, "servonaut_tools", None) is not None:
+                    self.servonaut_tools.set_secret_provider(None)
             # Wire the hosted Servonaut AI provider now that api_client +
             # auth_service exist. The provider is keyless (OAuth bearer) and
             # gated on the ``premium_ai`` entitlement.

--- a/src/servonaut/cli/db.py
+++ b/src/servonaut/cli/db.py
@@ -1,0 +1,131 @@
+"""``servonaut db setup`` — interactive DB credential setup.
+
+The deterministic, no-model-context companion to the ``db_setup_scan`` /
+``db_setup_save`` MCP tools: it drives the same ``ServonautTools`` logic
+(on-box read-only scan → secret store → db_profile) but the user picks the
+candidate at the keyboard, so no secret or prompt ever transits an LLM.
+
+Reuses ``ServonautTools`` directly so the scan/stage/save behaviour is
+identical across the MCP, chat and CLI surfaces.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def add_db_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "db", help="Database tooling (credential setup for db_processlist etc.)",
+    )
+    sub = parser.add_subparsers(dest="db_command")
+    setup = sub.add_parser(
+        "setup",
+        help="Discover and store DB credentials for an instance.",
+    )
+    setup.add_argument("instance", help="Instance name or ID.")
+    setup.add_argument(
+        "--search-path", default="",
+        help="Directory on the box to search (or a local .env path).",
+    )
+    setup.add_argument(
+        "--source", choices=["auto", "ssh", "local"], default="auto",
+        help="Where to scan: auto/ssh read the box (default), local reads --search-path.",
+    )
+
+
+def handle_db_command(args: argparse.Namespace) -> int:
+    if getattr(args, "db_command", None) != "setup":
+        print("Usage: servonaut db setup <instance> [--search-path PATH] "
+              "[--source auto|ssh|local]")
+        return 1
+    try:
+        return asyncio.run(_run_setup(args))
+    except KeyboardInterrupt:
+        print("\nCancelled.")
+        return 130
+
+
+def _build_tools():
+    """Construct a minimal ServonautTools for the CLI (user-authorized)."""
+    from dataclasses import replace
+
+    from servonaut.config.manager import ConfigManager
+    from servonaut.services.cache_service import CacheService
+    from servonaut.services.aws_service import AWSService
+    from servonaut.services.ssh_service import SSHService
+    from servonaut.services.connection_service import ConnectionService
+    from servonaut.services.custom_server_service import CustomServerService
+    from servonaut.services.scp_service import SCPService
+    from servonaut.mcp.guards import CommandGuard
+    from servonaut.mcp.audit import AuditTrail
+    from servonaut.mcp.tools import ServonautTools
+
+    config_manager = ConfigManager()
+    config = config_manager.get()
+    cache_service = CacheService(ttl_seconds=config.cache_ttl_seconds)
+
+    # The user is at the keyboard and explicitly ran this command, so the
+    # guard must permit the standard-tier setup tools regardless of the MCP
+    # guard_level configured for headless agents.
+    guard = CommandGuard(replace(config.mcp, guard_level="dangerous"), config_manager)
+
+    secret_provider = None
+    try:
+        from servonaut.services.auth_service import AuthService
+        from servonaut.services.entitlement_guard import EntitlementGuard
+        from servonaut.services.secret_provider_resolver import resolve_secret_provider
+        auth = AuthService()
+        secret_provider = resolve_secret_provider(auth, EntitlementGuard(auth))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Secret provider unavailable: %s", exc)
+
+    return ServonautTools(
+        config_manager=config_manager,
+        aws_service=AWSService(cache_service),
+        custom_server_service=CustomServerService(config_manager),
+        cache_service=cache_service,
+        ssh_service=SSHService(config_manager),
+        connection_service=ConnectionService(config_manager),
+        scp_service=SCPService(),
+        guard=guard,
+        audit=AuditTrail(config.mcp.audit_path),
+        secret_provider=secret_provider,
+    ), secret_provider
+
+
+async def _run_setup(args: argparse.Namespace) -> int:
+    tools, secret_provider = _build_tools()
+    if secret_provider is None:
+        print("No secret store is active. Run `servonaut login` first (the "
+              "secret store is a Solo/Teams feature), then retry.")
+        return 1
+
+    print(f"Scanning {args.instance} for DB credentials (read-only)...")
+    scan_out = await tools.db_setup_scan(
+        args.instance, search_path=args.search_path, source=args.source,
+    )
+    print("\n" + scan_out)
+
+    if "token=" not in scan_out:
+        return 0  # nothing found / error already printed
+
+    token = input("\nToken to save (blank to cancel): ").strip()
+    if not token:
+        print("Cancelled.")
+        return 0
+
+    confirm = input(
+        f"Store credentials for '{args.instance}' from {token} into your "
+        "secret store and write a db_profile? [y/N]: "
+    ).strip().lower()
+    if confirm not in ("y", "yes"):
+        print("Cancelled.")
+        return 0
+
+    save_out = await tools.db_setup_save(token, instance_id=args.instance)
+    print("\n" + save_out)
+    return 0 if save_out.startswith("Saved") else 1

--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -17,6 +17,7 @@ from .schema import (
     AWSConfig,
     AzureConfig,
     CustomServer,
+    DBProfile,
     GCPConfig,
     HetznerConfig,
     IPBanConfig,
@@ -586,6 +587,10 @@ class ConfigManager:
             _coerce(IPBanConfig, c, 'ip_ban_configs')
             for c in raw_data.get('ip_ban_configs', [])
         ]
+        db_profiles = [
+            _coerce(DBProfile, p, 'db_profiles')
+            for p in raw_data.get('db_profiles', [])
+        ]
         ai_provider = _coerce(AIProviderConfig, raw_data.get('ai_provider', {}), 'ai_provider')
         mcp = _coerce(MCPConfig, raw_data.get('mcp', {}), 'mcp')
         relay = _coerce(RelayConfig, raw_data.get('relay', {}), 'relay')
@@ -626,6 +631,7 @@ class ConfigManager:
         config_dict['connection_rules'] = connection_rules
         config_dict['custom_servers'] = custom_servers
         config_dict['ip_ban_configs'] = ip_ban_configs
+        config_dict['db_profiles'] = db_profiles
         config_dict['ai_provider'] = ai_provider
         config_dict['mcp'] = mcp
         config_dict['relay'] = relay

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -138,6 +138,37 @@ class IPBanConfig:
 
 
 @dataclass
+class DBProfile:
+    """Database connection profile for the ``db_processlist`` / ``db_top_queries`` tools.
+
+    The credential never lives in this dataclass. ``password_secret`` is the
+    *name* of a secret in the user's active secret store (LocalProvider or
+    Bitwarden — whichever ``resolve_secret_provider`` returns); the tool
+    resolves it at call time and passes it to the on-box DB client via an
+    environment variable (``MYSQL_PWD`` / ``PGPASSWORD``), never on argv.
+
+    Attributes:
+        instance: Instance id or name this profile applies to (matched
+            case-insensitively against both, like ``_find_instance``).
+        engine: ``"mysql"`` (covers MariaDB) or ``"postgres"``.
+        host: DB host as seen *from the box* (usually ``127.0.0.1`` or an
+            RDS endpoint reachable from the instance).
+        port: DB port (3306 mysql / 5432 postgres).
+        user: DB username.
+        password_secret: Name of the password secret in the active secret
+            store. Empty means "no password" (socket / trust / IAM auth).
+        database: Optional default database to connect to.
+    """
+    instance: str
+    engine: str = "mysql"  # mysql | postgres
+    host: str = "127.0.0.1"
+    port: int = 3306
+    user: str = "root"
+    password_secret: str = ""
+    database: str = ""
+
+
+@dataclass
 class AIProviderConfig:
     """AI provider configuration.
 
@@ -792,6 +823,7 @@ class AppConfig:
     abuseipdb_api_key: str = ""
     ip_ban_configs: List[IPBanConfig] = field(default_factory=list)
     ip_ban_audit_path: str = "~/.servonaut/ip_ban_audit.json"
+    db_profiles: List[DBProfile] = field(default_factory=list)
     ai_provider: AIProviderConfig = field(default_factory=AIProviderConfig)
     ai_chunk_size: int = 100000
     ai_system_prompt: str = (
@@ -849,3 +881,23 @@ class AppConfig:
     # banner is suppressed globally; the ``servonaut memory reset-prompts``
     # command resets it back to 0 so users can re-enable the nudge later.
     memory_first_connect_dismissed_count: int = 0
+
+    def db_profile_for(
+        self, instance_id: str, instance_name: str = "",
+    ) -> Optional["DBProfile"]:
+        """Return the :class:`DBProfile` matching an instance, or ``None``.
+
+        Matches ``profile.instance`` case-insensitively against either the
+        instance id or its name — same dual-key matching the rest of the
+        tool surface uses so a profile keyed by name still resolves when the
+        caller passes an id (and vice versa).
+        """
+        targets = {
+            (instance_id or "").strip().lower(),
+            (instance_name or "").strip().lower(),
+        }
+        targets.discard("")
+        for profile in self.db_profiles:
+            if (profile.instance or "").strip().lower() in targets:
+                return profile
+        return None

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -835,6 +835,10 @@ def main() -> None:
     from servonaut.cli.servers import add_servers_parser, handle_servers_command
     add_servers_parser(subparsers)
 
+    # ---- db subcommand (DB credential setup for db_processlist/db_top_queries) ----
+    from servonaut.cli.db import add_db_parser
+    add_db_parser(subparsers)
+
     args = parser.parse_args()
 
     # Top-level --ai-provider / --no-tools flags propagate via env vars so
@@ -865,6 +869,11 @@ def main() -> None:
     if getattr(args, 'subcommand', None) == 'servers':
         _setup_logging(debug=args.debug)
         sys.exit(handle_servers_command(args))
+
+    if getattr(args, 'subcommand', None) == 'db':
+        _setup_logging(debug=args.debug)
+        from servonaut.cli.db import handle_db_command
+        sys.exit(handle_db_command(args))
 
     if getattr(args, 'subcommand', None) == 'memory':
         _setup_logging(debug=args.debug)

--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -78,6 +78,16 @@ class CommandGuard:
             'aws_list_key_pairs', 'aws_list_subnets', 'aws_list_security_groups',
             # S3 — read tools (provider-parameterised).
             's3_list_buckets', 's3_list_objects',
+            # Incident-response read-only probes. web_traffic_summary and
+            # fleet_health_snapshot run SSH info-gathering commands — same
+            # read-only posture as get_server_info (also readonly). enrich_ips
+            # is network-only (rDNS / ASN / abuse lookups).
+            'web_traffic_summary', 'fleet_health_snapshot', 'enrich_ips',
+            # describe_ingress_path is boto3 elbv2/wafv2/ec2 Describe — pure
+            # read-only AWS topology, same posture as cloudwatch_* / cloudtrail_*.
+            'describe_ingress_path',
+            # rds_metrics is boto3 cloudwatch:GetMetricStatistics — read-only.
+            'rds_metrics',
         }
         standard_tools = readonly_tools | {
             'run_command', 'get_logs',
@@ -106,6 +116,15 @@ class CommandGuard:
             'aws_start_instance', 'aws_stop_instance', 'aws_reboot_instance',
             # S3 read-to-local — analogous to get_logs / transfer_file (download).
             's3_download_object',
+            # DB introspection — read-only queries, but they execute a DB
+            # client on the box using stored credentials, so they sit at the
+            # standard tier (alongside run_command) rather than readonly.
+            'db_processlist', 'db_top_queries',
+            # DB credential setup: scan reads secrets on the box (side-effectful
+            # SSH); save writes the secret store + local config. Neither touches
+            # a cloud resource, so standard (not dangerous) — the staging-token
+            # design keeps the plaintext out of the model context regardless.
+            'db_setup_scan', 'db_setup_save', 'db_setup_remove',
         }
         dangerous_tools = standard_tools | {
             'transfer_file',
@@ -113,6 +132,8 @@ class CommandGuard:
             # group, or a NACL. Security-sensitive and immediately affects
             # live traffic, so it stays at the dangerous tier.
             'ip_ban_set',
+            # Group C WAF mitigation — mutate live WebACL rules / firewall.
+            'waf_rate_rule_set', 'block_ip',
             # Mutating tools that cost money / cannot be undone without
             # re-creating from scratch. Reserved for dangerous mode.
             'hetzner_create_server', 'hetzner_delete_server',

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -165,6 +165,35 @@ def create_mcp_server():
     except Exception as e:
         logger.error("Failed to initialise object storage services for MCP: %s", e)
 
+    # Secret provider — same resolver app.py uses, so db_processlist /
+    # db_top_queries read passwords from the user's selected secret store
+    # (LocalProvider / Bitwarden). None for unauthenticated / Free tier;
+    # the DB tools then return a clear "log in" error.
+    secret_provider = None
+    try:
+        from servonaut.services.entitlement_guard import EntitlementGuard
+        from servonaut.services.secret_provider_resolver import (
+            resolve_secret_provider,
+        )
+        secret_provider = resolve_secret_provider(
+            auth_service, EntitlementGuard(auth_service),
+        )
+        if secret_provider is not None:
+            logger.info(
+                "Secret provider bound for MCP: %s",
+                secret_provider.provider_name,
+            )
+    except Exception as e:
+        logger.warning("Could not resolve secret provider for MCP: %s", e)
+
+    # IP enrichment (rDNS / ASN / abuse) for enrich_ips.
+    ip_enrichment_service = None
+    try:
+        from servonaut.services.ip_enrichment_service import IPEnrichmentService
+        ip_enrichment_service = IPEnrichmentService(config_manager)
+    except Exception as e:
+        logger.warning("Could not initialise IP enrichment service for MCP: %s", e)
+
     tools = ServonautTools(
         config_manager, aws_service, custom_server_service, cache_service,
         ssh_service, connection_service, scp_service,
@@ -185,6 +214,8 @@ def create_mcp_server():
         aws_object_storage_service=aws_object_storage_service,
         hetzner_object_storage_service=hetzner_object_storage_service,
         ovh_object_storage_service=ovh_object_storage_service,
+        secret_provider=secret_provider,
+        ip_enrichment_service=ip_enrichment_service,
     )
 
     _instructions = (

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -76,7 +76,11 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
         "chat_exposed": True,
     },
     "run_command": {
-        "description": "Run a command on any managed instance via SSH.",
+        "description": (
+            "Run a command on any managed instance. Defaults to SSH with "
+            "automatic failover to AWS SSM when sshd is unreachable (e.g. "
+            "under heavy load) on SSM-managed AWS instances."
+        ),
         "schema": {
             "type": "object",
             "properties": {
@@ -85,6 +89,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "description": "Instance ID, name, or custom-server name.",
                 },
                 "command": {"type": "string", "description": "Command to execute."},
+                "transport": {
+                    "type": "string",
+                    "enum": ["auto", "ssh", "ssm"],
+                    "description": "Execution channel. 'auto' (default) tries "
+                                   "SSH then falls back to AWS SSM if the SSH "
+                                   "connection fails; 'ssh' forces SSH; 'ssm' "
+                                   "forces AWS Systems Manager (AWS-only).",
+                    "default": "auto",
+                },
             },
             "required": ["instance_id", "command"],
         },
@@ -886,8 +899,11 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     },
     "cloudwatch_get_log_events": {
         "description": (
-            "Fetch recent events from a CloudWatch log group within the "
-            "last N hours, with an optional CloudWatch filter pattern."
+            "Fetch recent events from a CloudWatch log group within the last N "
+            "hours, with an optional filter pattern. Set group_by "
+            "(clientIp|status|uri) to get a server-side ranked summary (top_n, "
+            "default 20) instead of raw lines — avoids dumping huge log pulls. "
+            "summary_only returns just the event count."
         ),
         "schema": {
             "type": "object",
@@ -914,6 +930,23 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "description": "Maximum events to return (0 = unlimited, "
                                    "capped at 50000).",
                     "default": 100,
+                },
+                "group_by": {
+                    "type": "string",
+                    "enum": ["clientIp", "status", "uri"],
+                    "description": "Aggregate the events by this structured "
+                                   "field and return a ranked summary.",
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "When group_by is set, how many top entries "
+                                   "to return (0 = default 20).",
+                    "default": 0,
+                },
+                "summary_only": {
+                    "type": "boolean",
+                    "description": "Return only the event count, not raw lines.",
+                    "default": False,
                 },
             },
             "required": ["log_group"],
@@ -1042,35 +1075,53 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     },
     "ip_ban_set": {
         "description": (
-            "Ban or unban an IP address via a named WAF/SecurityGroup/NACL "
-            "config. Set action='ban' to block or action='unban' to remove "
-            "the block. Mutates live traffic rules — confirm with the user "
-            "first."
+            "Ban or unban IP(s)/CIDR(s) via a named WAF/SecurityGroup/NACL "
+            "config OR via a site's WebACL. Accepts a single ip_address (IP or "
+            "CIDR), a bulk ip_addresses[] list, or a 'site' (WebACL ARN, ALB "
+            "ARN, or instance id/name) that resolves the WebACL actually "
+            "fronting the box. Returns an applied/failed split. Mutates live "
+            "traffic rules — confirm with the user first."
         ),
         "schema": {
             "type": "object",
             "properties": {
                 "ip_address": {
                     "type": "string",
-                    "description": "The IPv4/IPv6 address to ban or unban.",
+                    "description": "An IPv4/IPv6 address or CIDR to ban/unban.",
+                },
+                "cidr": {
+                    "type": "string",
+                    "description": "Alias for ip_address accepting a CIDR block.",
+                },
+                "ip_addresses": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Bulk list of IPs/CIDRs to ban/unban.",
                 },
                 "config_name": {
                     "type": "string",
                     "description": "Name of the IP-ban config "
                                    "(see ip_ban_list_configs).",
                 },
+                "site": {
+                    "type": "string",
+                    "description": "WebACL ARN, ALB ARN, or instance id/name — "
+                                   "bans into the WebACL fronting it (alternative "
+                                   "to config_name).",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region override for the site path.",
+                },
                 "action": {
                     "type": "string",
                     "enum": ["ban", "unban"],
-                    "description": "'ban' to block the IP, 'unban' to remove "
-                                   "an existing block.",
+                    "description": "'ban' to block, 'unban' to remove a block.",
                     "default": "ban",
                 },
             },
-            "required": ["ip_address", "config_name"],
         },
         "chat_exposed": True,
-        "required_service": "ip_ban",
     },
 
     # --- AWS EC2 lifecycle ---------------------------------------------
@@ -1638,6 +1689,383 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
             "required": ["provider", "bucket", "key"],
         },
         "chat_exposed": False,
+    },
+    # --- Incident-response tools (Group A) -------------------------------
+    "web_traffic_summary": {
+        "description": (
+            "Summarize a managed instance's OWN web access logs "
+            "(X-Forwarded-For / mod_remoteip aware): per-vhost request volume, "
+            "approx req/s, status-code mix, top client IPs and top URLs. Reads "
+            "the decisive on-box data that cloudwatch_top_ips (WAF logs only) "
+            "cannot see. Auto-discovers nginx/apache/httpd logs when log_path "
+            "is omitted. Read-only."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID, name, or custom-server name.",
+                },
+                "log_path": {
+                    "type": "string",
+                    "description": "Explicit access-log path. Empty = "
+                                   "auto-discover nginx/apache/httpd access logs.",
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "Lines to tail per log file (100–200000, default 10000).",
+                    "default": 10000,
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "How many top IPs/URLs to report (1–100, default 15).",
+                    "default": 15,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "fleet_health_snapshot": {
+        "description": (
+            "Triage the whole fleet in one table via SSH fan-out: load, CPU "
+            "count, memory %, php-fpm pool saturation (active/max_children) and "
+            "listening web stack across all managed instances. Surfaces the "
+            "sick box without SSH'ing into each by hand. Unreachable hosts are "
+            "listed separately. Read-only."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string",
+                    "description": "Optional region filter.",
+                },
+                "running_only": {
+                    "type": "boolean",
+                    "description": "Probe only running instances (default true).",
+                    "default": True,
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Per-host SSH timeout in seconds (5–60, default 15).",
+                    "default": 15,
+                },
+            },
+        },
+        "chat_exposed": True,
+    },
+    "enrich_ips": {
+        "description": (
+            "Enrich a list of IPs with reverse DNS, ASN/org, country and "
+            "AbuseIPDB score. Helps decide HOW to block: a single /32 rotates, "
+            "but an ASN/org (bulletproof host) can be blocked wholesale. "
+            "ASN/geo via ip-api.com (free); abuse score requires an AbuseIPDB "
+            "key in Settings. Read-only."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "ips": {
+                    "type": "string",
+                    "description": "IP addresses, comma/space/newline separated "
+                                   "(max 100).",
+                },
+            },
+            "required": ["ips"],
+        },
+        "chat_exposed": True,
+    },
+    "db_processlist": {
+        "description": (
+            "Show an instance's live DB sessions + connection saturation. "
+            "MySQL/MariaDB: Threads_connected vs max_connections + SHOW FULL "
+            "PROCESSLIST. Postgres: non-idle pg_stat_activity. Requires a "
+            "db_profile for the instance; the password is read from your "
+            "secret store. Read-only query."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID, name, or custom-server name.",
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "db_top_queries": {
+        "description": (
+            "Show the slowest / heaviest queries for an instance's DB. MySQL: "
+            "performance_schema digest summary. Postgres: pg_stat_statements "
+            "(extension must be enabled). For the shared-RDS noisy-neighbour "
+            "case. Requires a db_profile; password from your secret store. "
+            "Read-only query."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID, name, or custom-server name.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "How many queries to return (1–100, default 15).",
+                    "default": 15,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "describe_ingress_path": {
+        "description": (
+            "Map an AWS instance's ingress path in one call: instance → target "
+            "group(s) → load balancer(s) → listeners/rules → associated WebACL "
+            "→ IP sets + rate-based rules, plus whether the box trusts "
+            "forwarded client IPs (mod_remoteip / real_ip). Answers 'behind "
+            "ALB or direct?', 'which WebACL fronts it?', 'is the WAF even "
+            "attached?'. Returns partial results when IAM scope is incomplete. "
+            "Read-only (boto3 elbv2/wafv2/ec2 Describe)."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "AWS instance ID or name.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region override (defaults to the "
+                                   "instance's region).",
+                },
+                "check_remoteip": {
+                    "type": "boolean",
+                    "description": "SSH to the box to detect mod_remoteip / "
+                                   "real_ip trust (default true).",
+                    "default": True,
+                },
+                "verbose": {
+                    "type": "boolean",
+                    "description": "Show every listener rule. Default false "
+                                   "collapses to the rule(s) routing to this "
+                                   "instance + a count of the rest.",
+                    "default": False,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "waf_rate_rule_set": {
+        "description": (
+            "Create/attach (or remove) a WAF rate-based rule on a site's "
+            "WebACL — the durable fix for a flood. 'site' is a WebACL ARN, ALB "
+            "ARN, or instance id/name. 'limit' is requests per 5-min window per "
+            "client IP; 'uri_scope' optionally restricts to a URI path prefix. "
+            "Reversible (remove=true). DANGEROUS — confirm with the user first."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "site": {
+                    "type": "string",
+                    "description": "WebACL ARN, ALB ARN, or instance id/name.",
+                },
+                "rule_name": {
+                    "type": "string",
+                    "description": "Rule name (idempotent — reusing it updates "
+                                   "the limit).",
+                    "default": "servonaut-rate",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Requests per 5-minute window per IP "
+                                   "(default 2000).",
+                    "default": 2000,
+                },
+                "uri_scope": {
+                    "type": "string",
+                    "description": "Optional URI path prefix to scope the rule "
+                                   "to (e.g. '/').",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["block", "count"],
+                    "description": "'block' enforces; 'count' only meters "
+                                   "(dry-run).",
+                    "default": "block",
+                },
+                "remove": {
+                    "type": "boolean",
+                    "description": "Remove the named rule instead of adding it.",
+                    "default": False,
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region override.",
+                },
+            },
+            "required": ["site"],
+        },
+        "chat_exposed": True,
+    },
+    "block_ip": {
+        "description": (
+            "Block (or unblock) an IP/CIDR at the layer that actually works. "
+            "Resolves the best layer for 'site' (WebACL/ALB ARN or instance): "
+            "prefers the WebACL (sees the real client IP behind an ALB), falls "
+            "back to a configured SG/NACL, and otherwise recommends the host "
+            "layer rather than silently editing the firewall. Reversible. "
+            "DANGEROUS — confirm with the user first."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "ip": {
+                    "type": "string",
+                    "description": "IP address or CIDR to block/unblock.",
+                },
+                "site": {
+                    "type": "string",
+                    "description": "WebACL ARN, ALB ARN, or instance id/name.",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["block", "unblock"],
+                    "description": "'block' or 'unblock'.",
+                    "default": "block",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region override.",
+                },
+            },
+            "required": ["ip", "site"],
+        },
+        "chat_exposed": True,
+    },
+    "rds_metrics": {
+        "description": (
+            "Snapshot an RDS instance's health from CloudWatch: CPU, "
+            "connections, CPU credit balance, read/write latency, freeable "
+            "memory. The first check for the shared-RDS noisy-neighbour case. "
+            "'db_instance' is the RDS DB instance identifier. Read-only."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "db_instance": {
+                    "type": "string",
+                    "description": "RDS DB instance identifier.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region of the RDS instance.",
+                },
+                "window_hours": {
+                    "type": "integer",
+                    "description": "Look-back window in hours (default 3).",
+                    "default": 3,
+                },
+            },
+            "required": ["db_instance"],
+        },
+        "chat_exposed": True,
+    },
+    "db_setup_scan": {
+        "description": (
+            "Discover an instance's DB credentials (from .env / DATABASE_URL / "
+            "wp-config.php / docker env) to set up the db tools with no manual "
+            "config. Reads the app config READ-ONLY over SSH on the box. Returns "
+            "REDACTED previews + a staging token per candidate; the password is "
+            "held server-side and never returned, so it can't leak into your "
+            "context. Then call db_setup_save with the chosen token. Read-only."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID, name, or custom-server name.",
+                },
+                "search_path": {
+                    "type": "string",
+                    "description": "Optional dir on the box to search (or a local "
+                                   ".env path). Empty = scan common web roots.",
+                },
+                "source": {
+                    "type": "string",
+                    "enum": ["auto", "ssh", "local"],
+                    "description": "Where to scan: 'auto'/'ssh' read the box "
+                                   "(default), 'local' reads search_path locally.",
+                    "default": "auto",
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "db_setup_save": {
+        "description": (
+            "Commit a staged DB credential (from db_setup_scan) to the secret "
+            "store and write a db_profile, making db_processlist / db_top_queries "
+            "work for the instance. The password is read from server-side "
+            "staging by token — never from your context. Mutating: confirm with "
+            "the user first."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "Staging token from db_setup_scan.",
+                },
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance to attach the profile to.",
+                },
+                "engine": {"type": "string", "description": "Override engine (mysql|postgres)."},
+                "host": {"type": "string", "description": "Override DB host."},
+                "port": {"type": "integer", "description": "Override DB port."},
+                "user": {"type": "string", "description": "Override DB user."},
+                "database": {"type": "string", "description": "Override default database."},
+                "password_secret": {
+                    "type": "string",
+                    "description": "Secret-store key name (default db/<instance>).",
+                },
+            },
+            "required": ["token"],
+        },
+        "chat_exposed": True,
+    },
+    "db_setup_remove": {
+        "description": (
+            "Remove an instance's db_profile and its stored DB secret — the undo "
+            "for db_setup_save. Mutating: confirm with the user first."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance whose db_profile to remove.",
+                },
+                "delete_secret": {
+                    "type": "boolean",
+                    "description": "Also delete the password from the secret "
+                                   "store (default true).",
+                    "default": True,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
     },
 }
 

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import shlex
 import time
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional
@@ -60,7 +61,9 @@ class ServonautTools:
                  auth_service=None, memory_service=None,
                  aws_object_storage_service=None,
                  hetzner_object_storage_service=None,
-                 ovh_object_storage_service=None) -> None:
+                 ovh_object_storage_service=None,
+                 secret_provider=None,
+                 ip_enrichment_service=None) -> None:
         self._config_manager = config_manager
         self._aws_service = aws_service
         self._custom_server_service = custom_server_service
@@ -86,14 +89,36 @@ class ServonautTools:
         self._aws_object_storage_service = aws_object_storage_service
         self._hetzner_object_storage_service = hetzner_object_storage_service
         self._ovh_object_storage_service = ovh_object_storage_service
+        # Active secret store (LocalProvider / BitwardenProvider / None) used
+        # to resolve DB passwords for db_processlist / db_top_queries. None
+        # when unauthenticated or not entitled — those tools then error clearly.
+        self._secret_provider = secret_provider
+        # IP enrichment (rDNS / ASN / abuse) for enrich_ips. Lazily built if
+        # not injected so the tool works even in minimal construction sites.
+        self._ip_enrichment_service = ip_enrichment_service
         self._max_lines = config_manager.get().mcp.max_output_lines
         self._api_request_window: Deque[float] = deque()
+        # Server-side staging for db_setup_scan → db_setup_save. Holds plaintext
+        # DBCandidate objects keyed by an opaque token so the secret is committed
+        # to the secret store WITHOUT ever entering a tool result / model context.
+        self._db_staging: Dict[str, Any] = {}
 
     @property
     def config_manager(self):
         """Expose the config manager so external adapters (e.g. chat) can
         reuse our MCP config without reaching into private attributes."""
         return self._config_manager
+
+    def set_secret_provider(self, provider) -> None:
+        """Bind/rebind the active secret store used by the DB tools.
+
+        Mirrors :meth:`SSHService.set_secret_provider` — the app resolves the
+        provider after the tools are constructed (and again on login / plan
+        change), so it's pushed in rather than passed at construction time.
+        ``None`` is valid (unauthenticated / Free tier); the DB tools then
+        return a clear "log in" error when a profile references a secret.
+        """
+        self._secret_provider = provider
 
     async def list_instances(self, region: str = "", state: str = "") -> str:
         """List all managed instances (AWS EC2 + custom servers), optionally filtered."""
@@ -126,48 +151,160 @@ class ServonautTools:
         self._audit.log('list_instances', {'region': region, 'state': state}, result, True)
         return result
 
-    async def run_command(self, instance_id: str, command: str) -> str:
-        """Run a command on a remote instance via SSH."""
+    async def run_command(
+        self, instance_id: str, command: str, transport: str = "auto",
+    ) -> str:
+        """Run a command on a managed instance.
+
+        ``transport`` (additive, default ``auto``):
+          - ``ssh``  — SSH only (the classic path).
+          - ``ssm``  — AWS Systems Manager only (rides the agent's OUTBOUND
+            channel; works when sshd refuses inbound, e.g. under heavy load).
+          - ``auto`` — try SSH; if the SSH *connection* fails (refused /
+            timed out / unreachable) and the instance is AWS + SSM-managed,
+            fall back to SSM. The result is annotated with which channel won.
+        """
+        args = {
+            'instance_id': instance_id, 'command': command, 'transport': transport,
+        }
         allowed, reason = self._guard.check_tool('run_command')
         if not allowed:
-            self._audit.log('run_command', {'instance_id': instance_id, 'command': command}, '', False, reason)
+            self._audit.log('run_command', args, '', False, reason)
             return f"Blocked: {reason}"
 
         cmd_allowed, cmd_reason = self._guard.check_command(command)
         if not cmd_allowed:
-            self._audit.log('run_command', {'instance_id': instance_id, 'command': command}, '', False, cmd_reason)
+            self._audit.log('run_command', args, '', False, cmd_reason)
             return f"Blocked: {cmd_reason}"
 
         instance = await self._find_instance(instance_id)
         if not instance:
+            self._audit.log('run_command', args, '', False, 'instance_not_found')
             return f"Instance not found: {instance_id}"
 
-        conn = self._resolve_connection(instance)
+        transport = (transport or "auto").strip().lower()
+        if transport not in ("auto", "ssh", "ssm"):
+            self._audit.log('run_command', args, '', False, 'bad_transport')
+            return f"Error: transport must be 'auto', 'ssh', or 'ssm'; got {transport!r}."
 
+        is_aws = not (
+            instance.get('is_custom') or instance.get('is_ovh')
+            or instance.get('is_hetzner')
+        )
+
+        # --- SSM-only transport ----------------------------------------
+        if transport == "ssm":
+            if not is_aws:
+                self._audit.log('run_command', args, '', False, 'ssm_non_aws')
+                return "Error: transport='ssm' is AWS-only (Systems Manager)."
+            return await self._run_command_via_ssm(instance, command, args)
+
+        # --- SSH (ssh / auto) ------------------------------------------
+        output, conn_failed = await self._run_command_via_ssh(instance, command)
+        if not conn_failed:
+            result = f"{output}\n[transport_used: ssh]"
+            self._audit.log('run_command', args, result, True)
+            return result
+
+        # SSH connection failed.
+        if transport == "ssh":
+            msg = (
+                "Error: SSH connection failed (host not reachable / sshd "
+                "refused). If the instance is AWS + SSM-managed, retry with "
+                "transport='ssm'."
+            )
+            self._audit.log('run_command', args, '', False, 'ssh_conn_failed')
+            return msg
+
+        # transport == auto → fall back to SSM when possible.
+        if not is_aws:
+            self._audit.log('run_command', args, '', False, 'ssh_conn_failed_non_aws')
+            return (
+                "Error: SSH connection failed and SSM fallback is AWS-only "
+                "(non-AWS instance)."
+            )
+        return await self._run_command_via_ssm(
+            instance, command, args, ssh_fell_back=True,
+        )
+
+    def _is_ssh_connection_failure(self, stderr_text: str) -> bool:
+        """True if stderr looks like a CONNECTION-level SSH failure.
+
+        Distinguishes "sshd unreachable" (worth an SSM fallback) from a
+        command that ran but exited non-zero, or an auth/config error (which
+        SSM can't fix and shouldn't mask).
+        """
+        low = stderr_text.lower()
+        signatures = (
+            "connection refused", "connection timed out", "operation timed out",
+            "connection reset", "connection closed", "no route to host",
+            "network is unreachable", "could not resolve hostname",
+            "connect to host", "timed out waiting",
+        )
+        return any(sig in low for sig in signatures)
+
+    async def _run_command_via_ssh(self, instance: Dict, command: str):
+        """Run via SSH. Returns (formatted_output_or_error, connection_failed)."""
+        conn = self._resolve_connection(instance)
         ssh_cmd = self._ssh_service.build_ssh_command(
             host=conn['host'], username=conn['username'], key_path=conn['key_path'],
             proxy_args=conn['proxy_args'], remote_command=command,
             port=conn.get('port'),
             extra_options=conn.get('extra_options') or [],
         )
-
         try:
             stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=60)
         except asyncio.TimeoutError:
-            return "Error: Command timed out after 60 seconds"
-        except Exception as e:
-            return f"Error: {e}"
+            return (None, True)  # timeout == connection-level failure
+        except Exception as e:  # noqa: BLE001
+            return (f"Error: {e}", False)
+
+        stderr_text = stderr.decode('utf-8', errors='replace') if stderr else ""
+        # Empty stdout + a connection signature in stderr → sshd unreachable.
+        if not stdout and self._is_ssh_connection_failure(stderr_text):
+            return (None, True)
 
         output = stdout.decode('utf-8', errors='replace')
         lines = output.split('\n')
         if len(lines) > self._max_lines:
             output = '\n'.join(lines[:self._max_lines]) + f'\n... (truncated, {len(lines)} total lines)'
+        if stderr_text:
+            output += f"\nSTDERR:\n{stderr_text}"
+        return (output, False)
 
-        if stderr:
-            output += f"\nSTDERR:\n{stderr.decode('utf-8', errors='replace')}"
+    async def _run_command_via_ssm(
+        self, instance: Dict, command: str, args: Dict, ssh_fell_back: bool = False,
+    ) -> str:
+        """Run via AWS SSM. Returns formatted output (already audited)."""
+        from servonaut.services.ssm_service import SSMService
+        prefix = "[SSH unreachable — fell back to SSM]\n" if ssh_fell_back else ""
+        region = instance.get('region') or ''
+        aws_id = instance.get('id', '')
+        try:
+            res = await SSMService().run_command(
+                aws_id, command, region=region, timeout=60,
+            )
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('run_command', args, '', False, f"ssm_error: {e}")
+            return f"{prefix}Error (SSM): {e}"
 
-        self._audit.log('run_command', {'instance_id': instance_id, 'command': command}, output, True)
-        return output
+        if not res.get("ok"):
+            err = res.get("error") or f"status {res.get('status', '?')}"
+            out = f"{prefix}Error (SSM): {err}"
+            if res.get("stderr"):
+                out += f"\nSTDERR:\n{res['stderr']}"
+            self._audit.log('run_command', args, '', False, f"ssm: {err}")
+            return out
+
+        output = res.get("stdout", "")
+        lines = output.split('\n')
+        if len(lines) > self._max_lines:
+            output = '\n'.join(lines[:self._max_lines]) + f'\n... (truncated, {len(lines)} total lines)'
+        if res.get("stderr"):
+            output += f"\nSTDERR:\n{res['stderr']}"
+        result = f"{prefix}{output}\n[transport_used: ssm]"
+        self._audit.log('run_command', args, result, True)
+        return result
 
     async def get_logs(self, instance_id: str, log_path: str = "/var/log/syslog", lines: int = 100) -> str:
         """Get log content from remote instance."""
@@ -1827,12 +1964,20 @@ class ServonautTools:
     async def cloudwatch_get_log_events(
         self, log_group: str, hours_back: int = 1,
         filter_pattern: str = "", region: str = "", max_events: int = 100,
+        group_by: str = "", top_n: int = 0, summary_only: bool = False,
     ) -> str:
-        """Get recent log events from a CloudWatch log group."""
+        """Get recent log events from a CloudWatch log group.
+
+        Additive aggregation (avoids dumping 1.5MB of raw events): set
+        ``group_by`` to ``clientIp``, ``status`` or ``uri`` to get back a
+        server-side ranked summary (top ``top_n``, default 20) instead of raw
+        lines. ``summary_only`` returns just the event count.
+        """
         args = {
             'log_group': log_group, 'hours_back': hours_back,
             'filter_pattern': filter_pattern, 'region': region,
-            'max_events': max_events,
+            'max_events': max_events, 'group_by': group_by,
+            'top_n': top_n, 'summary_only': summary_only,
         }
         allowed, reason = self._guard.check_tool('cloudwatch_get_log_events')
         if not allowed:
@@ -1843,6 +1988,14 @@ class ServonautTools:
                 'cloudwatch_get_log_events', args, '', False, 'service_unavailable',
             )
             return "Error: CloudWatch service is not available."
+
+        group = (group_by or "").strip()
+        if group and group not in ("clientIp", "status", "uri"):
+            self._audit.log(
+                'cloudwatch_get_log_events', args, '', False, 'bad_group_by',
+            )
+            return (f"Error: group_by must be 'clientIp', 'status', or 'uri'; "
+                    f"got {group_by!r}.")
 
         from datetime import datetime, timedelta
         end_time = datetime.utcnow()
@@ -1862,6 +2015,38 @@ class ServonautTools:
         if not events:
             self._audit.log('cloudwatch_get_log_events', args, '0 events', True)
             return f"No log events in {log_group} for the last {hours_back}h."
+
+        # --- aggregation mode --------------------------------------------
+        if group:
+            limit = top_n if top_n and top_n > 0 else 20
+            agg = self._cloudwatch_service.aggregate_events(events, group, limit)
+            sampled = len(events) >= max_events
+            out = [
+                f"CloudWatch {log_group} (last {hours_back}h) — top {group} "
+                f"by count [{agg['total_matched']}/{agg['total_events']} events"
+                + (", SAMPLED (hit max_events — widen max_events for full counts)"
+                   if sampled else "") + "]:",
+                f"  {'key':<46} {'count':<8} pct",
+                "  " + "-" * 62,
+            ]
+            for row in agg["ranking"]:
+                out.append(f"  {str(row['key'])[:46]:<46} "
+                           f"{row['count']:<8} {row['pct']}%")
+            if not agg["ranking"]:
+                out.append(f"  (no events carried a {group} field — not "
+                           "structured WAF/ALB JSON?)")
+            result = "\n".join(out)
+            self._audit.log('cloudwatch_get_log_events', args, result, True)
+            return result
+
+        # --- summary-only mode -------------------------------------------
+        if summary_only:
+            result = (f"{len(events)} events in {log_group} over the last "
+                      f"{hours_back}h"
+                      + (" (sampled — hit max_events)"
+                         if len(events) >= max_events else "") + ".")
+            self._audit.log('cloudwatch_get_log_events', args, result, True)
+            return result
 
         lines = [
             f"CloudWatch events: {log_group} "
@@ -3015,3 +3200,1190 @@ class ServonautTools:
             'expires_in': expires_in,
             'provider': provider,
         })
+
+    # ------------------------------------------------------------------
+    # Incident-response tools (Group A): SSH/network only, read-only
+    # ------------------------------------------------------------------
+
+    async def _exec_ssh(
+        self, instance: Dict, command: str, timeout: int = 60,
+    ) -> tuple:
+        """Run a read-only command on an instance over SSH.
+
+        Shared helper for the incident-response probes. ``command`` is passed
+        as a single SSH argument, so the *remote* shell parses it — nested
+        single-quoted awk/grep is safe (there is no intermediate local shell;
+        see ``run_ssh_subprocess`` which uses ``create_subprocess_exec``).
+        Returns ``(stdout_str, stderr_str)``.
+        """
+        conn = self._resolve_connection(instance)
+        ssh_cmd = self._ssh_service.build_ssh_command(
+            host=conn['host'], username=conn['username'],
+            key_path=conn['key_path'], proxy_args=conn['proxy_args'],
+            remote_command=command, port=conn.get('port'),
+            extra_options=conn.get('extra_options') or [],
+        )
+        stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
+        return (
+            stdout.decode('utf-8', errors='replace'),
+            stderr.decode('utf-8', errors='replace'),
+        )
+
+    async def _gather_all_instances(self) -> List[Dict]:
+        """Merge instances across every wired provider (AWS + custom + OVH + Hetzner)."""
+        aws_instances = await self._aws_service.fetch_instances_cached()
+        custom_instances = self._custom_server_service.list_as_instances()
+        ovh_instances = (
+            await self._ovh_service.fetch_instances_cached()
+            if self._ovh_service is not None else []
+        )
+        hetzner_instances = (
+            await self._hetzner_service.fetch_instances_cached()
+            if self._hetzner_service is not None else []
+        )
+        return aws_instances + custom_instances + ovh_instances + hetzner_instances
+
+    async def web_traffic_summary(
+        self, instance_id: str, log_path: str = "",
+        lines: int = 10000, top_n: int = 15,
+    ) -> str:
+        """Summarize a box's OWN web access logs (XFF / mod_remoteip aware).
+
+        Parses the instance's access logs to report, per vhost: request
+        volume, approx req/s, status-code mix, top client IPs and top URLs.
+        Unlike ``cloudwatch_top_ips`` (which only sees WAF logs), this reads
+        the decisive data that lives on the box. When ``log_path`` is empty
+        it auto-discovers nginx/apache/httpd access logs.
+        """
+        args = {
+            'instance_id': instance_id, 'log_path': log_path,
+            'lines': lines, 'top_n': top_n,
+        }
+        allowed, reason = self._guard.check_tool('web_traffic_summary')
+        if not allowed:
+            self._audit.log('web_traffic_summary', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('web_traffic_summary', args, '', False, 'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        n = max(100, min(int(lines or 10000), 200000))
+        top = max(1, min(int(top_n or 15), 100))
+
+        if log_path:
+            quoted = shlex.quote(log_path)
+            remote = f'echo "===VHOST:{log_path}==="; tail -n {n} -- {quoted}'
+            hint = log_path
+        else:
+            remote = (
+                'for f in $(ls -1t /var/log/nginx/*access*.log '
+                '/var/log/apache2/*access*.log /var/log/httpd/*access*.log '
+                '2>/dev/null | head -20); do '
+                f'echo "===VHOST:$f==="; tail -n {n} "$f"; done'
+            )
+            hint = "auto-discovered nginx/apache/httpd access logs"
+
+        try:
+            stdout, stderr = await self._exec_ssh(instance, remote, timeout=90)
+        except asyncio.TimeoutError:
+            self._audit.log('web_traffic_summary', args, '', False, 'timeout')
+            return "Error: web_traffic_summary timed out after 90 seconds"
+        except Exception as e:
+            self._audit.log('web_traffic_summary', args, '', False, f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        from servonaut.utils.log_analysis import (
+            summarize_web_traffic, format_web_traffic,
+        )
+        summary = summarize_web_traffic(stdout, top)
+        result = format_web_traffic(summary, log_hint=hint)
+        if not summary.get("vhosts") and stderr.strip():
+            result += f"\n\n(stderr: {stderr.strip()[:300]})"
+        self._audit.log('web_traffic_summary', args, result, True)
+        return result
+
+    # Single read-only probe per host: load, cpu, mem, php-fpm saturation,
+    # web stack, listening ports. Emits KEY=VALUE lines parsed in Python.
+    _FLEET_PROBE_CMD = (
+        'echo "LOAD=$(awk \'{print $1, $2, $3}\' /proc/loadavg 2>/dev/null)"; '
+        'echo "CPU=$(nproc 2>/dev/null)"; '
+        'echo "MEM=$(free -m 2>/dev/null | awk \'/^Mem:/{print $2, $3, $4}\')"; '
+        # Active php-fpm workers: count worker processes (title "php-fpm: pool …"),
+        # with a ps fallback for systems where pgrep can't see arg titles.
+        'FPM_A=$(pgrep -c -f \'php-fpm: pool\' 2>/dev/null); '
+        '[ -z "$FPM_A" ] || [ "$FPM_A" = "0" ] && '
+        'FPM_A=$(ps -e -o args= 2>/dev/null | grep -c \'[p]hp-fpm: pool\'); '
+        # max_children across the common config locations (Debian/Ubuntu,
+        # RHEL/Amazon Linux /etc/php-fpm.d, source builds under /usr/local).
+        'FPM_M=$(grep -rhoE \'^[[:space:]]*pm.max_children[[:space:]]*=[[:space:]]*[0-9]+\' '
+        '/etc/php*/fpm/pool.d /etc/php-fpm.d /usr/local/etc/php-fpm.d '
+        '/etc/php/*/fpm/pool.d 2>/dev/null | grep -oE \'[0-9]+\' '
+        '| sort -rn | head -1); '
+        'if [ "${FPM_A:-0}" -gt 0 ] 2>/dev/null || [ -n "$FPM_M" ]; '
+        'then echo "FPM=${FPM_A:-0}/${FPM_M:-?}"; else echo "FPM="; fi; '
+        'S=""; pgrep -x nginx >/dev/null 2>&1 && S="$S nginx"; '
+        'pgrep -x apache2 >/dev/null 2>&1 && S="$S apache"; '
+        'pgrep -x httpd >/dev/null 2>&1 && S="$S httpd"; '
+        'pgrep -f php-fpm >/dev/null 2>&1 && S="$S php-fpm"; '
+        'pgrep -x node >/dev/null 2>&1 && S="$S node"; '
+        'echo "STACK=$(echo $S)"; '
+        'echo "LISTEN=$(ss -ltn 2>/dev/null | awk \'NR>1{n=split($4,a,":"); '
+        'print a[n]}\' | sort -un | tr \'\\n\' \',\')"'
+    )
+
+    async def fleet_health_snapshot(
+        self, region: str = "", running_only: bool = True, timeout: int = 15,
+    ) -> str:
+        """Triage the whole fleet in one table: load, CPU, mem, FPM, web stack.
+
+        SSH fan-out across every managed instance. Surfaces the sick box (high
+        load / saturated php-fpm pool) without SSH'ing into each one by hand.
+        Unreachable hosts are listed separately rather than failing the call.
+        """
+        args = {'region': region, 'running_only': running_only, 'timeout': timeout}
+        allowed, reason = self._guard.check_tool('fleet_health_snapshot')
+        if not allowed:
+            self._audit.log('fleet_health_snapshot', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instances = await self._gather_all_instances()
+        if region:
+            instances = [i for i in instances if i.get('region') == region]
+        if running_only:
+            instances = [
+                i for i in instances
+                if (i.get('state') or 'running').lower() in ('running', '')
+            ]
+        if not instances:
+            self._audit.log('fleet_health_snapshot', args, '0 targets', True)
+            return "No instances to probe (after region/state filtering)."
+
+        per_host_timeout = max(5, min(int(timeout or 15), 60))
+
+        from servonaut.utils.log_analysis import (
+            fleet_row_from_probe, format_fleet_table,
+        )
+
+        async def _probe(inst: Dict) -> Dict:
+            name = inst.get('name') or inst.get('id') or '?'
+            try:
+                stdout, _ = await self._exec_ssh(
+                    inst, self._FLEET_PROBE_CMD, timeout=per_host_timeout,
+                )
+                return fleet_row_from_probe(name, stdout)
+            except asyncio.TimeoutError:
+                return {'name': name, 'error': 'timeout'}
+            except Exception as e:  # noqa: BLE001 — one bad host must not fail all
+                return {'name': name, 'error': str(e)[:80]}
+
+        rows = await asyncio.gather(*(_probe(i) for i in instances))
+        result = format_fleet_table(list(rows))
+        self._audit.log('fleet_health_snapshot', args, result, True)
+        return result
+
+    async def enrich_ips(self, ips: str) -> str:
+        """Enrich IPs with rDNS, ASN/org, country and AbuseIPDB score.
+
+        Accepts a comma/space/newline-separated list. Helps decide *how* to
+        block: a single /32 rotates, but an ASN/org (bulletproof host) can be
+        blocked wholesale. ASN/geo via ip-api.com (free); abuse score via
+        AbuseIPDB when an API key is set in Settings.
+        """
+        args = {'ips': ips}
+        allowed, reason = self._guard.check_tool('enrich_ips')
+        if not allowed:
+            self._audit.log('enrich_ips', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        import re as _re
+        ip_list = [t for t in _re.split(r'[\s,]+', ips or '') if t]
+        if not ip_list:
+            self._audit.log('enrich_ips', args, '', False, 'no_ips')
+            return "Error: provide one or more IP addresses (comma or space separated)."
+
+        service = self._ip_enrichment_service
+        if service is None:
+            from servonaut.services.ip_enrichment_service import IPEnrichmentService
+            service = IPEnrichmentService(self._config_manager)
+            self._ip_enrichment_service = service
+
+        if len(ip_list) > service.max_ips:
+            ip_list = ip_list[:service.max_ips]
+
+        try:
+            rows = await service.enrich(ip_list)
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('enrich_ips', args, '', False, f"lookup_error: {e}")
+            return f"Error enriching IPs: {e}"
+
+        from servonaut.services.ip_enrichment_service import format_enrichment
+        result = format_enrichment(rows)
+        self._audit.log('enrich_ips', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # Database introspection tools (Group A): read-only, secret-store creds
+    # ------------------------------------------------------------------
+
+    async def _resolve_db(self, instance_id: str, tool_name: str, args: Dict):
+        """Resolve (instance, profile, password) for the DB tools.
+
+        Returns ``(instance, profile, password, error_str)``. ``error_str`` is
+        non-empty (and the rest None) when resolution fails — the caller
+        returns it directly. The password is fetched from the user's active
+        secret store and is NEVER placed in the audit trail.
+        """
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log(tool_name, args, '', False, 'instance_not_found')
+            return None, None, None, f"Instance not found: {instance_id}"
+
+        config = self._config_manager.get()
+        profile = config.db_profile_for(
+            instance.get('id', ''), instance.get('name', ''),
+        )
+        if profile is None:
+            self._audit.log(tool_name, args, '', False, 'no_db_profile')
+            return None, None, None, (
+                f"No db_profile configured for {instance_id}. To set one up "
+                f"automatically, call db_setup_scan(instance_id='{instance_id}') "
+                "— it reads the app's DB credentials from the box (read-only) "
+                "and stages them; then ask the user to confirm and call "
+                "db_setup_save. (Or the user can run `servonaut db setup "
+                f"{instance_id}`.)"
+            )
+
+        engine = (profile.engine or 'mysql').strip().lower()
+        if engine not in ('mysql', 'mariadb', 'postgres', 'postgresql'):
+            self._audit.log(tool_name, args, '', False, f"bad_engine:{engine}")
+            return None, None, None, (
+                f"Unsupported db engine {engine!r}; use 'mysql' or 'postgres'."
+            )
+
+        password = ""
+        if profile.password_secret:
+            if self._secret_provider is None:
+                self._audit.log(tool_name, args, '', False, 'no_secret_provider')
+                return None, None, None, (
+                    "DB profile references a secret but no secret store is "
+                    "active. Run `servonaut login` (the secret store is a "
+                    "Solo/Teams feature) so the password can be resolved."
+                )
+            try:
+                password = await self._secret_provider.get_secret(
+                    profile.password_secret,
+                )
+            except Exception as e:  # noqa: BLE001
+                self._audit.log(tool_name, args, '', False, f"secret_error: {e}")
+                return None, None, None, f"Error reading secret: {e}"
+            if password is None:
+                self._audit.log(tool_name, args, '', False, 'secret_not_found')
+                return None, None, None, (
+                    f"Secret {profile.password_secret!r} not found in the "
+                    "active secret store."
+                )
+
+        return instance, profile, (password or ""), ""
+
+    # PHP fallbacks used when the box has no mysql/psql CLI (common on Joomla /
+    # PHP web boxes — PHP + mysqli/PDO are always present). Read connection +
+    # SQL from exported env vars so no credential lands in php's own argv.
+    # Single-quoted at the call site; these use ONLY double quotes internally.
+    _PHP_MYSQLI_FALLBACK = (
+        '$m=@new mysqli(getenv("DBH"),getenv("DBU"),getenv("DBP"),'
+        'getenv("DBN")?:NULL,(int)getenv("DBPORT"));'
+        'if($m->connect_errno){fwrite(STDERR,"connect: ".$m->connect_error);exit(1);}'
+        '$q=getenv("DBSQL");'
+        'if($m->multi_query($q)){do{if($r=$m->store_result()){'
+        '$h=array();foreach($r->fetch_fields() as $c)$h[]=$c->name;'
+        'echo implode("\\t",$h)."\\n";'
+        'while($w=$r->fetch_row())echo implode("\\t",array_map('
+        'function($x){return $x===null?"NULL":$x;},$w))."\\n";'
+        'echo "\\n";$r->free();}}while($m->more_results()&&$m->next_result());}'
+        'if($m->errno)fwrite(STDERR,"query: ".$m->error);'
+    )
+    _PHP_PDO_PGSQL_FALLBACK = (
+        'try{$p=new PDO("pgsql:host=".getenv("DBH").";port=".getenv("DBPORT").'
+        '";dbname=".(getenv("DBN")?:"postgres"),getenv("DBU"),getenv("DBP"));}'
+        'catch(Exception $e){fwrite(STDERR,$e->getMessage());exit(1);}'
+        '$first=true;foreach($p->query(getenv("DBSQL")) as $row){'
+        '$row=array_filter($row,"is_string",ARRAY_FILTER_USE_KEY);'
+        'if($first){echo implode("\\t",array_keys($row))."\\n";$first=false;}'
+        'echo implode("\\t",array_map(function($x){return $x===null?"NULL":$x;},'
+        '$row))."\\n";}'
+    )
+
+    def _build_db_command(self, profile, sql: str, password: str) -> str:
+        """Build the on-box DB command for *sql*, with a no-client fallback.
+
+        Prefers the native CLI (mysql/psql); if it's absent — common on Joomla
+        web boxes — falls back to ``php -r`` (mysqli / PDO_pgsql), which is
+        guaranteed on a PHP box. Credentials + SQL are passed via exported env
+        vars (not argv on the DB client), so the password never appears in the
+        client's own process list. The whole string is one SSH argument, parsed
+        by the remote shell.
+        """
+        engine = (profile.engine or 'mysql').strip().lower()
+        host = profile.host or '127.0.0.1'
+        port = int(profile.port or (5432 if engine.startswith('postgres') else 3306))
+        user = profile.user or 'root'
+        is_pg = engine.startswith('postgres')
+        database = profile.database or ('postgres' if is_pg else '')
+
+        q = shlex.quote
+        env = (
+            f"DBH={q(host)}; DBU={q(user)}; DBP={q(password)}; "
+            f"DBN={q(database)}; DBPORT={q(str(port))}; DBSQL={q(sql)}; "
+            "export DBH DBU DBP DBN DBPORT DBSQL; "
+        )
+        if is_pg:
+            native = (
+                'PGPASSWORD="$DBP" psql -h "$DBH" -p "$DBPORT" -U "$DBU" '
+                '-d "${DBN:-postgres}" --no-psqlrc -P pager=off -c "$DBSQL"'
+            )
+            php = f"php -r {q(self._PHP_PDO_PGSQL_FALLBACK)}"
+            client = "psql"
+        else:
+            native = (
+                'MYSQL_PWD="$DBP" mysql -h "$DBH" -P "$DBPORT" -u "$DBU" '
+                '${DBN:+"$DBN"} --batch --table -e "$DBSQL"'
+            )
+            php = f"php -r {q(self._PHP_MYSQLI_FALLBACK)}"
+            client = "mysql"
+        return (
+            f"{env}"
+            f"if command -v {client} >/dev/null 2>&1; then {native}; "
+            f"elif command -v php >/dev/null 2>&1; then {php}; "
+            f"else echo 'ERROR: no {client} client and no php on this host' >&2; "
+            f"exit 127; fi"
+        )
+
+    async def db_processlist(self, instance_id: str) -> str:
+        """Show the live DB session list + connection saturation for an instance.
+
+        MySQL/MariaDB: ``Threads_connected`` vs ``max_connections`` plus
+        ``SHOW FULL PROCESSLIST``. Postgres: ``pg_stat_activity`` (non-idle).
+        Credentials come from the instance's db_profile + your secret store.
+        """
+        args = {'instance_id': instance_id}
+        allowed, reason = self._guard.check_tool('db_processlist')
+        if not allowed:
+            self._audit.log('db_processlist', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instance, profile, password, err = await self._resolve_db(
+            instance_id, 'db_processlist', args,
+        )
+        if err:
+            return f"Error: {err}"
+
+        engine = (profile.engine or 'mysql').strip().lower()
+        if engine.startswith('postgres'):
+            sql = (
+                "SELECT pid, usename, state, wait_event_type, "
+                "now()-query_start AS duration, left(query,80) AS query "
+                "FROM pg_stat_activity WHERE state IS DISTINCT FROM 'idle' "
+                "ORDER BY query_start NULLS LAST;"
+            )
+        else:
+            sql = (
+                "SHOW STATUS LIKE 'Threads_connected'; "
+                "SHOW VARIABLES LIKE 'max_connections'; "
+                "SHOW FULL PROCESSLIST;"
+            )
+
+        command = self._build_db_command(profile, sql, password)
+        try:
+            stdout, stderr = await self._exec_ssh(instance, command, timeout=30)
+        except asyncio.TimeoutError:
+            self._audit.log('db_processlist', args, '', False, 'timeout')
+            return "Error: db_processlist timed out after 30 seconds"
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('db_processlist', args, '', False, f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        output = stdout or ""
+        if stderr.strip():
+            output += f"\nSTDERR:\n{stderr.strip()[:500]}"
+        # Audit WITHOUT the command (it carries the password via env).
+        self._audit.log('db_processlist', args, output, True)
+        return output or "(no rows)"
+
+    async def db_top_queries(self, instance_id: str, limit: int = 15) -> str:
+        """Show the slowest / heaviest queries for an instance's DB.
+
+        MySQL: ``performance_schema.events_statements_summary_by_digest``.
+        Postgres: ``pg_stat_statements`` (extension must be enabled). Useful
+        for the shared-RDS noisy-neighbour case. Creds via db_profile + secret
+        store.
+        """
+        args = {'instance_id': instance_id, 'limit': limit}
+        allowed, reason = self._guard.check_tool('db_top_queries')
+        if not allowed:
+            self._audit.log('db_top_queries', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instance, profile, password, err = await self._resolve_db(
+            instance_id, 'db_top_queries', args,
+        )
+        if err:
+            return f"Error: {err}"
+
+        n = max(1, min(int(limit or 15), 100))
+        engine = (profile.engine or 'mysql').strip().lower()
+        if engine.startswith('postgres'):
+            sql = (
+                "SELECT left(query,80) AS query, calls, "
+                "round(total_exec_time::numeric,2) AS total_ms, "
+                "round(mean_exec_time::numeric,2) AS mean_ms "
+                "FROM pg_stat_statements ORDER BY total_exec_time DESC "
+                f"LIMIT {n};"
+            )
+        else:
+            sql = (
+                "SELECT DIGEST_TEXT, COUNT_STAR AS calls, "
+                "ROUND(SUM_TIMER_WAIT/1e12,2) AS total_s, "
+                "ROUND(AVG_TIMER_WAIT/1e9,2) AS avg_ms "
+                "FROM performance_schema.events_statements_summary_by_digest "
+                f"ORDER BY SUM_TIMER_WAIT DESC LIMIT {n};"
+            )
+
+        command = self._build_db_command(profile, sql, password)
+        try:
+            stdout, stderr = await self._exec_ssh(instance, command, timeout=30)
+        except asyncio.TimeoutError:
+            self._audit.log('db_top_queries', args, '', False, 'timeout')
+            return "Error: db_top_queries timed out after 30 seconds"
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('db_top_queries', args, '', False, f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        output = stdout or ""
+        if stderr.strip():
+            output += f"\nSTDERR:\n{stderr.strip()[:500]}"
+        self._audit.log('db_top_queries', args, output, True)
+        return output or "(no rows)"
+
+    # ------------------------------------------------------------------
+    # Incident-response tools (Group B): boto3 AWS topology (read-only)
+    # ------------------------------------------------------------------
+
+    # Best-effort on-box check for whether the web server trusts a proxy's
+    # forwarded client IP (Apache mod_remoteip / nginx real_ip). Read-only.
+    _REMOTEIP_PROBE_CMD = (
+        "grep -rliE "
+        "'remoteipheader|mod_remoteip|set_real_ip_from|real_ip_header' "
+        "/etc/apache2 /etc/httpd /etc/nginx 2>/dev/null | head -1"
+    )
+
+    async def _detect_mod_remoteip(self, instance: Dict):
+        """Return True/False/None for whether the box trusts forwarded client IPs."""
+        try:
+            stdout, _ = await self._exec_ssh(
+                instance, self._REMOTEIP_PROBE_CMD, timeout=15,
+            )
+        except Exception:  # noqa: BLE001 — best-effort; unknown on failure
+            return None
+        return bool(stdout.strip())
+
+    async def describe_ingress_path(
+        self, instance_id: str, region: str = "", check_remoteip: bool = True,
+        verbose: bool = False,
+    ) -> str:
+        """Map an instance's ALB/WAF ingress path in one call.
+
+        instance → target group(s) → load balancer(s) → listeners/rules →
+        associated WebACL → IP sets + rate-based rules, plus a flag for whether
+        the box trusts forwarded client IPs (mod_remoteip / real_ip). Answers
+        "behind ALB or direct?", "which WebACL fronts it?", and "is the WAF even
+        attached?" — the questions that cost the most time in the incident.
+        Partial results are returned when IAM scope is incomplete.
+        """
+        args = {'instance_id': instance_id, 'region': region,
+                'check_remoteip': check_remoteip, 'verbose': verbose}
+        allowed, reason = self._guard.check_tool('describe_ingress_path')
+        if not allowed:
+            self._audit.log('describe_ingress_path', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('describe_ingress_path', args, '', False, 'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        if instance.get('is_custom') or instance.get('is_ovh') or instance.get('is_hetzner'):
+            self._audit.log('describe_ingress_path', args, '', False, 'not_aws')
+            return (
+                "describe_ingress_path is AWS-only (ALB/WAF topology). "
+                f"{instance_id} is a non-AWS instance."
+            )
+
+        aws_id = instance.get('id', '')
+        private_ip = instance.get('private_ip') or ''
+        eff_region = region or instance.get('region') or ''
+
+        from servonaut.services.ingress_path_service import (
+            IngressPathService, format_ingress_path,
+        )
+        try:
+            topo = await IngressPathService().describe(
+                aws_id, private_ip, eff_region,
+            )
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('describe_ingress_path', args, '', False, f"aws_error: {e}")
+            return f"Error walking ingress path: {e}"
+
+        remoteip = None
+        if check_remoteip:
+            remoteip = await self._detect_mod_remoteip(instance)
+
+        result = format_ingress_path(topo, remoteip, verbose=verbose)
+        self._audit.log('describe_ingress_path', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # Incident-response tools (Group C): WAF mitigation (dangerous tier)
+    # ------------------------------------------------------------------
+
+    async def _resolve_webacl(self, target: str, region: str = "") -> Dict[str, Any]:
+        """Resolve a WebACL from a WebACL ARN, an ALB ARN, or an instance.
+
+        Returns {name, id, scope, region, arn} or {error}. For an instance it
+        walks the ingress path (Group B) to find the WebACL fronting its ALB.
+        """
+        from servonaut.services.waf_management_service import (
+            WAFManagementService, parse_wafv2_arn,
+        )
+        target = (target or "").strip()
+        if not target:
+            return {"error": "no target (need a WebACL/ALB ARN or instance)."}
+
+        if target.startswith("arn:aws:wafv2:"):
+            parsed = parse_wafv2_arn(target)
+            if not parsed or parsed["kind"] != "webacl":
+                return {"error": f"not a WebACL ARN: {target}"}
+            return {"name": parsed["name"], "id": parsed["id"],
+                    "scope": parsed["scope"], "region": parsed["region"] or region,
+                    "arn": target}
+
+        if target.startswith("arn:aws:elasticloadbalancing:"):
+            alb_region = (target.split(":")[3] if ":" in target else "") or region
+            summ = await WAFManagementService().get_web_acl_for_resource(
+                target, alb_region,
+            )
+            if not summ:
+                return {"error": f"no WebACL attached to {target}"}
+            parsed = parse_wafv2_arn(summ["arn"])
+            return {"name": summ["name"], "id": summ["id"],
+                    "scope": parsed["scope"] if parsed else "REGIONAL",
+                    "region": (parsed["region"] if parsed else alb_region) or region,
+                    "arn": summ["arn"]}
+
+        # Otherwise treat target as an instance id/name → walk its ingress path.
+        instance = await self._find_instance(target)
+        if not instance:
+            return {"error": f"instance not found: {target}"}
+        if instance.get("is_custom") or instance.get("is_ovh") or instance.get("is_hetzner"):
+            return {"error": f"{target} is not an AWS instance"}
+        from servonaut.services.ingress_path_service import IngressPathService
+        eff_region = region or instance.get("region") or ""
+        topo = await IngressPathService().describe(
+            instance.get("id", ""), instance.get("private_ip") or "", eff_region,
+        )
+        for lb in topo.get("load_balancers", []):
+            acl = lb.get("web_acl")
+            if acl and acl.get("arn"):
+                parsed = parse_wafv2_arn(acl["arn"])
+                if parsed:
+                    return {"name": parsed["name"], "id": parsed["id"],
+                            "scope": parsed["scope"],
+                            "region": parsed["region"] or eff_region, "arn": acl["arn"]}
+        return {"error": f"no WebACL found fronting {target}"}
+
+    def _collect_ban_targets(self, ip_address, cidr, ip_addresses) -> List[str]:
+        """Union ip_address + cidr + ip_addresses[], deduped, order-preserving."""
+        out: List[str] = []
+        for src in (ip_address, cidr):
+            if src and src.strip() and src.strip() not in out:
+                out.append(src.strip())
+        for ip in (ip_addresses or []):
+            if ip and str(ip).strip() and str(ip).strip() not in out:
+                out.append(str(ip).strip())
+        return out
+
+    async def ip_ban_set(
+        self, ip_address: str = "", config_name: str = "", action: str = "ban",
+        ip_addresses: Optional[List[str]] = None, cidr: str = "",
+        site: str = "", region: str = "",
+    ) -> str:
+        """Ban/unban IP(s) or CIDR(s) via a named config OR a site's WebACL.
+
+        Additive (old ``ip_address`` + ``config_name`` calls unchanged): accepts
+        CIDR in ``ip_address``/``cidr``, a bulk ``ip_addresses[]`` list, and a
+        ``site`` (WebACL ARN, ALB ARN, or instance id/name) that resolves the
+        WebACL fronting it — so you can ban into the WebACL that actually fronts
+        the box without a pre-defined config. Returns an applied/failed split.
+        """
+        args = {
+            'ip_address': ip_address, 'config_name': config_name, 'action': action,
+            'ip_addresses': ip_addresses, 'cidr': cidr, 'site': site, 'region': region,
+        }
+        allowed, reason = self._guard.check_tool('ip_ban_set')
+        if not allowed:
+            self._audit.log('ip_ban_set', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        action_norm = (action or "").strip().lower()
+        if action_norm not in ('ban', 'unban'):
+            self._audit.log('ip_ban_set', args, '', False, 'invalid_action')
+            return f"Error: action must be 'ban' or 'unban', got {action!r}."
+
+        targets = self._collect_ban_targets(ip_address, cidr, ip_addresses)
+        if not targets:
+            self._audit.log('ip_ban_set', args, '', False, 'no_targets')
+            return "Error: provide at least one ip_address, cidr, or ip_addresses[]."
+
+        # --- site path: resolve the WebACL fronting the site/instance ---
+        if site and not config_name:
+            return await self._ip_ban_via_site(site, targets, action_norm, region, args)
+
+        # --- named-config path (existing behaviour, now CIDR + bulk aware) ---
+        if not config_name:
+            self._audit.log('ip_ban_set', args, '', False, 'no_target_selector')
+            return "Error: provide config_name or site."
+        if self._ip_ban_service is None:
+            self._audit.log('ip_ban_set', args, '', False, 'service_unavailable')
+            return "Error: IP ban service is not available."
+
+        applied: List[str] = []
+        failed: List[Dict[str, str]] = []
+        for target in targets:
+            try:
+                if action_norm == 'ban':
+                    res = await self._ip_ban_service.ban_ip(target, config_name)
+                else:
+                    res = await self._ip_ban_service.unban_ip(target, config_name)
+            except Exception as e:  # noqa: BLE001
+                failed.append({"ip": target, "reason": str(e)})
+                continue
+            if res.get('success'):
+                applied.append(target)
+            else:
+                failed.append({"ip": target, "reason": res.get('message', 'failed')})
+
+        result = self._format_ban_result(
+            target_label=config_name, web_acl="", action=action_norm,
+            applied=applied, failed=failed,
+        )
+        self._audit.log('ip_ban_set', args, result, bool(applied) and not failed)
+        return result
+
+    async def _ip_ban_via_site(
+        self, site: str, targets: List[str], action_norm: str,
+        region: str, args: Dict,
+    ) -> str:
+        acl = await self._resolve_webacl(site, region)
+        if acl.get("error"):
+            self._audit.log('ip_ban_set', args, '', False, f"webacl: {acl['error']}")
+            return f"Error: {acl['error']}"
+        from servonaut.services.waf_management_service import WAFManagementService
+        res = await WAFManagementService().add_ip_to_block_ipset(
+            acl["name"], acl["id"], acl["scope"], acl["region"],
+            cidrs=targets, remove=(action_norm == 'unban'),
+        )
+        if res.get("error") and not res.get("applied"):
+            self._audit.log('ip_ban_set', args, '', False, f"waf: {res['error']}")
+            return (f"Error banning via WebACL {acl['name']}: {res['error']}")
+        result = self._format_ban_result(
+            target_label=site, web_acl=f"{acl['name']} (IP set {res.get('ip_set','?')})",
+            action=action_norm, applied=res.get("applied", []),
+            failed=res.get("failed", []),
+        )
+        self._audit.log('ip_ban_set', args, result, bool(res.get("applied")))
+        return result
+
+    def _format_ban_result(
+        self, target_label, web_acl, action, applied, failed,
+    ) -> str:
+        verb = "Banned" if action == "ban" else "Unbanned"
+        undo = "unban" if action == "ban" else "ban"
+        lines = [f"ip_ban_set {action} via {target_label}:"]
+        if web_acl:
+            lines.append(f"  WebACL: {web_acl}")
+        lines.append(f"  {verb} ({len(applied)}): {', '.join(applied) or '-'}")
+        if failed:
+            lines.append(f"  Failed ({len(failed)}):")
+            for f in failed:
+                lines.append(f"    {f.get('ip','')}: {f.get('reason','')}")
+        if applied:
+            lines.append(f"  reverse_hint: ip_ban_set action={undo} "
+                         + (f"site={target_label}" if web_acl else f"config_name={target_label}")
+                         + f" ip_addresses={applied}")
+        return "\n".join(lines)
+
+    async def waf_rate_rule_set(
+        self, site: str, rule_name: str = "servonaut-rate", limit: int = 2000,
+        uri_scope: str = "", action: str = "block", remove: bool = False,
+        region: str = "",
+    ) -> str:
+        """Create/attach (or remove) a WAF rate-based rule on a site's WebACL.
+
+        ``site`` is a WebACL ARN, ALB ARN, or instance id/name. ``limit`` is the
+        request count per 5-minute window per client IP; ``uri_scope`` optionally
+        restricts the rule to a URI path prefix (e.g. ``/``). This is the durable
+        fix for a flood — applied reversibly (``remove=true`` undoes it).
+        """
+        args = {
+            'site': site, 'rule_name': rule_name, 'limit': limit,
+            'uri_scope': uri_scope, 'action': action, 'remove': remove,
+            'region': region,
+        }
+        allowed, reason = self._guard.check_tool('waf_rate_rule_set')
+        if not allowed:
+            self._audit.log('waf_rate_rule_set', args, '', False, reason)
+            return f"Blocked: {reason}"
+        act = (action or "block").strip().lower()
+        if act not in ('block', 'count'):
+            self._audit.log('waf_rate_rule_set', args, '', False, 'bad_action')
+            return f"Error: action must be 'block' or 'count', got {action!r}."
+
+        acl = await self._resolve_webacl(site, region)
+        if acl.get("error"):
+            self._audit.log('waf_rate_rule_set', args, '', False, f"webacl: {acl['error']}")
+            return f"Error: {acl['error']}"
+
+        from servonaut.services.waf_management_service import WAFManagementService
+        res = await WAFManagementService().set_rate_rule(
+            acl["name"], acl["id"], acl["scope"], acl["region"],
+            rule_name=rule_name, limit=int(limit), uri_scope=uri_scope,
+            action=act, remove=remove,
+        )
+        if not res.get("applied"):
+            err = res.get("error", "unknown error")
+            self._audit.log('waf_rate_rule_set', args, '', False, f"waf: {err}")
+            return f"Error setting rate rule on WebACL {acl['name']}: {err}"
+
+        prev = res.get("previous")
+        if remove:
+            lines = [f"Removed rate rule '{rule_name}' from WebACL {acl['name']}."]
+            if prev:
+                lines.append(
+                    f"  previous: {prev.get('limit')} req/5min, action="
+                    f"{prev.get('action')}{', uri-scoped' if prev.get('uri_scoped') else ''}")
+                lines.append(
+                    f"  reverse_hint: waf_rate_rule_set site={site} "
+                    f"rule_name={rule_name} limit={prev.get('limit')} "
+                    f"action={prev.get('action')}  (re-creates the removed rule)")
+            else:
+                lines.append(
+                    f"  reverse_hint: re-add with waf_rate_rule_set site={site} "
+                    f"rule_name={rule_name} limit={limit}"
+                    + (f" uri_scope={uri_scope}" if uri_scope else ""))
+            body = "\n".join(lines)
+        else:
+            scope_note = f" scoped to URI {uri_scope!r}" if uri_scope else ""
+            verb = res.get("created_or_updated", "applied")
+            lines = [
+                f"{verb.capitalize()} rate rule '{rule_name}' on WebACL "
+                f"{acl['name']}: {limit} req/5min per IP{scope_note}, action={act}.",
+            ]
+            if verb == "updated" and prev:
+                # Reversible to the PRIOR state, not just deletable.
+                lines.append(
+                    f"  previous: {prev.get('limit')} req/5min, action="
+                    f"{prev.get('action')}{', uri-scoped' if prev.get('uri_scoped') else ''}")
+                lines.append(
+                    f"  reverse_hint: restore prior with waf_rate_rule_set "
+                    f"site={site} rule_name={rule_name} limit={prev.get('limit')} "
+                    f"action={prev.get('action')}")
+            else:
+                lines.append(
+                    f"  reverse_hint: waf_rate_rule_set site={site} "
+                    f"rule_name={rule_name} remove=true")
+            body = "\n".join(lines)
+        self._audit.log('waf_rate_rule_set', args, body, True)
+        return body
+
+    async def block_ip(
+        self, ip: str, site: str = "", action: str = "block", region: str = "",
+    ) -> str:
+        """Block (or unblock) an IP/CIDR at the layer that actually works.
+
+        Resolves the best layer for ``site`` (a WebACL/ALB ARN or instance):
+        prefers the WebACL (it sees the real client IP behind an ALB); falls
+        back to a configured SG/NACL ip_ban config; and if neither exists,
+        recommends the host layer rather than silently editing the firewall.
+        Always reversible. ``action`` is ``block`` or ``unblock``.
+        """
+        args = {'ip': ip, 'site': site, 'action': action, 'region': region}
+        allowed, reason = self._guard.check_tool('block_ip')
+        if not allowed:
+            self._audit.log('block_ip', args, '', False, reason)
+            return f"Blocked: {reason}"
+        act = (action or "block").strip().lower()
+        if act not in ('block', 'unblock'):
+            self._audit.log('block_ip', args, '', False, 'bad_action')
+            return f"Error: action must be 'block' or 'unblock', got {action!r}."
+        if not ip.strip():
+            self._audit.log('block_ip', args, '', False, 'no_ip')
+            return "Error: provide an ip or CIDR to block."
+        if not site.strip():
+            self._audit.log('block_ip', args, '', False, 'no_site')
+            return "Error: provide a site (WebACL/ALB ARN or instance id/name)."
+
+        ban_action = 'ban' if act == 'block' else 'unban'
+
+        # --- layer 1: WebACL (sees the real client IP behind an ALB) ---
+        acl = await self._resolve_webacl(site, region)
+        if not acl.get("error"):
+            from servonaut.services.waf_management_service import WAFManagementService
+            res = await WAFManagementService().add_ip_to_block_ipset(
+                acl["name"], acl["id"], acl["scope"], acl["region"],
+                cidrs=[ip], remove=(ban_action == 'unban'),
+            )
+            if not res.get("error") or res.get("applied"):
+                applied = bool(res.get("applied"))
+                out = self._format_block_ip(
+                    site, ip, act, layer="waf", applied=applied,
+                    detail=f"WebACL {acl['name']} IP set {res.get('ip_set','?')}",
+                    failed=res.get("failed", []),
+                    rationale=(
+                        "a WebACL fronts this site — a ban here matches the "
+                        "real client IP; host/SG bans would see only the ALB hop."
+                    ),
+                )
+                self._audit.log('block_ip', args, out, applied)
+                return out
+            webacl_note = res.get("error", "")
+        else:
+            webacl_note = acl["error"]
+
+        # --- layer 2: a configured SG/NACL/WAF ip_ban config ---
+        if self._ip_ban_service is not None:
+            configs = self._ip_ban_service.get_configs()
+            if configs:
+                cfg = configs[0]
+                try:
+                    if ban_action == 'ban':
+                        res = await self._ip_ban_service.ban_ip(ip, cfg.name)
+                    else:
+                        res = await self._ip_ban_service.unban_ip(ip, cfg.name)
+                except Exception as e:  # noqa: BLE001
+                    res = {'success': False, 'message': str(e)}
+                layer = getattr(cfg, 'method', 'sg')
+                layer = {'security_group': 'sg', 'nacl': 'nacl', 'waf': 'waf'}.get(layer, layer)
+                out = self._format_block_ip(
+                    site, ip, act, layer=layer, applied=bool(res.get('success')),
+                    detail=f"config '{cfg.name}' ({getattr(cfg,'method','')}): {res.get('message','')}",
+                    failed=[] if res.get('success') else [{"ip": ip, "reason": res.get('message','')}],
+                    rationale=(
+                        f"no WebACL resolved ({webacl_note}); used the configured "
+                        f"{getattr(cfg,'method','')} '{cfg.name}'. Note: SG/NACL match by "
+                        "source IP — best for direct-to-instance traffic; for "
+                        "ALB-fronted traffic prefer a WebACL (source IP is the ALB)."
+                    ),
+                )
+                self._audit.log('block_ip', args, out, bool(res.get('success')))
+                return out
+
+        # --- layer 3: no AWS layer available → recommend host-level ---
+        out = self._format_block_ip(
+            site, ip, act, layer="host", applied=False,
+            detail=(
+                f"No WebACL ({webacl_note}) and no SG/NACL ip_ban config. "
+                "Block at the host instead — but only if the box trusts "
+                "forwarded IPs (check describe_ingress_path). Apache: "
+                f"'Require not ip {ip}'; nginx: 'deny {ip};'. Not applied "
+                "automatically (host firewall edits aren't auto-reversible here)."
+            ),
+            failed=[],
+            rationale=(
+                "no AWS edge layer (WebACL/SG/NACL) is available for this site, "
+                "so the only place left to block is the host itself — and only "
+                "if it trusts forwarded IPs."
+            ),
+        )
+        self._audit.log('block_ip', args, out, False, 'no_aws_layer')
+        return out
+
+    def _format_block_ip(self, site, ip, action, layer, applied, detail,
+                         failed, rationale=""):
+        undo = 'unblock' if action == 'block' else 'block'
+        lines = [
+            f"block_ip {action} {ip} on {site}:",
+            f"  layer_used: {layer}",
+        ]
+        if rationale:
+            lines.append(f"  why: {rationale}")
+        lines.append(f"  applied: {applied}")
+        lines.append(f"  detail: {detail}")
+        if failed:
+            for f in failed:
+                lines.append(f"  failed: {f.get('ip','')}: {f.get('reason','')}")
+        if applied:
+            lines.append(f"  reverse_hint: block_ip ip={ip} site={site} action={undo}")
+        return "\n".join(lines)
+
+    async def rds_metrics(
+        self, db_instance: str, region: str = "", window_hours: int = 3,
+    ) -> str:
+        """Snapshot an RDS instance's health: CPU, connections, credit, latency.
+
+        Reads CloudWatch AWS/RDS metrics (CPUUtilization, DatabaseConnections,
+        CPUCreditBalance, Read/WriteLatency, FreeableMemory) for the named DB
+        instance. The first thing to check for the shared-RDS noisy-neighbour
+        case. ``db_instance`` is the RDS DB instance identifier. Read-only.
+        """
+        args = {'db_instance': db_instance, 'region': region,
+                'window_hours': window_hours}
+        allowed, reason = self._guard.check_tool('rds_metrics')
+        if not allowed:
+            self._audit.log('rds_metrics', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if not db_instance.strip():
+            self._audit.log('rds_metrics', args, '', False, 'no_db_instance')
+            return "Error: provide a db_instance (the RDS DB instance identifier)."
+
+        from servonaut.services.rds_metrics_service import (
+            RDSMetricsService, format_rds_metrics,
+        )
+        try:
+            data = await RDSMetricsService().fetch(
+                db_instance, region=region, window_hours=max(1, int(window_hours or 3)),
+            )
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('rds_metrics', args, '', False, f"aws_error: {e}")
+            return f"Error fetching RDS metrics: {e}"
+
+        result = format_rds_metrics(data)
+        self._audit.log('rds_metrics', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # DB credential setup (staging-token pattern — secrets never in context)
+    # ------------------------------------------------------------------
+
+    async def db_setup_scan(
+        self, instance_id: str, search_path: str = "", source: str = "auto",
+    ) -> str:
+        """Discover DB credentials for an instance and stage them for setup.
+
+        Reads the app's config (``.env`` / ``DATABASE_URL`` / ``wp-config.php``
+        / docker env) — for a managed instance, READ-ONLY over SSH on the box.
+        Returns a REDACTED preview plus a staging token per candidate; the
+        plaintext password is held server-side and is NEVER returned (so it
+        can't leak into your model context). Then call ``db_setup_save`` with
+        the chosen token to commit it to the secret store. Read-only.
+        """
+        args = {'instance_id': instance_id, 'search_path': search_path,
+                'source': source}
+        allowed, reason = self._guard.check_tool('db_setup_scan')
+        if not allowed:
+            self._audit.log('db_setup_scan', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('db_setup_scan', args, '', False, 'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        from servonaut.services.db_credential_scanner import (
+            DBCredentialScanner, redact,
+        )
+        scanner = DBCredentialScanner()
+        src = (source or "auto").strip().lower()
+
+        # On-box (SSH) is primary; local-path scan only when explicitly asked
+        # AND search_path points at a local file the agent/user named.
+        candidates = []
+        if src in ("auto", "ssh"):
+            command = scanner.build_scan_command(search_path)
+            try:
+                stdout, _ = await self._exec_ssh(instance, command, timeout=30)
+                candidates = scanner.parse(stdout)
+            except Exception as e:  # noqa: BLE001
+                if src == "ssh":
+                    self._audit.log('db_setup_scan', args, '', False, f"ssh_error: {e}")
+                    return f"Error scanning on box: {e}"
+        if not candidates and src in ("auto", "local") and search_path:
+            import os
+            if os.path.isfile(os.path.expanduser(search_path)):
+                try:
+                    with open(os.path.expanduser(search_path), "r",
+                              encoding="utf-8", errors="replace") as fh:
+                        candidates = scanner.parse_text(fh.read(), search_path)
+                except OSError as e:
+                    self._audit.log('db_setup_scan', args, '', False, f"local_read: {e}")
+                    return f"Error reading {search_path}: {e}"
+
+        if not candidates:
+            self._audit.log('db_setup_scan', args, '0 candidates', True)
+            return (
+                f"No DB credentials found for {instance_id}"
+                + (f" under {search_path}" if search_path else "")
+                + ". Try db_setup_scan with an explicit search_path (a dir on "
+                "the box, or a local .env file), or ask the user for the DSN."
+            )
+
+        import secrets as _secrets
+        lines = [
+            f"Found {len(candidates)} DB credential candidate(s) for "
+            f"{instance_id} (passwords hidden — held server-side):",
+        ]
+        previews = []
+        for cand in candidates:
+            token = "dbstg_" + _secrets.token_urlsafe(6)
+            self._db_staging[token] = cand
+            r = redact(cand)
+            previews.append(r)
+            lines.append(
+                f"  token={token}  {r['engine']} {r['user']}@{r['host']}:"
+                f"{r['port']}/{r['database'] or '?'}  pw={r['password_preview']}  "
+                f"(from {r['source']})"
+            )
+        lines.append(
+            "\nReview with the user, then commit ONE with: db_setup_save("
+            "token=<token>, instance_id='" + instance_id + "'). The password is "
+            "NOT shown here and will go straight to the secret store."
+        )
+        # Audit stores only redacted previews — never the plaintext.
+        self._audit.log('db_setup_scan', args, f"{len(previews)} candidates staged", True)
+        return "\n".join(lines)
+
+    async def db_setup_save(
+        self, token: str, instance_id: str = "", engine: str = "",
+        host: str = "", port: int = 0, user: str = "", database: str = "",
+        password_secret: str = "",
+    ) -> str:
+        """Commit a staged DB credential (from db_setup_scan) to the secret store.
+
+        Looks up the staged candidate by ``token``, applies any non-empty
+        overrides, writes the password into your active secret store, and saves
+        a db_profile so db_processlist / db_top_queries work. The password is
+        read from server-side staging — never from your context. Mutating:
+        confirm with the user first.
+        """
+        args = {'token': token, 'instance_id': instance_id, 'engine': engine,
+                'host': host, 'port': port, 'user': user, 'database': database,
+                'password_secret': password_secret}
+        allowed, reason = self._guard.check_tool('db_setup_save')
+        if not allowed:
+            self._audit.log('db_setup_save', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        cand = self._db_staging.get(token)
+        if cand is None:
+            self._audit.log('db_setup_save', args, '', False, 'unknown_token')
+            return (f"Error: unknown or expired staging token {token!r}. Run "
+                    "db_setup_scan again to re-stage.")
+
+        if self._secret_provider is None:
+            self._audit.log('db_setup_save', args, '', False, 'no_secret_provider')
+            return (
+                "Error: no secret store is active. Run `servonaut login` (the "
+                "secret store is a Solo/Teams feature) so the password can be "
+                "stored, then retry."
+            )
+
+        target_instance = instance_id.strip() or cand.host
+        eff_engine = (engine.strip() or cand.engine).lower()
+        eff_host = host.strip() or cand.host
+        eff_port = int(port) if port else cand.port
+        eff_user = user.strip() or cand.user
+        eff_db = database.strip() or cand.database
+        secret_name = (
+            password_secret.strip() or f"db/{target_instance}".replace(" ", "_")
+        )
+
+        try:
+            await self._secret_provider.set_secret(secret_name, cand.password)
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('db_setup_save', args, '', False, f"secret_error: {e}")
+            return f"Error storing secret: {e}"
+
+        # Persist the db_profile (replace any existing one for this instance).
+        from servonaut.config.schema import DBProfile
+        config = self._config_manager.get()
+        profiles = [
+            p for p in config.db_profiles
+            if (p.instance or "").strip().lower() != target_instance.strip().lower()
+        ]
+        profiles.append(DBProfile(
+            instance=target_instance, engine=eff_engine, host=eff_host,
+            port=eff_port, user=eff_user, password_secret=secret_name,
+            database=eff_db,
+        ))
+        try:
+            self._config_manager.update(db_profiles=profiles)
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('db_setup_save', args, '', False, f"config_error: {e}")
+            return f"Error saving db_profile: {e}"
+
+        # Consume the token so the staged plaintext doesn't linger.
+        self._db_staging.pop(token, None)
+
+        result = (
+            f"Saved db_profile for {target_instance}: {eff_engine} "
+            f"{eff_user}@{eff_host}:{eff_port}/{eff_db or '?'} "
+            f"(password in secret store as {secret_name!r}). "
+            "db_processlist / db_top_queries are ready for this instance.\n"
+            f"  tip: {eff_user!r} looks like the app user — for routine "
+            "diagnostics prefer a dedicated read-only DB user (SELECT + "
+            "PROCESS) over storing app/admin creds.\n"
+            f"  undo: db_setup_remove(instance_id='{target_instance}')"
+        )
+        self._audit.log('db_setup_save', args, result, True)
+        return result
+
+    async def db_setup_remove(
+        self, instance_id: str, delete_secret: bool = True,
+    ) -> str:
+        """Remove an instance's db_profile (and its stored secret) — the undo
+        for db_setup_save. Deletes the db_profile from config; when
+        ``delete_secret`` is true (default) also deletes the password from the
+        secret store. Mutating: confirm with the user first.
+        """
+        args = {'instance_id': instance_id, 'delete_secret': delete_secret}
+        allowed, reason = self._guard.check_tool('db_setup_remove')
+        if not allowed:
+            self._audit.log('db_setup_remove', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        config = self._config_manager.get()
+        target = instance_id.strip().lower()
+        match = next(
+            (p for p in config.db_profiles
+             if (p.instance or "").strip().lower() == target), None,
+        )
+        if match is None:
+            self._audit.log('db_setup_remove', args, '', False, 'no_db_profile')
+            return f"No db_profile found for {instance_id}."
+
+        remaining = [
+            p for p in config.db_profiles
+            if (p.instance or "").strip().lower() != target
+        ]
+        try:
+            self._config_manager.update(db_profiles=remaining)
+        except Exception as e:  # noqa: BLE001
+            self._audit.log('db_setup_remove', args, '', False, f"config_error: {e}")
+            return f"Error removing db_profile: {e}"
+
+        secret_note = ""
+        if delete_secret and match.password_secret and self._secret_provider is not None:
+            try:
+                deleted = await self._secret_provider.delete_secret(match.password_secret)
+                secret_note = (f" Secret {match.password_secret!r} "
+                               + ("deleted." if deleted else "was not present."))
+            except Exception as e:  # noqa: BLE001
+                secret_note = (f" (could not delete secret "
+                               f"{match.password_secret!r}: {e})")
+        elif match.password_secret:
+            secret_note = (f" Secret {match.password_secret!r} left in the "
+                           "store (delete_secret=false or no provider).")
+
+        result = f"Removed db_profile for {instance_id}.{secret_note}"
+        self._audit.log('db_setup_remove', args, result, True)
+        return result

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -87,6 +87,22 @@ _TOOL_GUARDS: Dict[str, Literal["readonly", "standard", "dangerous"]] = {
     "hetzner_create_ssh_key": "standard",
     "hetzner_create_server": "dangerous",
     "hetzner_delete_server": "dangerous",
+    # Incident-response tools (Group A). Read-only probes are readonly; the
+    # DB tools execute a client on the box with stored creds → standard.
+    "web_traffic_summary": "readonly",
+    "fleet_health_snapshot": "readonly",
+    "enrich_ips": "readonly",
+    "db_processlist": "standard",
+    "db_top_queries": "standard",
+    "db_setup_scan": "standard",
+    "db_setup_save": "standard",
+    "db_setup_remove": "standard",
+    # Group B: boto3 AWS topology / metrics read.
+    "describe_ingress_path": "readonly",
+    "rds_metrics": "readonly",
+    # Group C: WAF mitigation — mutate live traffic handling.
+    "waf_rate_rule_set": "dangerous",
+    "block_ip": "dangerous",
 }
 
 # Strict ordering of guard severity. Used by :func:`_escalate_guard` to
@@ -237,6 +253,20 @@ _LOCAL_TOOL_HANDLERS: Dict[str, str] = {
     "list_server_memories":       "list_server_memories",
     "build_server_memory":        "build_server_memory",
     "refresh_server_memory":      "refresh_server_memory",
+
+    # --- Incident-response tools (Group A): SSH/network + DB introspection ---
+    "web_traffic_summary":        "web_traffic_summary",
+    "fleet_health_snapshot":      "fleet_health_snapshot",
+    "enrich_ips":                 "enrich_ips",
+    "db_processlist":             "db_processlist",
+    "db_top_queries":             "db_top_queries",
+    "db_setup_scan":              "db_setup_scan",
+    "db_setup_save":              "db_setup_save",
+    "db_setup_remove":            "db_setup_remove",
+    "describe_ingress_path":      "describe_ingress_path",
+    "rds_metrics":                "rds_metrics",
+    "waf_rate_rule_set":          "waf_rate_rule_set",
+    "block_ip":                   "block_ip",
 }
 
 # Tools the catalog advertises but that aren't dispatchable on this

--- a/src/servonaut/services/cloudwatch_service.py
+++ b/src/servonaut/services/cloudwatch_service.py
@@ -189,3 +189,79 @@ class CloudWatchService:
             }
             for ip, count in total_counter.most_common(limit)
         ]
+
+    @staticmethod
+    def aggregate_events(
+        events: List[Dict[str, Any]],
+        group_by: str,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        """Rank log events by a structured field (clientIp / status / uri).
+
+        Returns ``{group_by, total_events, total_matched, ranking}`` where
+        ranking is ``[{key, count, pct}]``. Lets callers get a server-side
+        ranked summary instead of dumping every raw event. ``total_matched``
+        is how many events yielded a value for the requested field.
+        """
+        counter: Counter = Counter()
+        matched = 0
+        for event in events:
+            message = event.get("message", "")
+            try:
+                parsed = json.loads(message)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            value = CloudWatchService._field_value(parsed, message, group_by)
+            if value is None or value == "":
+                continue
+            matched += 1
+            counter[str(value)] += 1
+
+        ranking = [
+            {"key": key, "count": count,
+             "pct": round(count / matched * 100, 1) if matched else 0.0}
+            for key, count in counter.most_common(limit)
+        ]
+        return {
+            "group_by": group_by,
+            "total_events": len(events),
+            "total_matched": matched,
+            "ranking": ranking,
+        }
+
+    @staticmethod
+    def _field_value(parsed, message: str, group_by: str):
+        """Extract the requested field from a parsed WAF/ALB log record."""
+        if group_by == "clientIp":
+            if isinstance(parsed, dict):
+                return (
+                    parsed.get("httpRequest", {}).get("clientIp")
+                    or parsed.get("clientIp")
+                    or parsed.get("client_ip")
+                )
+            return None
+        if group_by == "status":
+            if isinstance(parsed, dict):
+                return (
+                    parsed.get("responseCodeSent")
+                    or parsed.get("elb_status_code")
+                    or parsed.get("status")
+                    or parsed.get("httpResponse", {}).get("status")
+                )
+            return None
+        if group_by == "uri":
+            if isinstance(parsed, dict):
+                uri = parsed.get("httpRequest", {}).get("uri")
+                if uri:
+                    return str(uri).split("?", 1)[0]
+                # ALB "request" field: '"GET https://h:443/path HTTP/1.1"'
+                req = parsed.get("request") or ""
+                parts = str(req).split(" ")
+                if len(parts) >= 2:
+                    path = parts[1]
+                    # Strip scheme/host if present.
+                    if "://" in path:
+                        path = "/" + path.split("://", 1)[1].split("/", 1)[-1]
+                    return path.split("?", 1)[0]
+            return None
+        return None

--- a/src/servonaut/services/db_credential_scanner.py
+++ b/src/servonaut/services/db_credential_scanner.py
@@ -1,0 +1,311 @@
+"""Discover database credentials from app config (.env, DATABASE_URL, etc.).
+
+Backs ``db_setup_scan`` / the ``servonaut db setup`` CLI. The goal is to make
+the DB introspection tools (db_processlist / db_top_queries) usable with zero
+manual config: read the credentials the app already has — usually in a ``.env``
+or ``wp-config.php`` on the managed box — and stage them so the operator can
+commit them to the secret store with one confirmation.
+
+CRITICAL SECURITY CONTRACT:
+- This module PARSES text into :class:`DBCandidate` objects (plaintext password
+  in-process only). The tool layer holds candidates in a SERVER-SIDE staging
+  area and returns only :func:`redact` previews to the agent. The plaintext
+  password must NEVER be placed in a tool result / model context — agents relay
+  context to their model provider, which may log it.
+- All file access is READ-ONLY (the on-box command uses ``find`` + ``sed -n``).
+
+Parsing is pure and IO-free so it's unit-testable; the SSH round-trip / local
+file read is done by the caller and the raw text handed in here.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from urllib.parse import urlparse, unquote
+
+# Marker the on-box command prints before each file's contents.
+FILE_MARKER = "===FILE:"
+
+# Default port per engine.
+_DEFAULT_PORT = {"mysql": 3306, "mariadb": 3306, "postgres": 5432, "postgresql": 5432}
+
+# DATABASE_URL scheme → engine.
+_SCHEME_ENGINE = {
+    "mysql": "mysql", "mysql2": "mysql", "mariadb": "mysql",
+    "postgres": "postgres", "postgresql": "postgres", "pgsql": "postgres",
+}
+
+
+@dataclass
+class DBCandidate:
+    """A discovered DB connection. ``password`` is plaintext — never serialize
+    it into a tool result; only :func:`redact` it."""
+    engine: str
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str = ""
+    source: str = ""
+
+    def is_usable(self) -> bool:
+        # We're collecting the password; without it the profile would rely on
+        # socket/trust auth and wouldn't need scanning anyway.
+        return bool(self.password and self.host and self.user)
+
+
+def redact(candidate: DBCandidate) -> Dict[str, object]:
+    """Model-safe preview of a candidate (password masked)."""
+    pw = candidate.password or ""
+    if len(pw) <= 4:
+        masked = "****"
+    else:
+        masked = "****" + pw[-3:]
+    return {
+        "engine": candidate.engine,
+        "host": candidate.host,
+        "port": candidate.port,
+        "user": candidate.user,
+        "database": candidate.database,
+        "password_preview": masked,
+        "source": candidate.source,
+    }
+
+
+def _strip(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        value = value[1:-1]
+    return value
+
+
+def _parse_dotenv(text: str) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.lower().startswith("export "):
+            line = line[7:]
+        key, _, val = line.partition("=")
+        env[key.strip()] = _strip(val)
+    return env
+
+
+def _from_database_url(url: str, source: str) -> Optional[DBCandidate]:
+    try:
+        p = urlparse(url)
+    except ValueError:
+        return None
+    engine = _SCHEME_ENGINE.get((p.scheme or "").lower())
+    if not engine or not p.hostname:
+        return None
+    return DBCandidate(
+        engine=engine,
+        host=p.hostname,
+        port=p.port or _DEFAULT_PORT.get(engine, 3306),
+        user=unquote(p.username or "") or "root",
+        password=unquote(p.password or ""),
+        database=(p.path or "").lstrip("/"),
+        source=source,
+    )
+
+
+def _from_dotenv_fields(env: Dict[str, str], source: str) -> Optional[DBCandidate]:
+    # 1. Explicit DATABASE_URL (Rails / Node / generic) wins.
+    for key in ("DATABASE_URL", "DB_URL", "DATABASE_DSN"):
+        if env.get(key):
+            cand = _from_database_url(env[key], source)
+            if cand:
+                return cand
+
+    # 2. Laravel / framework DB_* fields.
+    if env.get("DB_PASSWORD") or env.get("DB_USERNAME") or env.get("DB_HOST"):
+        conn = (env.get("DB_CONNECTION") or "mysql").lower()
+        engine = "postgres" if conn.startswith("pg") or conn == "postgres" else "mysql"
+        return DBCandidate(
+            engine=engine,
+            host=env.get("DB_HOST", "127.0.0.1") or "127.0.0.1",
+            port=int(env["DB_PORT"]) if env.get("DB_PORT", "").isdigit()
+            else _DEFAULT_PORT.get(engine, 3306),
+            user=env.get("DB_USERNAME", "") or env.get("DB_USER", "") or "root",
+            password=env.get("DB_PASSWORD", ""),
+            database=env.get("DB_DATABASE", "") or env.get("DB_NAME", ""),
+            source=source,
+        )
+
+    # 3. docker-compose style POSTGRES_* / MYSQL_*.
+    if env.get("POSTGRES_PASSWORD"):
+        return DBCandidate(
+            engine="postgres", host=env.get("POSTGRES_HOST", "127.0.0.1"),
+            port=int(env["POSTGRES_PORT"]) if env.get("POSTGRES_PORT", "").isdigit() else 5432,
+            user=env.get("POSTGRES_USER", "postgres"),
+            password=env["POSTGRES_PASSWORD"],
+            database=env.get("POSTGRES_DB", ""), source=source,
+        )
+    if env.get("MYSQL_PASSWORD") or env.get("MYSQL_ROOT_PASSWORD"):
+        return DBCandidate(
+            engine="mysql", host=env.get("MYSQL_HOST", "127.0.0.1"),
+            port=int(env["MYSQL_PORT"]) if env.get("MYSQL_PORT", "").isdigit() else 3306,
+            user=env.get("MYSQL_USER", "root"),
+            password=env.get("MYSQL_PASSWORD") or env.get("MYSQL_ROOT_PASSWORD", ""),
+            database=env.get("MYSQL_DATABASE", ""), source=source,
+        )
+    return None
+
+
+_WP_DEFINE_RE = re.compile(
+    r"""define\(\s*['"](DB_[A-Z]+)['"]\s*,\s*['"]([^'"]*)['"]\s*\)""",
+)
+
+# Joomla configuration.php: `public $host = 'localhost';` etc.
+_JOOMLA_RE = re.compile(r"""public\s+\$(\w+)\s*=\s*['"]([^'"]*)['"]""")
+
+
+def _split_host_port(host: str, default_port: int) -> tuple:
+    host = host or "localhost"
+    if ":" in host:
+        h, _, p = host.partition(":")
+        return (h or "127.0.0.1"), (int(p) if p.isdigit() else default_port)
+    return host, default_port
+
+
+def _from_joomla(text: str, source: str) -> Optional[DBCandidate]:
+    found = {m.group(1): m.group(2) for m in _JOOMLA_RE.finditer(text)}
+    # Joomla's JConfig always defines $password together with $db/$dbtype —
+    # require that combo so we don't misfire on an unrelated `public $password`.
+    if "password" not in found or not ("db" in found or "dbtype" in found):
+        return None
+    dbtype = (found.get("dbtype", "mysqli") or "mysqli").lower()
+    engine = "postgres" if ("pgsql" in dbtype or "postgre" in dbtype) else "mysql"
+    port = int(found["dbport"]) if found.get("dbport", "").isdigit() \
+        else _DEFAULT_PORT.get(engine, 3306)
+    host, port = _split_host_port(found.get("host", "localhost"), port)
+    return DBCandidate(
+        engine=engine, host=host, port=port,
+        user=found.get("user", "") or "root",
+        password=found.get("password", ""),
+        database=found.get("db", ""), source=source,
+    )
+
+
+def _from_magento(text: str, source: str) -> Optional[DBCandidate]:
+    # Magento app/etc/env.php — nested PHP array. Grab the first occurrence of
+    # each connection key (the 'default' connection appears first).
+    def grab(key: str) -> str:
+        m = re.search(r"'%s'\s*=>\s*'([^']*)'" % key, text)
+        return m.group(1) if m else ""
+
+    pw, user = grab("password"), grab("username")
+    if not pw and not user:
+        return None
+    host, port = _split_host_port(grab("host") or "localhost", 3306)
+    return DBCandidate(
+        engine="mysql", host=host, port=port, user=user or "root",
+        password=pw, database=grab("dbname"), source=source,
+    )
+
+
+def _from_wp_config(text: str, source: str) -> Optional[DBCandidate]:
+    found = {m.group(1): m.group(2) for m in _WP_DEFINE_RE.finditer(text)}
+    if not found.get("DB_PASSWORD") and not found.get("DB_USER"):
+        return None
+    host = found.get("DB_HOST", "localhost") or "localhost"
+    port = 3306
+    if ":" in host:
+        host, _, p = host.partition(":")
+        if p.isdigit():
+            port = int(p)
+    return DBCandidate(
+        engine="mysql", host=host or "127.0.0.1", port=port,
+        user=found.get("DB_USER", "root"), password=found.get("DB_PASSWORD", ""),
+        database=found.get("DB_NAME", ""), source=source,
+    )
+
+
+class DBCredentialScanner:
+    """Parse app-config text into staged DB credential candidates."""
+
+    # Read-only one-liner: find common config files under the search roots and
+    # print each prefixed by a FILE marker. `sed -n` never writes.
+    @staticmethod
+    def build_scan_command(search_path: str = "") -> str:
+        # Web apps nest deep on shared hosts (e.g. /home/<user>/<domain>/
+        # <sub>/html/configuration.php), so search to depth 7. Known DB-config
+        # filenames across stacks: dotenv, WordPress, Joomla (configuration.php),
+        # Magento (app/etc/env.php). Config files are listed first so they're
+        # never truncated by the line cap when many .env files exist.
+        roots = search_path.strip() or ". /var/www /srv /home /opt /usr/share/nginx"
+        names = (
+            "\\( -name configuration.php -o -name wp-config.php -o -name env.php "
+            "-o -name .env -o -name .env.local -o -name .env.production \\)"
+        )
+        return (
+            f'for d in {roots}; do '
+            f'find "$d" -maxdepth 7 -type f {names} 2>/dev/null; '
+            f'done | head -60 | while read f; do '
+            f'echo "{FILE_MARKER}$f==="; sed -n "1,250p" "$f"; done'
+        )
+
+    def parse(self, raw: str) -> List[DBCandidate]:
+        """Parse the on-box / local scan output into usable candidates."""
+        candidates: List[DBCandidate] = []
+        for source, text in self._split_files(raw).items():
+            cand = self._parse_one(text, source)
+            if cand and cand.is_usable():
+                candidates.append(cand)
+        # De-dup identical (host,user,db) — same secret found in two files.
+        seen = set()
+        unique: List[DBCandidate] = []
+        for c in candidates:
+            key = (c.engine, c.host, c.port, c.user, c.database)
+            if key not in seen:
+                seen.add(key)
+                unique.append(c)
+        return unique
+
+    def parse_text(self, text: str, source: str) -> List[DBCandidate]:
+        """Parse a single file's contents (local-path mode)."""
+        cand = self._parse_one(text, source)
+        return [cand] if cand and cand.is_usable() else []
+
+    def _parse_one(self, text: str, source: str) -> Optional[DBCandidate]:
+        low = source.lower()
+        # Joomla configuration.php (JConfig) — check before dotenv since the
+        # file is PHP and would otherwise be misread as KEY=VALUE.
+        if low.endswith("configuration.php") or (
+            "public $password" in text and ("public $db" in text or "public $dbtype" in text)
+        ):
+            j = _from_joomla(text, source)
+            if j:
+                return j
+        # Magento app/etc/env.php.
+        if low.endswith("env.php") or ("'connection'" in text and "'password'" in text):
+            mg = _from_magento(text, source)
+            if mg:
+                return mg
+        if "wp-config" in low or ("define(" in text and "DB_NAME" in text):
+            wp = _from_wp_config(text, source)
+            if wp:
+                return wp
+        env = _parse_dotenv(text)
+        if env:
+            return _from_dotenv_fields(env, source)
+        return None
+
+    def _split_files(self, raw: str) -> Dict[str, List[str]]:
+        sections: Dict[str, str] = {}
+        current = None
+        buf: List[str] = []
+        for line in raw.splitlines():
+            if line.startswith(FILE_MARKER):
+                if current is not None:
+                    sections[current] = "\n".join(buf)
+                current = line[len(FILE_MARKER):].rstrip("=").strip()
+                buf = []
+            elif current is not None:
+                buf.append(line)
+        if current is not None:
+            sections[current] = "\n".join(buf)
+        return sections

--- a/src/servonaut/services/ingress_path_service.py
+++ b/src/servonaut/services/ingress_path_service.py
@@ -1,0 +1,419 @@
+"""Walk an EC2 instance's ALB/WAF ingress path in one call.
+
+Backs the ``describe_ingress_path`` tool. During the incident, ~6 rounds went
+to proving "behind ALB, not direct", discovering mod_remoteip, and finding the
+WAF wasn't even attached to the right ALB. This service answers all of that at
+once:
+
+    instance → target group(s) → load balancer(s) → listeners/rules
+             → associated WebACL → IP sets + rate-based rules
+
+Design notes:
+
+- **Partial-failure tolerant.** The incident agent had an incomplete IAM
+  scope (wafv2 denied). Every phase is wrapped: an ``AccessDenied`` on the WAF
+  walk still returns the target-group + load-balancer topology, with the
+  failure recorded in ``errors``. We never raise out of the walk — a partial
+  map beats a hard failure.
+- **boto3 runs in a thread** (``run_in_executor``) like CloudWatchService, so
+  the TUI stays responsive.
+- Matches an instance target by BOTH instance-id (instance-type target
+  groups) and private IP (ip-type target groups).
+- mod_remoteip trust is NOT determined here — that's an on-box fact the tool
+  layer adds (memory / SSH). This service is pure AWS topology.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+class IngressPathService:
+    """Resolve the ALB/WAF ingress topology fronting an EC2 instance."""
+
+    async def describe(
+        self, instance_id: str, private_ip: str = "", region: str = "",
+    ) -> Dict[str, Any]:
+        """Return the ingress topology for *instance_id* (boto3 in a thread)."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._describe_sync, instance_id, private_ip, region,
+        )
+
+    # ------------------------------------------------------------------
+    # Sync walk
+    # ------------------------------------------------------------------
+
+    def _describe_sync(
+        self, instance_id: str, private_ip: str, region: str,
+    ) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "instance_id": instance_id,
+            "region": region,
+            "target_groups": [],
+            "load_balancers": [],
+            "errors": [],
+        }
+        kwargs = {"region_name": region} if region else {}
+
+        try:
+            elbv2 = boto3.client("elbv2", **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            result["errors"].append(f"elbv2 client: {exc}")
+            return result
+
+        # --- target groups containing this instance -------------------
+        matched_tgs = self._find_target_groups(
+            elbv2, instance_id, private_ip, result["errors"],
+        )
+        result["target_groups"] = [
+            {k: tg[k] for k in ("name", "arn", "port", "protocol", "target_state")}
+            for tg in matched_tgs
+        ]
+
+        # --- load balancers fronting those target groups --------------
+        lb_arns: List[str] = []
+        for tg in matched_tgs:
+            for arn in tg.get("lb_arns", []):
+                if arn not in lb_arns:
+                    lb_arns.append(arn)
+        if not lb_arns:
+            return result
+
+        load_balancers = self._describe_load_balancers(
+            elbv2, lb_arns, result["errors"],
+        )
+
+        # --- listeners + rules per LB ---------------------------------
+        our_tg_arns = {tg["arn"] for tg in matched_tgs}
+        for lb in load_balancers:
+            lb["listeners"] = self._describe_listeners(
+                elbv2, lb["arn"], result["errors"], our_tg_arns,
+            )
+
+        # --- WebACL per (application) LB ------------------------------
+        wafv2 = None
+        try:
+            wafv2 = boto3.client("wafv2", **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            result["errors"].append(f"wafv2 client: {exc}")
+        if wafv2 is not None:
+            for lb in load_balancers:
+                if lb.get("type") and lb["type"] != "application":
+                    # Only ALBs can carry a WAFv2 WebACL.
+                    lb["web_acl"] = None
+                    continue
+                lb["web_acl"] = self._describe_web_acl(
+                    wafv2, lb["arn"], region, result["errors"],
+                )
+
+        result["load_balancers"] = load_balancers
+        return result
+
+    def _find_target_groups(
+        self, elbv2, instance_id: str, private_ip: str, errors: List[str],
+    ) -> List[Dict[str, Any]]:
+        matched: List[Dict[str, Any]] = []
+        targets = {t for t in (instance_id, private_ip) if t}
+        try:
+            paginator = elbv2.get_paginator("describe_target_groups")
+            tgs = []
+            for page in paginator.paginate():
+                tgs.extend(page.get("TargetGroups", []))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"describe_target_groups: {exc}")
+            return matched
+
+        for tg in tgs:
+            arn = tg.get("TargetGroupArn", "")
+            try:
+                health = elbv2.describe_target_health(TargetGroupArn=arn)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"describe_target_health({tg.get('TargetGroupName')}): {exc}")
+                continue
+            state = None
+            for desc in health.get("TargetHealthDescriptions", []):
+                tid = desc.get("Target", {}).get("Id", "")
+                if tid in targets:
+                    state = desc.get("TargetHealth", {}).get("State")
+                    break
+            if state is None:
+                continue
+            matched.append({
+                "name": tg.get("TargetGroupName", ""),
+                "arn": arn,
+                "port": tg.get("Port"),
+                "protocol": tg.get("Protocol", ""),
+                "target_state": state,
+                "lb_arns": tg.get("LoadBalancerArns", []),
+            })
+        return matched
+
+    def _describe_load_balancers(
+        self, elbv2, lb_arns: List[str], errors: List[str],
+    ) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        try:
+            resp = elbv2.describe_load_balancers(LoadBalancerArns=lb_arns)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"describe_load_balancers: {exc}")
+            # Still return ARNs we know about so the agent sees the linkage.
+            return [{"arn": a, "dns_name": "", "type": "", "scheme": "",
+                     "listeners": [], "web_acl": None} for a in lb_arns]
+        for lb in resp.get("LoadBalancers", []):
+            out.append({
+                "arn": lb.get("LoadBalancerArn", ""),
+                "dns_name": lb.get("DNSName", ""),
+                "type": lb.get("Type", ""),
+                "scheme": lb.get("Scheme", ""),
+                "listeners": [],
+                "web_acl": None,
+            })
+        return out
+
+    def _describe_listeners(
+        self, elbv2, lb_arn: str, errors: List[str], our_tg_arns=None,
+    ) -> List[Dict[str, Any]]:
+        our_tg_arns = our_tg_arns or set()
+        listeners: List[Dict[str, Any]] = []
+        try:
+            resp = elbv2.describe_listeners(LoadBalancerArn=lb_arn)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"describe_listeners: {exc}")
+            return listeners
+        for li in resp.get("Listeners", []):
+            li_arn = li.get("ListenerArn", "")
+            entry = {
+                "port": li.get("Port"),
+                "protocol": li.get("Protocol", ""),
+                "rules": [],
+            }
+            try:
+                rules_resp = elbv2.describe_rules(ListenerArn=li_arn)
+                entry["rules"] = [
+                    self._summarize_rule(r, our_tg_arns)
+                    for r in rules_resp.get("Rules", [])
+                ]
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"describe_rules: {exc}")
+            listeners.append(entry)
+        return listeners
+
+    @staticmethod
+    def _rule_target_arns(rule: Dict[str, Any]) -> List[str]:
+        """All target-group ARNs a rule forwards to (direct + ForwardConfig)."""
+        arns: List[str] = []
+        for a in rule.get("Actions", []):
+            if a.get("TargetGroupArn"):
+                arns.append(a["TargetGroupArn"])
+            for tg in a.get("ForwardConfig", {}).get("TargetGroups", []):
+                if tg.get("TargetGroupArn"):
+                    arns.append(tg["TargetGroupArn"])
+        return arns
+
+    @staticmethod
+    def _summarize_rule(rule: Dict[str, Any], our_tg_arns=None) -> Dict[str, Any]:
+        our_tg_arns = our_tg_arns or set()
+        conditions: List[str] = []
+        for cond in rule.get("Conditions", []):
+            field = cond.get("Field", "")
+            values = cond.get("Values", []) or [
+                v for vk in ("HostHeaderConfig", "PathPatternConfig")
+                if (vk in cond) for v in cond[vk].get("Values", [])
+            ]
+            conditions.append(f"{field}={','.join(values)}" if values else field)
+        actions = [a.get("Type", "") for a in rule.get("Actions", [])]
+        targets = IngressPathService._rule_target_arns(rule)
+        return {
+            "priority": rule.get("Priority", ""),
+            "conditions": conditions,
+            "actions": actions,
+            # True when this rule routes to the target group holding our instance
+            # — the rule(s) that actually matter for this box.
+            "targets_our_tg": any(a in our_tg_arns for a in targets),
+        }
+
+    def _describe_web_acl(
+        self, wafv2, lb_arn: str, region: str, errors: List[str],
+    ) -> Optional[Dict[str, Any]]:
+        # ALB → REGIONAL scope. (CLOUDFRONT scope is global/us-east-1 and only
+        # applies to CloudFront distributions, not ALBs.)
+        try:
+            resp = wafv2.get_web_acl_for_resource(ResourceArn=lb_arn)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"get_web_acl_for_resource: {exc}")
+            return None
+        summary = resp.get("WebACL")
+        if not summary:
+            return None  # No WebACL attached — a key incident finding.
+        acl = {
+            "arn": summary.get("ARN", ""),
+            "name": summary.get("Name", ""),
+            "ip_sets": [],
+            "rate_rules": [],
+        }
+        # get_web_acl needs Name + Id + Scope to read the rule set.
+        try:
+            full = wafv2.get_web_acl(
+                Name=summary.get("Name", ""),
+                Scope="REGIONAL",
+                Id=summary.get("Id", ""),
+            )
+            web_acl = full.get("WebACL", {})
+            acl["default_action"] = (
+                "allow" if "Allow" in web_acl.get("DefaultAction", {}) else "block"
+            )
+            for r in web_acl.get("Rules", []):
+                self._collect_rule_refs(r, acl)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"get_web_acl({summary.get('Name')}): {exc}")
+        return acl
+
+    def _collect_rule_refs(self, rule: Dict[str, Any], acl: Dict[str, Any]) -> None:
+        """Pull IP-set references and rate-based rules out of one WebACL rule."""
+        stmt = rule.get("Statement", {})
+        name = rule.get("Name", "")
+        # IP set reference (possibly nested under And/Or/Not — scan recursively).
+        for ip_arn in self._scan_ipset_arns(stmt):
+            acl["ip_sets"].append({"rule": name, "arn": ip_arn})
+        # Rate-based rule (top level or as a scope-down container).
+        rate = self._find_rate_statement(stmt)
+        if rate is not None:
+            acl["rate_rules"].append({
+                "rule": name,
+                "limit_per_5min": rate.get("Limit"),
+                "aggregate_key": rate.get("AggregateKeyType", "IP"),
+            })
+
+    def _scan_ipset_arns(self, stmt: Dict[str, Any]) -> List[str]:
+        found: List[str] = []
+        if not isinstance(stmt, dict):
+            return found
+        if "IPSetReferenceStatement" in stmt:
+            arn = stmt["IPSetReferenceStatement"].get("ARN", "")
+            if arn:
+                found.append(arn)
+        for key in ("AndStatement", "OrStatement"):
+            for sub in stmt.get(key, {}).get("Statements", []):
+                found.extend(self._scan_ipset_arns(sub))
+        if "NotStatement" in stmt:
+            found.extend(self._scan_ipset_arns(stmt["NotStatement"].get("Statement", {})))
+        return found
+
+    def _find_rate_statement(self, stmt: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(stmt, dict):
+            return None
+        if "RateBasedStatement" in stmt:
+            return stmt["RateBasedStatement"]
+        for key in ("AndStatement", "OrStatement"):
+            for sub in stmt.get(key, {}).get("Statements", []):
+                found = self._find_rate_statement(sub)
+                if found is not None:
+                    return found
+        return None
+
+
+def _format_web_acl(acl: Optional[Dict[str, Any]], lb: Dict[str, Any]) -> List[str]:
+    lines: List[str] = []
+    if acl is None:
+        lines.append(
+            f"  WebACL fronting {lb.get('dns_name', lb.get('arn', '?'))}: "
+            "NONE attached"
+            + (" ⚠ (ALB has no WAF in front of it — a flood hits the app "
+               "directly)" if lb.get("type") == "application" else ""))
+        return lines
+    lines.append(f"  WebACL: {acl.get('name', '')} "
+                 f"(default={acl.get('default_action', '?')})  on "
+                 f"{lb.get('dns_name', '')}")
+    for ips in acl.get("ip_sets", []):
+        lines.append(f"    IP set (rule {ips.get('rule', '')}): {ips.get('arn', '')}")
+    for rr in acl.get("rate_rules", []):
+        lines.append(f"    rate rule '{rr.get('rule', '')}': "
+                     f"{rr.get('limit_per_5min', '?')}/5min by "
+                     f"{rr.get('aggregate_key', 'IP')}")
+    if not acl.get("ip_sets") and not acl.get("rate_rules"):
+        lines.append("    (no IP-set or rate-based rules)")
+    return lines
+
+
+def format_ingress_path(
+    topo: Dict[str, Any], mod_remoteip_trusted: Optional[bool],
+    verbose: bool = False,
+) -> str:
+    """Render the topology as a skimmable report (WebACL first; verbatim-relayed).
+
+    Listener rules are collapsed to the one(s) routing to THIS instance's target
+    group plus a count of the rest (an ALB can carry 100+ host-header rules);
+    pass ``verbose=True`` to show every rule.
+    """
+    out: List[str] = []
+    out.append(f"Ingress path for {topo.get('instance_id', '?')} "
+               f"(region {topo.get('region') or 'default'}):")
+
+    trust = (
+        "yes" if mod_remoteip_trusted is True
+        else "no" if mod_remoteip_trusted is False
+        else "unknown"
+    )
+    out.append(f"  mod_remoteip / real-IP trust on box: {trust}")
+    if mod_remoteip_trusted is False:
+        out.append("    ⚠ %h in access logs is the ALB hop, not the client — "
+                   "iptables/host bans by %h will NOT match real clients; "
+                   "block at the WebACL.")
+
+    lbs = topo.get("load_balancers", [])
+
+    # WebACL FIRST — it's the gold (which WAF fronts the box, its IP sets +
+    # rate rules; or the critical "no WAF attached" finding).
+    if lbs:
+        out.append("\n  == WAF / WebACL ==")
+        for lb in lbs:
+            out.extend(_format_web_acl(lb.get("web_acl"), lb))
+
+    tgs = topo.get("target_groups", [])
+    if not tgs:
+        out.append("\n  No target groups contain this instance — it is NOT "
+                   "behind an ALB/NLB (or you lack elbv2:Describe*). Traffic "
+                   "may be hitting it directly.")
+    else:
+        out.append(f"\n  Target groups ({len(tgs)}):")
+        for tg in tgs:
+            out.append(f"    {tg.get('name','')}  "
+                       f"{tg.get('protocol','')}:{tg.get('port','')}  "
+                       f"target={tg.get('target_state','?')}")
+
+    if lbs:
+        out.append(f"\n  Load balancers ({len(lbs)}):")
+        for lb in lbs:
+            out.append(f"    {lb.get('type','?')} {lb.get('dns_name','')} "
+                       f"({lb.get('scheme','')})")
+            for li in lb.get("listeners", []):
+                rules = li.get("rules", [])
+                matching = [r for r in rules if r.get("targets_our_tg")]
+                shown = rules if verbose else (matching or rules[:1])
+                out.append(f"      listener {li.get('protocol','')}:"
+                           f"{li.get('port','')} ({len(rules)} rule(s))")
+                for rule in shown:
+                    conds = "; ".join(rule.get("conditions", [])) or "default"
+                    acts = ",".join(rule.get("actions", []))
+                    mark = " ←this instance" if rule.get("targets_our_tg") else ""
+                    out.append(f"        rule[{rule.get('priority','')}] "
+                               f"{conds} → {acts}{mark}")
+                hidden = len(rules) - len(shown)
+                if hidden > 0:
+                    out.append(f"        +{hidden} other rule(s) "
+                               "(other vhosts/targets — pass verbose=true to see)")
+
+    errors = topo.get("errors", [])
+    if errors:
+        out.append("\n  Partial result — some calls failed "
+                   "(likely missing IAM scope):")
+        for e in errors[:10]:
+            out.append(f"    - {e}")
+
+    return "\n".join(out)

--- a/src/servonaut/services/ip_ban_service.py
+++ b/src/servonaut/services/ip_ban_service.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _to_cidr(ip_address: str) -> str:
+    """Normalize an IP or CIDR to CIDR form (a bare IP becomes /32)."""
+    return ip_address if "/" in ip_address else f"{ip_address}/32"
+
+
 class WAFStrategy(IPBanStrategyInterface):
     """Ban IPs via AWS WAFv2 IP sets."""
 
@@ -34,7 +39,7 @@ class WAFStrategy(IPBanStrategyInterface):
                 Id=config.ip_set_id,
             )
             addresses = list(response['IPSet']['Addresses'])
-            cidr = f"{ip_address}/32"
+            cidr = _to_cidr(ip_address)
             if cidr in addresses:
                 return {'success': False, 'message': f'{ip_address} already banned in WAF'}
             addresses.append(cidr)
@@ -61,7 +66,7 @@ class WAFStrategy(IPBanStrategyInterface):
                 Id=config.ip_set_id,
             )
             addresses = list(response['IPSet']['Addresses'])
-            cidr = f"{ip_address}/32"
+            cidr = _to_cidr(ip_address)
             if cidr not in addresses:
                 return {'success': False, 'message': f'{ip_address} not found in WAF ban list'}
             addresses.remove(cidr)
@@ -110,7 +115,7 @@ class SecurityGroupStrategy(IPBanStrategyInterface):
             existing = sg_response['SecurityGroups'][0].get('IpPermissions', [])
             for perm in existing:
                 for ip_range in perm.get('IpRanges', []):
-                    if (ip_range.get('CidrIp') == f"{ip_address}/32"
+                    if (ip_range.get('CidrIp') == _to_cidr(ip_address)
                             and ip_range.get('Description') == SecurityGroupStrategy._BAN_DESCRIPTION):
                         return {'success': False, 'message': f'{ip_address} already banned in security group'}
             ec2.authorize_security_group_ingress(
@@ -118,7 +123,7 @@ class SecurityGroupStrategy(IPBanStrategyInterface):
                 IpPermissions=[{
                     'IpProtocol': '-1',
                     'IpRanges': [{
-                        'CidrIp': f"{ip_address}/32",
+                        'CidrIp': _to_cidr(ip_address),
                         'Description': SecurityGroupStrategy._BAN_DESCRIPTION,
                     }],
                 }],
@@ -139,7 +144,7 @@ class SecurityGroupStrategy(IPBanStrategyInterface):
                     IpPermissions=[{
                         'IpProtocol': '-1',
                         'IpRanges': [{
-                            'CidrIp': f"{ip_address}/32",
+                            'CidrIp': _to_cidr(ip_address),
                             'Description': SecurityGroupStrategy._BAN_DESCRIPTION,
                         }],
                     }],
@@ -189,7 +194,7 @@ class NACLStrategy(IPBanStrategyInterface):
             while rule_number in used_numbers:
                 rule_number += 1
             # Check if IP already banned
-            cidr = f"{ip_address}/32"
+            cidr = _to_cidr(ip_address)
             for entry in entries:
                 if (entry.get('CidrBlock') == cidr
                         and entry.get('RuleAction') == 'deny'
@@ -215,7 +220,7 @@ class NACLStrategy(IPBanStrategyInterface):
             ec2 = boto3.client('ec2', region_name=config.region or 'us-east-1')
             response = ec2.describe_network_acls(NetworkAclIds=[config.nacl_id])
             entries = response['NetworkAcls'][0].get('Entries', [])
-            cidr = f"{ip_address}/32"
+            cidr = _to_cidr(ip_address)
             rule_number = None
             for entry in entries:
                 if (entry.get('CidrBlock') == cidr
@@ -307,8 +312,12 @@ class IPBanService(IPBanServiceInterface):
         return self._config_manager.get().ip_ban_configs
 
     def validate_ip(self, ip_address: str) -> bool:
+        """Accept a bare IP or a CIDR block (additive — old callers unaffected)."""
         try:
-            ipaddress.ip_address(ip_address)
+            if "/" in ip_address:
+                ipaddress.ip_network(ip_address, strict=False)
+            else:
+                ipaddress.ip_address(ip_address)
             return True
         except ValueError:
             return False

--- a/src/servonaut/services/ip_enrichment_service.py
+++ b/src/servonaut/services/ip_enrichment_service.py
@@ -1,0 +1,231 @@
+"""Enrich IP addresses with rDNS, ASN/org, geolocation and abuse score.
+
+Backs the ``enrich_ips`` MCP/chat tool. During an incident the agent has a
+list of offender IPs and needs to decide *how* to block them — a single /32
+through rotation is whack-a-mole, but an ASN/org (e.g. a bulletproof host)
+can be blocked wholesale. This service answers "who owns these IPs and how
+bad are they" in one call.
+
+Data sources (both free):
+
+- **ip-api.com** ``/batch`` — geolocation + ASN + org + reverse DNS for up
+  to 100 IPs per request. No key. Rate-limited (~15 req/min) so we batch.
+- **AbuseIPDB** ``/check`` — abuse confidence score, only when the operator
+  has configured ``config.abuseipdb_api_key`` (``$ENV_VAR`` syntax honoured,
+  matching the CloudWatch Top-IPs feature).
+
+Transport: prefers ``httpx`` (the optional ``[ai]`` extra) but falls back to
+the stdlib ``urllib`` so the headless ``--mcp`` build works without it. All
+blocking IO is pushed to a thread via ``run_in_executor`` to stay async.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_IP_API_BATCH_URL = "http://ip-api.com/batch"
+# query is appended as a query-string field list; ``reverse`` triggers rDNS.
+_IP_API_FIELDS = "status,message,query,country,countryCode,isp,org,as,reverse,proxy,hosting"
+_ABUSEIPDB_URL = "https://api.abuseipdb.com/api/v2/check"
+
+# Defensive caps so a runaway agent can't issue thousands of lookups.
+_MAX_IPS = 100
+_HTTP_TIMEOUT = 10
+
+
+def _resolve_key(raw: str) -> str:
+    """Resolve a config value that may use ``$ENV_VAR`` indirection."""
+    raw = (raw or "").strip()
+    if raw.startswith("$"):
+        return os.environ.get(raw[1:], "")
+    return raw
+
+
+class IPEnrichmentService:
+    """Look up ownership + abuse metadata for a batch of IPs."""
+
+    def __init__(self, config_manager=None) -> None:
+        self._config_manager = config_manager
+
+    @property
+    def max_ips(self) -> int:
+        return _MAX_IPS
+
+    def _abuseipdb_key(self) -> str:
+        if self._config_manager is None:
+            return ""
+        config = self._config_manager.get()
+        return _resolve_key(getattr(config, "abuseipdb_api_key", "") or "")
+
+    async def enrich(self, ips: List[str]) -> List[Dict[str, Any]]:
+        """Return one enrichment dict per input IP (order preserved).
+
+        Each row: ``ip``, ``rdns``, ``asn``, ``org``, ``country``,
+        ``hosting`` (bool), ``proxy`` (bool), ``abuse_score`` (int|None),
+        ``total_reports`` (int|None), ``error`` (str, when a lookup failed).
+        """
+        unique = list(dict.fromkeys(i.strip() for i in ips if i and i.strip()))
+        if not unique:
+            return []
+        if len(unique) > _MAX_IPS:
+            unique = unique[:_MAX_IPS]
+
+        geo_by_ip = await self._fetch_geo_batch(unique)
+
+        key = self._abuseipdb_key()
+        abuse_by_ip: Dict[str, Dict[str, Any]] = {}
+        if key:
+            # AbuseIPDB free tier has no batch endpoint; check each IP.
+            results = await asyncio.gather(
+                *(self._fetch_abuse(ip, key) for ip in unique),
+                return_exceptions=True,
+            )
+            for ip, res in zip(unique, results):
+                if isinstance(res, dict):
+                    abuse_by_ip[ip] = res
+
+        rows: List[Dict[str, Any]] = []
+        for ip in unique:
+            geo = geo_by_ip.get(ip, {})
+            abuse = abuse_by_ip.get(ip, {})
+            rows.append({
+                "ip": ip,
+                "rdns": geo.get("reverse") or "",
+                "asn": geo.get("as") or "",
+                "org": geo.get("org") or geo.get("isp") or "",
+                "country": geo.get("countryCode") or geo.get("country") or "",
+                "hosting": bool(geo.get("hosting")),
+                "proxy": bool(geo.get("proxy")),
+                "abuse_score": abuse.get("abuseConfidenceScore") if abuse else None,
+                "total_reports": abuse.get("totalReports") if abuse else None,
+                "error": geo.get("_error", ""),
+            })
+        return rows
+
+    # ------------------------------------------------------------------
+    # ip-api.com batch
+    # ------------------------------------------------------------------
+
+    async def _fetch_geo_batch(self, ips: List[str]) -> Dict[str, Dict[str, Any]]:
+        payload = [{"query": ip, "fields": _IP_API_FIELDS} for ip in ips]
+        try:
+            data = await self._post_json(_IP_API_BATCH_URL, payload)
+        except Exception as exc:  # noqa: BLE001 — network best-effort
+            logger.warning("ip-api batch lookup failed: %s", exc)
+            return {ip: {"_error": f"geo lookup failed: {exc}"} for ip in ips}
+        out: Dict[str, Dict[str, Any]] = {}
+        if isinstance(data, list):
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+                q = entry.get("query")
+                if not q:
+                    continue
+                if entry.get("status") != "success":
+                    entry = {"_error": entry.get("message", "lookup failed")}
+                out[q] = entry
+        return out
+
+    async def _fetch_abuse(self, ip: str, key: str) -> Optional[Dict[str, Any]]:
+        try:
+            data = await self._get_json(
+                _ABUSEIPDB_URL,
+                params={"ipAddress": ip, "maxAgeInDays": "90"},
+                headers={"Key": key, "Accept": "application/json"},
+            )
+        except Exception as exc:  # noqa: BLE001 — network best-effort
+            logger.warning("AbuseIPDB lookup failed for %s: %s", ip, exc)
+            return None
+        if isinstance(data, dict):
+            return data.get("data")
+        return None
+
+    # ------------------------------------------------------------------
+    # Transport (httpx preferred, urllib fallback)
+    # ------------------------------------------------------------------
+
+    async def _post_json(self, url: str, body: Any) -> Any:
+        try:
+            import httpx
+        except ImportError:
+            return await self._urllib_request(
+                url, method="POST", json_body=body,
+                headers={"Content-Type": "application/json"},
+            )
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.post(url, json=body)
+            return resp.json()
+
+    async def _get_json(
+        self, url: str, params: Dict[str, str], headers: Dict[str, str],
+    ) -> Any:
+        try:
+            import httpx
+        except ImportError:
+            query = "&".join(f"{k}={v}" for k, v in params.items())
+            return await self._urllib_request(
+                f"{url}?{query}", method="GET", headers=headers,
+            )
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(url, params=params, headers=headers)
+            return resp.json()
+
+    async def _urllib_request(
+        self, url: str, method: str,
+        json_body: Any = None, headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        """Blocking urllib request executed in a thread pool."""
+        def _do() -> Any:
+            data = None
+            if json_body is not None:
+                data = json.dumps(json_body).encode("utf-8")
+            req = urllib.request.Request(
+                url, data=data, method=method, headers=headers or {},
+            )
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, _do)
+
+
+def format_enrichment(rows: List[Dict[str, Any]]) -> str:
+    """Render enrichment rows as a readable table."""
+    if not rows:
+        return "No valid IP addresses to enrich."
+    out: List[str] = [
+        f"{'IP':<40} {'Abuse':<7} {'ASN / Org':<32} {'Country':<8} Flags / rDNS",
+        "-" * 110,
+    ]
+    for r in rows:
+        score = r.get("abuse_score")
+        score_str = f"{score}%" if score is not None else "-"
+        asn = r.get("asn") or ""
+        org = r.get("org") or ""
+        asn_org = (f"{asn} {org}".strip())[:32]
+        flags = []
+        if r.get("hosting"):
+            flags.append("hosting")
+        if r.get("proxy"):
+            flags.append("proxy")
+        if r.get("total_reports"):
+            flags.append(f"{r['total_reports']} reports")
+        tail = ", ".join(flags)
+        if r.get("rdns"):
+            tail = f"{tail}  {r['rdns']}" if tail else r["rdns"]
+        if r.get("error"):
+            tail = r["error"]
+        out.append(
+            f"{str(r.get('ip', ''))[:40]:<40} "
+            f"{score_str:<7} "
+            f"{asn_org:<32} "
+            f"{str(r.get('country', '') or '-'):<8} "
+            f"{tail}"
+        )
+    return "\n".join(out)

--- a/src/servonaut/services/rds_metrics_service.py
+++ b/src/servonaut/services/rds_metrics_service.py
@@ -1,0 +1,146 @@
+"""Read RDS instance health metrics via CloudWatch GetMetricStatistics.
+
+Backs the ``rds_metrics`` tool. The recurring DB-saturation incidents (shared
+RDS, noisy neighbour) needed CPU / connections / credit-balance / latency at a
+glance — and Performance Insights was IAM-denied, so plain CloudWatch metrics
+are the reliable first look.
+
+boto3 runs in a thread (``run_in_executor``); the service never raises out of
+:meth:`fetch` — failures come back in the ``errors`` list so a partial read
+(e.g. CPUCreditBalance only exists for burstable classes) is still useful.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACE = "AWS/RDS"
+
+# metric name → (key in result, unit transform). Latency is seconds → ms.
+_METRICS = [
+    ("CPUUtilization", "cpu_pct", 1.0),
+    ("DatabaseConnections", "connections", 1.0),
+    ("CPUCreditBalance", "cpu_credit_balance", 1.0),
+    ("ReadLatency", "read_latency_ms", 1000.0),
+    ("WriteLatency", "write_latency_ms", 1000.0),
+    ("FreeableMemory", "freeable_memory_mb", 1.0 / (1024 * 1024)),
+]
+
+
+class RDSMetricsService:
+    """Fetch a snapshot of an RDS instance's CloudWatch metrics."""
+
+    async def fetch(
+        self, db_instance: str, region: str = "", window_hours: int = 3,
+    ) -> Dict[str, Any]:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._fetch_sync, db_instance, region, window_hours,
+        )
+
+    def _fetch_sync(
+        self, db_instance: str, region: str, window_hours: int,
+    ) -> Dict[str, Any]:
+        from datetime import datetime, timedelta
+
+        result: Dict[str, Any] = {
+            "db_instance": db_instance,
+            "window_hours": window_hours,
+            "metrics": {},
+            "errors": [],
+        }
+        kwargs = {"region_name": region} if region else {}
+        try:
+            cw = boto3.client("cloudwatch", **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            result["errors"].append(f"cloudwatch client: {exc}")
+            return result
+
+        end = datetime.utcnow()
+        start = end - timedelta(hours=max(int(window_hours), 1))
+        # Period: keep the datapoint count sane across the window.
+        period = 300 if window_hours <= 6 else 3600
+
+        for metric_name, key, factor in _METRICS:
+            try:
+                resp = cw.get_metric_statistics(
+                    Namespace=_NAMESPACE,
+                    MetricName=metric_name,
+                    Dimensions=[{"Name": "DBInstanceIdentifier", "Value": db_instance}],
+                    StartTime=start, EndTime=end, Period=period,
+                    Statistics=["Average", "Maximum", "Minimum"],
+                )
+            except Exception as exc:  # noqa: BLE001
+                result["errors"].append(f"{metric_name}: {exc}")
+                continue
+            datapoints = resp.get("Datapoints", [])
+            if not datapoints:
+                continue
+            result["metrics"][key] = self._summarize(datapoints, factor)
+
+        return result
+
+    @staticmethod
+    def _summarize(datapoints: List[Dict[str, Any]], factor: float) -> Dict[str, Any]:
+        avgs = [d["Average"] * factor for d in datapoints if "Average" in d]
+        maxs = [d["Maximum"] * factor for d in datapoints if "Maximum" in d]
+        mins = [d["Minimum"] * factor for d in datapoints if "Minimum" in d]
+        latest = max(datapoints, key=lambda d: d.get("Timestamp"))
+        return {
+            "avg": round(sum(avgs) / len(avgs), 2) if avgs else None,
+            "max": round(max(maxs), 2) if maxs else None,
+            "min": round(min(mins), 2) if mins else None,
+            "latest": round(
+                (latest.get("Average", latest.get("Maximum", 0)) * factor), 2
+            ),
+        }
+
+
+def format_rds_metrics(data: Dict[str, Any]) -> str:
+    """Render an RDS metrics snapshot as a skimmable report."""
+    m = data.get("metrics", {})
+    out = [
+        f"RDS metrics for {data.get('db_instance','?')} "
+        f"(last {data.get('window_hours','?')}h):",
+    ]
+    if not m:
+        out.append("  No datapoints returned. Check the DB instance identifier "
+                   "and region, and that cloudwatch:GetMetricStatistics is "
+                   "permitted.")
+
+    def line(label, key, suffix=""):
+        s = m.get(key)
+        if not s:
+            return
+        out.append(
+            f"  {label:<22} avg {s.get('avg')}{suffix}"
+            f"  max {s.get('max')}{suffix}"
+            + (f"  latest {s.get('latest')}{suffix}"
+               if s.get('latest') is not None else "")
+        )
+
+    line("CPU", "cpu_pct", "%")
+    line("Connections", "connections")
+    line("Read latency", "read_latency_ms", "ms")
+    line("Write latency", "write_latency_ms", "ms")
+    line("Freeable memory", "freeable_memory_mb", "MB")
+    # CPU credit balance: only meaningful for burstable (t-class); show latest/min.
+    credit = m.get("cpu_credit_balance")
+    if credit:
+        out.append(
+            f"  {'CPU credit balance':<22} latest {credit.get('latest')}"
+            f"  min {credit.get('min')}"
+            "   (burstable class — low/zero means CPU is throttled)"
+        )
+
+    if data.get("errors"):
+        out.append("  Partial — some metrics failed (likely IAM scope or "
+                   "metric not emitted for this class):")
+        for e in data["errors"][:8]:
+            out.append(f"    - {e}")
+    return "\n".join(out)

--- a/src/servonaut/services/ssm_service.py
+++ b/src/servonaut/services/ssm_service.py
@@ -1,0 +1,115 @@
+"""Run shell commands on an EC2 instance via AWS Systems Manager (SSM).
+
+Backs the ``transport=ssm`` path of ``run_command``. The single biggest
+blocker in the incident was sshd refusing connections at load 700+ — there was
+no way to apply the fix. SSM rides the instance's *outbound* agent channel, so
+it works even when sshd can't accept inbound connections.
+
+Prerequisites (documented for the operator, enforced by AWS at call time):
+- The target instance runs the SSM agent and has an instance profile granting
+  ``AmazonSSMManagedInstanceCore``.
+- The CLI's AWS identity has ``ssm:SendCommand`` + ``ssm:GetCommandInvocation``.
+
+Like the other AWS services here, boto3 runs in a thread (``run_in_executor``)
+and the service never raises out of :meth:`run_command` — failures come back as
+a structured dict so the caller can decide whether to surface or fall through.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+# Statuses that mean the invocation is finished (success or otherwise).
+_TERMINAL = {"Success", "Cancelled", "TimedOut", "Failed"}
+
+# How long stdout/stderr we surface (SSM inline output caps at 24000 chars; we
+# stay well under and let the caller's own max-lines clamp apply on top).
+_MAX_OUTPUT = 24000
+
+
+class SSMService:
+    """Execute commands on EC2 instances over the SSM agent channel."""
+
+    async def run_command(
+        self, instance_id: str, command: str,
+        region: str = "", timeout: int = 60,
+    ) -> Dict[str, Any]:
+        """Send *command* via SSM and poll for the result.
+
+        Returns a dict: ``{ok: bool, status: str, stdout: str, stderr: str,
+        error: str}``. ``ok`` is True only when the invocation reached
+        ``Success``. ``error`` is set for setup failures (instance not
+        SSM-managed, access denied, timeout waiting for the result).
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._run_sync, instance_id, command, region, timeout,
+        )
+
+    def _run_sync(
+        self, instance_id: str, command: str, region: str, timeout: int,
+    ) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "ok": False, "status": "", "stdout": "", "stderr": "", "error": "",
+        }
+        kwargs = {"region_name": region} if region else {}
+        try:
+            ssm = boto3.client("ssm", **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            result["error"] = f"ssm client: {exc}"
+            return result
+
+        try:
+            send = ssm.send_command(
+                InstanceIds=[instance_id],
+                DocumentName="AWS-RunShellScript",
+                Parameters={"commands": [command]},
+                TimeoutSeconds=max(30, min(int(timeout), 2592000)),
+            )
+        except Exception as exc:  # noqa: BLE001
+            # InvalidInstanceId = not SSM-managed (no agent / no instance role);
+            # AccessDenied = missing ssm:SendCommand. Both surface verbatim.
+            result["error"] = f"send_command: {exc}"
+            return result
+
+        command_id = send.get("Command", {}).get("CommandId", "")
+        if not command_id:
+            result["error"] = "send_command returned no CommandId"
+            return result
+
+        deadline = time.monotonic() + max(10, int(timeout))
+        poll_interval = 1.0
+        while True:
+            try:
+                inv = ssm.get_command_invocation(
+                    CommandId=command_id, InstanceId=instance_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # InvocationDoesNotExist is expected briefly after send_command
+                # (eventual consistency) — keep polling until the deadline.
+                if "InvocationDoesNotExist" in str(exc) and time.monotonic() < deadline:
+                    time.sleep(poll_interval)
+                    continue
+                result["error"] = f"get_command_invocation: {exc}"
+                return result
+
+            status = inv.get("Status", "")
+            result["status"] = status
+            if status in _TERMINAL:
+                result["stdout"] = (inv.get("StandardOutputContent", "") or "")[:_MAX_OUTPUT]
+                result["stderr"] = (inv.get("StandardErrorContent", "") or "")[:_MAX_OUTPUT]
+                result["ok"] = status == "Success"
+                if not result["ok"] and not result["error"]:
+                    result["error"] = f"command status: {status}"
+                return result
+
+            if time.monotonic() >= deadline:
+                result["error"] = f"timed out waiting for SSM result (last status: {status or 'pending'})"
+                return result
+            time.sleep(poll_interval)

--- a/src/servonaut/services/waf_management_service.py
+++ b/src/servonaut/services/waf_management_service.py
@@ -1,0 +1,305 @@
+"""Mutating WAFv2 operations for the Group C incident-mitigation tools.
+
+Backs ``waf_rate_rule_set`` and the WebACL paths of ``ip_ban_set`` / ``block_ip``.
+The incident lesson was "apply the fix reversibly, at the layer that actually
+sees the client IP" — for an ALB-fronted app that layer is the WebACL, not the
+host firewall (which only sees the ALB hop) and not a SG/NACL that isn't even
+attached to the right ALB.
+
+Everything here MUTATES live traffic handling, so:
+- boto3 runs in a thread (``run_in_executor``);
+- every method returns a structured dict with ``applied`` + a ``reverse_hint``
+  describing exactly how to undo the change (the whole point of the tool);
+- methods never raise — failures come back as ``{applied: False, error: ...}``.
+
+A WebACL is identified by (Name, Id, Scope, region). Callers usually have only
+an ARN (from ``get_web_acl_for_resource`` or ``describe_ingress_path``);
+:func:`parse_wafv2_arn` derives the rest.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+# arn:aws:wafv2:<region>:<acct>:<regional|global>/<webacl|ipset>/<name>/<id>
+_WAF_ARN_RE = re.compile(
+    r"^arn:aws:wafv2:(?P<region>[^:]*):[^:]+:"
+    r"(?P<scope>regional|global)/(?P<kind>webacl|ipset)/"
+    r"(?P<name>[^/]+)/(?P<id>[^/]+)$"
+)
+
+# Metric names must be [A-Za-z0-9_]{1,128}.
+_METRIC_SAFE_RE = re.compile(r"[^A-Za-z0-9_]")
+
+
+def parse_wafv2_arn(arn: str) -> Optional[Dict[str, str]]:
+    """Parse a WAFv2 ARN into {region, scope, kind, name, id}.
+
+    ``scope`` is normalized to the API form (REGIONAL / CLOUDFRONT).
+    """
+    m = _WAF_ARN_RE.match(arn or "")
+    if not m:
+        return None
+    d = m.groupdict()
+    d["scope"] = "REGIONAL" if d["scope"] == "regional" else "CLOUDFRONT"
+    return d
+
+
+class WAFManagementService:
+    """Add IPs to a WebACL's block IP set, and add/remove rate-based rules."""
+
+    async def get_web_acl_for_resource(
+        self, resource_arn: str, region: str = "",
+    ) -> Optional[Dict[str, str]]:
+        """Return {arn, name, id} of the WebACL fronting an ALB, or None."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._get_web_acl_for_resource_sync, resource_arn, region,
+        )
+
+    def _get_web_acl_for_resource_sync(
+        self, resource_arn: str, region: str,
+    ) -> Optional[Dict[str, str]]:
+        kwargs = {"region_name": region} if region else {}
+        try:
+            client = boto3.client("wafv2", **kwargs)
+            resp = client.get_web_acl_for_resource(ResourceArn=resource_arn)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_web_acl_for_resource(%s): %s", resource_arn, exc)
+            return None
+        acl = resp.get("WebACL")
+        if not acl:
+            return None
+        return {"arn": acl.get("ARN", ""), "name": acl.get("Name", ""),
+                "id": acl.get("Id", "")}
+
+    # ------------------------------------------------------------------
+    # Add an IP/CIDR to the IP set referenced by a WebACL's block rule
+    # ------------------------------------------------------------------
+
+    async def add_ip_to_block_ipset(
+        self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
+        cidrs: List[str], remove: bool = False,
+    ) -> Dict[str, Any]:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._add_ip_to_block_ipset_sync,
+            web_acl_name, web_acl_id, scope, region, cidrs, remove,
+        )
+
+    def _add_ip_to_block_ipset_sync(
+        self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
+        cidrs: List[str], remove: bool,
+    ) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "applied": [], "failed": [], "ip_set": "", "error": "",
+        }
+        kwargs = {"region_name": region} if region else {}
+        try:
+            client = boto3.client("wafv2", **kwargs)
+            acl = client.get_web_acl(Name=web_acl_name, Scope=scope, Id=web_acl_id)
+        except Exception as exc:  # noqa: BLE001
+            out["error"] = f"get_web_acl: {exc}"
+            return out
+
+        ip_set_arn = self._first_block_ipset_arn(acl.get("WebACL", {}))
+        if not ip_set_arn:
+            out["error"] = (
+                "WebACL has no block rule referencing an IP set. Create an IP "
+                "set + block rule first (or use a named ip_ban config / "
+                "waf_rate_rule_set)."
+            )
+            return out
+        parsed = parse_wafv2_arn(ip_set_arn)
+        if not parsed:
+            out["error"] = f"unparseable IP set ARN: {ip_set_arn}"
+            return out
+        out["ip_set"] = parsed["name"]
+
+        try:
+            ipset = client.get_ip_set(
+                Name=parsed["name"], Scope=scope, Id=parsed["id"],
+            )
+        except Exception as exc:  # noqa: BLE001
+            out["error"] = f"get_ip_set: {exc}"
+            return out
+        addresses = list(ipset["IPSet"]["Addresses"])
+        lock = ipset["LockToken"]
+
+        changed = False
+        for cidr in cidrs:
+            norm = cidr if "/" in cidr else f"{cidr}/32"
+            if remove:
+                if norm in addresses:
+                    addresses.remove(norm)
+                    out["applied"].append(cidr)
+                    changed = True
+                else:
+                    out["failed"].append({"ip": cidr, "reason": "not present"})
+            else:
+                if norm in addresses:
+                    out["failed"].append({"ip": cidr, "reason": "already present"})
+                else:
+                    addresses.append(norm)
+                    out["applied"].append(cidr)
+                    changed = True
+
+        if changed:
+            try:
+                client.update_ip_set(
+                    Name=parsed["name"], Scope=scope, Id=parsed["id"],
+                    Addresses=addresses, LockToken=lock,
+                )
+            except Exception as exc:  # noqa: BLE001
+                out["error"] = f"update_ip_set: {exc}"
+                # The applied list is now untrustworthy — surface the failure.
+                out["failed"].extend({"ip": c, "reason": f"update failed: {exc}"}
+                                     for c in out["applied"])
+                out["applied"] = []
+        return out
+
+    def _first_block_ipset_arn(self, web_acl: Dict[str, Any]) -> Optional[str]:
+        """Return the IP set ARN used by the WebACL's first Block rule."""
+        for rule in web_acl.get("Rules", []):
+            if "Block" not in rule.get("Action", {}):
+                continue
+            for arn in self._scan_ipset_arns(rule.get("Statement", {})):
+                return arn
+        # Fall back: any IP-set reference at all (some setups block via default).
+        for rule in web_acl.get("Rules", []):
+            for arn in self._scan_ipset_arns(rule.get("Statement", {})):
+                return arn
+        return None
+
+    def _scan_ipset_arns(self, stmt: Dict[str, Any]) -> List[str]:
+        found: List[str] = []
+        if not isinstance(stmt, dict):
+            return found
+        if "IPSetReferenceStatement" in stmt:
+            arn = stmt["IPSetReferenceStatement"].get("ARN", "")
+            if arn:
+                found.append(arn)
+        for key in ("AndStatement", "OrStatement"):
+            for sub in stmt.get(key, {}).get("Statements", []):
+                found.extend(self._scan_ipset_arns(sub))
+        if "NotStatement" in stmt:
+            found.extend(self._scan_ipset_arns(stmt["NotStatement"].get("Statement", {})))
+        return found
+
+    # ------------------------------------------------------------------
+    # Add / remove a rate-based rule on a WebACL
+    # ------------------------------------------------------------------
+
+    async def set_rate_rule(
+        self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
+        rule_name: str, limit: int = 2000, uri_scope: str = "",
+        action: str = "block", remove: bool = False,
+    ) -> Dict[str, Any]:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._set_rate_rule_sync,
+            web_acl_name, web_acl_id, scope, region,
+            rule_name, limit, uri_scope, action, remove,
+        )
+
+    def _rate_rule_state(self, rule: Dict[str, Any]) -> Dict[str, Any]:
+        """Snapshot an existing rate rule's reversible state."""
+        rb = rule.get("Statement", {}).get("RateBasedStatement", {})
+        return {
+            "limit": rb.get("Limit"),
+            "uri_scoped": bool(rb.get("ScopeDownStatement")),
+            "action": "count" if "Count" in rule.get("Action", {}) else "block",
+        }
+
+    def _set_rate_rule_sync(
+        self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
+        rule_name: str, limit: int, uri_scope: str, action: str, remove: bool,
+    ) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "applied": False, "error": "", "rule_name": rule_name,
+            "created_or_updated": "", "previous": None,
+        }
+        kwargs = {"region_name": region} if region else {}
+        try:
+            client = boto3.client("wafv2", **kwargs)
+            resp = client.get_web_acl(Name=web_acl_name, Scope=scope, Id=web_acl_id)
+        except Exception as exc:  # noqa: BLE001
+            out["error"] = f"get_web_acl: {exc}"
+            return out
+
+        web_acl = resp["WebACL"]
+        lock = resp["LockToken"]
+        rules = list(web_acl.get("Rules", []))
+        existing = next((r for r in rules if r.get("Name") == rule_name), None)
+
+        if remove:
+            new_rules = [r for r in rules if r.get("Name") != rule_name]
+            if len(new_rules) == len(rules):
+                out["error"] = f"rule {rule_name!r} not found on WebACL"
+                return out
+            # Capture what we removed so the caller can re-create it exactly.
+            if existing is not None:
+                out["previous"] = self._rate_rule_state(existing)
+            rules = new_rules
+        else:
+            # Reversibility: record the prior state when UPDATING an existing
+            # rule, so the operator can restore the old limit/action (not just
+            # delete the rule). null when newly created.
+            if existing is not None:
+                out["previous"] = self._rate_rule_state(existing)
+            out["created_or_updated"] = "updated" if existing is not None else "created"
+            # Build the rate-based rule (replace if a rule of the same name exists
+            # so the call is idempotent / used to bump the limit).
+            existing_prios = {r.get("Priority", 0) for r in rules
+                              if r.get("Name") != rule_name}
+            priority = (max(existing_prios) + 1) if existing_prios else 0
+            rules = [r for r in rules if r.get("Name") != rule_name]
+            rate_stmt: Dict[str, Any] = {
+                "Limit": int(limit), "AggregateKeyType": "IP",
+            }
+            if uri_scope:
+                rate_stmt["ScopeDownStatement"] = {
+                    "ByteMatchStatement": {
+                        "SearchString": uri_scope.encode("utf-8"),
+                        "FieldToMatch": {"UriPath": {}},
+                        "TextTransformations": [{"Priority": 0, "Type": "NONE"}],
+                        "PositionalConstraint": "STARTS_WITH",
+                    }
+                }
+            metric = _METRIC_SAFE_RE.sub("_", rule_name)[:128] or "servonautRate"
+            rules.append({
+                "Name": rule_name,
+                "Priority": priority,
+                "Statement": {"RateBasedStatement": rate_stmt},
+                "Action": {"Count": {}} if action == "count" else {"Block": {}},
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": metric,
+                },
+            })
+
+        update_kwargs = {
+            "Name": web_acl_name, "Scope": scope, "Id": web_acl_id,
+            "DefaultAction": web_acl["DefaultAction"],
+            "Rules": rules,
+            "VisibilityConfig": web_acl["VisibilityConfig"],
+            "LockToken": lock,
+        }
+        if web_acl.get("Description"):
+            update_kwargs["Description"] = web_acl["Description"]
+        if web_acl.get("CustomResponseBodies"):
+            update_kwargs["CustomResponseBodies"] = web_acl["CustomResponseBodies"]
+        try:
+            client.update_web_acl(**update_kwargs)
+        except Exception as exc:  # noqa: BLE001
+            out["error"] = f"update_web_acl: {exc}"
+            return out
+        out["applied"] = True
+        return out

--- a/src/servonaut/utils/log_analysis.py
+++ b/src/servonaut/utils/log_analysis.py
@@ -1,0 +1,351 @@
+"""Pure parsers for incident-response tools.
+
+These functions are deliberately free of any IO so they can be unit-tested
+with fixtures — the SSH round-trip lives in the MCP tool layer and only
+hands raw stdout strings to the parsers here.
+
+Two families:
+
+- :func:`summarize_web_traffic` — turns raw access-log lines (combined /
+  common log format, optionally with X-Forwarded-For appended) into a
+  per-vhost summary: request volume, req/s, status-code mix, top client
+  IPs (XFF / mod_remoteip aware) and top URLs. Backs ``web_traffic_summary``.
+- :func:`parse_fleet_probe` / :func:`format_fleet_table` — turn the
+  ``KEY=VALUE`` output of the fleet health one-liner into a structured
+  row and a sortable table. Backs ``fleet_health_snapshot``.
+"""
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections import Counter
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+# Marker the remote one-liner prints before each vhost's log tail so we can
+# split a multi-file pull back into per-vhost sections.
+VHOST_MARKER_PREFIX = "===VHOST:"
+
+# Combined / common log format head:
+#   192.0.2.1 - - [10/Oct/2024:13:55:36 +0000] "GET /path?q=1 HTTP/1.1" 200 1234 ...
+_LOG_RE = re.compile(
+    r'^(?P<host>\S+)\s+\S+\s+\S+\s+'
+    r'\[(?P<ts>[^\]]+)\]\s+'
+    r'"(?P<method>[A-Z]+)\s+(?P<url>\S+)[^"]*"\s+'
+    r'(?P<status>\d{3})'
+)
+
+# IPv4 + a loose IPv6 token matcher. Candidates are validated through
+# ``ipaddress`` so false positives (version strings, etc.) are dropped.
+_IP_TOKEN_RE = re.compile(
+    r'\b\d{1,3}(?:\.\d{1,3}){3}\b'           # IPv4
+    r'|\b(?:[0-9A-Fa-f]{1,4}:){2,7}[0-9A-Fa-f]{0,4}\b'  # IPv6 (loose)
+)
+
+# Apache/nginx access-log timestamp, e.g. ``10/Oct/2024:13:55:36 +0000``.
+_TS_FMT = "%d/%b/%Y:%H:%M:%S %z"
+
+
+def _is_public(ip: str) -> Optional[bool]:
+    """Return True/False for a valid IP's public-ness, or None if not an IP."""
+    try:
+        parsed = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    return not (parsed.is_private or parsed.is_loopback or parsed.is_reserved
+                or parsed.is_link_local)
+
+
+def extract_client_ip(line: str, host_field: str) -> str:
+    """Resolve the *real* client IP for one access-log line.
+
+    Strategy (mod_remoteip / X-Forwarded-For aware):
+
+    1. If the leading ``%h`` field is already a public IP, trust it — the
+       server is either internet-facing or mod_remoteip already rewrote
+       ``%h`` to the real client.
+    2. Otherwise (``%h`` is the ALB / private hop, or not an IP at all),
+       scan the rest of the line for the first public IP — this catches
+       the case where the real client lives in a logged
+       ``X-Forwarded-For`` field instead.
+    3. Fall back to the raw ``%h`` field if nothing public is found.
+    """
+    if _is_public(host_field):
+        return host_field
+    for token in _IP_TOKEN_RE.findall(line):
+        if token == host_field:
+            continue
+        if _is_public(token):
+            return token
+    return host_field
+
+
+# Generic log basenames that don't name a site — keep the full path instead so
+# distinct default logs don't collide and the operator can see which one it is.
+_GENERIC_LOG_NAMES = frozenset({
+    "", "access", "error", "other", "default", "ssl", "other_vhosts", "host",
+})
+
+
+def vhost_label(path: str) -> str:
+    """Derive a site label from an access-log path (full path if it's generic)."""
+    base = path.rsplit("/", 1)[-1] or path
+    name = re.sub(r"\.(access|error)?[._-]?log(\.\d+)?$", "", base, flags=re.I)
+    name = re.sub(r"[._-]?(access|error)$", "", name, flags=re.I)
+    if name.lower() in _GENERIC_LOG_NAMES:
+        return path  # keep the full path to disambiguate generic/default logs
+    return name
+
+
+def _split_vhosts(raw: str) -> Dict[str, List[str]]:
+    """Split raw output into ``{vhost_label: [lines]}``.
+
+    Labels are derived site names (``app.access.log`` → ``app``); generic
+    logs (``access.log``) keep their full path so default/catch-all vhosts are
+    distinguishable. When no marker is present the whole blob is ``"(all)"``.
+    """
+    sections: Dict[str, List[str]] = {}
+    current = "(all)"
+    saw_marker = False
+    for line in raw.splitlines():
+        if line.startswith(VHOST_MARKER_PREFIX):
+            saw_marker = True
+            full = line[len(VHOST_MARKER_PREFIX):].rstrip("=").strip()
+            current = vhost_label(full) or full
+            sections.setdefault(current, [])
+            continue
+        sections.setdefault(current, []).append(line)
+    if not saw_marker:
+        return {"(all)": raw.splitlines()}
+    return sections
+
+
+def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
+    total = 0
+    parsed = 0
+    statuses: Counter = Counter()
+    ips: Counter = Counter()
+    urls: Counter = Counter()
+    timestamps: List[datetime] = []
+
+    for line in lines:
+        if not line.strip():
+            continue
+        total += 1
+        m = _LOG_RE.match(line)
+        if not m:
+            continue
+        parsed += 1
+        statuses[m.group("status")] += 1
+        client = extract_client_ip(line, m.group("host"))
+        ips[client] += 1
+        # Strip the query string so /search?q=a and /search?q=b group together.
+        url = m.group("url").split("?", 1)[0]
+        urls[url] += 1
+        try:
+            timestamps.append(datetime.strptime(m.group("ts"), _TS_FMT))
+        except ValueError:
+            pass
+
+    window_seconds = 0.0
+    if len(timestamps) >= 2:
+        window_seconds = (max(timestamps) - min(timestamps)).total_seconds()
+    req_per_sec = (parsed / window_seconds) if window_seconds > 0 else 0.0
+
+    return {
+        "requests": parsed,
+        "unparsed": total - parsed,
+        "window_seconds": round(window_seconds, 1),
+        "req_per_sec": round(req_per_sec, 2),
+        "status_mix": dict(statuses.most_common()),
+        "top_ips": ips.most_common(top_n),
+        "top_urls": urls.most_common(top_n),
+    }
+
+
+def summarize_web_traffic(raw: str, top_n: int = 15) -> Dict[str, Any]:
+    """Summarize access-log output into a per-vhost structure.
+
+    Returns ``{"vhosts": {label: {...}}, "total_requests": int}``. Each
+    vhost summary carries ``requests``, ``req_per_sec``, ``window_seconds``,
+    ``status_mix``, ``top_ips`` and ``top_urls``.
+    """
+    sections = _split_vhosts(raw)
+    vhosts: Dict[str, Any] = {}
+    total = 0
+    unparsed_total = 0
+    for label, lines in sections.items():
+        summary = _summarize_section(lines, top_n)
+        unparsed_total += summary["unparsed"]
+        # Drop sections with nothing parseable — they'd only show empty
+        # tables. The unparsed count is preserved at the top level so the
+        # formatter can still tell the user "we saw lines but couldn't read
+        # them" (wrong path / non-standard format).
+        if summary["requests"] == 0:
+            continue
+        vhosts[label] = summary
+        total += summary["requests"]
+    return {
+        "vhosts": vhosts,
+        "total_requests": total,
+        "unparsed_total": unparsed_total,
+    }
+
+
+def format_web_traffic(summary: Dict[str, Any], log_hint: str = "") -> str:
+    """Render :func:`summarize_web_traffic` output as a readable report."""
+    vhosts = summary.get("vhosts", {})
+    if not vhosts:
+        unparsed = summary.get("unparsed_total", 0)
+        seen = f" ({unparsed} line(s) seen but unparseable)" if unparsed else ""
+        return (
+            "No parseable access-log lines found"
+            + (f" (looked at: {log_hint})" if log_hint else "")
+            + seen
+            + ". The log may use a non-standard format, or the path may be wrong."
+        )
+    out: List[str] = []
+    if log_hint:
+        out.append(f"Source: {log_hint}")
+    out.append(f"Total parsed requests: {summary.get('total_requests', 0)}")
+    # Busiest vhost first.
+    ordered = sorted(
+        vhosts.items(), key=lambda kv: kv[1].get("requests", 0), reverse=True
+    )
+    for label, s in ordered:
+        out.append("")
+        # A label that's still a path is a generic/default log we couldn't tie
+        # to a named site — flag it so the operator knows it's the catch-all.
+        suffix = "  (default/unmatched vhost — log path shown)" if "/" in label else ""
+        out.append(f"── {label} ──{suffix}")
+        rps = s.get("req_per_sec", 0.0)
+        win = s.get("window_seconds", 0.0)
+        out.append(
+            f"  Requests: {s.get('requests', 0)}"
+            f"   ~{rps} req/s over {win}s"
+            + (f"   ({s['unparsed']} unparsed lines)" if s.get("unparsed") else "")
+        )
+        mix = s.get("status_mix", {})
+        if mix:
+            mix_str = "  ".join(f"{code}×{cnt}" for code, cnt in mix.items())
+            out.append(f"  Status:   {mix_str}")
+        top_ips = s.get("top_ips", [])
+        if top_ips:
+            out.append("  Top client IPs:")
+            for ip, cnt in top_ips:
+                out.append(f"    {ip:<40} {cnt}")
+        top_urls = s.get("top_urls", [])
+        if top_urls:
+            out.append("  Top URLs:")
+            for url, cnt in top_urls:
+                out.append(f"    {url[:60]:<60} {cnt}")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Fleet health
+# ---------------------------------------------------------------------------
+
+def parse_fleet_probe(raw: str) -> Dict[str, str]:
+    """Parse ``KEY=VALUE`` lines emitted by the fleet health one-liner."""
+    out: Dict[str, str] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key.isupper() and key.replace("_", "").isalpha():
+            out[key] = value.strip()
+    return out
+
+
+def fleet_row_from_probe(name: str, raw: str) -> Dict[str, Any]:
+    """Turn one host's probe output into a normalized row dict.
+
+    If the SSH call succeeded but produced no recognizable ``KEY=VALUE`` data
+    (restricted shell, missing perms, non-POSIX login shell), return an error
+    row with a reason rather than a silent all-blank line.
+    """
+    kv = parse_fleet_probe(raw)
+    if not any(k in kv for k in ("LOAD", "CPU", "MEM")):
+        return {"name": name,
+                "error": "connected, no probe data (restricted shell / perms?)"}
+    load1 = ""
+    load_field = kv.get("LOAD", "")
+    if load_field:
+        load1 = load_field.split()[0]
+    mem = kv.get("MEM", "")  # "total used free" in MB
+    mem_pct = ""
+    if mem:
+        parts = mem.split()
+        if len(parts) >= 2:
+            try:
+                total_mb = float(parts[0])
+                used_mb = float(parts[1])
+                if total_mb > 0:
+                    mem_pct = f"{round(used_mb / total_mb * 100)}%"
+            except ValueError:
+                pass
+    fpm = kv.get("FPM", "")  # "active/max" or "" when no php-fpm
+    cores = kv.get("CPU", "")
+    # Load-per-core is the triage ratio (≈1.0 = saturated; >2 = overloaded).
+    load_per_core = ""
+    try:
+        if load1 and cores and float(cores) > 0:
+            load_per_core = f"{float(load1) / float(cores):.2f}"
+    except (ValueError, ZeroDivisionError):
+        pass
+    return {
+        "name": name,
+        "load1": load1,
+        "load": load_field,
+        "cores": cores,
+        "load_per_core": load_per_core,
+        "mem_pct": mem_pct,
+        "mem": mem,
+        "fpm": fpm,
+        "stack": kv.get("STACK", ""),
+        "listen": kv.get("LISTEN", ""),
+    }
+
+
+def _load_sort_key(row: Dict[str, Any]) -> float:
+    try:
+        return float(row.get("load1") or -1)
+    except (ValueError, TypeError):
+        return -1.0
+
+
+def format_fleet_table(rows: List[Dict[str, Any]]) -> str:
+    """Render fleet rows as a table, busiest (highest load) first."""
+    if not rows:
+        return "No reachable instances to report on."
+    ok_rows = [r for r in rows if not r.get("error")]
+    err_rows = [r for r in rows if r.get("error")]
+    ok_rows.sort(key=_load_sort_key, reverse=True)
+
+    out: List[str] = [
+        f"{'Instance':<28} {'Load(1m)':<9} {'Cores':<6} {'L/core':<7} "
+        f"{'Mem':<6} {'FPM':<10} {'Web stack':<22} Listen",
+        "-" * 108,
+    ]
+    for r in ok_rows:
+        out.append(
+            f"{str(r.get('name', ''))[:28]:<28} "
+            f"{str(r.get('load1', '') or '-'):<9} "
+            f"{str(r.get('cores', '') or '-'):<6} "
+            f"{str(r.get('load_per_core', '') or '-'):<7} "
+            f"{str(r.get('mem_pct', '') or '-'):<6} "
+            f"{str(r.get('fpm', '') or '-'):<10} "
+            f"{str(r.get('stack', '') or '-')[:22]:<22} "
+            f"{str(r.get('listen', '') or '-')}"
+        )
+    for r in err_rows:
+        out.append(
+            f"{str(r.get('name', ''))[:28]:<28} "
+            f"{str(r.get('error', ''))[:60]}"
+        )
+    if err_rows:
+        out.append(f"\n({len(err_rows)} host(s) returned no data — see reasons above.)")
+    return "\n".join(out)

--- a/tests/fixtures/server_catalog_v1.json
+++ b/tests/fixtures/server_catalog_v1.json
@@ -11,11 +11,20 @@
     "aws_start_instance",
     "aws_stop_instance",
     "aws_terminate_instance",
+    "block_ip",
     "build_server_memory",
     "cloudtrail_lookup_events",
     "cloudwatch_get_log_events",
     "cloudwatch_list_log_groups",
     "cloudwatch_top_ips",
+    "db_processlist",
+    "db_setup_remove",
+    "db_setup_save",
+    "db_setup_scan",
+    "db_top_queries",
+    "describe_ingress_path",
+    "enrich_ips",
+    "fleet_health_snapshot",
     "get_logs",
     "get_server_memory",
     "hetzner_create_server",
@@ -47,6 +56,7 @@
     "ovh_ssh_keys",
     "ovh_start_instance",
     "ovh_stop_instance",
+    "rds_metrics",
     "refresh_server_memory",
     "run_command",
     "s3_copy_object",
@@ -59,6 +69,8 @@
     "s3_list_objects",
     "s3_move_object",
     "s3_upload_object",
-    "transfer_file"
+    "transfer_file",
+    "waf_rate_rule_set",
+    "web_traffic_summary"
   ]
 }

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -90,11 +90,20 @@ class TestLocalToolHandlerMapCompleteness:
             f"from ServonautTools: {missing}"
         )
 
-    def test_new_entries_count_is_57(self):
-        """PR5' adds exactly 57 entries on top of the 2 original ones."""
+    def test_new_entries_count_is_69(self):
+        """Local-handler entries beyond the 2 originals.
+
+        PR5' seeded 57; incident-response tools added the rest:
+        Group A (web_traffic_summary, fleet_health_snapshot, enrich_ips,
+        db_processlist, db_top_queries) → 62; describe_ingress_path → 63;
+        Group C waf_rate_rule_set + block_ip → 65; rds_metrics → 66;
+        db_setup_scan + db_setup_save → 68; db_setup_remove → 69. All dispatch
+        locally (CLI's own SSH / boto3 / network surface); the server catalog
+        mirror is tracked separately (see test_catalog_drift::CATALOG_PENDING_SERVER).
+        """
         new_entries = {k for k in _LOCAL_TOOL_HANDLERS if k not in _ORIGINAL_TOOLS}
-        assert len(new_entries) == 57, (
-            f"Expected 57 new entries, got {len(new_entries)}: {sorted(new_entries)}"
+        assert len(new_entries) == 69, (
+            f"Expected 69 new entries, got {len(new_entries)}: {sorted(new_entries)}"
         )
 
 

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -1,11 +1,11 @@
-"""CI gate: CLI tool inventory must match server's catalog.
+"""CI gate: CLI tool inventory must match the server's published catalog.
 
-Locked formula from agent-bus thread d59dd956-...:
-    set(catalog) == set(tool_schemas.TOOL_SCHEMAS) - CATALOG_EXCLUDED_CLI_ONLY
+    set(catalog) == set(tool_schemas.TOOL_SCHEMAS)
+                    - CATALOG_EXCLUDED_CLI_ONLY
+                    - CATALOG_PENDING_SERVER
 
-The fixture mirrors PR1''s 60-entry seed verbatim. When the server
-catalog changes, the fixture updates in the same PR. Drift fails CI
-loudly.
+The fixture mirrors the server's tool catalog. When the server catalog
+changes, the fixture updates in the same change. Drift fails CI loudly.
 """
 from __future__ import annotations
 
@@ -25,6 +25,14 @@ CATALOG_EXCLUDED_CLI_ONLY: frozenset[str] = frozenset({
     "get_server_info",
 })
 
+# Tools that exist on the CLI (MCP + local chat dispatch) AHEAD of the server
+# catalog — they run on the CLI's own SSH / boto3 / network surface, so they
+# can ship CLI-first. This set is INTENTIONALLY TEMPORARY (unlike
+# CATALOG_EXCLUDED_CLI_ONLY, which is permanently CLI-only): when a tool is
+# added to the server catalog, move it out of here and into the fixture in the
+# same change, keeping the gate honest both ways. Empty = fully converged.
+CATALOG_PENDING_SERVER: frozenset[str] = frozenset()
+
 
 _FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "server_catalog_v1.json"
 
@@ -36,7 +44,7 @@ def _server_catalog_names() -> set[str]:
 
 def test_catalog_matches_cli_minus_local_only():
     cli_tools = set(tool_schemas.TOOL_SCHEMAS.keys())
-    expected = cli_tools - CATALOG_EXCLUDED_CLI_ONLY
+    expected = cli_tools - CATALOG_EXCLUDED_CLI_ONLY - CATALOG_PENDING_SERVER
     actual = _server_catalog_names()
     missing = expected - actual
     extra = actual - expected
@@ -47,11 +55,26 @@ def test_catalog_matches_cli_minus_local_only():
     )
 
 
-def test_catalog_fixture_has_60_entries():
-    """Sanity check: the fixture must contain exactly 60 names."""
+def test_pending_server_tools_not_yet_in_catalog():
+    """Pending (CLI-ahead) tools must NOT already be in the server fixture.
+
+    Guards the convergence protocol: once a tool is added to the catalog, this
+    fails until it's also removed from CATALOG_PENDING_SERVER — forcing the two
+    halves of the contract to move together.
+    """
+    catalog = _server_catalog_names()
+    leaked = CATALOG_PENDING_SERVER & catalog
+    assert not leaked, (
+        f"Pending tools already in server catalog — move them out of "
+        f"CATALOG_PENDING_SERVER and update the fixture: {sorted(leaked)}"
+    )
+
+
+def test_catalog_fixture_has_72_entries():
+    """Sanity check: the fixture must contain exactly 72 names."""
     names = _server_catalog_names()
-    assert len(names) == 60, (
-        f"Expected 60 catalog entries, got {len(names)}: {sorted(names)}"
+    assert len(names) == 72, (
+        f"Expected 72 catalog entries, got {len(names)}: {sorted(names)}"
     )
 
 

--- a/tests/test_incident_response_tools.py
+++ b/tests/test_incident_response_tools.py
@@ -1,0 +1,1147 @@
+"""Tests for the Group A incident-response tools.
+
+Covers the pure parsers (log_analysis), config plumbing (db_profiles), secret
+handling for the DB tools, the on-box DB command builder, and IP-enrichment
+formatting. All IO-free: no SSH, no network — the SSH round-trip and the
+HTTP calls live behind seams the tool layer owns.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from servonaut.config.schema import AppConfig, DBProfile
+from servonaut.config.manager import ConfigManager
+from servonaut.mcp.guards import CommandGuard, GuardLevel
+from servonaut.mcp.tools import ServonautTools
+from servonaut.services.ip_enrichment_service import (
+    IPEnrichmentService, format_enrichment, _resolve_key,
+)
+from servonaut.utils.log_analysis import (
+    extract_client_ip, summarize_web_traffic, format_web_traffic,
+    parse_fleet_probe, fleet_row_from_probe, format_fleet_table,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tools(config: AppConfig | None = None, secret_provider=None) -> ServonautTools:
+    """Minimal ServonautTools for testing pure-ish methods (no live services)."""
+    cfg = config or AppConfig()
+    cm = MagicMock()
+    cm.get.return_value = cfg
+    return ServonautTools(
+        config_manager=cm,
+        aws_service=MagicMock(),
+        custom_server_service=MagicMock(),
+        cache_service=MagicMock(),
+        ssh_service=MagicMock(),
+        connection_service=MagicMock(),
+        scp_service=MagicMock(),
+        guard=CommandGuard(cfg.mcp),
+        audit=MagicMock(),
+        secret_provider=secret_provider,
+    )
+
+
+# ---------------------------------------------------------------------------
+# web_traffic_summary parsing
+# ---------------------------------------------------------------------------
+
+# Real public IPs (RFC-5737 doc ranges are is_private=True on Python 3.12+).
+_PUB_A = "1.1.1.1"
+_PUB_B = "8.8.8.8"
+_ALB = "10.0.4.21"
+
+
+def test_extract_client_ip_direct():
+    assert extract_client_ip(f'{_PUB_A} - - ...', _PUB_A) == _PUB_A
+
+
+def test_extract_client_ip_xff_behind_alb():
+    line = f'{_ALB} - - [..] "GET / HTTP/1.1" 503 0 "-" "curl" "{_PUB_A}"'
+    # %h is the private ALB hop → real client comes from the XFF tail.
+    assert extract_client_ip(line, _ALB) == _PUB_A
+
+
+def test_summarize_web_traffic_multi_vhost():
+    raw = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [03/Jun/2026:10:00:00 +0000] "GET / HTTP/1.1" 200 12\n'
+        f'{_PUB_A} - - [03/Jun/2026:10:00:30 +0000] "GET /search?q=a HTTP/1.1" 503 0\n'
+        f'{_PUB_B} - - [03/Jun/2026:10:00:40 +0000] "GET /login HTTP/1.1" 200 99\n'
+        f'{_ALB} - - [03/Jun/2026:10:01:00 +0000] "GET / HTTP/1.1" 503 0 "-" "x" "{_PUB_A}"\n'
+        "===VHOST:/var/log/apache2/blog.access.log===\n"
+        f'{_PUB_B} - - [03/Jun/2026:10:00:00 +0000] "POST /api HTTP/1.1" 201 5\n'
+    )
+    s = summarize_web_traffic(raw, top_n=5)
+    assert s["total_requests"] == 5
+    # Label derived from the log filename: shop.access.log → "shop".
+    shop = s["vhosts"]["shop"]
+    assert shop["requests"] == 4
+    # _PUB_A: 2 direct + 1 via XFF == 3, the top IP.
+    assert shop["top_ips"][0] == (_PUB_A, 3)
+    # Query string stripped: /search?q=a groups under /search.
+    urls = dict(shop["top_urls"])
+    assert urls["/"] == 2 and urls["/search"] == 1
+    assert shop["status_mix"]["503"] == 2
+    # 60s window over 4 reqs.
+    assert shop["window_seconds"] == 60.0
+    assert "blog" in s["vhosts"]
+
+
+def test_vhost_label_generic_keeps_full_path():
+    from servonaut.utils.log_analysis import vhost_label
+    assert vhost_label("/var/log/nginx/shop.access.log") == "shop"
+    assert vhost_label("/var/log/apache2/shop-access.log") == "shop"
+    # Generic default log → keep the full path so it's recognizable, not "access".
+    assert vhost_label("/var/log/nginx/access.log") == "/var/log/nginx/access.log"
+
+
+def test_summarize_web_traffic_empty():
+    s = summarize_web_traffic("not a log line at all\n", top_n=5)
+    assert s["vhosts"] == {}
+    out = format_web_traffic(s, "somepath")
+    assert "No parseable" in out and "somepath" in out
+
+
+def test_format_web_traffic_busiest_first():
+    raw = (
+        "===VHOST:/var/log/nginx/sitea.access.log===\n"
+        f'{_PUB_A} - - [03/Jun/2026:10:00:00 +0000] "GET / HTTP/1.1" 200 1\n'
+        "===VHOST:/var/log/nginx/siteb.access.log===\n"
+        f'{_PUB_A} - - [03/Jun/2026:10:00:00 +0000] "GET / HTTP/1.1" 200 1\n'
+        f'{_PUB_B} - - [03/Jun/2026:10:00:01 +0000] "GET / HTTP/1.1" 200 1\n'
+    )
+    out = format_web_traffic(summarize_web_traffic(raw))
+    assert out.index("siteb") < out.index("sitea")
+
+
+# ---------------------------------------------------------------------------
+# fleet_health_snapshot parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_fleet_probe_and_row():
+    probe = (
+        "LOAD=78.20 60.10 40.00\nCPU=4\nMEM=16000 15000 1000\n"
+        "FPM=80/80\nSTACK= nginx php-fpm\nLISTEN=80,443,9000,\n"
+    )
+    kv = parse_fleet_probe(probe)
+    assert kv["LOAD"].startswith("78.20")
+    row = fleet_row_from_probe("web-prod-1", probe)
+    assert row["load1"] == "78.20"
+    assert row["mem_pct"] == "94%"  # 15000/16000
+    assert row["fpm"] == "80/80"
+    assert "nginx" in row["stack"]
+
+
+def test_format_fleet_table_sorts_load_desc_errors_last():
+    rows = [
+        fleet_row_from_probe("idle", "LOAD=0.10 0.1 0.1\nCPU=2\nMEM=4000 1000 3000\nFPM=\nSTACK= nginx\nLISTEN=80,"),
+        fleet_row_from_probe("busy", "LOAD=78.2 60 40\nCPU=4\nMEM=16000 15000 1000\nFPM=80/80\nSTACK= nginx\nLISTEN=80,"),
+        {"name": "dead", "error": "timeout"},
+    ]
+    out = format_fleet_table(rows)
+    assert out.index("busy") < out.index("idle") < out.index("dead")
+    assert "timeout" in out  # the dead host's reason is shown, not a generic word
+    assert "L/core" in out   # load-per-core column present
+
+
+# ---------------------------------------------------------------------------
+# db_profiles config + resolver
+# ---------------------------------------------------------------------------
+
+def test_db_profile_for_matches_by_id_and_name():
+    cfg = AppConfig(db_profiles=[
+        DBProfile(instance="i-123", engine="mysql"),
+        DBProfile(instance="prod-db", engine="postgres"),
+    ])
+    assert cfg.db_profile_for("i-123").engine == "mysql"
+    assert cfg.db_profile_for("nope", "prod-db").engine == "postgres"
+    assert cfg.db_profile_for("PROD-DB").engine == "postgres"  # case-insensitive
+    assert cfg.db_profile_for("unknown") is None
+
+
+def test_db_profiles_round_trip_through_manager(tmp_path, monkeypatch):
+    """from_dict must coerce db_profiles dicts into DBProfile instances."""
+    raw = {
+        "version": AppConfig().version,
+        "db_profiles": [
+            {"instance": "i-1", "engine": "mysql", "user": "app",
+             "password_secret": "db/app", "port": 3306,
+             "unknown_key": "dropped"},
+        ],
+    }
+    cm = ConfigManager.__new__(ConfigManager)  # bypass __init__/disk load
+    cfg = cm._deserialize(raw)
+    assert len(cfg.db_profiles) == 1
+    p = cfg.db_profiles[0]
+    assert isinstance(p, DBProfile)
+    assert p.instance == "i-1" and p.password_secret == "db/app"
+
+
+# ---------------------------------------------------------------------------
+# DB command builder — password via env, never via -p / argv on the box
+# ---------------------------------------------------------------------------
+
+def test_build_db_command_mysql_password_in_env_not_client_argv():
+    t = _tools()
+    profile = DBProfile(instance="x", engine="mysql", host="127.0.0.1",
+                        port=3306, user="root")
+    cmd = t._build_db_command(profile, "SHOW PROCESSLIST;", "s3cr3t")
+    # Password is exported as DBP (env), consumed via MYSQL_PWD="$DBP" — never
+    # as a -p argv on the mysql client itself.
+    assert "DBP='s3cr3t'" in cmd or "DBP=s3cr3t" in cmd
+    assert "-ps3cr3t" not in cmd and "-p s3cr3t" not in cmd
+    assert 'MYSQL_PWD="$DBP" mysql -h "$DBH"' in cmd
+
+
+def test_build_db_command_has_php_fallback_when_no_mysql_client():
+    t = _tools()
+    cmd = t._build_db_command(
+        DBProfile(instance="x", engine="mysql", user="root"),
+        "SHOW FULL PROCESSLIST;", "pw")
+    # The decisive fix: when the box has no mysql client, fall back to php
+    # (always present on a PHP/Joomla box).
+    assert "command -v mysql" in cmd
+    assert "elif command -v php" in cmd and "php -r" in cmd and "multi_query" in cmd
+    # The password is NOT inside the php -r argument (php reads it via getenv).
+    php_part = cmd.split("php -r", 1)[1]
+    assert "pw" not in php_part
+
+
+def test_build_db_command_postgres_uses_pdo_fallback():
+    t = _tools()
+    cmd = t._build_db_command(
+        DBProfile(instance="x", engine="postgres", host="db.internal",
+                  port=5432, user="app", database="appdb"),
+        "SELECT 1;", "pw")
+    assert 'PGPASSWORD="$DBP" psql -h "$DBH"' in cmd
+    assert "command -v psql" in cmd and "PDO" in cmd  # php PDO_pgsql fallback
+
+
+def test_build_db_command_quotes_dangerous_password():
+    t = _tools()
+    # A password with shell metacharacters must be shlex-quoted in the DBP
+    # export so it can't break out of the command.
+    cmd = t._build_db_command(
+        DBProfile(instance="x", engine="mysql", user="root"),
+        "SELECT 1;", "p@ss'; rm -rf /")
+    assert "DBP='p@ss'\"'\"'; rm -rf /'" in cmd  # shlex-quoted, inert
+
+
+def test_db_setup_remove():
+    cfg = AppConfig(db_profiles=[
+        DBProfile(instance="web", engine="mysql", password_secret="db/web"),
+    ])
+    t = _tools(cfg)
+    sp = MagicMock(); sp.delete_secret = AsyncMock(return_value=True)
+    t._secret_provider = sp
+    out = asyncio.run(t.db_setup_remove("web"))
+    assert "Removed db_profile for web" in out and "deleted" in out
+    sp.delete_secret.assert_awaited_once_with("db/web")
+    t._config_manager.update.assert_called_once()
+
+
+def test_db_setup_remove_no_profile():
+    t = _tools(AppConfig())
+    out = asyncio.run(t.db_setup_remove("nope"))
+    assert "No db_profile found" in out
+
+
+def test_scan_command_searches_deep():
+    cmd = DBCredentialScanner.build_scan_command()
+    assert "-maxdepth 7" in cmd  # reaches /home/<user>/<domain>/<sub>/html/...
+    assert "configuration.php" in cmd
+
+
+# ---------------------------------------------------------------------------
+# DB tool error paths (no secret provider / no profile)
+# ---------------------------------------------------------------------------
+
+def test_db_processlist_errors_without_profile():
+    t = _tools(AppConfig())
+    t._find_instance = _async_return({"id": "i-1", "name": "n"})  # type: ignore
+    out = asyncio.run(t.db_processlist("i-1"))
+    assert "No db_profile configured" in out
+
+
+def test_db_processlist_errors_without_secret_provider():
+    cfg = AppConfig(db_profiles=[
+        DBProfile(instance="i-1", engine="mysql", password_secret="db/app"),
+    ])
+    t = _tools(cfg, secret_provider=None)
+    t._find_instance = _async_return({"id": "i-1", "name": "n"})  # type: ignore
+    out = asyncio.run(t.db_processlist("i-1"))
+    assert "no secret store is" in out.lower() or "log in" in out.lower()
+
+
+def _async_return(value):
+    async def _f(*_a, **_k):
+        return value
+    return _f
+
+
+# ---------------------------------------------------------------------------
+# IP enrichment
+# ---------------------------------------------------------------------------
+
+def test_resolve_key_env_indirection(monkeypatch):
+    monkeypatch.setenv("MY_ABUSE_KEY", "abc123")
+    assert _resolve_key("$MY_ABUSE_KEY") == "abc123"
+    assert _resolve_key("literal") == "literal"
+    assert _resolve_key("") == ""
+
+
+def test_format_enrichment_table():
+    rows = [{
+        "ip": "1.1.1.1", "rdns": "bad.example.net", "asn": "AS12345",
+        "org": "Bulletproof LLC", "country": "RU", "hosting": True,
+        "proxy": False, "abuse_score": 100, "total_reports": 42, "error": "",
+    }]
+    out = format_enrichment(rows)
+    assert "1.1.1.1" in out and "100%" in out and "AS12345" in out
+    assert "hosting" in out and "42 reports" in out
+
+
+def test_enrich_ips_caps_and_dedupes():
+    svc = IPEnrichmentService(config_manager=None)
+    assert svc.max_ips == 100
+    # No network: empty input returns empty without any HTTP.
+    assert asyncio.run(svc.enrich([])) == []
+
+
+# ---------------------------------------------------------------------------
+# Guard tiers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tool", ["web_traffic_summary", "fleet_health_snapshot", "enrich_ips"])
+def test_readonly_probes_allowed_at_readonly(tool):
+    cfg = AppConfig()
+    cfg.mcp.guard_level = GuardLevel.READONLY
+    g = CommandGuard(cfg.mcp)
+    ok, _ = g.check_tool(tool)
+    assert ok
+
+
+@pytest.mark.parametrize("tool", ["db_processlist", "db_top_queries"])
+def test_db_tools_blocked_at_readonly_allowed_at_standard(tool):
+    cfg = AppConfig()
+    cfg.mcp.guard_level = GuardLevel.READONLY
+    assert not CommandGuard(cfg.mcp).check_tool(tool)[0]
+    cfg.mcp.guard_level = GuardLevel.STANDARD
+    assert CommandGuard(cfg.mcp).check_tool(tool)[0]
+
+
+def test_describe_ingress_path_allowed_at_readonly():
+    cfg = AppConfig()
+    cfg.mcp.guard_level = GuardLevel.READONLY
+    assert CommandGuard(cfg.mcp).check_tool("describe_ingress_path")[0]
+
+
+# ---------------------------------------------------------------------------
+# describe_ingress_path — boto3 topology walk (mocked clients)
+# ---------------------------------------------------------------------------
+
+from servonaut.services import ingress_path_service as ips_mod
+from servonaut.services.ingress_path_service import (
+    IngressPathService, format_ingress_path,
+)
+
+_LB_ARN = "arn:aws:elasticloadbalancing:eu-west-1:1:loadbalancer/app/shop/abc"
+_TG_ARN = "arn:aws:elasticloadbalancing:eu-west-1:1:targetgroup/shop-tg/xyz"
+
+
+def _fake_elbv2(target_id, *, tg_lb_arns=(_LB_ARN,)):
+    c = MagicMock()
+    c.get_paginator.return_value.paginate.return_value = [{
+        "TargetGroups": [{
+            "TargetGroupArn": _TG_ARN, "TargetGroupName": "shop-tg",
+            "Port": 443, "Protocol": "HTTPS",
+            "LoadBalancerArns": list(tg_lb_arns),
+        }],
+    }]
+    c.describe_target_health.return_value = {
+        "TargetHealthDescriptions": [
+            {"Target": {"Id": target_id}, "TargetHealth": {"State": "healthy"}},
+        ],
+    }
+    c.describe_load_balancers.return_value = {
+        "LoadBalancers": [{
+            "LoadBalancerArn": _LB_ARN, "DNSName": "shop-123.elb.amazonaws.com",
+            "Type": "application", "Scheme": "internet-facing",
+        }],
+    }
+    c.describe_listeners.return_value = {
+        "Listeners": [{"ListenerArn": "li-1", "Port": 443, "Protocol": "HTTPS"}],
+    }
+    c.describe_rules.return_value = {
+        "Rules": [{
+            "Priority": "1",
+            "Conditions": [{"Field": "host-header", "Values": ["shop.example"]}],
+            "Actions": [{"Type": "forward"}],
+        }],
+    }
+    return c
+
+
+def _fake_wafv2(*, attached=True, raise_for_resource=False):
+    c = MagicMock()
+    if raise_for_resource:
+        c.get_web_acl_for_resource.side_effect = RuntimeError("AccessDenied")
+        return c
+    c.get_web_acl_for_resource.return_value = (
+        {"WebACL": {"ARN": "acl-arn", "Name": "am-aws-waf", "Id": "acl-id"}}
+        if attached else {}
+    )
+    c.get_web_acl.return_value = {"WebACL": {
+        "DefaultAction": {"Allow": {}},
+        "Rules": [
+            {"Name": "ipblock", "Statement": {
+                "IPSetReferenceStatement": {"ARN": "ipset-arn"}}},
+            {"Name": "rate", "Statement": {"AndStatement": {"Statements": [
+                {"RateBasedStatement": {"Limit": 2000, "AggregateKeyType": "IP"}},
+            ]}}},
+        ],
+    }}
+    return c
+
+
+def _patch_boto3(monkeypatch, elbv2, wafv2):
+    def _factory(service, **_kw):
+        return {"elbv2": elbv2, "wafv2": wafv2}[service]
+    monkeypatch.setattr(ips_mod.boto3, "client", _factory)
+
+
+def test_ingress_full_topology(monkeypatch):
+    _patch_boto3(monkeypatch, _fake_elbv2("i-123"), _fake_wafv2())
+    topo = asyncio.run(IngressPathService().describe("i-123", "10.0.0.9", "eu-west-1"))
+    assert topo["errors"] == []
+    assert topo["target_groups"][0]["name"] == "shop-tg"
+    lb = topo["load_balancers"][0]
+    assert lb["type"] == "application"
+    assert lb["listeners"][0]["rules"][0]["actions"] == ["forward"]
+    acl = lb["web_acl"]
+    assert acl["name"] == "am-aws-waf"
+    assert acl["ip_sets"][0]["arn"] == "ipset-arn"
+    # Rate rule nested in AndStatement is found by the recursive scan.
+    assert acl["rate_rules"][0]["limit_per_5min"] == 2000
+    out = format_ingress_path(topo, mod_remoteip_trusted=False)
+    assert "am-aws-waf" in out and "2000/5min" in out
+    assert "real-IP trust on box: no" in out
+
+
+def test_ingress_match_by_private_ip(monkeypatch):
+    # Target registered by IP (ip-type TG), not instance id.
+    _patch_boto3(monkeypatch, _fake_elbv2("10.0.0.9"), _fake_wafv2())
+    topo = asyncio.run(IngressPathService().describe("i-999", "10.0.0.9", "eu-west-1"))
+    assert topo["target_groups"], "should match on private IP"
+
+
+def test_ingress_no_target_groups(monkeypatch):
+    elbv2 = _fake_elbv2("i-OTHER")  # health lists a different target
+    _patch_boto3(monkeypatch, elbv2, _fake_wafv2())
+    topo = asyncio.run(IngressPathService().describe("i-123", "10.0.0.9", "eu-west-1"))
+    assert topo["target_groups"] == []
+    assert topo["load_balancers"] == []
+    out = format_ingress_path(topo, None)
+    assert "NOT" in out and "ALB" in out
+
+
+def test_ingress_no_webacl_attached(monkeypatch):
+    _patch_boto3(monkeypatch, _fake_elbv2("i-123"), _fake_wafv2(attached=False))
+    topo = asyncio.run(IngressPathService().describe("i-123", "", "eu-west-1"))
+    assert topo["load_balancers"][0]["web_acl"] is None
+    out = format_ingress_path(topo, True)
+    assert "NONE attached" in out and "no WAF" in out
+
+
+def test_ingress_partial_failure_on_waf(monkeypatch):
+    # wafv2 denied → topology still returned, error recorded (incident reality).
+    _patch_boto3(monkeypatch, _fake_elbv2("i-123"),
+                 _fake_wafv2(raise_for_resource=True))
+    topo = asyncio.run(IngressPathService().describe("i-123", "", "eu-west-1"))
+    assert topo["target_groups"], "TG topology survives a WAF denial"
+    assert any("get_web_acl_for_resource" in e for e in topo["errors"])
+    out = format_ingress_path(topo, None)
+    assert "Partial result" in out
+
+
+# ---------------------------------------------------------------------------
+# run_command transport (SSH → SSM fallback)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import AsyncMock
+from servonaut.mcp import tools as tools_mod
+from servonaut.services import ssm_service as ssm_mod
+
+_AWS_INSTANCE = {"id": "i-1", "name": "web", "region": "eu-west-1",
+                 "private_ip": "10.0.0.1"}
+
+
+def _run_tools():
+    cfg = AppConfig()
+    cfg.mcp.guard_level = GuardLevel.DANGEROUS  # so 'ls' passes the command guard
+    t = _tools(cfg)
+    t._find_instance = _async_return(_AWS_INSTANCE)  # type: ignore
+    return t
+
+
+def _patch_ssh(monkeypatch, *, stdout=b"", stderr=b"", timeout=False):
+    if timeout:
+        monkeypatch.setattr(tools_mod, "run_ssh_subprocess",
+                            AsyncMock(side_effect=asyncio.TimeoutError()))
+    else:
+        monkeypatch.setattr(tools_mod, "run_ssh_subprocess",
+                            AsyncMock(return_value=(stdout, stderr)))
+
+
+def _patch_ssm(monkeypatch, result):
+    fake = MagicMock()
+    fake.run_command = AsyncMock(return_value=result)
+    monkeypatch.setattr(ssm_mod, "SSMService", lambda: fake)
+    return fake
+
+
+def test_run_command_ssh_success_annotates_transport(monkeypatch):
+    _patch_ssh(monkeypatch, stdout=b"hello\n")
+    out = asyncio.run(_run_tools().run_command("i-1", "ls", transport="ssh"))
+    assert "hello" in out and "[transport_used: ssh]" in out
+
+
+def test_run_command_ssh_only_conn_failure_suggests_ssm(monkeypatch):
+    _patch_ssh(monkeypatch, stdout=b"", stderr=b"ssh: connect to host x port 22: Connection refused")
+    out = asyncio.run(_run_tools().run_command("i-1", "ls", transport="ssh"))
+    assert "SSH connection failed" in out and "ssm" in out.lower()
+
+
+def test_run_command_auto_falls_back_to_ssm_on_conn_failure(monkeypatch):
+    _patch_ssh(monkeypatch, stdout=b"", stderr=b"Connection timed out")
+    _patch_ssm(monkeypatch, {"ok": True, "status": "Success",
+                             "stdout": "from-ssm\n", "stderr": "", "error": ""})
+    out = asyncio.run(_run_tools().run_command("i-1", "ls"))  # auto
+    assert "fell back to SSM" in out
+    assert "from-ssm" in out and "[transport_used: ssm]" in out
+
+
+def test_run_command_auto_timeout_triggers_ssm(monkeypatch):
+    _patch_ssh(monkeypatch, timeout=True)
+    _patch_ssm(monkeypatch, {"ok": True, "status": "Success",
+                             "stdout": "ok", "stderr": "", "error": ""})
+    out = asyncio.run(_run_tools().run_command("i-1", "ls"))
+    assert "[transport_used: ssm]" in out
+
+
+def test_run_command_auto_ssh_success_no_ssm(monkeypatch):
+    _patch_ssh(monkeypatch, stdout=b"direct\n")
+    fake = _patch_ssm(monkeypatch, {"ok": True})
+    out = asyncio.run(_run_tools().run_command("i-1", "ls"))
+    assert "[transport_used: ssh]" in out
+    fake.run_command.assert_not_called()  # SSH worked → SSM never touched
+
+
+def test_run_command_ssm_forced(monkeypatch):
+    fake = _patch_ssm(monkeypatch, {"ok": True, "status": "Success",
+                                    "stdout": "ssm-out", "stderr": "", "error": ""})
+    out = asyncio.run(_run_tools().run_command("i-1", "ls", transport="ssm"))
+    assert "ssm-out" in out and "[transport_used: ssm]" in out
+    fake.run_command.assert_called_once()
+
+
+def test_run_command_ssm_non_aws_rejected(monkeypatch):
+    t = _run_tools()
+    t._find_instance = _async_return(  # type: ignore
+        {"id": "srv", "name": "c", "is_custom": True})
+    out = asyncio.run(t.run_command("srv", "ls", transport="ssm"))
+    assert "AWS-only" in out
+
+
+def test_run_command_invalid_transport(monkeypatch):
+    out = asyncio.run(_run_tools().run_command("i-1", "ls", transport="carrier-pigeon"))
+    assert "transport must be" in out
+
+
+def test_run_command_auto_ssm_failure_reports_both(monkeypatch):
+    _patch_ssh(monkeypatch, stdout=b"", stderr=b"Connection refused")
+    _patch_ssm(monkeypatch, {"ok": False, "status": "Failed",
+                             "stdout": "", "stderr": "agent error",
+                             "error": "send_command: InvalidInstanceId"})
+    out = asyncio.run(_run_tools().run_command("i-1", "ls"))
+    assert "fell back to SSM" in out and "Error (SSM)" in out
+
+
+def test_is_ssh_connection_failure_detection():
+    t = _tools()
+    assert t._is_ssh_connection_failure("ssh: connect to host: Connection refused")
+    assert t._is_ssh_connection_failure("Connection timed out during banner exchange")
+    # A command that ran but failed is NOT a connection failure.
+    assert not t._is_ssh_connection_failure("bash: foo: command not found")
+    assert not t._is_ssh_connection_failure("Permission denied (publickey).")
+
+
+# ---------------------------------------------------------------------------
+# Group C: WAF mitigation
+# ---------------------------------------------------------------------------
+
+from servonaut.services import waf_management_service as waf_mod
+from servonaut.services.waf_management_service import (
+    WAFManagementService, parse_wafv2_arn,
+)
+from servonaut.services.ip_ban_service import IPBanService, _to_cidr
+
+_WEBACL_ARN = "arn:aws:wafv2:eu-west-1:123:regional/webacl/am-aws-waf/acl-id"
+_IPSET_ARN = "arn:aws:wafv2:eu-west-1:123:regional/ipset/blocklist/ip-id"
+
+
+def test_parse_wafv2_arn():
+    p = parse_wafv2_arn(_WEBACL_ARN)
+    assert p == {"region": "eu-west-1", "scope": "REGIONAL", "kind": "webacl",
+                 "name": "am-aws-waf", "id": "acl-id"}
+    assert parse_wafv2_arn(_IPSET_ARN)["kind"] == "ipset"
+    assert parse_wafv2_arn("not-an-arn") is None
+
+
+def test_to_cidr_and_validate():
+    assert _to_cidr("1.2.3.4") == "1.2.3.4/32"
+    assert _to_cidr("1.2.3.0/24") == "1.2.3.0/24"
+    svc = IPBanService(MagicMock())
+    assert svc.validate_ip("1.1.1.1")
+    assert svc.validate_ip("8.8.0.0/16")
+    assert not svc.validate_ip("not-an-ip")
+
+
+def _fake_wafv2_for_ipset(monkeypatch, addresses):
+    client = MagicMock()
+    client.get_web_acl.return_value = {"WebACL": {"Rules": [{
+        "Name": "blockrule", "Action": {"Block": {}},
+        "Statement": {"IPSetReferenceStatement": {"ARN": _IPSET_ARN}},
+    }]}}
+    client.get_ip_set.return_value = {
+        "IPSet": {"Addresses": list(addresses)}, "LockToken": "lt"}
+    monkeypatch.setattr(waf_mod.boto3, "client", lambda *a, **k: client)
+    return client
+
+
+def test_add_ip_to_block_ipset_applies(monkeypatch):
+    client = _fake_wafv2_for_ipset(monkeypatch, ["9.9.9.9/32"])  # pre-existing entry
+    res = asyncio.run(WAFManagementService().add_ip_to_block_ipset(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1", ["1.1.1.1"]))
+    assert res["applied"] == ["1.1.1.1"] and res["ip_set"] == "blocklist"
+    # update_ip_set called with the new address appended.
+    _, kw = client.update_ip_set.call_args
+    assert "1.1.1.1/32" in kw["Addresses"]
+
+
+def test_add_ip_to_block_ipset_duplicate(monkeypatch):
+    _fake_wafv2_for_ipset(monkeypatch, ["1.1.1.1/32"])
+    res = asyncio.run(WAFManagementService().add_ip_to_block_ipset(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1", ["1.1.1.1"]))
+    assert res["applied"] == []
+    assert res["failed"][0]["reason"] == "already present"
+
+
+def test_add_ip_to_block_ipset_no_blockset(monkeypatch):
+    client = MagicMock()
+    client.get_web_acl.return_value = {"WebACL": {"Rules": []}}
+    monkeypatch.setattr(waf_mod.boto3, "client", lambda *a, **k: client)
+    res = asyncio.run(WAFManagementService().add_ip_to_block_ipset(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1", ["1.1.1.1"]))
+    assert "no block rule" in res["error"].lower()
+
+
+def test_set_rate_rule_add_and_remove(monkeypatch):
+    client = MagicMock()
+    client.get_web_acl.return_value = {
+        "WebACL": {"DefaultAction": {"Allow": {}},
+                   "VisibilityConfig": {"SampledRequestsEnabled": True,
+                                        "CloudWatchMetricsEnabled": True,
+                                        "MetricName": "acl"},
+                   "Rules": []},
+        "LockToken": "lt"}
+    monkeypatch.setattr(waf_mod.boto3, "client", lambda *a, **k: client)
+    res = asyncio.run(WAFManagementService().set_rate_rule(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1",
+        rule_name="flood", limit=500, uri_scope="/"))
+    assert res["applied"] is True
+    _, kw = client.update_web_acl.call_args
+    rule = kw["Rules"][0]
+    assert rule["Statement"]["RateBasedStatement"]["Limit"] == 500
+    assert "ScopeDownStatement" in rule["Statement"]["RateBasedStatement"]
+
+    assert res["created_or_updated"] == "created" and res["previous"] is None
+
+    # Removing a non-existent rule errors.
+    res2 = asyncio.run(WAFManagementService().set_rate_rule(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1",
+        rule_name="ghost", remove=True))
+    assert res2["applied"] is False and "not found" in res2["error"]
+
+
+def test_set_rate_rule_update_captures_previous(monkeypatch):
+    # An existing rule of the same name → updated + previous state captured
+    # (so the change is reversible to the prior limit, not just deletable).
+    client = MagicMock()
+    client.get_web_acl.return_value = {
+        "WebACL": {"DefaultAction": {"Allow": {}},
+                   "VisibilityConfig": {"SampledRequestsEnabled": True,
+                                        "CloudWatchMetricsEnabled": True,
+                                        "MetricName": "acl"},
+                   "Rules": [{
+                       "Name": "flood", "Priority": 3,
+                       "Statement": {"RateBasedStatement": {"Limit": 1000}},
+                       "Action": {"Block": {}},
+                       "VisibilityConfig": {"SampledRequestsEnabled": True,
+                                            "CloudWatchMetricsEnabled": True,
+                                            "MetricName": "flood"},
+                   }]},
+        "LockToken": "lt"}
+    monkeypatch.setattr(waf_mod.boto3, "client", lambda *a, **k: client)
+    res = asyncio.run(WAFManagementService().set_rate_rule(
+        "am-aws-waf", "acl-id", "REGIONAL", "eu-west-1",
+        rule_name="flood", limit=500))
+    assert res["applied"] is True
+    assert res["created_or_updated"] == "updated"
+    assert res["previous"] == {"limit": 1000, "uri_scoped": False, "action": "block"}
+
+
+# --- tool-level flows -------------------------------------------------------
+
+class _FakeWAF:
+    """Fake WAFManagementService injected into the tools module."""
+    def __init__(self, *, ipset=None, rate=None):
+        self._ipset = ipset or {"applied": ["1.1.1.1"], "failed": [], "ip_set": "blocklist", "error": ""}
+        self._rate = rate or {"applied": True, "error": "", "rule_name": "servonaut-rate",
+                              "created_or_updated": "created", "previous": None}
+    async def add_ip_to_block_ipset(self, *a, **k):
+        return self._ipset
+    async def set_rate_rule(self, *a, **k):
+        return self._rate
+
+
+def test_ip_ban_set_bulk_via_config(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._find_instance = _async_return({"id": "i-1"})  # type: ignore
+    svc = MagicMock()
+    svc.ban_ip = AsyncMock(side_effect=[
+        {"success": True, "message": "ok"},
+        {"success": False, "message": "invalid"},
+    ])
+    t._ip_ban_service = svc
+    out = asyncio.run(t.ip_ban_set(
+        config_name="waf-set", action="ban",
+        ip_addresses=["1.1.1.1", "999.0.0.0"]))
+    assert "Banned (1): 1.1.1.1" in out
+    assert "Failed (1)" in out and "999.0.0.0" in out
+    assert "reverse_hint: ip_ban_set action=unban" in out
+
+
+def test_ip_ban_set_via_site(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._resolve_webacl = _async_return(  # type: ignore
+        {"name": "am-aws-waf", "id": "acl-id", "scope": "REGIONAL",
+         "region": "eu-west-1", "arn": _WEBACL_ARN})
+    monkeypatch.setattr(waf_mod, "WAFManagementService", lambda: _FakeWAF())
+    out = asyncio.run(t.ip_ban_set(site="shop-ec2", ip_address="1.1.1.1/32"))
+    assert "WebACL: am-aws-waf" in out and "Banned (1)" in out
+
+
+def test_waf_rate_rule_set_apply(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._resolve_webacl = _async_return(  # type: ignore
+        {"name": "am-aws-waf", "id": "acl-id", "scope": "REGIONAL",
+         "region": "eu-west-1", "arn": _WEBACL_ARN})
+    monkeypatch.setattr(waf_mod, "WAFManagementService", lambda: _FakeWAF())
+    out = asyncio.run(t.waf_rate_rule_set(
+        site="shop-ec2", rule_name="flood", limit=500, uri_scope="/"))
+    assert "Created rate rule 'flood'" in out and "500 req/5min" in out
+    assert "reverse_hint" in out and "remove=true" in out
+
+
+def test_waf_rate_rule_set_update_surfaces_previous(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._resolve_webacl = _async_return(  # type: ignore
+        {"name": "am-aws-waf", "id": "acl-id", "scope": "REGIONAL",
+         "region": "eu-west-1", "arn": _WEBACL_ARN})
+    rate = {"applied": True, "error": "", "rule_name": "flood",
+            "created_or_updated": "updated",
+            "previous": {"limit": 1000, "uri_scoped": False, "action": "block"}}
+    monkeypatch.setattr(waf_mod, "WAFManagementService",
+                        lambda: _FakeWAF(rate=rate))
+    out = asyncio.run(t.waf_rate_rule_set(site="shop-ec2", rule_name="flood", limit=500))
+    assert "Updated rate rule 'flood'" in out
+    assert "previous: 1000 req/5min" in out
+    # reverse_hint restores the PRIOR limit, not a delete.
+    assert "restore prior" in out and "limit=1000" in out
+
+
+def test_block_ip_prefers_webacl(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._resolve_webacl = _async_return(  # type: ignore
+        {"name": "am-aws-waf", "id": "acl-id", "scope": "REGIONAL",
+         "region": "eu-west-1", "arn": _WEBACL_ARN})
+    monkeypatch.setattr(waf_mod, "WAFManagementService", lambda: _FakeWAF())
+    out = asyncio.run(t.block_ip("1.1.1.1", site="shop-ec2"))
+    assert "layer_used: waf" in out and "applied: True" in out
+    assert "why:" in out and "real client IP" in out  # layer rationale surfaced
+
+
+def test_block_ip_falls_back_to_host_recommendation(monkeypatch):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    t = _tools(cfg)
+    t._resolve_webacl = _async_return({"error": "no WebACL found"})  # type: ignore
+    t._ip_ban_service = None
+    out = asyncio.run(t.block_ip("1.1.1.1", site="shop-ec2"))
+    assert "layer_used: host" in out and "applied: False" in out
+    assert "Require not ip" in out  # host-level recommendation, not auto-applied
+
+
+@pytest.mark.parametrize("tool", ["waf_rate_rule_set", "block_ip"])
+def test_group_c_dangerous_tier(tool):
+    cfg = AppConfig()
+    cfg.mcp.guard_level = GuardLevel.STANDARD
+    assert not CommandGuard(cfg.mcp).check_tool(tool)[0]
+    cfg.mcp.guard_level = GuardLevel.DANGEROUS
+    assert CommandGuard(cfg.mcp).check_tool(tool)[0]
+
+
+# ---------------------------------------------------------------------------
+# rds_metrics
+# ---------------------------------------------------------------------------
+
+from datetime import datetime as _dt
+import servonaut.services.rds_metrics_service as rds_mod
+from servonaut.services.cloudwatch_service import CloudWatchService as _CWS
+
+
+def test_rds_metrics_service(monkeypatch):
+    client = MagicMock()
+
+    def _gms(**kw):
+        name = kw["MetricName"]
+        dp = {"Timestamp": _dt(2026, 6, 3, 10)}
+        if name == "CPUUtilization":
+            return {"Datapoints": [{**dp, "Average": 40, "Maximum": 95, "Minimum": 10}]}
+        if name == "DatabaseConnections":
+            return {"Datapoints": [{**dp, "Average": 50, "Maximum": 80, "Minimum": 20}]}
+        if name == "ReadLatency":  # seconds → ms
+            return {"Datapoints": [{**dp, "Average": 0.005, "Maximum": 0.02, "Minimum": 0.001}]}
+        return {"Datapoints": []}
+
+    client.get_metric_statistics.side_effect = _gms
+    monkeypatch.setattr(rds_mod.boto3, "client", lambda *a, **k: client)
+    data = asyncio.run(rds_mod.RDSMetricsService().fetch(
+        "db-1", region="eu-west-1", window_hours=3))
+    assert data["metrics"]["cpu_pct"]["max"] == 95
+    assert data["metrics"]["read_latency_ms"]["avg"] == 5.0  # 0.005s → 5ms
+    # CPUCreditBalance had no datapoints → absent, not an error.
+    assert "cpu_credit_balance" not in data["metrics"]
+    out = rds_mod.format_rds_metrics(data)
+    assert "RDS metrics for db-1" in out and "95.0%" in out and "Read latency" in out
+
+
+def test_rds_metrics_partial_failure(monkeypatch):
+    client = MagicMock()
+    client.get_metric_statistics.side_effect = RuntimeError("AccessDenied")
+    monkeypatch.setattr(rds_mod.boto3, "client", lambda *a, **k: client)
+    data = asyncio.run(rds_mod.RDSMetricsService().fetch("db-1", region="eu-west-1"))
+    assert data["metrics"] == {} and data["errors"]
+    assert "No datapoints" in rds_mod.format_rds_metrics(data)
+
+
+def test_rds_metrics_tool(monkeypatch):
+    class _FakeRDS:
+        async def fetch(self, *a, **k):
+            return {"db_instance": "db-1", "window_hours": 3,
+                    "metrics": {"cpu_pct": {"avg": 40, "max": 95, "min": 10, "latest": 40}},
+                    "errors": []}
+    monkeypatch.setattr(rds_mod, "RDSMetricsService", lambda: _FakeRDS())
+    out = asyncio.run(_tools().rds_metrics("db-1", region="eu-west-1"))
+    assert "RDS metrics for db-1" in out and "95%" in out
+
+
+def test_rds_metrics_requires_id():
+    out = asyncio.run(_tools().rds_metrics(""))
+    assert "provide a db_instance" in out
+
+
+def test_rds_metrics_readonly_tier():
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.READONLY
+    assert CommandGuard(cfg.mcp).check_tool("rds_metrics")[0]
+
+
+# ---------------------------------------------------------------------------
+# cloudwatch_get_log_events aggregation
+# ---------------------------------------------------------------------------
+
+def _cw_tools(events):
+    t = _tools()
+    cw = MagicMock()
+    cw.get_log_events = AsyncMock(return_value=events)
+    cw.aggregate_events = _CWS.aggregate_events  # real static aggregator
+    t._cloudwatch_service = cw
+    return t
+
+
+def test_cloudwatch_group_by_clientip():
+    import json
+    ev = [{"message": json.dumps({"httpRequest": {"clientIp": "1.1.1.1"},
+                                  "action": "BLOCK"})}] * 3
+    out = asyncio.run(_cw_tools(ev).cloudwatch_get_log_events(
+        "waf-lg", group_by="clientIp"))
+    assert "top clientIp" in out and "1.1.1.1" in out and "100.0%" in out
+
+
+def test_cloudwatch_group_by_uri_strips_query():
+    import json
+    ev = [
+        {"message": json.dumps({"httpRequest": {"clientIp": "1.1.1.1", "uri": "/search?q=a"}})},
+        {"message": json.dumps({"httpRequest": {"clientIp": "1.1.1.1", "uri": "/search?q=b"}})},
+    ]
+    out = asyncio.run(_cw_tools(ev).cloudwatch_get_log_events(
+        "lg", group_by="uri", top_n=5))
+    assert "/search" in out and "2" in out
+
+
+def test_cloudwatch_bad_group_by():
+    out = asyncio.run(_cw_tools([{"message": "x"}]).cloudwatch_get_log_events(
+        "lg", group_by="banana"))
+    assert "group_by must be" in out
+
+
+def test_cloudwatch_summary_only():
+    out = asyncio.run(_cw_tools([{"message": "x"}] * 5).cloudwatch_get_log_events(
+        "lg", summary_only=True))
+    assert "5 events in lg" in out
+
+
+def test_cloudwatch_raw_listing_still_default():
+    ts = _dt(2026, 6, 3, 10)
+    out = asyncio.run(_cw_tools([{"timestamp": ts, "message": "hello"}]
+                                ).cloudwatch_get_log_events("lg"))
+    assert "hello" in out and "top " not in out
+
+
+# ---------------------------------------------------------------------------
+# DB credential scanner + db_setup_scan / db_setup_save
+# ---------------------------------------------------------------------------
+
+from servonaut.services.db_credential_scanner import (
+    DBCredentialScanner, DBCandidate, redact,
+)
+
+_SECRET_PW = "s3cr3tP@ss!word"
+
+
+def test_scanner_parses_laravel_dotenv():
+    text = ("===FILE:/var/www/app/.env===\n"
+            "DB_CONNECTION=mysql\nDB_HOST=10.0.0.5\nDB_PORT=3306\n"
+            f"DB_USERNAME=app\nDB_PASSWORD={_SECRET_PW}\nDB_DATABASE=appdb\n")
+    cands = DBCredentialScanner().parse(text)
+    assert len(cands) == 1
+    c = cands[0]
+    assert (c.engine, c.host, c.port, c.user, c.database) == \
+        ("mysql", "10.0.0.5", 3306, "app", "appdb")
+    assert c.password == _SECRET_PW
+
+
+def test_scanner_parses_database_url():
+    text = (f"===FILE:/app/.env===\nDATABASE_URL=postgres://u:{_SECRET_PW}@db.x:5433/mydb\n")
+    c = DBCredentialScanner().parse(text)[0]
+    assert c.engine == "postgres" and c.host == "db.x" and c.port == 5433
+    assert c.user == "u" and c.database == "mydb" and c.password == _SECRET_PW
+
+
+def test_scanner_parses_wp_config():
+    text = ("===FILE:/var/www/html/wp-config.php===\n"
+            "<?php\ndefine('DB_NAME', 'wp');\ndefine('DB_USER', 'wpuser');\n"
+            f"define('DB_PASSWORD', '{_SECRET_PW}');\n"
+            "define('DB_HOST', 'localhost:3307');\n")
+    c = DBCredentialScanner().parse(text)[0]
+    assert c.engine == "mysql" and c.user == "wpuser" and c.port == 3307
+    assert c.database == "wp" and c.password == _SECRET_PW
+
+
+def test_scanner_parses_docker_postgres():
+    text = ("===FILE:/srv/.env===\nPOSTGRES_USER=pg\n"
+            f"POSTGRES_PASSWORD={_SECRET_PW}\nPOSTGRES_DB=app\n")
+    c = DBCredentialScanner().parse(text)[0]
+    assert c.engine == "postgres" and c.user == "pg" and c.database == "app"
+
+
+def test_scanner_skips_unusable_and_dedupes():
+    text = (
+        "===FILE:/a/.env===\nDB_HOST=h\n"  # no password → unusable
+        "===FILE:/b/.env===\nDB_HOST=h2\nDB_USERNAME=u\nDB_PASSWORD=p\n"
+        "===FILE:/c/.env===\nDB_HOST=h2\nDB_USERNAME=u\nDB_PASSWORD=p\n"  # dup of b
+    )
+    cands = DBCredentialScanner().parse(text)
+    assert len(cands) == 1  # unusable skipped, duplicate collapsed
+
+
+def test_redact_masks_password():
+    c = DBCandidate("mysql", "h", 3306, "u", _SECRET_PW)
+    r = redact(c)
+    assert _SECRET_PW not in str(r)
+    assert r["password_preview"].startswith("****")
+
+
+def test_db_setup_scan_stages_without_leaking_password():
+    t = _tools()
+    t._find_instance = _async_return({"id": "i-1", "name": "web"})  # type: ignore
+    dump = ("===FILE:/var/www/app/.env===\nDB_CONNECTION=mysql\nDB_HOST=127.0.0.1\n"
+            f"DB_PORT=3306\nDB_USERNAME=app\nDB_PASSWORD={_SECRET_PW}\nDB_DATABASE=appdb\n")
+    t._exec_ssh = _async_return((dump, ""))  # type: ignore
+    out = asyncio.run(t.db_setup_scan("i-1"))
+    # The plaintext password must NEVER appear in the model-facing result...
+    assert _SECRET_PW not in out
+    assert "token=dbstg_" in out and "****" in out
+    # ...but it IS held server-side for the commit step.
+    assert len(t._db_staging) == 1
+    assert list(t._db_staging.values())[0].password == _SECRET_PW
+    # ...and never reaches the audit trail either.
+    audit_blob = str([c.args for c in t._audit.log.call_args_list])
+    assert _SECRET_PW not in audit_blob
+
+
+def test_db_setup_save_commits_and_consumes_token():
+    t = _tools()
+    sp = MagicMock(); sp.set_secret = AsyncMock()
+    t._secret_provider = sp
+    t._db_staging["tok1"] = DBCandidate(
+        "mysql", "127.0.0.1", 3306, "app", _SECRET_PW, "appdb", "/x/.env")
+    out = asyncio.run(t.db_setup_save("tok1", instance_id="web"))
+    assert "Saved db_profile for web" in out
+    assert _SECRET_PW not in out
+    # Secret stored with the plaintext; result/audit carry only the key name.
+    name, value = sp.set_secret.call_args.args
+    assert name == "db/web" and value == _SECRET_PW
+    t._config_manager.update.assert_called_once()
+    assert "tok1" not in t._db_staging  # token consumed
+    audit_blob = str([c.args for c in t._audit.log.call_args_list])
+    assert _SECRET_PW not in audit_blob
+
+
+def test_db_setup_save_unknown_token():
+    t = _tools()
+    t._secret_provider = MagicMock()
+    out = asyncio.run(t.db_setup_save("nope"))
+    assert "unknown or expired" in out
+
+
+def test_db_setup_save_no_secret_provider():
+    t = _tools(secret_provider=None)
+    t._db_staging["tok"] = DBCandidate("mysql", "h", 3306, "u", _SECRET_PW)
+    out = asyncio.run(t.db_setup_save("tok"))
+    assert "no secret store" in out.lower()
+
+
+@pytest.mark.parametrize("tool", ["db_setup_scan", "db_setup_save"])
+def test_db_setup_tools_standard_tier(tool):
+    cfg = AppConfig(); cfg.mcp.guard_level = GuardLevel.READONLY
+    assert not CommandGuard(cfg.mcp).check_tool(tool)[0]
+    cfg.mcp.guard_level = GuardLevel.STANDARD
+    assert CommandGuard(cfg.mcp).check_tool(tool)[0]
+
+
+# ---------------------------------------------------------------------------
+# Feedback round: Joomla/Magento scanner, FPM/load-per-core, rule collapse
+# ---------------------------------------------------------------------------
+
+def test_scanner_parses_joomla_configuration():
+    text = (
+        "===FILE:/var/www/shop/configuration.php===\n<?php\nclass JConfig {\n"
+        "public $dbtype = 'mysqli';\npublic $host = 'db.internal';\n"
+        "public $user = 'joomla';\n"
+        f"public $password = '{_SECRET_PW}';\npublic $db = 'shop';\n"
+        "public $dbprefix = 'jos_';\n}\n"
+    )
+    c = DBCredentialScanner().parse(text)[0]
+    assert c.engine == "mysql" and c.host == "db.internal" and c.user == "joomla"
+    assert c.database == "shop" and c.password == _SECRET_PW
+
+
+def test_scanner_joomla_pgsql_engine():
+    text = ("===FILE:/srv/site/configuration.php===\n"
+            "public $dbtype = 'pgsql';\npublic $host = 'h';\npublic $user = 'u';\n"
+            f"public $password = '{_SECRET_PW}';\npublic $db = 'd';\n")
+    assert DBCredentialScanner().parse(text)[0].engine == "postgres"
+
+
+def test_scanner_parses_magento_env():
+    text = (
+        "===FILE:/var/www/m/app/etc/env.php===\n<?php return ['db'=>['connection'=>"
+        "['default'=>[\n'host' => 'localhost',\n'dbname' => 'magento',\n"
+        f"'username' => 'mage',\n'password' => '{_SECRET_PW}',\n]]]];\n"
+    )
+    c = DBCredentialScanner().parse(text)[0]
+    assert c.engine == "mysql" and c.user == "mage"
+    assert c.database == "magento" and c.password == _SECRET_PW
+
+
+def test_scan_command_includes_joomla_magento():
+    cmd = DBCredentialScanner.build_scan_command()
+    assert "configuration.php" in cmd and "env.php" in cmd and "wp-config.php" in cmd
+
+
+def test_fleet_row_load_per_core_and_fpm():
+    probe = ("LOAD=8.0 4.0 2.0\nCPU=4\nMEM=16000 8000 8000\n"
+             "FPM=80/80\nSTACK= nginx php-fpm\nLISTEN=80,443,")
+    row = fleet_row_from_probe("busy", probe)
+    assert row["cores"] == "4"
+    assert row["load_per_core"] == "2.00"  # 8.0 / 4 — the triage ratio
+    assert row["fpm"] == "80/80"
+
+
+def test_fleet_row_no_data_becomes_error():
+    row = fleet_row_from_probe("weird", "some ssh login banner, no KEY=VALUE\n")
+    assert row.get("error") and "no probe data" in row["error"]
+
+
+def test_fleet_table_has_cores_and_lcore_headers():
+    row = fleet_row_from_probe("h", "LOAD=1.0 1 1\nCPU=2\nMEM=4000 1000 3000\nFPM=\nSTACK= nginx\nLISTEN=80,")
+    out = format_fleet_table([row])
+    assert "Cores" in out and "L/core" in out and "CPU" not in out.split("\n")[0]
+
+
+def test_format_ingress_collapses_and_surfaces_webacl_first():
+    topo = {
+        "instance_id": "i-1", "region": "eu-west-1",
+        "target_groups": [{"name": "shop-tg", "arn": "a", "port": 443,
+                           "protocol": "HTTPS", "target_state": "healthy"}],
+        "load_balancers": [{
+            "arn": "lb", "dns_name": "x.elb", "type": "application",
+            "scheme": "internet-facing",
+            "listeners": [{"port": 443, "protocol": "HTTPS", "rules": [
+                {"priority": "1", "conditions": ["host-header=shop.example"],
+                 "actions": ["forward"], "targets_our_tg": True},
+                {"priority": "2", "conditions": ["host-header=other.example"],
+                 "actions": ["forward"], "targets_our_tg": False},
+                {"priority": "3", "conditions": ["host-header=z.example"],
+                 "actions": ["forward"], "targets_our_tg": False},
+            ]}],
+            "web_acl": {"name": "ELB-WAF-ACL", "default_action": "allow",
+                        "ip_sets": [], "rate_rules": [
+                            {"rule": "Rate_limit_shop", "limit_per_5min": 1000,
+                             "aggregate_key": "IP"}]},
+        }],
+        "errors": [],
+    }
+    out = format_ingress_path(topo, True)
+    # WebACL gold surfaced before the load-balancer detail.
+    assert out.index("WAF / WebACL") < out.index("Load balancers")
+    assert "Rate_limit_shop" in out and "1000/5min" in out
+    # Matching rule shown + marked; non-matching collapsed to a count.
+    assert "shop.example" in out and "←this instance" in out
+    assert "+2 other rule(s)" in out
+    assert "other.example" not in out
+    # verbose shows everything.
+    assert "other.example" in format_ingress_path(topo, True, verbose=True)

--- a/tests/test_mcp_aws_security_tools.py
+++ b/tests/test_mcp_aws_security_tools.py
@@ -260,14 +260,15 @@ class TestIPBanSet:
         svc.ban_ip.assert_not_called()
 
     def test_ban_success(self):
+        # Enhanced ip_ban_set returns an applied/failed split (not "OK:/Failed:").
         svc = MagicMock()
         svc.ban_ip = AsyncMock(
             return_value={"success": True, "message": "Banned 1.2.3.4 via WAF IP set"}
         )
         tools = _make_tools(ip_ban_service=svc)
         out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="ban"))
-        assert out.startswith("OK: ")
-        assert "Banned 1.2.3.4" in out
+        assert "Banned (1): 1.2.3.4" in out
+        assert "reverse_hint: ip_ban_set action=unban" in out
         svc.ban_ip.assert_awaited_once_with("1.2.3.4", "prod-waf")
 
     def test_unban_dispatch(self):
@@ -277,7 +278,7 @@ class TestIPBanSet:
         )
         tools = _make_tools(ip_ban_service=svc)
         out = _run(tools.ip_ban_set("1.2.3.4", "prod-waf", action="unban"))
-        assert out.startswith("OK: ")
+        assert "Unbanned (1): 1.2.3.4" in out
         svc.unban_ip.assert_awaited_once_with("1.2.3.4", "prod-waf")
 
     def test_ban_failure_surfaces_message(self):
@@ -287,5 +288,5 @@ class TestIPBanSet:
         )
         tools = _make_tools(ip_ban_service=svc)
         out = _run(tools.ip_ban_set("nope", "prod-waf", action="ban"))
-        assert out.startswith("Failed: ")
+        assert "Failed (1)" in out
         assert "Invalid IP address" in out

--- a/tests/test_mcp_tool_list_gating.py
+++ b/tests/test_mcp_tool_list_gating.py
@@ -57,7 +57,13 @@ def test_hetzner_gate_drops_only_hetzner_tools():
 
 def test_ip_ban_gate_drops_only_ip_ban_tools():
     off = _names(have_ip_ban=False)
-    assert not any(n.startswith("ip_ban_") for n in off)
+    # The ip_ban *inventory* tools are gated on a ban config existing.
+    assert "ip_ban_list_configs" not in off
+    assert "ip_ban_list_banned" not in off
+    # ip_ban_set is intentionally UNGATED: its `site` path resolves the WebACL
+    # fronting an ALB/instance and needs no pre-defined config, so it must stay
+    # available even when no ip_ban_configs exist.
+    assert "ip_ban_set" in off
     # CloudWatch/CloudTrail share the security theme but are NOT gated.
     assert "cloudwatch_top_ips" in off and "cloudtrail_lookup_events" in off
 


### PR DESCRIPTION
## Summary

Adds a suite of MCP/chat tools for diagnosing and mitigating live incidents on managed instances, plus zero-config database credential setup. Everything runs through the existing MCP guard tiers and audit trail; mutating tools follow the confirmation protocol.

## Diagnostics (read-only)

- **`web_traffic_summary`** — per-vhost req/s, status-code mix, top client IPs and URLs from a box's own access logs (X-Forwarded-For / `mod_remoteip` aware).
- **`fleet_health_snapshot`** — load, cores, load-per-core, memory %, php-fpm pool saturation and web stack across all instances in one table.
- **`describe_ingress_path`** — instance → target groups → load balancer/listeners → WebACL (IP sets + rate rules), with `mod_remoteip` trust detection. WebACL summary surfaced first; listener rules collapse to the one(s) routing to the instance (`verbose=true` shows all). Partial results when IAM scope is incomplete.
- **`rds_metrics`** — CPU, connections, CPU credit balance, read/write latency from CloudWatch.
- **`enrich_ips`** — reverse DNS, ASN/org, geolocation and abuse score for a list of IPs.
- **`cloudwatch_get_log_events`** — gains optional server-side `group_by`/`top_n`/`summary_only` aggregation so large pulls return a ranked summary instead of raw lines.

## Database introspection + setup

- **`db_processlist` / `db_top_queries`** — live sessions + connection saturation and heaviest queries. Uses a **native-client-or-PHP connector fallback**, so they work on boxes that have no `mysql`/`psql` client installed.
- **`db_setup_scan` / `db_setup_save` / `db_setup_remove`** — discover DB credentials from app config (`.env`, `DATABASE_URL`, `wp-config.php`, Joomla `configuration.php`, Magento `env.php`, docker env) and store them in the secret store. **Passwords are held server-side by an opaque token and never enter the model context.**
- **`servonaut db setup`** — interactive CLI for the same flow (no model exposure).

## Mitigation (dangerous tier, reversible)

- **`ip_ban_set`** — CIDR + bulk + `site`-resolved WebACL banning; applied/failed split + copy-pasteable reverse hint.
- **`waf_rate_rule_set`** — create / update / remove a WAF rate-based rule (reports prior state so updates are reversible).
- **`block_ip`** — layer-agnostic (WebACL / SG / NACL / host) blocking that explains which layer it chose and why, with reverse hints.

## Resilient exec

- **`run_command`** gains `transport=auto|ssh|ssm` with automatic SSH → AWS SSM failover when the SSH connection is refused.

## Notes

- New services: log analysis, IP enrichment, ingress-path walk, RDS metrics, SSM exec, WAF management, DB credential scanner. Config gains `db_profiles`.
- Secret handling: DB passwords go to the active secret store via env (never the client's argv), are never written to the audit trail, and never returned in a tool result.
- The catalog-drift CI gate and the chat tool catalog are kept in sync with the new tools.

## Testing

- New `tests/test_incident_response_tools.py` plus updates to catalog/dispatch/gating tests.
- Full suite green (the only failures in the local run are unrelated and pre-existing: the optional `hcloud` SDK isn't installed locally).
- Parsers and the generated shell/PHP fallbacks were validated against a real machine (`sh -n` + `php -l`).

> Note: the boto3 / remote-SSH paths are unit-tested with mocks; they were not exercised end-to-end against a live AWS account in CI.
