### PR TITLE
feat(mcp): generic AWS passthrough, Logs Insights, control-plane STS factory

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -265,6 +265,11 @@ class ServonautApp(App):
         from servonaut.services.aws_audit import AWSAuditLogger
         from servonaut.services.object_storage_factory import build_object_storage_services
         self.aws_audit = AWSAuditLogger(config.aws.audit_path)
+        # Shared boto3 client factory — control-plane STS role / region pinning.
+        # Backs aws_call + CloudWatch reads; defaults to the ambient credential
+        # chain when no control-plane role is configured (no behaviour change).
+        from servonaut.services.aws_client_factory import build_aws_client_factory
+        self.aws_client_factory = build_aws_client_factory(config)
         # Delegate object-storage construction to the shared factory so that
         # the headless MCP server (mcp/server.py) reuses the same logic.
         (
@@ -282,7 +287,9 @@ class ServonautApp(App):
         self.custom_server_service = CustomServerService(self.config_manager)
         self.log_viewer_service = LogViewerService(self.config_manager)
         self.cloudtrail_service = CloudTrailService(self.config_manager)
-        self.cloudwatch_service = CloudWatchService()
+        self.cloudwatch_service = CloudWatchService(
+            client_factory=self.aws_client_factory
+        )
         self.ip_ban_service = IPBanService(self.config_manager)
         from servonaut.services.memory import MemoryService
         from servonaut.services.memory.store import MemoryStore
@@ -419,6 +426,7 @@ class ServonautApp(App):
             cloudtrail_service=self.cloudtrail_service,
             cloudwatch_service=self.cloudwatch_service,
             ip_ban_service=self.ip_ban_service,
+            aws_client_factory=self.aws_client_factory,
             auth_service=self.auth_service,
             memory_service=self.memory_service,
             aws_object_storage_service=self.aws_object_storage_service,

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -297,6 +297,18 @@ class AWSConfig:
         cache_path: On-disk cache file path.
         audit_path: JSONL audit trail path for mutating EC2 operations.
         object_storage: S3 object storage credentials and endpoint override.
+        control_plane_role_arn: Default IAM role ARN that Servonaut assumes (via
+            STS) for control-plane reads (SGs, WAF, ELB, logs, metrics). Empty
+            ("") means use the ambient credential chain (env / shared config /
+            host instance profile) exactly as before — no behaviour change.
+        control_plane_role_arns: Per-account override mapping ``account_id ->
+            role_arn``. Looked up first by the ``account`` argument; falls back
+            to ``control_plane_role_arn`` when the account is absent or unset.
+        control_plane_external_id: Optional STS ``ExternalId`` passed on
+            AssumeRole (confused-deputy hardening). Supports ``$ENV_VAR`` /
+            ``file:`` prefixes resolved at use time.
+        assume_role_session_name: ``RoleSessionName`` used on AssumeRole; shows
+            up in CloudTrail so control-plane reads are attributable.
     """
 
     enabled: bool = True
@@ -305,15 +317,30 @@ class AWSConfig:
     cache_path: str = "~/.servonaut/aws_cache.json"
     audit_path: str = "~/.servonaut/aws_audit.jsonl"
     object_storage: ObjectStorageConfig = field(default_factory=ObjectStorageConfig)
+    control_plane_role_arn: str = ""
+    control_plane_role_arns: Dict[str, str] = field(default_factory=dict)
+    control_plane_external_id: str = ""  # supports $ENV_VAR / file: prefix
+    assume_role_session_name: str = "servonaut-control-plane"
+    # Separate write-capable role for the aws_call mutate path. The control-
+    # plane read role is intentionally read-only (the backstop), so mutations
+    # must NOT assume it — when no mutate role is set, the aws_call write path
+    # falls back to the ambient credential chain instead of the read role.
+    control_plane_mutate_role_arn: str = ""
+    control_plane_mutate_role_arns: Dict[str, str] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         """Custom repr that redacts any nested secrets."""
+        ext_repr = "'<set>'" if self.control_plane_external_id else "''"
         return (
             f"AWSConfig(enabled={self.enabled!r}, "
             f"default_region={self.default_region!r}, "
             f"cache_ttl_seconds={self.cache_ttl_seconds!r}, "
             f"cache_path={self.cache_path!r}, "
             f"audit_path={self.audit_path!r}, "
+            f"control_plane_role_arn={self.control_plane_role_arn!r}, "
+            f"control_plane_role_arns={self.control_plane_role_arns!r}, "
+            f"control_plane_external_id={ext_repr}, "
+            f"assume_role_session_name={self.assume_role_session_name!r}, "
             f"object_storage={self.object_storage!r})"
         )
 

--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -70,7 +70,12 @@ class CommandGuard:
             # AWS CloudWatch Logs / CloudTrail — purely read-only AWS API
             # queries (describe / filter / lookup); they mutate nothing.
             'cloudwatch_list_log_groups', 'cloudwatch_get_log_events',
-            'cloudwatch_top_ips', 'cloudtrail_lookup_events',
+            'cloudwatch_top_ips', 'cloudwatch_insights', 'cloudtrail_lookup_events',
+            # Generic AWS read passthrough — verb-allowlisted to Describe/Get/
+            # List/Filter/Lookup at the tool layer, IAM is the real backstop.
+            # Read posture, so available at readonly tier like cloudwatch_*.
+            # The mutating path is gated separately via 'aws_call_mutate'.
+            'aws_call',
             # IP ban inventory — reads existing WAF/SG/NACL state only.
             'ip_ban_list_configs', 'ip_ban_list_banned',
             # AWS — readonly catalogue / inventory queries.
@@ -146,6 +151,11 @@ class CommandGuard:
             'hetzner_delete_ssh_key',
             # AWS — costs money / irreversible.
             'aws_terminate_instance', 'aws_run_instances',
+            # Generic AWS mutate passthrough — the write half of aws_call.
+            # Pseudo-tool checked only when aws_call is invoked with mutate=true,
+            # so arbitrary state changes require the dangerous tier (destructive
+            # delete/terminate verbs are still hard-refused at the tool layer).
+            'aws_call_mutate',
             # S3 — every mutation + presigned URL (URL is a bearer secret).
             's3_create_bucket', 's3_delete_bucket', 's3_upload_object',
             's3_delete_object', 's3_copy_object', 's3_move_object',

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -138,12 +138,17 @@ def create_mcp_server():
     cloudtrail_service = None
     cloudwatch_service = None
     ip_ban_service = None
+    # Shared boto3 client factory (control-plane STS role / region pinning).
+    # Built unconditionally so aws_call and CloudWatch reads share it; no role
+    # configured → ambient credential chain, exactly as before.
+    from servonaut.services.aws_client_factory import build_aws_client_factory
+    aws_client_factory = build_aws_client_factory(config)
     try:
         from servonaut.services.cloudtrail_service import CloudTrailService
         from servonaut.services.cloudwatch_service import CloudWatchService
         from servonaut.services.ip_ban_service import IPBanService
         cloudtrail_service = CloudTrailService(config_manager)
-        cloudwatch_service = CloudWatchService()
+        cloudwatch_service = CloudWatchService(client_factory=aws_client_factory)
         ip_ban_service = IPBanService(config_manager)
         logger.info("CloudWatch/CloudTrail/IP-ban services initialized for MCP")
     except Exception as e:
@@ -209,6 +214,7 @@ def create_mcp_server():
         cloudtrail_service=cloudtrail_service,
         cloudwatch_service=cloudwatch_service,
         ip_ban_service=ip_ban_service,
+        aws_client_factory=aws_client_factory,
         auth_service=auth_service,
         memory_service=memory_service,
         aws_object_storage_service=aws_object_storage_service,

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -919,7 +919,16 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 },
                 "filter_pattern": {
                     "type": "string",
-                    "description": "CloudWatch Logs filter pattern (optional).",
+                    "description": "CloudWatch Logs filter pattern (optional). A "
+                                   "bare literal (an IP, a path) is auto-quoted "
+                                   "so it matches reliably; JSON/space-delimited "
+                                   "patterns are passed through untouched.",
+                },
+                "client_ip": {
+                    "type": "string",
+                    "description": "Convenience: build the structured WAF/ALB "
+                                   "selector { $.httpRequest.clientIp = \"x\" } "
+                                   "for this IP. Overrides filter_pattern.",
                 },
                 "region": {
                     "type": "string",
@@ -994,6 +1003,114 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 },
             },
             "required": ["log_group"],
+        },
+        "chat_exposed": True,
+    },
+    "cloudwatch_insights": {
+        "description": (
+            "Run a CloudWatch Logs Insights query over one or more log groups. "
+            "The general aggregation primitive (top IPs, status mix, URI "
+            "ranking, time-bucketing) — use it when cloudwatch_top_ips doesn't "
+            "compute what you need. Provide a query plus log_group or log_groups."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Logs Insights query string, e.g. "
+                                   "'stats count(*) as hits by "
+                                   "httpRequest.clientIp | sort hits desc "
+                                   "| limit 20'.",
+                },
+                "log_group": {
+                    "type": "string",
+                    "description": "A single log group name (or use log_groups).",
+                },
+                "log_groups": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of log group names to query together.",
+                },
+                "hours_back": {
+                    "type": "integer",
+                    "description": "How many hours back the query window spans.",
+                    "default": 1,
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region (optional).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max rows Insights returns.",
+                    "default": 1000,
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": "Max seconds to wait for the query to finish.",
+                    "default": 60,
+                },
+            },
+            "required": ["query"],
+        },
+        "chat_exposed": True,
+    },
+    "aws_call": {
+        "description": (
+            "Generic boto3 passthrough for the AWS read surface: call any "
+            "Describe*/Get*/List*/Filter*/Lookup* operation that isn't pre-"
+            "wrapped (DescribeSecurityGroupRules, GetIPSet, GetWebACL, "
+            "FilterLogEvents, DescribeTargetHealth, …). operation is the boto3 "
+            "snake_case method name; params is the boto3 argument object "
+            "(PascalCase keys). Reads auto-paginate and run read-only. Mutating "
+            "ops need mutate=true AND dangerous guard mode; destructive verbs "
+            "(delete/terminate/destroy/purge) are always refused — use a "
+            "curated tool. region/account pin the call."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "service": {
+                    "type": "string",
+                    "description": "AWS service id, e.g. 'ec2', 'wafv2', "
+                                   "'elbv2', 'logs', 'rds'.",
+                },
+                "operation": {
+                    "type": "string",
+                    "description": "boto3 snake_case operation, e.g. "
+                                   "'describe_security_group_rules', "
+                                   "'get_ip_set', 'filter_log_events'.",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "boto3 argument object (PascalCase keys), e.g. "
+                                   "{\"GroupIds\": [\"sg-0abc\"]}.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": "AWS region. Empty uses the configured "
+                                   "default region.",
+                },
+                "account": {
+                    "type": "string",
+                    "description": "Account id selecting a per-account control-"
+                                   "plane role (optional).",
+                },
+                "mutate": {
+                    "type": "boolean",
+                    "description": "Required true to run a non-read operation "
+                                   "(still refused for destructive verbs).",
+                    "default": False,
+                },
+                "max_items": {
+                    "type": "integer",
+                    "description": "Cap on auto-paginated read items "
+                                   "(0 = default 1000).",
+                    "default": 0,
+                },
+            },
+            "required": ["service", "operation"],
         },
         "chat_exposed": True,
     },
@@ -1779,11 +1896,13 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     },
     "db_processlist": {
         "description": (
-            "Show an instance's live DB sessions + connection saturation. "
-            "MySQL/MariaDB: Threads_connected vs max_connections + SHOW FULL "
-            "PROCESSLIST. Postgres: non-idle pg_stat_activity. Requires a "
-            "db_profile for the instance; the password is read from your "
-            "secret store. Read-only query."
+            "Show an instance's DB connection saturation + a session summary. "
+            "By default SUMMARISES server-side (saturation, sessions grouped by "
+            "command/state with counts + oldest age, and the 10 longest-running "
+            "queries) instead of dumping every row. Pass full=true for the raw "
+            "SHOW FULL PROCESSLIST / pg_stat_activity dump. Requires a "
+            "db_profile for the instance; password from your secret store. "
+            "Read-only query."
         ),
         "schema": {
             "type": "object",
@@ -1791,6 +1910,12 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 "instance_id": {
                     "type": "string",
                     "description": "Instance ID, name, or custom-server name.",
+                },
+                "full": {
+                    "type": "boolean",
+                    "description": "Return the raw per-session dump instead of "
+                                   "the summary.",
+                    "default": False,
                 },
             },
             "required": ["instance_id"],

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import shlex
 import time
 from collections import deque
@@ -30,6 +31,24 @@ _API_REQUEST_MAX_PER_WINDOW = 30
 
 # Supported object-storage providers — single source of truth for validation.
 _S3_PROVIDERS: frozenset = frozenset({"aws", "hetzner", "ovh"})
+
+# --- aws_call passthrough -------------------------------------------------
+# boto3 operation names are snake_case (describe_security_group_rules, get_ip_set,
+# filter_log_events, …). These prefixes mark a call as a read; reads run at the
+# readonly guard tier (IAM is the real backstop). Anything else is "mutating".
+_AWS_READ_PREFIXES = (
+    "describe_", "get_", "list_", "filter_", "lookup_",
+    "head_", "batch_get_", "search_",
+)
+# Destructive verbs are refused even with mutate=true (the catastrophic-verb
+# blocklist). Irreversible / fleet- or data-destroying — use a curated tool.
+_AWS_DESTRUCTIVE_PREFIXES = ("delete_", "terminate_", "destroy_", "purge_")
+_AWS_SERVICE_RE = re.compile(r"^[a-z][a-z0-9-]{1,63}$")
+_AWS_OPERATION_RE = re.compile(r"^[a-z][a-z0-9_]{1,127}$")
+# Cap a single aws_call result so an over-broad Describe can't flood the model
+# context. Reads auto-paginate up to this many items when no max_items is given.
+_AWS_CALL_MAX_RESULT_CHARS = 200_000
+_AWS_CALL_DEFAULT_MAX_ITEMS = 1000
 
 
 def _error(code: str, message: str) -> Dict[str, Any]:
@@ -58,6 +77,7 @@ class ServonautTools:
                  hetzner_service=None,
                  cloudtrail_service=None, cloudwatch_service=None,
                  ip_ban_service=None,
+                 aws_client_factory=None,
                  auth_service=None, memory_service=None,
                  aws_object_storage_service=None,
                  hetzner_object_storage_service=None,
@@ -84,6 +104,10 @@ class ServonautTools:
         self._cloudtrail_service = cloudtrail_service
         self._cloudwatch_service = cloudwatch_service
         self._ip_ban_service = ip_ban_service
+        # Shared boto3 client factory (STS control-plane role / region pinning).
+        # Lazily built from config on first aws_call use when not injected, so
+        # the 4 minimal construction sites don't all need updating.
+        self._aws_client_factory = aws_client_factory
         self._auth_service = auth_service
         self._memory_service = memory_service
         self._aws_object_storage_service = aws_object_storage_service
@@ -1965,6 +1989,7 @@ class ServonautTools:
         self, log_group: str, hours_back: int = 1,
         filter_pattern: str = "", region: str = "", max_events: int = 100,
         group_by: str = "", top_n: int = 0, summary_only: bool = False,
+        client_ip: str = "",
     ) -> str:
         """Get recent log events from a CloudWatch log group.
 
@@ -1972,12 +1997,20 @@ class ServonautTools:
         ``group_by`` to ``clientIp``, ``status`` or ``uri`` to get back a
         server-side ranked summary (top ``top_n``, default 20) instead of raw
         lines. ``summary_only`` returns just the event count.
+
+        Filter handling: a bare ``filter_pattern`` literal (an IP, a path) is
+        auto-quoted before it reaches CloudWatch — a raw dotted string is
+        tokenised and silently fails to match otherwise. Pass ``client_ip`` to
+        build the structured WAF/ALB selector ``{ $.httpRequest.clientIp = "x" }``
+        server-side. An empty result is reported as "0 matched filter X",
+        never conflated with "the group is empty".
         """
         args = {
             'log_group': log_group, 'hours_back': hours_back,
             'filter_pattern': filter_pattern, 'region': region,
             'max_events': max_events, 'group_by': group_by,
             'top_n': top_n, 'summary_only': summary_only,
+            'client_ip': client_ip,
         }
         allowed, reason = self._guard.check_tool('cloudwatch_get_log_events')
         if not allowed:
@@ -1997,6 +2030,26 @@ class ServonautTools:
             return (f"Error: group_by must be 'clientIp', 'status', or 'uri'; "
                     f"got {group_by!r}.")
 
+        # Resolve the effective CloudWatch filter pattern. client_ip builds a
+        # structured selector; otherwise a bare literal term is auto-quoted.
+        raw_filter = (filter_pattern or "").strip()
+        if client_ip:
+            ip_arg = client_ip.strip()
+            try:
+                from ipaddress import ip_address
+                ip_address(ip_arg)
+            except ValueError:
+                self._audit.log(
+                    'cloudwatch_get_log_events', args, '', False, 'bad_client_ip',
+                )
+                return f"Error: client_ip {client_ip!r} is not a valid IP address."
+            effective_filter = '{ $.httpRequest.clientIp = "%s" }' % ip_arg
+        else:
+            effective_filter = self._cloudwatch_service.normalize_filter_pattern(
+                raw_filter
+            )
+        filter_rewritten = bool(effective_filter) and effective_filter != raw_filter
+
         from datetime import datetime, timedelta
         end_time = datetime.utcnow()
         start_time = end_time - timedelta(hours=max(int(hours_back), 1))
@@ -2004,7 +2057,7 @@ class ServonautTools:
         try:
             events = await self._cloudwatch_service.get_log_events(
                 log_group, start_time, end_time,
-                filter_pattern, region, max_events,
+                effective_filter, region, max_events,
             )
         except Exception as e:
             self._audit.log(
@@ -2014,6 +2067,16 @@ class ServonautTools:
 
         if not events:
             self._audit.log('cloudwatch_get_log_events', args, '0 events', True)
+            if effective_filter:
+                # Critical: a filtered empty result means "nothing matched",
+                # NOT "the group is empty" — conflating the two sent a live
+                # investigation toward a false WAF-bypass conclusion.
+                return (
+                    f"0 events matched filter {effective_filter!r} in {log_group} "
+                    f"over the last {hours_back}h. The group may still be "
+                    f"receiving traffic that doesn't match — re-run without a "
+                    f"filter (or with cloudwatch_top_ips) to confirm it's live."
+                )
             return f"No log events in {log_group} for the last {hours_back}h."
 
         # --- aggregation mode --------------------------------------------
@@ -2048,10 +2111,14 @@ class ServonautTools:
             self._audit.log('cloudwatch_get_log_events', args, result, True)
             return result
 
+        matched_note = " matched" if effective_filter else ""
         lines = [
             f"CloudWatch events: {log_group} "
-            f"(last {hours_back}h, {len(events)} events)"
+            f"(last {hours_back}h, {len(events)}{matched_note} events)"
         ]
+        if filter_rewritten:
+            lines.append(f"  (filter normalized to {effective_filter!r} so it "
+                         "matches reliably)")
         display = events
         if len(display) > self._max_lines:
             display = display[-self._max_lines:]
@@ -2150,6 +2217,234 @@ class ServonautTools:
         result = '\n'.join(lines)
         self._audit.log('cloudwatch_top_ips', args, result, True)
         return result
+
+    async def cloudwatch_insights(
+        self, query: str, log_groups: Optional[List[str]] = None,
+        log_group: str = "", hours_back: int = 1, region: str = "",
+        limit: int = 1000, timeout_seconds: int = 60,
+    ) -> str:
+        """Run a CloudWatch Logs Insights query over one or more log groups.
+
+        Insights is the general aggregation primitive — top IPs, status mix,
+        URI ranking, time-bucketing — so you don't need a bespoke parser per
+        question. Pass either ``log_group`` (single) or ``log_groups`` (list)
+        plus a ``query`` string, e.g.::
+
+            stats count(*) as hits by httpRequest.clientIp
+            | sort hits desc | limit 20
+        """
+        groups = list(log_groups or [])
+        if log_group:
+            groups.append(log_group)
+        groups = [g for g in (g.strip() for g in groups) if g]
+        args = {
+            'query': query, 'log_groups': groups, 'hours_back': hours_back,
+            'region': region, 'limit': limit, 'timeout_seconds': timeout_seconds,
+        }
+        allowed, reason = self._guard.check_tool('cloudwatch_insights')
+        if not allowed:
+            self._audit.log('cloudwatch_insights', args, '', False, reason)
+            return f"Blocked: {reason}"
+        if self._cloudwatch_service is None:
+            self._audit.log(
+                'cloudwatch_insights', args, '', False, 'service_unavailable',
+            )
+            return "Error: CloudWatch service is not available."
+        if not groups:
+            self._audit.log('cloudwatch_insights', args, '', False, 'no_log_group')
+            return "Error: provide a log_group or a non-empty log_groups list."
+        if not (query or "").strip():
+            self._audit.log('cloudwatch_insights', args, '', False, 'empty_query')
+            return "Error: query must not be empty."
+
+        from datetime import datetime, timedelta
+        end_time = datetime.utcnow()
+        start_time = end_time - timedelta(hours=max(int(hours_back), 1))
+
+        try:
+            res = await self._cloudwatch_service.run_insights_query(
+                groups, query, start_time, end_time, region,
+                max(1, int(limit)), max(5, int(timeout_seconds)),
+            )
+        except Exception as e:
+            self._audit.log(
+                'cloudwatch_insights', args, '', False, f"api_error: {e}",
+            )
+            return f"Error running CloudWatch Logs Insights query: {e}"
+
+        status = res.get("status", "Unknown")
+        rows = res.get("rows", [])
+        columns = res.get("columns", [])
+        if status != "Complete":
+            note = {
+                "Timeout": (f"query did not finish within {timeout_seconds}s — "
+                            "narrow the window or raise timeout_seconds"),
+                "Failed": "query failed — check the query syntax",
+                "Cancelled": "query was cancelled",
+            }.get(status, f"query ended with status {status}")
+            result = f"CloudWatch Insights ({status}): {note}."
+            self._audit.log('cloudwatch_insights', args, result, True)
+            return result
+        if not rows:
+            result = (f"CloudWatch Insights: 0 rows over the last {hours_back}h "
+                      f"across {len(groups)} group(s).")
+            self._audit.log('cloudwatch_insights', args, result, True)
+            return result
+
+        # Drop the synthetic @ptr column Insights appends to non-stats queries.
+        cols = [c for c in columns if c != "@ptr"] or columns
+        widths = {c: max(len(c), *(len(str(r.get(c, ""))) for r in rows)) for c in cols}
+        out = [
+            f"CloudWatch Insights — {len(rows)} row(s), last {hours_back}h "
+            f"({len(groups)} group(s)):",
+            "  " + "  ".join(c.ljust(min(widths[c], 48)) for c in cols),
+            "  " + "-" * min(sum(min(widths[c], 48) + 2 for c in cols), 110),
+        ]
+        for r in rows[:self._max_lines]:
+            out.append("  " + "  ".join(
+                str(r.get(c, "")).ljust(min(widths[c], 48)) for c in cols
+            ))
+        if len(rows) > self._max_lines:
+            out.append(f"  ... ({len(rows) - self._max_lines} more rows; "
+                       "tighten the query's limit)")
+        result = "\n".join(out)
+        self._audit.log('cloudwatch_insights', args, result, True)
+        return result
+
+    # ------------------------------------------------------------------
+    # Generic AWS API passthrough (aws_call)
+    # ------------------------------------------------------------------
+
+    def _get_aws_factory(self):
+        """Return the shared AWS client factory, building it lazily from config."""
+        if self._aws_client_factory is None:
+            from servonaut.services.aws_client_factory import (
+                build_aws_client_factory,
+            )
+            self._aws_client_factory = build_aws_client_factory(
+                self._config_manager.get()
+            )
+        return self._aws_client_factory
+
+    async def aws_call(
+        self, service: str, operation: str,
+        params: Optional[Dict[str, Any]] = None,
+        region: str = "", account: str = "",
+        mutate: bool = False, max_items: int = 0,
+    ) -> str:
+        """Generic boto3 passthrough — call any AWS describe/get/list/filter op.
+
+        This ends the "not pre-wrapped" dead-ends: any read in the account's
+        IAM scope is reachable without a bespoke tool (DescribeSecurityGroupRules,
+        GetIPSet, GetWebACL, FilterLogEvents, DescribeTargetHealth, …).
+
+        ``operation`` is the boto3 snake_case method name (``get_ip_set``,
+        ``describe_security_group_rules``). Reads (Describe/Get/List/Filter/
+        Lookup/Head/BatchGet/Search prefixes) run read-only and auto-paginate.
+        Mutating ops require ``mutate=true`` AND dangerous guard mode; destructive
+        verbs (delete/terminate/destroy/purge) are always refused — use a curated
+        tool. ``region``/``account`` pin the call; the configured control-plane
+        STS role (if any) is assumed automatically.
+        """
+        params = params or {}
+        args = {
+            'service': service, 'operation': operation, 'params': params,
+            'region': region, 'account': account, 'mutate': mutate,
+            'max_items': max_items,
+        }
+        allowed, reason = self._guard.check_tool('aws_call')
+        if not allowed:
+            self._audit.log('aws_call', args, '', False, reason)
+            return f"Blocked: {reason}"
+
+        svc = (service or "").strip()
+        op = (operation or "").strip()
+        if not _AWS_SERVICE_RE.match(svc):
+            self._audit.log('aws_call', args, '', False, 'validation: bad_service')
+            return f"Error: invalid service name {service!r}."
+        if not _AWS_OPERATION_RE.match(op):
+            self._audit.log('aws_call', args, '', False, 'validation: bad_operation')
+            return (f"Error: invalid operation {operation!r} — expected a boto3 "
+                    "snake_case method name like 'describe_security_group_rules'.")
+        if not isinstance(params, dict):
+            self._audit.log('aws_call', args, '', False, 'validation: bad_params')
+            return "Error: params must be an object (mapping of boto3 arguments)."
+
+        is_read = op.startswith(_AWS_READ_PREFIXES)
+        is_destructive = op.startswith(_AWS_DESTRUCTIVE_PREFIXES)
+        if is_destructive:
+            self._audit.log('aws_call', args, '', False, 'blocked_destructive')
+            return (f"Error: '{op}' is a destructive operation and is not "
+                    "available via aws_call. Use a curated tool "
+                    "(aws_terminate_instance, s3_delete_object, …) or the console.")
+        if not is_read:
+            if not mutate:
+                self._audit.log('aws_call', args, '', False, 'mutate_required')
+                return (f"Error: '{op}' is not a read operation. Re-run with "
+                        "mutate=true (requires dangerous guard mode) if you "
+                        "intend to change state, or use a curated tool.")
+            m_allowed, m_reason = self._guard.check_tool('aws_call_mutate')
+            if not m_allowed:
+                self._audit.log('aws_call', args, '', False, m_reason)
+                return f"Blocked: {m_reason}"
+
+        try:
+            result = await asyncio.to_thread(
+                self._aws_call_sync, svc, op, params, region, account,
+                is_read, max_items,
+            )
+        except ValueError as e:
+            self._audit.log('aws_call', args, '', False, f"validation: {e}")
+            return f"Error: {e}"
+        except Exception as e:  # noqa: BLE001 - surface boto3/botocore errors
+            self._audit.log('aws_call', args, '', False, f"api_error: {e}")
+            return f"Error calling {svc}.{op}: {e}"
+
+        text = self._format_aws_call_result(svc, op, result)
+        self._audit.log('aws_call', args, text, True)
+        return text
+
+    def _aws_call_sync(
+        self, service: str, operation: str, params: Dict[str, Any],
+        region: str, account: str, is_read: bool, max_items: int,
+    ) -> Any:
+        """Build the client (via factory) and invoke the boto3 operation."""
+        factory = self._get_aws_factory()
+        # Write calls use the separate mutate role (or ambient creds) — never
+        # the read-only control-plane role, which would only AccessDenied.
+        client = factory.client(
+            service, region=region, account=account, mutate=not is_read,
+        )
+        method = getattr(client, operation, None)
+        if method is None or not callable(method):
+            raise ValueError(
+                f"operation '{operation}' is not valid for service '{service}'"
+            )
+        # Auto-paginate reads so a windowed query returns the full result set
+        # (capped) rather than just the first page.
+        if is_read and client.can_paginate(operation):
+            cap = max_items if max_items and max_items > 0 \
+                else _AWS_CALL_DEFAULT_MAX_ITEMS
+            paginator = client.get_paginator(operation)
+            paginate_kwargs = dict(params)
+            paginate_kwargs["PaginationConfig"] = {"MaxItems": cap}
+            return paginator.paginate(**paginate_kwargs).build_full_result()
+        return method(**params)
+
+    @staticmethod
+    def _format_aws_call_result(service: str, operation: str, result: Any) -> str:
+        """Serialise a boto3 response to JSON, dropping noise and capping size."""
+        if isinstance(result, dict):
+            result = {k: v for k, v in result.items() if k != "ResponseMetadata"}
+        body = json.dumps(result, indent=2, default=str, sort_keys=True)
+        truncated = len(body) > _AWS_CALL_MAX_RESULT_CHARS
+        if truncated:
+            body = body[:_AWS_CALL_MAX_RESULT_CHARS]
+        header = f"aws_call {service}.{operation} →"
+        if truncated:
+            body += (f"\n... [truncated at {_AWS_CALL_MAX_RESULT_CHARS} chars — "
+                     "narrow params or lower max_items]")
+        return f"{header}\n{body}"
 
     # ------------------------------------------------------------------
     # AWS CloudTrail tools (read-only)
@@ -3310,23 +3605,32 @@ class ServonautTools:
         'echo "LOAD=$(awk \'{print $1, $2, $3}\' /proc/loadavg 2>/dev/null)"; '
         'echo "CPU=$(nproc 2>/dev/null)"; '
         'echo "MEM=$(free -m 2>/dev/null | awk \'/^Mem:/{print $2, $3, $4}\')"; '
-        # Active php-fpm workers: count worker processes (title "php-fpm: pool …"),
-        # with a ps fallback for systems where pgrep can't see arg titles.
-        'FPM_A=$(pgrep -c -f \'php-fpm: pool\' 2>/dev/null); '
-        '[ -z "$FPM_A" ] || [ "$FPM_A" = "0" ] && '
-        'FPM_A=$(ps -e -o args= 2>/dev/null | grep -c \'[p]hp-fpm: pool\'); '
-        # max_children across the common config locations (Debian/Ubuntu,
-        # RHEL/Amazon Linux /etc/php-fpm.d, source builds under /usr/local).
-        'FPM_M=$(grep -rhoE \'^[[:space:]]*pm.max_children[[:space:]]*=[[:space:]]*[0-9]+\' '
-        '/etc/php*/fpm/pool.d /etc/php-fpm.d /usr/local/etc/php-fpm.d '
-        '/etc/php/*/fpm/pool.d 2>/dev/null | grep -oE \'[0-9]+\' '
-        '| sort -rn | head -1); '
-        'if [ "${FPM_A:-0}" -gt 0 ] 2>/dev/null || [ -n "$FPM_M" ]; '
-        'then echo "FPM=${FPM_A:-0}/${FPM_M:-?}"; else echo "FPM="; fi; '
+        # php-fpm saturation. Detect presence via the MASTER process title
+        # ("php-fpm: master process …") — this matches whether or not any
+        # worker is currently spawned (an idle pm=ondemand/dynamic pool has 0
+        # workers at the probe instant) and, unlike a bare "php-fpm" match,
+        # cannot self-match the probe shell's own command line. Whenever php-fpm
+        # is present we ALWAYS emit a column (active/max, max="?" if the pool
+        # config isn't readable) so the key triage signal never goes blank.
+        'if pgrep -f \'php-fpm: master\' >/dev/null 2>&1; then '
+        'FPM_A=$(pgrep -c -f \'php-fpm: pool\' 2>/dev/null || echo 0); '
+        'FPM_RE=\'^[[:space:]]*pm.max_children[[:space:]]*=[[:space:]]*[0-9]+\'; '
+        'FPM_P="/etc/php*/fpm/pool.d /etc/php-fpm.d /usr/local/etc/php-fpm.d /etc/php/*/fpm/pool.d"; '
+        # Total worker capacity = SUM of pm.max_children across every pool
+        # (so it's comparable to the active count, which spans all pools). Try
+        # an unprivileged read first; only fall back to sudo -n (never prompts)
+        # when nothing was readable, so world-readable pool.d files are never
+        # double-counted.
+        'FPM_M=$(grep -rhoE "$FPM_RE" $FPM_P 2>/dev/null '
+        '| grep -oE \'[0-9]+\' | awk \'{s+=$1} END{if(s>0)print s}\'); '
+        '[ -z "$FPM_M" ] && FPM_M=$(sudo -n grep -rhoE "$FPM_RE" $FPM_P 2>/dev/null '
+        '| grep -oE \'[0-9]+\' | awk \'{s+=$1} END{if(s>0)print s}\'); '
+        'echo "FPM=${FPM_A:-0}/${FPM_M:-?}"; '
+        'else echo "FPM="; fi; '
         'S=""; pgrep -x nginx >/dev/null 2>&1 && S="$S nginx"; '
         'pgrep -x apache2 >/dev/null 2>&1 && S="$S apache"; '
         'pgrep -x httpd >/dev/null 2>&1 && S="$S httpd"; '
-        'pgrep -f php-fpm >/dev/null 2>&1 && S="$S php-fpm"; '
+        'pgrep -f \'php-fpm: master\' >/dev/null 2>&1 && S="$S php-fpm"; '
         'pgrep -x node >/dev/null 2>&1 && S="$S node"; '
         'echo "STACK=$(echo $S)"; '
         'echo "LISTEN=$(ss -ltn 2>/dev/null | awk \'NR>1{n=split($4,a,":"); '
@@ -3560,14 +3864,20 @@ class ServonautTools:
             f"exit 127; fi"
         )
 
-    async def db_processlist(self, instance_id: str) -> str:
-        """Show the live DB session list + connection saturation for an instance.
+    async def db_processlist(self, instance_id: str, full: bool = False) -> str:
+        """Show DB connection saturation + a session summary for an instance.
 
-        MySQL/MariaDB: ``Threads_connected`` vs ``max_connections`` plus
-        ``SHOW FULL PROCESSLIST``. Postgres: ``pg_stat_activity`` (non-idle).
-        Credentials come from the instance's db_profile + your secret store.
+        By default this SUMMARISES server-side instead of dumping every row (a
+        busy box can have hundreds of sessions): connection saturation, a
+        breakdown of sessions by command/state with counts + oldest age, and the
+        10 longest-running non-idle queries. Pass ``full=true`` for the raw
+        ``SHOW FULL PROCESSLIST`` / full ``pg_stat_activity`` dump.
+
+        MySQL/MariaDB uses ``information_schema.PROCESSLIST``; Postgres uses
+        ``pg_stat_activity``. Credentials come from the instance's db_profile +
+        your secret store.
         """
-        args = {'instance_id': instance_id}
+        args = {'instance_id': instance_id, 'full': full}
         allowed, reason = self._guard.check_tool('db_processlist')
         if not allowed:
             self._audit.log('db_processlist', args, '', False, reason)
@@ -3580,19 +3890,58 @@ class ServonautTools:
             return f"Error: {err}"
 
         engine = (profile.engine or 'mysql').strip().lower()
-        if engine.startswith('postgres'):
-            sql = (
-                "SELECT pid, usename, state, wait_event_type, "
-                "now()-query_start AS duration, left(query,80) AS query "
-                "FROM pg_stat_activity WHERE state IS DISTINCT FROM 'idle' "
-                "ORDER BY query_start NULLS LAST;"
-            )
+        is_postgres = engine.startswith('postgres')
+        if is_postgres:
+            if full:
+                sql = (
+                    "SELECT pid, usename, state, wait_event_type, "
+                    "now()-query_start AS duration, left(query,80) AS query "
+                    "FROM pg_stat_activity WHERE state IS DISTINCT FROM 'idle' "
+                    "ORDER BY query_start NULLS LAST;"
+                )
+            else:
+                # Saturation, by-state breakdown, and the 10 oldest non-idle.
+                sql = (
+                    "SELECT count(*) AS total, "
+                    "count(*) FILTER (WHERE state IS DISTINCT FROM 'idle') "
+                    "AS active, "
+                    "(SELECT setting FROM pg_settings "
+                    "WHERE name='max_connections') AS max_connections "
+                    "FROM pg_stat_activity; "
+                    "SELECT state, wait_event_type, count(*) AS sessions, "
+                    "max(now()-query_start) AS max_age FROM pg_stat_activity "
+                    "GROUP BY state, wait_event_type ORDER BY sessions DESC; "
+                    "SELECT pid, usename, state, now()-query_start AS age, "
+                    "left(regexp_replace(query,'\\s+',' ','g'),80) AS query "
+                    "FROM pg_stat_activity WHERE state IS DISTINCT FROM 'idle' "
+                    "AND query_start IS NOT NULL "
+                    "ORDER BY query_start LIMIT 10;"
+                )
         else:
-            sql = (
-                "SHOW STATUS LIKE 'Threads_connected'; "
-                "SHOW VARIABLES LIKE 'max_connections'; "
-                "SHOW FULL PROCESSLIST;"
-            )
+            if full:
+                sql = (
+                    "SHOW STATUS LIKE 'Threads_connected'; "
+                    "SHOW VARIABLES LIKE 'max_connections'; "
+                    "SHOW FULL PROCESSLIST;"
+                )
+            else:
+                # Saturation, by command/state breakdown, and the 10 oldest
+                # active queries — all aggregated in-DB so the result is a
+                # handful of rows even when hundreds of sessions are open.
+                sql = (
+                    "SHOW STATUS LIKE 'Threads_connected'; "
+                    "SHOW STATUS LIKE 'Threads_running'; "
+                    "SHOW VARIABLES LIKE 'max_connections'; "
+                    "SELECT COMMAND, COALESCE(STATE,'') AS STATE, "
+                    "COUNT(*) AS sessions, MAX(TIME) AS max_age_s "
+                    "FROM information_schema.PROCESSLIST "
+                    "GROUP BY COMMAND, STATE ORDER BY sessions DESC; "
+                    "SELECT ID, USER, DB, TIME AS age_s, STATE, "
+                    "LEFT(REPLACE(REPLACE(INFO,'\\n',' '),'\\t',' '),80) AS info "
+                    "FROM information_schema.PROCESSLIST "
+                    "WHERE INFO IS NOT NULL AND COMMAND <> 'Sleep' "
+                    "ORDER BY TIME DESC LIMIT 10;"
+                )
 
         command = self._build_db_command(profile, sql, password)
         try:

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -100,6 +100,12 @@ _TOOL_GUARDS: Dict[str, Literal["readonly", "standard", "dangerous"]] = {
     # Group B: boto3 AWS topology / metrics read.
     "describe_ingress_path": "readonly",
     "rds_metrics": "readonly",
+    # CloudWatch Logs Insights — read-only aggregation query.
+    "cloudwatch_insights": "readonly",
+    # Generic AWS passthrough — reads are read-only, but the tool can mutate
+    # when invoked with mutate=true (server enforces the dangerous tier for
+    # that path), so the chat-side floor is "standard", not "readonly".
+    "aws_call": "standard",
     # Group C: WAF mitigation — mutate live traffic handling.
     "waf_rate_rule_set": "dangerous",
     "block_ip": "dangerous",

--- a/src/servonaut/services/aws_client_factory.py
+++ b/src/servonaut/services/aws_client_factory.py
@@ -1,0 +1,185 @@
+"""Shared boto3 client factory with optional STS AssumeRole + region/account pinning.
+
+This is the single construction point for *control-plane* boto3 clients used by
+the generic ``aws_call`` passthrough, the CloudWatch Logs Insights tool, and
+(incrementally) the curated describe/list services. It exists so the
+"control-plane / host-plane split" from the tooling feedback has a real home:
+control-plane reads (security groups, WAF, ELB, logs, metrics) go through a
+dedicated least-privilege IAM role assumed via STS, instead of leaning on a
+per-box instance profile or the operator's personal credentials.
+
+Behaviour contract:
+
+- **No role configured → no behaviour change.** When ``control_plane_role_arn``
+  (and the per-account map) are empty, ``client()`` builds the boto3 client
+  straight off the ambient credential chain (env vars / shared config / host
+  instance profile) — byte-for-byte what the services did before this factory
+  existed. The STS path is strictly opt-in.
+- **Role configured → STS AssumeRole.** Temporary credentials are cached per
+  ``(role_arn, region)`` until ~5 minutes before expiry, so a burst of
+  control-plane reads during an incident does not hammer ``sts:AssumeRole``.
+- **Per-account override.** ``control_plane_role_arns`` maps ``account_id ->
+  role_arn``; the ``account`` argument selects it, falling back to the default
+  role ARN when the account is absent.
+
+The factory never raises on construction and does no IO until ``client()`` is
+called. An AssumeRole failure surfaces as the underlying botocore exception to
+the caller (the tool layer turns it into an ``api_error`` audit row).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import boto3
+
+from servonaut.config.schema import AWSConfig
+from servonaut.config.secrets import resolve_secret
+
+logger = logging.getLogger(__name__)
+
+# Refresh assumed-role credentials this many seconds before they actually
+# expire, so an in-flight call never races the expiry boundary.
+_CREDENTIAL_SKEW_SECONDS = 300
+
+
+@dataclass
+class _CachedCredentials:
+    """STS temporary credentials with their absolute expiry (epoch seconds)."""
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    expiry_epoch: float
+
+    def is_fresh(self, now: float) -> bool:
+        return self.expiry_epoch - _CREDENTIAL_SKEW_SECONDS > now
+
+
+class AWSClientFactory:
+    """Builds boto3 clients, optionally via STS AssumeRole, with creds caching."""
+
+    def __init__(self, aws_config: Optional[AWSConfig] = None) -> None:
+        self._config = aws_config or AWSConfig()
+        self._cred_cache: Dict[str, _CachedCredentials] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def default_region(self) -> str:
+        """Region used when a caller passes none (empty defers to boto3)."""
+        return self._config.default_region or ""
+
+    def role_for(self, account: str = "", mutate: bool = False) -> str:
+        """Resolve the role ARN to assume for *account*.
+
+        Read calls use the control-plane (read-only) role. Write calls
+        (``mutate=True``) use the SEPARATE mutate role and never fall back to
+        the read role — the read role is the read-only backstop, so assuming it
+        for a write would only ever hit AccessDenied. An empty result means
+        "use the ambient credential chain".
+        """
+        if mutate:
+            if account:
+                mapped = (self._config.control_plane_mutate_role_arns or {}).get(account)
+                if mapped:
+                    return mapped
+            return self._config.control_plane_mutate_role_arn or ""
+        if account:
+            mapped = (self._config.control_plane_role_arns or {}).get(account)
+            if mapped:
+                return mapped
+        return self._config.control_plane_role_arn or ""
+
+    def uses_assumed_role(self, account: str = "", mutate: bool = False) -> bool:
+        """True when calls for *account* go through STS."""
+        return bool(self.role_for(account, mutate))
+
+    def client(
+        self,
+        service: str,
+        region: str = "",
+        account: str = "",
+        mutate: bool = False,
+    ) -> Any:
+        """Return a boto3 client for *service*.
+
+        When a role is configured for this call (read role for reads, mutate
+        role for ``mutate=True``), the client is built from freshly-assumed STS
+        credentials; otherwise it falls back to the ambient credential chain.
+        ``region`` empty uses the configured ``default_region`` (and, if that
+        too is empty, boto3's own default region resolution).
+        """
+        region_name = region or self.default_region or None
+        role_arn = self.role_for(account, mutate)
+        if not role_arn:
+            kwargs: Dict[str, Any] = {}
+            if region_name:
+                kwargs["region_name"] = region_name
+            return boto3.client(service, **kwargs)
+
+        creds = self._assume(role_arn)
+        kwargs = {
+            "aws_access_key_id": creds.access_key_id,
+            "aws_secret_access_key": creds.secret_access_key,
+            "aws_session_token": creds.session_token,
+        }
+        if region_name:
+            kwargs["region_name"] = region_name
+        return boto3.client(service, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _assume(self, role_arn: str) -> _CachedCredentials:
+        """Return cached STS creds for *role_arn*, assuming the role if stale."""
+        now = time.time()
+        with self._lock:
+            cached = self._cred_cache.get(role_arn)
+            if cached and cached.is_fresh(now):
+                return cached
+
+        # AssumeRole outside the lock — the STS round-trip can take a moment and
+        # we don't want to serialise every other role's lookups behind it.
+        sts = boto3.client("sts")
+        assume_kwargs: Dict[str, Any] = {
+            "RoleArn": role_arn,
+            "RoleSessionName": self._config.assume_role_session_name
+            or "servonaut-control-plane",
+        }
+        external_id = resolve_secret(self._config.control_plane_external_id or "")
+        if external_id:
+            assume_kwargs["ExternalId"] = external_id
+
+        resp = sts.assume_role(**assume_kwargs)
+        c = resp["Credentials"]
+        fresh = _CachedCredentials(
+            access_key_id=c["AccessKeyId"],
+            secret_access_key=c["SecretAccessKey"],
+            session_token=c["SessionToken"],
+            expiry_epoch=c["Expiration"].timestamp(),
+        )
+        with self._lock:
+            self._cred_cache[role_arn] = fresh
+        logger.debug("Assumed control-plane role %s (expires %s)",
+                     role_arn, c["Expiration"].isoformat())
+        return fresh
+
+
+def build_aws_client_factory(config) -> AWSClientFactory:
+    """Construct an :class:`AWSClientFactory` from an :class:`AppConfig`.
+
+    Mirrors :func:`servonaut.services.object_storage_factory.build_object_storage_services`
+    — the single shared construction helper called by every wiring site
+    (``app.py``, ``mcp/server.py``, the CLI) so the STS/region resolution logic
+    lives in exactly one place.
+    """
+    aws_config = getattr(config, "aws", None)
+    return AWSClientFactory(aws_config)

--- a/src/servonaut/services/cloudwatch_service.py
+++ b/src/servonaut/services/cloudwatch_service.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from collections import Counter
 from datetime import datetime, timedelta
 from ipaddress import ip_address, ip_network
 from typing import Any, Dict, List, Optional
 
 import boto3
+
+# Single bare token (no whitespace) that contains a char CloudWatch Logs
+# tokenises on (``.`` ``:`` ``/`` ``-`` etc.). Such a term MUST be double-quoted
+# in a filter pattern or it silently fails to match — the bug that sent a live
+# investigation toward a false "WAF bypass" hypothesis. Alphanumeric-only tokens
+# (e.g. ``ERROR``) match fine unquoted, so we leave those alone.
+_BARE_LITERAL_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 class CloudWatchService:
@@ -22,6 +30,61 @@ class CloudWatchService:
         ip_network("192.168.0.0/16"),
         ip_network("127.0.0.0/8"),
     ]
+
+    def __init__(self, client_factory=None) -> None:
+        """Args:
+        client_factory: Optional :class:`AWSClientFactory`. When supplied, every
+            ``logs`` client is built through it — honouring the control-plane
+            STS role / region pinning. When ``None`` (the default), clients are
+            built off the ambient credential chain exactly as before.
+        """
+        self._client_factory = client_factory
+
+    def _logs_client(self, region: str):
+        """Build a CloudWatch Logs client via the factory, or boto3 directly."""
+        if self._client_factory is not None:
+            return self._client_factory.client("logs", region=region)
+        kwargs: Dict[str, str] = {}
+        if region:
+            kwargs["region_name"] = region
+        return boto3.client("logs", **kwargs)
+
+    @staticmethod
+    def normalize_filter_pattern(pattern: str) -> str:
+        """Quote a bare literal filter term so CloudWatch matches it reliably.
+
+        CloudWatch Logs tokenises unstructured filter terms on non-alphanumerics,
+        so a bare ``9.9.9.9`` or ``/wp-login.php`` does NOT match — it has
+        to be double-quoted (``"9.9.9.9"``). This helper rewrites exactly
+        that case and leaves every richer form untouched:
+
+        - ``{ $.field = "x" }`` JSON selectors — pass through.
+        - ``[w1, w2, ...]`` space-delimited (metric-filter) patterns — pass.
+        - already-``"quoted"`` terms — pass.
+        - multi-token / operator expressions (whitespace, ``?`` ``-`` ``&&``
+          present beyond a leading sign) — pass; we don't second-guess them.
+        - a single bare token containing a tokeniser char — wrap in quotes
+          (preserving a leading ``?`` optional / ``-`` exclusion sign).
+        """
+        p = pattern.strip()
+        if not p:
+            return ""
+        if p[0] in "{[" or (p.startswith('"') and p.endswith('"')):
+            return p
+        # Preserve a single leading optional/exclusion sign, quote the remainder.
+        sign = ""
+        body = p
+        if body[0] in "?-":
+            sign, body = body[0], body[1:]
+        # Anything with internal whitespace or filter operators is a richer
+        # expression — leave it exactly as the caller wrote it.
+        if (not body) or any(c.isspace() for c in body) or "&&" in body or "||" in body:
+            return p
+        if body.startswith('"') and body.endswith('"'):
+            return p
+        if _BARE_LITERAL_RE.match(body):
+            return p  # plain alphanumeric token already matches unquoted
+        return f'{sign}"{body}"'
 
     async def list_log_groups(
         self, prefix: str = "", region: str = ""
@@ -35,10 +98,7 @@ class CloudWatchService:
     def _list_log_groups_sync(
         self, prefix: str, region: str
     ) -> List[Dict[str, Any]]:
-        kwargs: Dict[str, str] = {}
-        if region:
-            kwargs["region_name"] = region
-        client = boto3.client("logs", **kwargs)
+        client = self._logs_client(region)
         groups: List[Dict[str, Any]] = []
         params: Dict[str, Any] = {}
         if prefix:
@@ -90,10 +150,7 @@ class CloudWatchService:
         region: str,
         max_events: int,
     ) -> List[Dict[str, Any]]:
-        kwargs: Dict[str, str] = {}
-        if region:
-            kwargs["region_name"] = region
-        client = boto3.client("logs", **kwargs)
+        client = self._logs_client(region)
         events: List[Dict[str, Any]] = []
         params: Dict[str, Any] = {
             "logGroupName": log_group,
@@ -120,6 +177,92 @@ class CloudWatchService:
                 break
             params["nextToken"] = token
         return events[:hard_limit] if max_events > 0 else events
+
+    # ------------------------------------------------------------------
+    # CloudWatch Logs Insights
+    # ------------------------------------------------------------------
+
+    async def run_insights_query(
+        self,
+        log_groups: List[str],
+        query: str,
+        start_time: datetime,
+        end_time: datetime,
+        region: str = "",
+        limit: int = 1000,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        """Run a CloudWatch Logs Insights query and return parsed results.
+
+        Insights is the right primitive for aggregation (top IPs, status mix,
+        URI ranking, time-bucketing) — it generalises the bespoke ``top_ips``
+        parser into one interface. The query runs server-side; we poll
+        ``get_query_results`` until it completes, fails, or ``timeout_seconds``
+        elapses (best-effort ``stop_query`` on timeout).
+
+        Returns ``{status, columns, rows, statistics, query_id}`` where ``rows``
+        is a list of dicts keyed by Insights field name.
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None,
+            self._run_insights_query_sync,
+            log_groups,
+            query,
+            start_time,
+            end_time,
+            region,
+            limit,
+            timeout_seconds,
+        )
+
+    def _run_insights_query_sync(
+        self,
+        log_groups: List[str],
+        query: str,
+        start_time: datetime,
+        end_time: datetime,
+        region: str,
+        limit: int,
+        timeout_seconds: int,
+    ) -> Dict[str, Any]:
+        client = self._logs_client(region)
+        start = client.start_query(
+            logGroupNames=log_groups,
+            startTime=int(start_time.timestamp()),
+            endTime=int(end_time.timestamp()),
+            queryString=query,
+            limit=max(1, limit),
+        )
+        query_id = start["queryId"]
+        deadline = time.time() + max(5, timeout_seconds)
+        result: Dict[str, Any] = {"status": "Unknown", "query_id": query_id}
+        poll_interval = 1.0
+        while time.time() < deadline:
+            resp = client.get_query_results(queryId=query_id)
+            status = resp.get("status", "Unknown")
+            result["status"] = status
+            result["statistics"] = resp.get("statistics", {})
+            if status in ("Complete", "Failed", "Cancelled", "Timeout"):
+                rows = [
+                    {col["field"]: col.get("value", "") for col in row}
+                    for row in resp.get("results", [])
+                ]
+                result["rows"] = rows
+                result["columns"] = list(rows[0].keys()) if rows else []
+                return result
+            time.sleep(poll_interval)
+            poll_interval = min(poll_interval * 1.5, 5.0)
+
+        # Timed out while still Running/Scheduled — stop the query best-effort.
+        try:
+            client.stop_query(queryId=query_id)
+        except Exception:  # noqa: BLE001 - stop is best-effort cleanup
+            pass
+        result["status"] = "Timeout"
+        result["rows"] = []
+        result["columns"] = []
+        return result
 
     @staticmethod
     def extract_top_ips(

--- a/tests/test_aws_call_tool.py
+++ b/tests/test_aws_call_tool.py
@@ -1,0 +1,261 @@
+"""Tests for the generic aws_call passthrough + cloudwatch_insights tool, and
+the cloudwatch_get_log_events filter-quoting fix.
+
+aws_call branches covered: guard rejection, service/operation validation,
+destructive-verb refusal, read dispatch (auto-paginate), mutate-required gate,
+and mutate dispatch at the dangerous tier. Each asserts the audit row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from servonaut.config.schema import AppConfig, MCPConfig
+from servonaut.mcp.guards import CommandGuard, GuardLevel
+from servonaut.mcp.tools import ServonautTools
+from servonaut.services.cloudwatch_service import CloudWatchService
+
+# The real normalizer is pure; reuse it on the mocked service so the tool's
+# auto-quote path runs exactly as in production.
+_NORMALIZE = CloudWatchService.normalize_filter_pattern
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_tools(*, guard_level=GuardLevel.READONLY, aws_factory=None,
+                cloudwatch_service=None):
+    config = AppConfig(mcp=MCPConfig(guard_level=guard_level))
+    config_manager = MagicMock()
+    config_manager.get.return_value = config
+
+    aws_service = MagicMock()
+    custom_server_service = MagicMock()
+    custom_server_service.list_as_instances.return_value = []
+    audit = MagicMock()
+    audit.log = MagicMock()
+    guard = CommandGuard(config.mcp, config_manager)
+
+    return ServonautTools(
+        config_manager, aws_service, custom_server_service, MagicMock(),
+        MagicMock(), MagicMock(), MagicMock(),
+        guard, audit,
+        cloudwatch_service=cloudwatch_service,
+        aws_client_factory=aws_factory,
+    )
+
+
+class _FakeFactory:
+    """Records client() calls and returns a preset boto3-like client."""
+
+    def __init__(self, client):
+        self._client = client
+        self.calls = []
+
+    def client(self, service, region="", account="", mutate=False):
+        self.calls.append((service, region, account, mutate))
+        return self._client
+
+
+# --- aws_call: validation + guard ---
+
+
+def test_aws_call_guard_rejects_when_below_tier():
+    # aws_call is readonly-tier; force a guard that disallows it by stubbing.
+    tools = _make_tools()
+    tools._guard.check_tool = lambda name: (False, "nope")
+    out = _run(tools.aws_call("ec2", "describe_instances"))
+    assert out.startswith("Blocked:")
+    tools._audit.log.assert_called_once()
+    assert tools._audit.log.call_args.args[3] is False
+
+
+def test_aws_call_invalid_operation():
+    tools = _make_tools()
+    out = _run(tools.aws_call("ec2", "Describe-Instances!"))
+    assert "invalid operation" in out
+    assert tools._audit.log.call_args.args[4].startswith("validation:")
+
+
+def test_aws_call_invalid_service():
+    tools = _make_tools()
+    out = _run(tools.aws_call("EC2!!", "describe_instances"))
+    assert "invalid service" in out
+
+
+def test_aws_call_destructive_refused_even_with_mutate():
+    tools = _make_tools(guard_level=GuardLevel.DANGEROUS)
+    out = _run(tools.aws_call("s3", "delete_bucket",
+                              params={"Bucket": "x"}, mutate=True))
+    assert "destructive" in out.lower()
+    assert tools._audit.log.call_args.args[4] == "blocked_destructive"
+
+
+# --- aws_call: read dispatch ---
+
+
+def test_aws_call_read_dispatch_paginates():
+    client = MagicMock()
+    client.can_paginate.return_value = True
+    paginator = MagicMock()
+    paginator.paginate.return_value.build_full_result.return_value = {
+        "SecurityGroupRules": [{"GroupId": "sg-1"}],
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+    }
+    client.get_paginator.return_value = paginator
+    factory = _FakeFactory(client)
+    tools = _make_tools(aws_factory=factory)
+
+    out = _run(tools.aws_call(
+        "ec2", "describe_security_group_rules",
+        params={"Filters": [{"Name": "group-id", "Values": ["sg-1"]}]},
+        region="us-east-1",
+    ))
+    assert "aws_call ec2.describe_security_group_rules" in out
+    # ResponseMetadata stripped from the serialized body.
+    assert "ResponseMetadata" not in out
+    assert "sg-1" in out
+    # Pinned region passed through; read path → mutate=False.
+    assert factory.calls == [("ec2", "us-east-1", "", False)]
+    # Pagination cap applied.
+    pag_kwargs = paginator.paginate.call_args.kwargs
+    assert pag_kwargs["PaginationConfig"]["MaxItems"] == 1000
+    assert tools._audit.log.call_args.args[3] is True
+
+
+def test_aws_call_read_non_paginable_direct_call():
+    client = MagicMock()
+    client.can_paginate.return_value = False
+    client.get_ip_set.return_value = {
+        "IPSet": {"Addresses": ["1.2.3.4/32"]},
+        "ResponseMetadata": {},
+    }
+    factory = _FakeFactory(client)
+    tools = _make_tools(aws_factory=factory)
+    out = _run(tools.aws_call("wafv2", "get_ip_set",
+                              params={"Name": "n", "Id": "i", "Scope": "REGIONAL"}))
+    assert "1.2.3.4/32" in out
+    client.get_ip_set.assert_called_once_with(Name="n", Id="i", Scope="REGIONAL")
+
+
+# --- aws_call: mutate gating ---
+
+
+def test_aws_call_mutate_required_for_write():
+    tools = _make_tools(guard_level=GuardLevel.READONLY)
+    out = _run(tools.aws_call("wafv2", "update_ip_set", params={"Id": "i"}))
+    assert "mutate=true" in out
+    assert tools._audit.log.call_args.args[4] == "mutate_required"
+
+
+def test_aws_call_mutate_blocked_below_dangerous():
+    tools = _make_tools(guard_level=GuardLevel.STANDARD)
+    out = _run(tools.aws_call("wafv2", "update_ip_set",
+                              params={"Id": "i"}, mutate=True))
+    assert out.startswith("Blocked:")
+
+
+def test_aws_call_mutate_dispatches_at_dangerous():
+    client = MagicMock()
+    client.can_paginate.return_value = False
+    client.update_ip_set.return_value = {"NextLockToken": "tok"}
+    factory = _FakeFactory(client)
+    tools = _make_tools(guard_level=GuardLevel.DANGEROUS, aws_factory=factory)
+    out = _run(tools.aws_call("wafv2", "update_ip_set",
+                              params={"Id": "i", "Addresses": ["1.2.3.4/32"]},
+                              mutate=True))
+    assert "NextLockToken" in out
+    client.update_ip_set.assert_called_once()
+    # Write path must request the client with mutate=True (→ mutate role).
+    assert factory.calls[-1] == ("wafv2", "", "", True)
+    assert tools._audit.log.call_args.args[3] is True
+
+
+# --- cloudwatch_get_log_events: filter quoting + empty messaging ---
+
+
+def test_get_log_events_auto_quotes_and_reports_match():
+    cw = MagicMock()
+    cw.normalize_filter_pattern = _NORMALIZE
+    cw.get_log_events = AsyncMock(return_value=[
+        {"timestamp": datetime(2024, 6, 1, 12, 0, 0),
+         "message": "hit from 9.9.9.9"},
+    ])
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_get_log_events(
+        "/aws/waf/logs", filter_pattern="9.9.9.9",
+    ))
+    # The effective (quoted) pattern reached the service.
+    effective = cw.get_log_events.call_args.args[3]
+    assert effective == '"9.9.9.9"'
+    assert "matched events" in out
+    assert "normalized to" in out
+
+
+def test_get_log_events_empty_filtered_is_not_empty_group():
+    cw = MagicMock()
+    cw.normalize_filter_pattern = _NORMALIZE
+    cw.get_log_events = AsyncMock(return_value=[])
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_get_log_events(
+        "/aws/waf/logs", filter_pattern="9.9.9.9",
+    ))
+    assert "0 events matched filter" in out
+    assert "doesn't match" in out  # explicitly warns it's not an empty group
+
+
+def test_get_log_events_client_ip_builds_selector():
+    cw = MagicMock()
+    cw.normalize_filter_pattern = _NORMALIZE
+    cw.get_log_events = AsyncMock(return_value=[])
+    tools = _make_tools(cloudwatch_service=cw)
+    _run(tools.cloudwatch_get_log_events("/g", client_ip="9.9.9.9"))
+    effective = cw.get_log_events.call_args.args[3]
+    assert effective == '{ $.httpRequest.clientIp = "9.9.9.9" }'
+
+
+def test_get_log_events_rejects_bad_client_ip():
+    cw = MagicMock()
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_get_log_events("/g", client_ip="not-an-ip"))
+    assert "not a valid IP" in out
+
+
+# --- cloudwatch_insights tool ---
+
+
+def test_cloudwatch_insights_formats_rows():
+    cw = MagicMock()
+    cw.run_insights_query = AsyncMock(return_value={
+        "status": "Complete",
+        "columns": ["clientIp", "hits"],
+        "rows": [{"clientIp": "1.2.3.4", "hits": "50"}],
+        "statistics": {},
+    })
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_insights(
+        query="stats count(*) by clientIp", log_group="/aws/waf/logs",
+    ))
+    assert "1.2.3.4" in out and "hits" in out
+    assert tools._audit.log.call_args.args[3] is True
+
+
+def test_cloudwatch_insights_requires_group():
+    cw = MagicMock()
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_insights(query="fields @message"))
+    assert "log_group" in out
+    assert tools._audit.log.call_args.args[4] == "no_log_group"
+
+
+def test_cloudwatch_insights_reports_timeout():
+    cw = MagicMock()
+    cw.run_insights_query = AsyncMock(return_value={
+        "status": "Timeout", "rows": [], "columns": [],
+    })
+    tools = _make_tools(cloudwatch_service=cw)
+    out = _run(tools.cloudwatch_insights(query="q", log_group="/g"))
+    assert "Timeout" in out

--- a/tests/test_aws_client_factory.py
+++ b/tests/test_aws_client_factory.py
@@ -1,0 +1,139 @@
+"""Tests for AWSClientFactory (STS control-plane role + region pinning)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from servonaut.config.schema import AWSConfig
+from servonaut.services.aws_client_factory import (
+    AWSClientFactory,
+    build_aws_client_factory,
+)
+
+
+def test_role_for_default_and_per_account():
+    cfg = AWSConfig(
+        control_plane_role_arn="arn:aws:iam::111:role/default",
+        control_plane_role_arns={"222": "arn:aws:iam::222:role/special"},
+    )
+    f = AWSClientFactory(cfg)
+    assert f.role_for() == "arn:aws:iam::111:role/default"
+    assert f.role_for("222") == "arn:aws:iam::222:role/special"
+    # Unknown account falls back to the default role.
+    assert f.role_for("999") == "arn:aws:iam::111:role/default"
+    assert f.uses_assumed_role() is True
+
+
+def test_mutate_role_is_separate_from_read_role():
+    """Writes must never assume the read-only role; they use the mutate role
+    (or ambient creds) so a correctly-provisioned read-only role doesn't
+    AccessDeny every mutate=true call."""
+    cfg = AWSConfig(
+        control_plane_role_arn="arn:aws:iam::111:role/read",
+        control_plane_mutate_role_arn="arn:aws:iam::111:role/write",
+        control_plane_role_arns={"222": "arn:aws:iam::222:role/read"},
+        control_plane_mutate_role_arns={"222": "arn:aws:iam::222:role/write"},
+    )
+    f = AWSClientFactory(cfg)
+    assert f.role_for() == "arn:aws:iam::111:role/read"
+    assert f.role_for(mutate=True) == "arn:aws:iam::111:role/write"
+    assert f.role_for("222", mutate=True) == "arn:aws:iam::222:role/write"
+
+
+def test_mutate_without_mutate_role_falls_back_to_ambient():
+    # Read role set, NO mutate role → write path must use ambient creds, NOT
+    # assume the read-only role.
+    cfg = AWSConfig(control_plane_role_arn="arn:aws:iam::111:role/read")
+    f = AWSClientFactory(cfg)
+    assert f.role_for(mutate=True) == ""  # ambient
+    with patch("servonaut.services.aws_client_factory.boto3") as boto3_mock:
+        f.client("wafv2", region="us-east-1", mutate=True)
+    boto3_mock.client.assert_called_once_with("wafv2", region_name="us-east-1")
+    assert all(c.args[0] != "sts" for c in boto3_mock.client.call_args_list)
+
+
+def test_no_role_uses_ambient_chain():
+    """With no role configured, client() must NOT call STS — ambient creds."""
+    f = AWSClientFactory(AWSConfig())  # empty role config
+    assert f.uses_assumed_role() is False
+    with patch("servonaut.services.aws_client_factory.boto3") as boto3_mock:
+        f.client("ec2", region="us-east-1")
+    # Exactly one client built; no assume_role anywhere.
+    boto3_mock.client.assert_called_once_with("ec2", region_name="us-east-1")
+    # sts client (for assume_role) must never have been requested.
+    assert all(
+        call.args and call.args[0] != "sts"
+        for call in boto3_mock.client.call_args_list
+    )
+
+
+def test_assume_role_builds_client_with_temp_creds_and_caches():
+    cfg = AWSConfig(
+        control_plane_role_arn="arn:aws:iam::111:role/r",
+        assume_role_session_name="servonaut-test",
+    )
+    f = AWSClientFactory(cfg)
+
+    expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+    sts = MagicMock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "AKIA",
+            "SecretAccessKey": "SECRET",
+            "SessionToken": "TOKEN",
+            "Expiration": expiry,
+        }
+    }
+    svc_client = MagicMock()
+
+    def _client(service, **kwargs):
+        return sts if service == "sts" else svc_client
+
+    with patch("servonaut.services.aws_client_factory.boto3") as boto3_mock:
+        boto3_mock.client.side_effect = _client
+        f.client("wafv2", region="us-east-1")
+        f.client("ec2", region="us-east-1")  # second call: creds cached
+
+    # assume_role called exactly once (cached on the second client build).
+    sts.assume_role.assert_called_once()
+    kwargs = sts.assume_role.call_args.kwargs
+    assert kwargs["RoleArn"] == "arn:aws:iam::111:role/r"
+    assert kwargs["RoleSessionName"] == "servonaut-test"
+    # The service clients were built with the temp credentials.
+    svc_calls = [
+        c for c in boto3_mock.client.call_args_list if c.args[0] != "sts"
+    ]
+    assert all(
+        c.kwargs.get("aws_session_token") == "TOKEN" for c in svc_calls
+    )
+
+
+def test_external_id_passed_when_set():
+    cfg = AWSConfig(
+        control_plane_role_arn="arn:aws:iam::111:role/r",
+        control_plane_external_id="ext-secret-123",
+    )
+    f = AWSClientFactory(cfg)
+    expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+    sts = MagicMock()
+    sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "A", "SecretAccessKey": "S",
+            "SessionToken": "T", "Expiration": expiry,
+        }
+    }
+    with patch("servonaut.services.aws_client_factory.boto3") as boto3_mock:
+        boto3_mock.client.side_effect = (
+            lambda service, **k: sts if service == "sts" else MagicMock()
+        )
+        f.client("ec2")
+    assert sts.assume_role.call_args.kwargs["ExternalId"] == "ext-secret-123"
+
+
+def test_build_factory_from_appconfig():
+    app_cfg = MagicMock()
+    app_cfg.aws = AWSConfig(default_region="ap-south-1")
+    f = build_aws_client_factory(app_cfg)
+    assert isinstance(f, AWSClientFactory)
+    assert f.default_region == "ap-south-1"

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -31,7 +31,13 @@ CATALOG_EXCLUDED_CLI_ONLY: frozenset[str] = frozenset({
 # CATALOG_EXCLUDED_CLI_ONLY, which is permanently CLI-only): when a tool is
 # added to the server catalog, move it out of here and into the fixture in the
 # same change, keeping the gate honest both ways. Empty = fully converged.
-CATALOG_PENDING_SERVER: frozenset[str] = frozenset()
+CATALOG_PENDING_SERVER: frozenset[str] = frozenset({
+    # CLI-first AWS control-plane tools — run entirely on the CLI's own boto3
+    # surface (generic passthrough + Logs Insights). Server catalog should add
+    # them. Move them to the fixture in the same change once they do.
+    "aws_call",
+    "cloudwatch_insights",
+})
 
 
 _FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "server_catalog_v1.json"

--- a/tests/test_cloudwatch_service.py
+++ b/tests/test_cloudwatch_service.py
@@ -284,3 +284,81 @@ def test_get_log_events_pagination(service: CloudWatchService) -> None:
     assert mock_client.filter_log_events.call_count == 2
     second_call_kwargs = mock_client.filter_log_events.call_args_list[1][1]
     assert second_call_kwargs["nextToken"] == "tok-xyz"
+
+
+# --- normalize_filter_pattern (the auto-quote fix) ---
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("9.9.9.9", '"9.9.9.9"'),   # bare IP must be quoted
+        ("/wp-login.php", '"/wp-login.php"'),     # path must be quoted
+        ("ERROR", "ERROR"),                        # alnum token unchanged
+        ("404", "404"),                            # numeric token unchanged
+        ('"9.9.9.9"', '"9.9.9.9"'),   # already quoted unchanged
+        ("{ $.httpRequest.clientIp = \"1.2.3.4\" }",
+         "{ $.httpRequest.clientIp = \"1.2.3.4\" }"),  # JSON selector unchanged
+        ("[ip, user, ts]", "[ip, user, ts]"),     # space-delimited unchanged
+        ("?ERROR ?WARN", "?ERROR ?WARN"),          # multi-term unchanged
+        ("-/health", '-"/health"'),                # exclusion path: sign kept
+        ("", ""),
+    ],
+)
+def test_normalize_filter_pattern(raw, expected):
+    assert CloudWatchService.normalize_filter_pattern(raw) == expected
+
+
+# --- run_insights_query ---
+
+
+def test_run_insights_query_polls_until_complete():
+    service = CloudWatchService()
+    client = MagicMock()
+    client.start_query.return_value = {"queryId": "q-1"}
+    client.get_query_results.side_effect = [
+        {"status": "Running", "results": []},
+        {
+            "status": "Complete",
+            "results": [
+                [{"field": "clientIp", "value": "1.2.3.4"},
+                 {"field": "hits", "value": "50"}],
+                [{"field": "clientIp", "value": "5.6.7.8"},
+                 {"field": "hits", "value": "9"}],
+            ],
+            "statistics": {"recordsScanned": 1000},
+        },
+    ]
+    start = datetime(2024, 6, 1, 11, 0, 0)
+    end = datetime(2024, 6, 1, 12, 0, 0)
+    with patch.object(service, "_logs_client", return_value=client), \
+            patch("servonaut.services.cloudwatch_service.time.sleep"):
+        res = service._run_insights_query_sync(
+            ["/aws/waf/logs"], "stats count(*) by clientIp",
+            start, end, "us-east-1", 1000, 60,
+        )
+    assert res["status"] == "Complete"
+    assert res["columns"] == ["clientIp", "hits"]
+    assert res["rows"][0] == {"clientIp": "1.2.3.4", "hits": "50"}
+    # start_query used epoch seconds, not millis.
+    assert client.start_query.call_args.kwargs["startTime"] == int(start.timestamp())
+
+
+def test_run_insights_query_timeout_stops_query():
+    service = CloudWatchService()
+    client = MagicMock()
+    client.start_query.return_value = {"queryId": "q-2"}
+    client.get_query_results.return_value = {"status": "Running", "results": []}
+    start = datetime(2024, 6, 1, 11, 0, 0)
+    end = datetime(2024, 6, 1, 12, 0, 0)
+    # Make the deadline already past so the loop exits immediately.
+    times = iter([1000.0, 2000.0, 3000.0, 4000.0])
+    with patch.object(service, "_logs_client", return_value=client), \
+            patch("servonaut.services.cloudwatch_service.time.sleep"), \
+            patch("servonaut.services.cloudwatch_service.time.time",
+                  side_effect=lambda: next(times)):
+        res = service._run_insights_query_sync(
+            ["/g"], "fields @message", start, end, "", 100, 5,
+        )
+    assert res["status"] == "Timeout"
+    client.stop_query.assert_called_once_with(queryId="q-2")

