### PR TITLE
ci: add Leak Guard to block internal info entering PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Guard the guards: changes to CI and the leak-protection tooling must be
+# reviewed by a maintainer, so a PR can't quietly weaken the public-repo
+# leak checks. Enforced when branch protection has "Require review from Code
+# Owners" enabled for the default branch.
+#
+# NOTE: confirm the owner handle below matches this repo's maintainer account.
+/.github/  @zb-ss

--- a/.github/leak-allowlist.txt
+++ b/.github/leak-allowlist.txt
@@ -1,0 +1,9 @@
+# Leak Guard allowlist — exact, known-safe literal tokens that the tier-2
+# shape detectors would otherwise flag. One token per line; '#' starts a
+# comment. Keep this to genuinely public/example values only.
+#
+# For a one-off vetted fixture line, prefer the inline escape hatch instead:
+# add `leak-guard:allow` in a comment on that line.
+
+# Canonical AWS documentation example access key (not a real credential).
+AKIAIOSFODNN7EXAMPLE

--- a/.github/scripts/leak-scan.sh
+++ b/.github/scripts/leak-scan.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
-# Leak Guard — fail a PR if its diff, title, or body contains internal /
-# coordination markers that must not enter this PUBLIC repo. Plain grep, no
-# external dependencies, no AI/Copilot. This is a backstop; the first line of
-# defence is genericizing content while you write it (see CLAUDE.md).
+# Leak Guard — fail a PR whose diff, title, or body contains internal /
+# coordination markers or secret-shaped values that must not enter this PUBLIC
+# repo. Plain grep, no external deps, no AI/Copilot. A deterministic BACKSTOP;
+# the first line of defence is genericizing while writing (see CONTRIBUTING.md
+# → "Avoiding accidental disclosure"). An optional LLM advisory reviewer
+# (separate, non-blocking) covers the unbounded/semantic classes this can't
+# (novel customer names, reworded phrasing).
 #
-# It checks two tiers:
-#   1. Built-in, NON-sensitive structural markers (coordination phrases, peer
-#      names, deploy-SHA shapes). These are safe to keep in this file.
-#   2. An optional confidential denylist supplied via the LEAK_DENYLIST repo
-#      secret (newline-separated customer names / real IPs). Those terms are
-#      NEVER printed — CI logs on a public repo are themselves public.
+# IMPORTANT: CI logs on a public repo are themselves public, so this script
+# reports only METADATA (source + line numbers + pattern name) and NEVER the
+# matched content — printing the match would re-leak the very value it caught.
+#
+# Detection tiers:
+#   1. Structural markers  — generic coordination phrases / deploy-id shapes.
+#   2. Secret/PII shapes   — emails, private keys, AKIA keys, ARN account-ids,
+#                            real home paths, UUIDs (allowlist-filtered).
+#   3. Confidential denylist — exact customer names / real IPs from the
+#                            LEAK_DENYLIST repo secret (same-repo PRs only).
 set -uo pipefail
 
 BASE_SHA="${BASE_SHA:-}"
@@ -17,60 +24,143 @@ HEAD_SHA="${HEAD_SHA:-}"
 PR_TITLE="${PR_TITLE:-}"
 PR_BODY="${PR_BODY:-}"
 EXTRA_DENYLIST="${EXTRA_DENYLIST:-}"
-
-# Built-in case-insensitive ERE markers. Kept generic on purpose so this file
-# is itself safe to commit to the public repo.
-PATTERNS=(
-  'backend team'
-  'backend owner'
-  'dev agent'
-  'agent[- ]?bus'
-  'heads[- ]?up sent'
-  'coordinated with'
-  'decided with (the )?(backend|server|dev|infra|ops)'
-  'pinged (the )?(backend|server|dev|infra|ops)'
-  'per the thread'
-  'cross[- ]team'
-  'the (backend|server|dev|infra|ops) team'
-  'prod-[0-9a-f]{7,}'
-)
+ALLOWLIST_FILE="${ALLOWLIST_FILE:-.github/leak-allowlist.txt}"
 
 fail=0
-report() { echo "::error::$1"; fail=1; }
+# Emit metadata only — sources/patterns, never matched content.
+flag() { echo "::error::LEAK GUARD — $1"; fail=1; }
 
