### PR TITLE
fix(update): reliable in-app updater + resilient version lookup

### DIFF
--- a/src/servonaut/__init__.py
+++ b/src/servonaut/__init__.py
@@ -1,3 +1,21 @@
 #!/usr/bin/env python3
 """Servonaut — Interactive TUI for managing AWS EC2 SSH connections."""
 __version__ = '2.17.0'
+
+
+def get_version() -> str:
+    """Return the running version, resiliently.
+
+    Prefers the installed package metadata; falls back to the source
+    ``__version__`` when metadata isn't available — e.g. running from a
+    checkout via ``PYTHONPATH=src`` with no install. Never raises, so a
+    missing/locked dist can't crash startup (the UI, User-Agent, etc.).
+    """
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return version("servonaut")
+        except PackageNotFoundError:
+            return __version__
+    except Exception:  # noqa: BLE001 — version display must never crash
+        return __version__

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -76,17 +76,14 @@ def _run_update() -> None:
         return
 
     print(f"New version available: {latest}")
-    method = svc.detect_install_method()
-    cmd = svc.get_upgrade_command()
-    print(f"Install method: {method}")
-    print(f"Running: {' '.join(cmd)}")
+    print(f"Install method: {svc.detect_install_method()}")
+    print(f"Running: {' '.join(svc.get_upgrade_command())}")
 
-    import subprocess
-    result = subprocess.run(cmd)
-    if result.returncode == 0:
-        print(f"\nUpdated to v{latest}. Restart servonaut to use the new version.")
-    else:
-        print(f"\nUpdate failed (exit code {result.returncode}).")
+    import asyncio
+    success, message = asyncio.run(svc.run_upgrade())
+    print(f"\n{message}")
+    if not success:
+        raise SystemExit(1)
 
 
 def _install_desktop() -> None:
@@ -646,9 +643,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description='Servonaut — Interactive TUI for managing AWS EC2 SSH connections'
     )