--- a/tests/test_incident_response_tools.py
+++ b/tests/test_incident_response_tools.py
@@ -1145,3 +1145,73 @@ def test_format_ingress_collapses_and_surfaces_webacl_first():
     assert "other.example" not in out
     # verbose shows everything.
     assert "other.example" in format_ingress_path(topo, True, verbose=True)
+
+
+# ---------------------------------------------------------------------------
+# Carry-over: db_processlist summarises by default; FPM probe robustness
+# ---------------------------------------------------------------------------
+
+def _db_tools_capturing_sql(engine: str):
+    """ServonautTools whose db_processlist SQL is captured, no live SSH/DB."""
+    cfg = AppConfig(db_profiles=[
+        DBProfile(instance="i-1", engine=engine, password_secret="db/app"),
+    ])
+    cfg.mcp.guard_level = GuardLevel.STANDARD
+    t = _tools(cfg)
+    profile = cfg.db_profiles[0]
+    captured: dict = {}
+    t._resolve_db = _async_return(({"id": "i-1", "name": "n"}, profile, "pw", ""))  # type: ignore
+
+    def _build(_p, sql, _pw):
+        captured["sql"] = sql
+        return "DBCMD"
+    t._build_db_command = _build  # type: ignore
+    t._exec_ssh = _async_return(("out", ""))  # type: ignore
+    return t, captured
+
+
+def test_db_processlist_summarises_by_default_mysql():
+    t, captured = _db_tools_capturing_sql("mysql")
+    asyncio.run(t.db_processlist("i-1"))
+    sql = captured["sql"]
+    assert "information_schema.PROCESSLIST" in sql
+    assert "GROUP BY COMMAND" in sql            # aggregated breakdown
+    assert "Threads_running" in sql             # saturation signal
+    assert "SHOW FULL PROCESSLIST" not in sql   # NOT the 300-row dump
+
+
+def test_db_processlist_full_dumps_mysql():
+    t, captured = _db_tools_capturing_sql("mysql")
+    asyncio.run(t.db_processlist("i-1", full=True))
+    assert "SHOW FULL PROCESSLIST" in captured["sql"]
+
+
+def test_db_processlist_summarises_by_default_postgres():
+    t, captured = _db_tools_capturing_sql("postgres")
+    asyncio.run(t.db_processlist("i-1"))
+    sql = captured["sql"]
+    assert "pg_stat_activity" in sql
+    assert "GROUP BY state" in sql
+    assert "max_connections" in sql
+    assert "LIMIT 10" in sql                     # only the 10 oldest non-idle
+
+
+def test_db_processlist_full_dumps_postgres():
+    t, captured = _db_tools_capturing_sql("postgres")
+    asyncio.run(t.db_processlist("i-1", full=True))
+    sql = captured["sql"]
+    assert "GROUP BY state" not in sql           # raw, not aggregated
+    assert "ORDER BY query_start NULLS LAST" in sql
+
+
+def test_fleet_probe_detects_fpm_via_master():
+    # Regression guard for the blank-FPM-column fix: presence is detected via
+    # the master process title (can't self-match the probe shell, survives an
+    # idle ondemand pool), capacity is SUMMED across pools, and a sudo fallback
+    # covers root-only pool.d configs.
+    cmd = ServonautTools._FLEET_PROBE_CMD
+    assert "php-fpm: master" in cmd
+    assert "php-fpm: pool" in cmd                # worker count
+    assert "pm.max_children" in cmd
+    assert "s+=$1" in cmd                        # summed capacity, not single max
+    assert "sudo -n" in cmd