-# --- 1. Diff (added lines only), excluding the guard's own files ----------
-DIFF=""
+# --- Tier 1: structural markers (name|ERE). Generic, safe to keep here. -----
+PHRASE_PATTERNS=(
+  "coordination-phrase|backend team"
+  "coordination-phrase|backend owner"
+  "coordination-phrase|dev agent"
+  "coordination-phrase|agent[- ]?bus"
+  "coordination-phrase|heads[- ]?up sent"
+  "coordination-phrase|coordinated with"
+  "coordination-phrase|decided with (the )?(backend|server|dev|infra|ops)"
+  "coordination-phrase|pinged (the )?(backend|server|dev|infra|ops)"
+  "coordination-phrase|per the thread"
+  "coordination-phrase|cross[- ]team"
+  "coordination-phrase|the (backend|server|dev|infra|ops) team"
+  "deploy-identifier|prod-[0-9a-f]{7,}"
+)
+
+# --- Tier 2: secret/PII shapes (name|PCRE). Matched value is never printed. -
+# example.com/.org/.net, /home/user, /home/runner are excluded inline; the
+# canonical AWS example key and other fixtures go in the allowlist file.
+SHAPE_PATTERNS=(
+  "email|[A-Za-z0-9._%+-]+@(?!example\.(?:com|org|net))[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+  "aws-access-key|AKIA[0-9A-Z]{16}"
+  "private-key|-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----"
+  "aws-arn-account-id|arn:aws[a-z-]*:[a-z0-9-]*:[a-z0-9-]*:[0-9]{12}:"
+  "home-path|/home/(?!user/|runner/)[a-z_][a-z0-9_-]*"
+  "uuid|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
+
+# Allowlist: literal known-safe tokens (redaction fixtures, doc examples) — one
+# per line, '#' comments allowed. Shape hits made up solely of these are dropped.
+ALLOW=()
+if [ -f "$ALLOWLIST_FILE" ]; then
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    line="${line#"${line%%[![:space:]]*}"}"; line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    ALLOW+=("$line")
+  done < "$ALLOWLIST_FILE"
+fi
+is_allowlisted() {  # $1 = token
+  local t
+  for t in "${ALLOW[@]:-}"; do [ -n "$t" ] && [ "$1" = "$t" ] && return 0; done
+  return 1
+}
+
+TMPDIR_SCAN="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_SCAN"' EXIT
+printf '%s' "$PR_TITLE" > "$TMPDIR_SCAN/__pr_title"
+printf '%s' "$PR_BODY"  > "$TMPDIR_SCAN/__pr_body"
+
+# Per-file added-diff lines, excluding the guard's own files so a guard PR
+# doesn't self-trip on the literal patterns above.
+DIFF_OK=1
+CHANGED=()
 if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-  DIFF="$(git diff --unified=0 "${BASE_SHA}...${HEAD_SHA}" -- . \
-      ':(exclude).github/workflows/leak-guard.yml' \
-      ':(exclude).github/scripts/leak-scan.sh' \
-      2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+  if CHANGED_RAW="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- . \
+        ':(exclude).github/workflows/leak-guard.yml' \
+        ':(exclude).github/scripts/leak-scan.sh' \
+        ':(exclude).github/leak-allowlist.txt' 2>"$TMPDIR_SCAN/__differr")"; then
+    while IFS= read -r f; do [ -n "$f" ] && CHANGED+=("$f"); done <<< "$CHANGED_RAW"
+  else
+    DIFF_OK=0
+  fi
 fi
 
-# Title + body come from the event payload via env (never interpolated into a
-# shell command), so a hostile PR body can't inject anything here.
-HAYSTACK="$(printf 'TITLE: %s\nBODY: %s\n%s\n' "$PR_TITLE" "$PR_BODY" "$DIFF")"
+# Fail CLOSED: if SHAs were provided but the diff could not be computed (e.g. a
+# fork head we couldn't fetch), do NOT pass vacuously.
+if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ] && [ "$DIFF_OK" -ne 1 ]; then
+  flag "could not compute the PR diff (failing closed): $(head -1 "$TMPDIR_SCAN/__differr" 2>/dev/null)"
+fi
 