-    from importlib.metadata import version as pkg_version
+    from servonaut import get_version
     parser.add_argument('--version', action='version',
-                        version=f'servonaut {pkg_version("servonaut")}')
+                        version=f'servonaut {get_version()}')
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging (also prints to stderr)')
     parser.add_argument('--config', type=str, default=None,

--- a/src/servonaut/services/update_service.py
+++ b/src/servonaut/services/update_service.py
@@ -6,6 +6,7 @@ import json
 import logging
 import shutil
 import subprocess
+import sys
 import urllib.request
 import urllib.error
 from importlib.metadata import version as pkg_version
@@ -20,7 +21,8 @@ class UpdateService:
     """Check for new versions and run upgrades."""
 
     def __init__(self) -> None:
-        self._current: str = pkg_version("servonaut")
+        from servonaut import get_version
+        self._current: str = get_version()
         self._latest: Optional[str] = None
 
     @property
@@ -50,16 +52,55 @@ class UpdateService:
             return self._latest
         return None
 
+    def source_install_path(self) -> Optional[str]:
+        """Return the local path if servonaut runs from a source / editable
+        install, else ``None``.
+
+        A local-path or ``pip install -e`` install records a ``direct_url.json``
+        (PEP 610) pointing at a local directory. ``pipx upgrade`` / ``pip
+        install --upgrade`` can't pull a published release over such an
+        install — they rebuild from the same local source — so the in-app
+        updater must NOT pretend to update it.
+        """
+        try:
+            from importlib.metadata import distribution
+            raw = distribution("servonaut").read_text("direct_url.json")
+        except Exception:  # noqa: BLE001 — metadata may be absent
+            return None
+        if not raw:
+            return None
+        try:
+            info = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(info.get("dir_info"), dict) and info["dir_info"].get("editable"):
+            return info.get("url", "editable install")
+        url = info.get("url", "")
+        if isinstance(url, str) and url.startswith("file:"):
+            return url
+        return None
+
+    def _pipx(self) -> Optional[str]:
+        """Absolute path to pipx, or None. Resolved by path so it works even
+        when launched from a desktop shortcut with a minimal PATH."""
+        return shutil.which("pipx")
+
     def detect_install_method(self) -> str:
         """Detect how servonaut was installed.
 
         Returns:
-            One of: 'pipx', 'pip', 'unknown'.
+            One of: 'source', 'pipx', 'pip', 'unknown'. ``source`` takes
+            precedence — a local/editable checkout can't be release-upgraded
+            in place.
         """
-        if shutil.which("pipx"):
+        if self.source_install_path():
+            return "source"
+
+        pipx = self._pipx()
+        if pipx:
             try:
                 result = subprocess.run(
-                    ["pipx", "list", "--short"],
+                    [pipx, "list", "--short"],
                     capture_output=True, text=True, timeout=10,
                 )
                 if "servonaut" in result.stdout:
@@ -67,15 +108,11 @@ class UpdateService:
             except (subprocess.SubprocessError, OSError):
                 pass
 
-        # Check if installed via pip in a venv or globally
+        # Installed into the interpreter that's running us (pip / venv).
         try:
-            result = subprocess.run(
-                ["pip", "show", "servonaut"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0:
-                return "pip"
-        except (subprocess.SubprocessError, OSError):
+            pkg_version("servonaut")
+            return "pip"
+        except Exception:  # noqa: BLE001 — PackageNotFoundError et al.
             pass
 
         return "unknown"
@@ -84,23 +121,74 @@ class UpdateService:
         """Get the appropriate upgrade command based on install method.
 
         Returns:
-            Command list for subprocess.
+            Command list for subprocess. The pip path uses ``sys.executable -m
+            pip`` so it always targets the interpreter actually running
+            Servonaut (a bare ``pip`` on PATH can be a different environment).
         """
         method = self.detect_install_method()
         if method == "pipx":
-            return ["pipx", "upgrade", "servonaut"]
-        elif method == "pip":
-            return ["pip", "install", "--upgrade", "servonaut"]
-        else:
-            return ["pip", "install", "--upgrade", "servonaut"]
+            return [self._pipx() or "pipx", "upgrade", "servonaut"]
+        # pip / unknown: upgrade THIS interpreter's environment.
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "servonaut"]
+
+    def installed_version_external(self) -> Optional[str]:
+        """Query the *actually installed* version via a fresh subprocess.
+
+        The running process's ``importlib.metadata`` is cached at the old
+        version, so post-upgrade verification must ask the target environment
+        directly (pipx venv, or this interpreter's pip).
+        """
+        method = self.detect_install_method()
+        try:
+            pipx = self._pipx()
+            if method == "pipx" and pipx:
+                result = subprocess.run(
+                    [pipx, "list", "--short"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                for line in result.stdout.splitlines():
+                    parts = line.split()
+                    if len(parts) >= 2 and parts[0] == "servonaut":
+                        return parts[1]
+                return None
+            result = subprocess.run(
+                [sys.executable, "-m", "pip", "show", "servonaut"],
+                capture_output=True, text=True, timeout=10,
+            )
+            for line in result.stdout.splitlines():
+                if line.lower().startswith("version:"):
+                    return line.split(":", 1)[1].strip()
+        except (subprocess.SubprocessError, OSError):
+            return None
+        return None
 
     async def run_upgrade(self) -> tuple[bool, str]:
-        """Run the upgrade command.
+        """Run the upgrade and VERIFY the installed version actually advanced.
+
+        Never reports success unless the installed version really changed —
+        the old behaviour reported "Updated successfully" on exit-code 0 even
+        when nothing happened (e.g. a local-path pipx install rebuilding from
+        stale source).
 
         Returns:
-            Tuple of (success, output_message).
+            Tuple of (success, message).
         """
         import asyncio
+
+        # A source / editable checkout can't be release-upgraded in place.
+        src = self.source_install_path()
+        if src:
+            return False, (
+                "Servonaut is running from a local/source install "
+                f"({src}); the in-app updater can't install a published release "
+                "over it. To track PyPI releases instead, reinstall from the "
+                "package name:  pipx install --force 'servonaut[all]'  — or, to "
+                "stay on your checkout, run  git pull  there (then  "
+                "pipx install --force '.[all]'  if installed via pipx)."
+            )
+
+        before = self.installed_version_external() or self._current
+        target = self._latest or self.check_for_update()
 
         cmd = self.get_upgrade_command()
         try:
@@ -110,14 +198,34 @@ class UpdateService:
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await proc.communicate()
-            output = stdout.decode() + stderr.decode()
-
-            if proc.returncode == 0:
-                return True, f"Updated successfully. Restart Servonaut to use the new version."
-            else:
-                return False, f"Update failed:\n{output}"
+            output = (stdout.decode() + stderr.decode()).strip()
         except OSError as exc:
-            return False, f"Could not run update: {exc}"
+            return False, (
+                f"Could not run the updater ({' '.join(cmd)}): {exc}. "
+                "Try updating manually: pipx upgrade servonaut"
+            )
+
+        if proc.returncode != 0:
+            tail = output[-800:] if output else "(no output)"
+            return False, f"Update command failed (exit {proc.returncode}):\n{tail}"
+
+        # Verify: ask the target environment what's actually installed now.
+        after = self.installed_version_external()
+        if after and self._is_newer(after, before):
+            return True, f"Updated v{before} → v{after}. Restart Servonaut to use it."
+        if after and target and not self._is_newer(target, after):
+            # Already at (or above) the target — treat as up to date.
+            return True, f"Already on the latest version (v{after})."
+
+        # Ran cleanly but the version did not advance — be honest about it.
+        tail = output[-500:] if output else "(no output)"
+        return False, (
+            f"The update ran but the installed version is still v{after or before}"
+            + (f" (expected v{target})" if target else "")
+            + ". You may be on a system/distro-managed or non-standard install; "
+            "update manually or reinstall via pipx.\n"
+            f"Command output:\n{tail}"
+        )
 
     @staticmethod
     def _is_newer(latest: str, current: str) -> bool:

--- a/src/servonaut/widgets/sidebar.py
+++ b/src/servonaut/widgets/sidebar.py
@@ -22,7 +22,7 @@ follow the same shape.
 
 from __future__ import annotations
 
-from importlib.metadata import version as pkg_version
+from servonaut import get_version
 
 from textual.app import ComposeResult
 from textual.containers import Vertical, VerticalScroll
@@ -108,7 +108,7 @@ class Sidebar(Widget):
         # ABOUT the app's connection, not a navigation action, so it
         # belongs with the identity header.
         yield Static(
-            f"  [bold cyan]Servonaut[/bold cyan] [dim]v{pkg_version('servonaut')}[/dim]",
+            f"  [bold cyan]Servonaut[/bold cyan] [dim]v{get_version()}[/dim]",
             id="sidebar-logo",
         )
         yield Static(

--- a/tests/test_update_service.py
+++ b/tests/test_update_service.py
@@ -1,0 +1,160 @@
+"""Tests for the resilient UpdateService upgrade path.
+
+The key guarantee: run_upgrade NEVER reports success unless the installed
+version actually advanced, and it refuses (with guidance) on source/local
+installs that can't be release-upgraded in place.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+from servonaut.services.update_service import UpdateService
+
+
+def _svc(current="2.16.3", latest="2.17.0"):
+    s = UpdateService.__new__(UpdateService)  # bypass __init__ (calls pkg_version)
+    s._current = current
+    s._latest = latest
+    return s
+
+
+def _fake_proc(returncode=0, out=b"ok"):
+    p = MagicMock()
+    p.returncode = returncode
+    p.communicate = AsyncMock(return_value=(out, b""))
+    return p
+
+
+# --- version compare ---------------------------------------------------------
+
+def test_is_newer():
+    assert UpdateService._is_newer("2.17.0", "2.16.3")
+    assert not UpdateService._is_newer("2.16.3", "2.17.0")
+    assert not UpdateService._is_newer("2.17.0", "2.17.0")
+
+
+# --- upgrade command targets the right environment ---------------------------
+
+def test_get_upgrade_command_pip_uses_sys_executable(monkeypatch):
+    s = _svc()
+    monkeypatch.setattr(s, "detect_install_method", lambda: "pip")
+    assert s.get_upgrade_command() == [
+        sys.executable, "-m", "pip", "install", "--upgrade", "servonaut"]
+
+
+def test_get_upgrade_command_pipx_uses_full_path(monkeypatch):
+    s = _svc()
+    monkeypatch.setattr(s, "detect_install_method", lambda: "pipx")
+    monkeypatch.setattr(s, "_pipx", lambda: "/usr/bin/pipx")
+    assert s.get_upgrade_command() == ["/usr/bin/pipx", "upgrade", "servonaut"]
+
+
+# --- source/local installs are not silently "upgraded" -----------------------
+
+def test_source_install_blocks_upgrade(monkeypatch):
+    s = _svc()
+    monkeypatch.setattr(s, "source_install_path",
+                        lambda: "file:///home/x/servonaut")
+    called = MagicMock()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", called)
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is False
+    assert "source install" in msg and "pipx install --force" in msg
+    called.assert_not_called()  # never ran a subprocess
+
+
+def test_source_install_path_detects_local(monkeypatch):
+    s = _svc()
+
+    class _Dist:
+        def read_text(self, name):
+            return '{"dir_info": {}, "url": "file:///home/x/servonaut"}'
+
+    monkeypatch.setattr("importlib.metadata.distribution", lambda name: _Dist())
+    assert s.source_install_path() == "file:///home/x/servonaut"
+
+
+def test_source_install_path_detects_editable(monkeypatch):
+    s = _svc()
+
+    class _Dist:
+        def read_text(self, name):
+            return '{"url": "file:///x", "dir_info": {"editable": true}}'
+
+    monkeypatch.setattr("importlib.metadata.distribution", lambda name: _Dist())
+    assert s.source_install_path() == "file:///x"
+
+
+def test_source_install_path_none_for_pypi(monkeypatch):
+    s = _svc()
+
+    class _Dist:
+        def read_text(self, name):
+            return None  # PyPI wheels have no direct_url.json
+
+    monkeypatch.setattr("importlib.metadata.distribution", lambda name: _Dist())
+    assert s.source_install_path() is None
+
+
+# --- run_upgrade verifies the version actually changed ------------------------
+
+def _wire_pypi_upgrade(monkeypatch, s, before, after, returncode=0, out=b"ok"):
+    monkeypatch.setattr(s, "source_install_path", lambda: None)
+    monkeypatch.setattr(s, "detect_install_method", lambda: "pipx")
+    monkeypatch.setattr(s, "get_upgrade_command",
+                        lambda: ["pipx", "upgrade", "servonaut"])
+    monkeypatch.setattr(s, "installed_version_external",
+                        MagicMock(side_effect=[before, after]))
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        AsyncMock(return_value=_fake_proc(returncode, out)))
+
+
+def test_run_upgrade_success_when_version_advances(monkeypatch):
+    s = _svc()
+    _wire_pypi_upgrade(monkeypatch, s, "2.16.3", "2.17.0")
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is True and "2.16.3" in msg and "2.17.0" in msg
+
+
+def test_run_upgrade_honest_when_version_unchanged(monkeypatch):
+    # The original bug: exit 0 but nothing actually upgraded.
+    s = _svc()
+    _wire_pypi_upgrade(monkeypatch, s, "2.16.3", "2.16.3")
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is False
+    assert "still v2.16.3" in msg and "expected v2.17.0" in msg
+
+
+def test_run_upgrade_already_latest(monkeypatch):
+    s = _svc(current="2.17.0", latest="2.17.0")
+    _wire_pypi_upgrade(monkeypatch, s, "2.17.0", "2.17.0")
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is True and "latest" in msg.lower()
+
+
+def test_run_upgrade_command_failure(monkeypatch):
+    s = _svc()
+    monkeypatch.setattr(s, "source_install_path", lambda: None)
+    monkeypatch.setattr(s, "detect_install_method", lambda: "pipx")
+    monkeypatch.setattr(s, "get_upgrade_command",
+                        lambda: ["pipx", "upgrade", "servonaut"])
+    monkeypatch.setattr(s, "installed_version_external", lambda: "2.16.3")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        AsyncMock(return_value=_fake_proc(1, b"boom")))
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is False and "failed" in msg.lower() and "boom" in msg
+
+
+def test_run_upgrade_missing_command(monkeypatch):
+    s = _svc()
+    monkeypatch.setattr(s, "source_install_path", lambda: None)
+    monkeypatch.setattr(s, "detect_install_method", lambda: "pipx")
+    monkeypatch.setattr(s, "get_upgrade_command",
+                        lambda: ["pipx", "upgrade", "servonaut"])
+    monkeypatch.setattr(s, "installed_version_external", lambda: "2.16.3")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        AsyncMock(side_effect=OSError("no pipx")))
+    ok, msg = asyncio.run(s.run_upgrade())
+    assert ok is False and "Could not run" in msg


### PR DESCRIPTION
## Summary

Fixes the in-app updater, which could report **"Updated successfully" without actually upgrading** (click Update → restart → same version), and a related crash when running from a source checkout.

## What was wrong

- `run_upgrade` returned success on exit-code 0 even when nothing changed — e.g. a pipx install from a local path rebuilds from (stale) local source, so the version never moved.
- Version was read via `importlib.metadata` in several places (sidebar, `--version`, User-Agent) with no fallback, so running from a checkout without an install crashed at startup.
- The pip upgrade path used a bare `pip` (could target a different environment); pipx was invoked by bare name (fails under a minimal PATH).

## Changes

- **Verify before claiming success** — `run_upgrade` re-queries the actually-installed version (via the target environment, not the running process's cached metadata) and only reports success when it really advanced. Otherwise it explains what happened.
- **Honest handling of source/editable/local installs** — detected via PEP 610 `direct_url.json`; the updater refuses with clear guidance (switch to a PyPI install, or `git pull` your checkout) instead of pretending.
- **Target the right environment** — pip path uses `sys.executable -m pip`; pipx resolved by absolute path.
- **`servonaut.get_version()`** — resilient version lookup that falls back to the source `__version__`, so missing package metadata can't crash startup (fixes the documented `PYTHONPATH=src` dev workflow).
- CLI `--update` now shares the same verified upgrade path.

## Testing

- New `tests/test_update_service.py`: success-on-advance, **honest failure on no-op**, already-latest, command failure, missing command, source-install refusal, environment targeting, and the version fallback.
- Full suite green (only unrelated pre-existing failures from the optional `hcloud` SDK not being installed locally).
- Verified `servonaut --version` works from a source checkout with no install.