--- a/tests/test_mcp_aws_security_tools.py
+++ b/tests/test_mcp_aws_security_tools.py
@@ -18,6 +18,12 @@ from unittest.mock import AsyncMock, MagicMock
 from servonaut.config.schema import AppConfig, IPBanConfig, MCPConfig
 from servonaut.mcp.guards import CommandGuard, GuardLevel
 from servonaut.mcp.tools import ServonautTools
+from servonaut.services.cloudwatch_service import CloudWatchService
+
+# The filter normalizer is pure; wire the real one onto mocked CloudWatch
+# services so the tool's auto-quote path behaves as in production rather than
+# returning a truthy MagicMock for the effective filter pattern.
+_NORMALIZE = CloudWatchService.normalize_filter_pattern
 
 
 def _run(coro):
@@ -100,6 +106,7 @@ class TestCloudWatchListLogGroups:
 class TestCloudWatchGetLogEvents:
     def test_dispatch_and_format(self):
         cw = MagicMock()
+        cw.normalize_filter_pattern = _NORMALIZE
         cw.get_log_events = AsyncMock(return_value=[
             {"timestamp": datetime(2026, 5, 21, 10, 0, 0),
              "message": "hello", "log_stream": "s1"},
@@ -116,10 +123,23 @@ class TestCloudWatchGetLogEvents:
 
     def test_empty(self):
         cw = MagicMock()
+        cw.normalize_filter_pattern = _NORMALIZE
         cw.get_log_events = AsyncMock(return_value=[])
         tools = _make_tools(cloudwatch_service=cw)
         out = _run(tools.cloudwatch_get_log_events("/aws/waf/prod"))
         assert "No log events" in out
+
+    def test_empty_with_filter_distinguishes_no_match(self):
+        # A filtered empty result must NOT read as "the group is empty" — that
+        # conflation produced a false WAF-bypass conclusion in the field.
+        cw = MagicMock()
+        cw.normalize_filter_pattern = _NORMALIZE
+        cw.get_log_events = AsyncMock(return_value=[])
+        tools = _make_tools(cloudwatch_service=cw)
+        out = _run(tools.cloudwatch_get_log_events(
+            "/aws/waf/prod", filter_pattern="9.9.9.9"))
+        assert "0 events matched filter" in out
+        assert '"9.9.9.9"' in out  # auto-quoted
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Broadens the AWS control-plane reach so investigations stop dead-ending on operations that weren't individually wrapped, fixes a CloudWatch filter foot-gun, and lays the identity foundation for a least-privilege control-plane role. Addresses the control-plane tooling feedback (priorities 1–4 + two carry-overs).

## Tools

- **`aws_call`** — generic boto3 passthrough. Reads (`Describe*/Get*/List*/Filter*/Lookup*/Head*/BatchGet*/Search*`) run read-only and **auto-paginate**; mutating ops require `mutate=true` **and** the dangerous guard tier; destructive verbs (`delete/terminate/destroy/purge`) are always refused (use a curated tool). Region/account pinning, output capping, full audit trail. Unlocks the long tail — `DescribeSecurityGroupRules`, `GetIPSet`, `GetWebACL`, `FilterLogEvents`, `DescribeTargetHealth`, … — with zero new code per need.
- **`cloudwatch_insights`** — CloudWatch Logs Insights (`start_query`/poll `get_query_results`). The general aggregation primitive: top IPs, status mix, URI ranking, time-bucketing.
- **`cloudwatch_get_log_events` filter fix** — a bare literal term (an IP, a path) is **auto-quoted** before it reaches CloudWatch (unquoted dotted strings are tokenised and silently fail to match). A filtered empty result now reports **`0 events matched filter X`** instead of conflating it with an empty group. New `client_ip` arg builds the structured `{ $.httpRequest.clientIp = "x" }` selector.

## Identity (control-plane / host-plane split)

- **`AWSClientFactory`** — shared boto3 construction with optional **STS AssumeRole**, per-account role map, ExternalId, and region pinning (temp creds cached). **No role configured → ambient credential chain (no behaviour change).**
- **Read vs write role split** (per-operator assume-role + ExternalId, no central principal): the control-plane role is **read-only**; the `aws_call` mutate path uses a *separate* `control_plane_mutate_role_arn` and **never assumes the read role** (falls back to ambient when unset), so a correctly-provisioned read-only role can't AccessDeny every write.
- New `AWSConfig` fields (all optional, default to today's behaviour): `control_plane_role_arn`, `control_plane_role_arns`, `control_plane_external_id`, `assume_role_session_name`, `control_plane_mutate_role_arn`, `control_plane_mutate_role_arns`.

> Provisioning the actual least-privilege IAM role + trust policy is an owner-driven account task (no backend/REST change). The setup-flow docs will reference the `servonaut-control-plane-readonly` role convention.

## Carry-over fixes

- **`fleet_health_snapshot`** — FPM column no longer goes blank: php-fpm is detected via the master process title (survives an idle `pm=ondemand` pool, can't self-match the probe shell), `pm.max_children` is summed across pools, with a `sudo -n` fallback for root-only `pool.d`. Verified live.
- **`db_processlist`** — summarises server-side by default (saturation + by-command/state breakdown + 10 longest-running queries) instead of dumping every session; `full=true` returns the raw dump.

(`db_setup_scan` auto-discovery of `configuration.php` and `describe_ingress_path` rule-collapsing were already shipped in prior rounds — verified, no change needed.)

## Tests

New `test_aws_client_factory.py`, `test_aws_call_tool.py`, plus additions to the cloudwatch / security / catalog / incident-response suites. Full suite green (the only failures locally are pre-existing hetzner tests that need the optional `hcloud` extra, unrelated to this change). `aws_call` + `cloudwatch_insights` are tracked as CLI-first in the catalog-drift gate pending server-catalog entries.