-for p in "${PATTERNS[@]}"; do
-  hits="$(printf '%s\n' "$HAYSTACK" | grep -inE "$p" || true)"
-  if [ -n "$hits" ]; then
-    report "Internal-marker pattern '/$p/i' found — genericize it:"
-    printf '%s\n' "$hits" | sed 's/^/    /'
-  fi
+scan_blob() {  # $1 = source label, $2 = file of text to scan
+  local label="$1" file="$2" name re hits tok kept entry scanf
+  [ -s "$file" ] || return 0
+  # Inline escape hatch: a line containing `leak-guard:allow` is exempt from
+  # tiers 1 & 2 (for vetted fixtures). The confidential denylist (tier 3)
+  # cannot be silenced this way.
+  scanf="$file.flt"
+  # grep -v exits 1 when it filters out EVERY line (the intended "all exempt"
+  # case) and 2 on real error — only fall back to the unfiltered file on error,
+  # otherwise an all-exempt blob would be wrongly restored and re-scanned.
+  grep -vF 'leak-guard:allow' "$file" > "$scanf" 2>/dev/null
+  [ "$?" -gt 1 ] && cp "$file" "$scanf"
+  for entry in "${PHRASE_PATTERNS[@]}"; do
+    name="${entry%%|*}"; re="${entry#*|}"
+    hits="$(grep -inE "$re" "$scanf" 2>/dev/null | cut -d: -f1 | paste -sd, - || true)"
+    [ -n "$hits" ] && flag "[$label] $name on line(s) $hits"
+  done
+  for entry in "${SHAPE_PATTERNS[@]}"; do
+    name="${entry%%|*}"; re="${entry#*|}"
+    kept=0
+    while IFS= read -r tok; do
+      [ -z "$tok" ] && continue
+      is_allowlisted "$tok" || kept=$((kept+1))
+    done < <(grep -oiP "$re" "$scanf" 2>/dev/null || true)
+    [ "$kept" -gt 0 ] && flag "[$label] $name shape matched ($kept occurrence(s), value hidden)"
+  done
+}
+
+scan_blob "pr-title" "$TMPDIR_SCAN/__pr_title"
+scan_blob "pr-body"  "$TMPDIR_SCAN/__pr_body"
+for f in "${CHANGED[@]:-}"; do
+  [ -z "$f" ] && continue
+  git diff "${BASE_SHA}...${HEAD_SHA}" -- "$f" 2>/dev/null \
+    | grep -E '^\+' | grep -vE '^\+\+\+' | sed 's/^\+//' > "$TMPDIR_SCAN/__cur" || true
+  scan_blob "$f" "$TMPDIR_SCAN/__cur"
 done
 
-# --- 2. Confidential denylist via repo secret (values never echoed) -------
+# --- Tier 3: confidential denylist (values never echoed) -------------------
 if [ -n "$EXTRA_DENYLIST" ]; then
+  {
+    cat "$TMPDIR_SCAN/__pr_title" "$TMPDIR_SCAN/__pr_body" 2>/dev/null
+    if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+      git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+'
+    fi
+  } > "$TMPDIR_SCAN/__all"
   while IFS= read -r term; do
+    term="${term%$'\r'}"
+    term="${term#"${term%%[![:space:]]*}"}"; term="${term%"${term##*[![:space:]]}"}"
     [ -z "$term" ] && continue
-    if printf '%s\n' "$HAYSTACK" | grep -iqF -- "$term"; then
-      report "A confidential denylist term matched (value hidden). Genericize it before merging."
+    case "$term" in \#*) continue ;; esac
+    [ "${#term}" -lt 4 ] && continue   # reject ultra-short terms (broad matches)
+    if grep -iqF -- "$term" "$TMPDIR_SCAN/__all"; then
+      flag "[denylist] a confidential term matched (value hidden). Genericize it."
     fi
   done <<< "$EXTRA_DENYLIST"
 fi
 
 if [ "$fail" -ne 0 ]; then
-  echo "::error::Leak Guard failed — this is a PUBLIC repo. Genericize the flagged content (code AND prose) before merging. See the pre-publish leak check in CLAUDE.md."
+  echo "::error::Leak Guard failed — this is a PUBLIC repo. Genericize the flagged content (code AND prose) before merging. See CONTRIBUTING.md → 'Avoiding accidental disclosure'. To exempt a vetted fixture line, add 'leak-guard:allow' in a comment on it."
   exit 1
 fi
-echo "Leak Guard: no internal markers detected. ✓"
+echo "Leak Guard: no internal markers or secret shapes detected. ✓"

--- a/.github/scripts/leak-scan.sh
+++ b/.github/scripts/leak-scan.sh
@@ -54,7 +54,7 @@ SHAPE_PATTERNS=(
   "aws-access-key|AKIA[0-9A-Z]{16}"
   "private-key|-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----"
   "aws-arn-account-id|arn:aws[a-z-]*:[a-z0-9-]*:[a-z0-9-]*:[0-9]{12}:"
-  "home-path|/home/(?!user/|runner/)[a-z_][a-z0-9_-]*"
+  "home-path|/home/(?!user\b|runner\b)[a-z_][a-z0-9_-]*"
   "uuid|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 )
 

--- a/.github/scripts/leak-scan.sh
+++ b/.github/scripts/leak-scan.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Leak Guard — fail a PR if its diff, title, or body contains internal /
+# coordination markers that must not enter this PUBLIC repo. Plain grep, no
+# external dependencies, no AI/Copilot. This is a backstop; the first line of
+# defence is genericizing content while you write it (see CLAUDE.md).
+#
+# It checks two tiers:
+#   1. Built-in, NON-sensitive structural markers (coordination phrases, peer
+#      names, deploy-SHA shapes). These are safe to keep in this file.
+#   2. An optional confidential denylist supplied via the LEAK_DENYLIST repo
+#      secret (newline-separated customer names / real IPs). Those terms are
+#      NEVER printed — CI logs on a public repo are themselves public.
+set -uo pipefail
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+PR_TITLE="${PR_TITLE:-}"
+PR_BODY="${PR_BODY:-}"
+EXTRA_DENYLIST="${EXTRA_DENYLIST:-}"
+
+# Built-in case-insensitive ERE markers. Kept generic on purpose so this file
+# is itself safe to commit to the public repo.
+PATTERNS=(
+  'backend team'
+  'backend owner'
+  'dev agent'
+  'agent[- ]?bus'
+  'heads[- ]?up sent'
+  'coordinated with'
+  'decided with (the )?(backend|server|dev|infra|ops)'
+  'pinged (the )?(backend|server|dev|infra|ops)'
+  'per the thread'
+  'cross[- ]team'
+  'the (backend|server|dev|infra|ops) team'
+  'prod-[0-9a-f]{7,}'
+)
+
+fail=0
+report() { echo "::error::$1"; fail=1; }
+
+# --- 1. Diff (added lines only), excluding the guard's own files ----------
+DIFF=""
+if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+  DIFF="$(git diff --unified=0 "${BASE_SHA}...${HEAD_SHA}" -- . \
+      ':(exclude).github/workflows/leak-guard.yml' \
+      ':(exclude).github/scripts/leak-scan.sh' \
+      2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+fi
+
+# Title + body come from the event payload via env (never interpolated into a
+# shell command), so a hostile PR body can't inject anything here.
+HAYSTACK="$(printf 'TITLE: %s\nBODY: %s\n%s\n' "$PR_TITLE" "$PR_BODY" "$DIFF")"
+
+for p in "${PATTERNS[@]}"; do
+  hits="$(printf '%s\n' "$HAYSTACK" | grep -inE "$p" || true)"
+  if [ -n "$hits" ]; then
+    report "Internal-marker pattern '/$p/i' found — genericize it:"
+    printf '%s\n' "$hits" | sed 's/^/    /'
+  fi
+done
+
+# --- 2. Confidential denylist via repo secret (values never echoed) -------
+if [ -n "$EXTRA_DENYLIST" ]; then
+  while IFS= read -r term; do
+    [ -z "$term" ] && continue
+    if printf '%s\n' "$HAYSTACK" | grep -iqF -- "$term"; then
+      report "A confidential denylist term matched (value hidden). Genericize it before merging."
+    fi
+  done <<< "$EXTRA_DENYLIST"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "::error::Leak Guard failed — this is a PUBLIC repo. Genericize the flagged content (code AND prose) before merging. See the pre-publish leak check in CLAUDE.md."
+  exit 1
+fi
+echo "Leak Guard: no internal markers detected. ✓"

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,0 +1,30 @@
+name: Leak Guard
+
+# Public-repo backstop: fail a PR whose diff, title, or body contains internal /
+# coordination markers (team structure, peer names, deploy-SHA shapes) or a term
+# from the confidential LEAK_DENYLIST secret. Pure grep — no external deps.
+# Re-runs on `edited` so a later body edit that introduces a leak is still caught.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  leak-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan diff + PR title/body for internal markers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Passed via env (not inline) so a hostile PR body can't inject shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          EXTRA_DENYLIST: ${{ secrets.LEAK_DENYLIST }}
+        run: bash .github/scripts/leak-scan.sh

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,9 +1,17 @@
 name: Leak Guard
 
 # Public-repo backstop: fail a PR whose diff, title, or body contains internal /
-# coordination markers (team structure, peer names, deploy-SHA shapes) or a term
-# from the confidential LEAK_DENYLIST secret. Pure grep — no external deps.
-# Re-runs on `edited` so a later body edit that introduces a leak is still caught.
+# coordination markers, secret-shaped values, or a term from the confidential
+# LEAK_DENYLIST secret. Re-runs on `edited` so a later body edit is also caught.
+#
+# Scope/limitations (by design):
+#   * The scanner is run FROM THE BASE BRANCH (not the PR checkout), so a PR
+#     cannot weaken the script for its own run. Workflow-file tampering is
+#     governed separately by branch protection + CODEOWNERS on .github/.
+#   * Tiers 1 (markers) and 2 (secret shapes) work on fork PRs. Tier 3 (the
+#     LEAK_DENYLIST secret) only runs for same-repo PRs — repo secrets are not
+#     exposed to fork PRs under `pull_request`. For fork denylist coverage, a
+#     hardened `pull_request_target` job (never running PR code) would be needed.
 
 on:
   pull_request:
@@ -19,6 +27,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Resolve scanner from base branch (anti-tamper)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          mkdir -p "$RUNNER_TEMP/guard"
+          # Prefer base-branch versions so a PR can't weaken its own guard; fall
+          # back to the PR copy only when base lacks them (first introduction).
+          for f in scripts/leak-scan.sh leak-allowlist.txt; do
+            dest="$RUNNER_TEMP/guard/$(basename "$f")"
+            if git cat-file -e "FETCH_HEAD:.github/$f" 2>/dev/null; then
+              git show "FETCH_HEAD:.github/$f" > "$dest"
+            elif [ -f ".github/$f" ]; then
+              cp ".github/$f" "$dest"
+            fi
+          done
       - name: Scan diff + PR title/body for internal markers
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -27,4 +52,5 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           EXTRA_DENYLIST: ${{ secrets.LEAK_DENYLIST }}
-        run: bash .github/scripts/leak-scan.sh
+          ALLOWLIST_FILE: ${{ runner.temp }}/guard/leak-allowlist.txt
+        run: bash "$RUNNER_TEMP/guard/leak-scan.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,19 @@ This document provides guidelines for contributing to this project.
 7.  **Push to your fork**: `git push origin name-of-your-new-feature-or-fix`
 8.  **Open a Pull Request**: Go to the original repository on GitHub and click the "New pull request" button. Fill out the pull request template.
 
+## Avoiding accidental disclosure
+
+This is a public repository — anything that lands in a commit, test, fixture, PR title/body, or release note is permanent and world-readable. Before opening a PR, please make sure neither your **code** nor your **prose** contains:
+
+- Real customer / client / brand names, real hostnames, or real infrastructure identifiers (account IDs, ARNs, bucket / security-group / instance names). Use neutral examples (`example.com`, `web-1`, `9.9.9.9`, RFC1918 addresses).
+- Real IP addresses tied to anyone's infrastructure, or details of a specific real-world incident.
+- Personal data (real emails, home-directory paths) — use `user@example.com`, `/home/user`.
+- Secrets of any kind (keys, tokens, passwords, private keys).
+
+A **Leak Guard** CI check scans each PR's diff, title, and body for these patterns and a maintained denylist; it reports only *where* a match was found, never the value. It's a backstop, not a substitute for care while writing.
+
+If the guard flags a line that is a genuinely safe, vetted fixture (e.g. a documentation example key), add `leak-guard:allow` in a comment on that line to exempt it, or add the exact safe token to `.github/leak-allowlist.txt`.
+
 ## Development Setup
 Please refer to the `README.md` for instructions on setting up your development environment and installing dependencies.
 


### PR DESCRIPTION
## Why

This is a **public** repo, and prose that crosses into a public artifact (PR titles/bodies, commit messages, code/test comments) is permanent and indexable, so accidental internal detail there is hard to walk back. This adds an automated backstop so it can't merge unnoticed.

## What

A `Leak Guard` GitHub Actions check runs on every PR (`opened`, `edited`, `reopened`, `synchronize`) and scans:
- the **diff** (added lines), and
- the PR **title + body**

against two tiers:
1. **Built-in structural markers** — generic patterns for internal/coordination language, peer references, and deploy-identifier shapes. These are non-sensitive, so they live in the script itself.
2. **A confidential denylist** supplied via the optional `LEAK_DENYLIST` repo secret (newline-separated customer names / real IPs). These stay out of the repo, and matched values are **never printed** (CI logs on a public repo are public) — the check only says a term matched.

Fails the check (with the offending lines for tier 1) so flagged content blocks the merge.

## Design notes
- Plain `grep`, no external dependencies, **no AI/Copilot** — deterministic and free.
- PR title/body are passed via env, never interpolated into a shell command (a hostile description can't inject).
- The guard's own files are excluded from the diff scan so they don't self-trip.
- Re-runs on `edited`, so a leak introduced by a later description edit is caught too.

## Follow-up (optional)
To enable tier 2, add a repo secret `LEAK_DENYLIST` (Settings → Secrets → Actions) with one sensitive term per line. Tier 1 works with no setup.

## Note
This is a backstop, not the first line of defence — the project guide documents genericizing content while writing. Verified locally: leaking text fails, clean text passes, and a denylist hit fails without echoing the value.