### PR TITLE
chore: scrub internal detail from tracked files (public-repo hygiene)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thank you for contributing to Servonaut!
 Please provide a clear description of your changes and link to any relevant issues.
 
 **Before submitting, please ensure you have:**
-- [ ] Read the [CONTRIBUTING.md](https://github.com/zb-ss/ec2-ssh/blob/master/CONTRIBUTING.md) guide.
+- [ ] Read the [CONTRIBUTING.md](https://github.com/zb-ss/servonaut/blob/master/CONTRIBUTING.md) guide.
 - [ ] Based your changes on the `main` branch (or the relevant development branch).
 - [ ] Ensured your code follows the project's coding style.
 - [ ] Added tests for your changes (if applicable).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ This document provides guidelines for contributing to this project.
 ## How Can I Contribute?
 
 ### Reporting Bugs
-*   Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/zb-ss/ec2-ssh/issues).
-*   If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/zb-ss/ec2-ssh/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample or an executable test case** demonstrating the expected behavior that is not occurring.
+*   Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/zb-ss/servonaut/issues).
+*   If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/zb-ss/servonaut/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample or an executable test case** demonstrating the expected behavior that is not occurring.
 
 ### Suggesting Enhancements
 *   Open a new issue to discuss your enhancement. Clearly describe the proposed enhancement and its potential benefits.
@@ -16,7 +16,7 @@ This document provides guidelines for contributing to this project.
 
 ### Pull Requests
 1.  **Fork the repository**: Click the "Fork" button at the top right of the repository page.
-2.  **Clone your fork**: `git clone https://github.com/zb-ss/ec2-ssh.git`.
+2.  **Clone your fork**: `git clone https://github.com/zb-ss/servonaut.git`.
 3.  **Create a new branch**: `git checkout -b name-of-your-new-feature-or-fix`
 4.  **Make your changes**: Make your changes in your local repository.
 5.  **Follow coding style**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,8 +336,8 @@ These can be set inline, exported, or added to `~/.secrets/servonaut.env`:
 
 ```
 # Point CLI at staging
-SERVONAUT_API_URL=https://staging.servonaut.dev
-SERVONAUT_MCP_URL=https://staging.servonaut.dev
+SERVONAUT_API_URL=https://staging.example.com
+SERVONAUT_MCP_URL=https://staging.example.com
 ```
 
 ## Supported Terminals

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -176,8 +176,7 @@ Downstream tools (`run_command`, `check_status`, `get_logs`,
 
 `scripts/demo-fleet.sh` spins up four servers, lists them, and tears
 them down — under one second wall clock against a warm API. Used as
-acceptance criterion #8 for the kickoff brief and as the canonical
-recording target for marketing videos.
+the canonical recording target for marketing videos.
 
 ```bash
 ./scripts/demo-fleet.sh                 # 4 servers, full create+destroy
@@ -278,14 +277,14 @@ Two options:
   reason: Hetzner would otherwise spawn one with a random root
   password the CLI discards, leaving a billed unreachable box.
 
-## Limitations (anti-scope for this kickoff)
+## Limitations (out of scope)
 
 These are deliberately out of scope:
 
 - Hetzner Robot (dedicated servers) — different API surface, smaller
-  user base. Future kickoff.
+  user base. Planned for the future.
 - Storage Boxes, DNS, Load Balancers, Volumes, Networks, Firewalls,
   Floating IPs, Placement Groups — manage these in the Hetzner
   Console for now.
 - Snapshot / image management.
-- AWS create/destroy parity — separate future kickoff.
+- AWS create/destroy parity — planned separately.

--- a/src/servonaut/cli/secrets.py
+++ b/src/servonaut/cli/secrets.py
@@ -1,7 +1,6 @@
 """CLI subcommand handlers for ``servonaut secrets``.
 
-Step 8 of the kickoff plan
-(``~/.dotfiles/org/org/servonaut/plans/kickoff-secrets-management.org``).
+Part of the secrets-management feature.
 
 MVP surface — kept deliberately small:
 

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -694,9 +694,7 @@ class SecretsConfig:
     :pyattr:`AuthToken.secrets_config`) and for the always-available
     LocalProvider fallback when no team config is in play.
 
-    Contract (locked with servonaut-web-backend on agent-bus thread
-    ``secrets-management-kickoff``; full doc at
-    ``~/.dotfiles/org/org/servonaut/plans/kickoff-secrets-management.org``):
+    The server-side contract is:
 
     Wire format from ``GET /api/v1/teams/{id}/secrets-config``::
 
@@ -717,7 +715,7 @@ class SecretsConfig:
     - ``updated_at`` — server-side wall-clock of the last admin change,
       ISO-8601 string. Compared against the CLI's cache timestamp so
       we can surface "team config changed since last fetch" without
-      polling the audit log (see kickoff doc §Audit log).
+      polling the audit log.
     """
 
     provider: str = "local"

--- a/src/servonaut/screens/ai_analysis.py
+++ b/src/servonaut/screens/ai_analysis.py
@@ -142,7 +142,7 @@ class AIAnalysisScreen(Screen):
 
         All user-influenced strings (model names from server, provider
         labels from config) are passed through :func:`rich.markup.escape`
-        before interpolation — see CLAUDE.md "Rich markup escape" rule.
+        before interpolation (Rich-markup escaping convention).
         """
         config = self.app.config_manager.get()
         ai_config = config.ai_provider

--- a/src/servonaut/screens/ai_conversations_screen.py
+++ b/src/servonaut/screens/ai_conversations_screen.py
@@ -7,7 +7,7 @@ Why a regular ``Screen`` and not a ``ModalScreen``: this is a content-heavy
 panel with multiple action rows, a filter input, a paginated DataTable, and
 multi-step flows (export prompts for a path, archive/delete confirms). The
 ``Sidebar`` widget MUST stay visible so users can navigate away mid-flow.
-See the "ModalScreen vs Screen" rule in CLAUDE.md.
+Uses a ModalScreen for this brief blocking view (project convention).
 
 The screen is opened from :meth:`ChatPanel._toggle_history` *only* when the
 user is signed in AND has the ``premium_ai`` entitlement; free / logged-out

--- a/src/servonaut/screens/ai_fallback_prompt_modal.py
+++ b/src/servonaut/screens/ai_fallback_prompt_modal.py
@@ -8,7 +8,7 @@ so the user-driven path doesn't read like a failure (the previous
 hardcoded "Servonaut AI is unavailable." text fired even when chat
 was working perfectly).
 
-Per CLAUDE.md ModalScreen rule: brief blocking choice ("which provider
+Per the project ModalScreen convention: brief blocking choice ("which provider
 do you want to use for THIS session"), so a Modal is the right fit.
 """
 from __future__ import annotations

--- a/src/servonaut/screens/ai_picker_modal.py
+++ b/src/servonaut/screens/ai_picker_modal.py
@@ -1,6 +1,6 @@
 """T4.5 first-run + empty-state provider picker modals.
 
-Both are :class:`ModalScreen` (per CLAUDE.md "ModalScreen vs Screen rule
+Both are :class:`ModalScreen` (per the "ModalScreen vs Screen" convention
 of thumb"): brief blocking choices with two or three buttons. The
 caller awaits the dismiss return value to decide what to do next.
 

--- a/src/servonaut/screens/ai_topup_modal.py
+++ b/src/servonaut/screens/ai_topup_modal.py
@@ -9,7 +9,7 @@ panel quota_exhausted / budget_exhausted handler, or
   returned ``checkout_url`` in the browser.
 - ``None`` — the user cancelled / pressed Escape.
 
-Per CLAUDE.md ModalScreen rule: this fits the brief-blocking-choice
+Per the project ModalScreen convention: this fits the brief-blocking-choice
 pattern. Multi-button row, single decision, no content beyond pack
 descriptions.
 """

--- a/src/servonaut/screens/bug_report_consent_modal.py
+++ b/src/servonaut/screens/bug_report_consent_modal.py
@@ -5,7 +5,7 @@ The user selects which categories to include and where to send the
 report.  A preview of the exact payload is shown on the next screen
 (BugReportScreen) before anything leaves the machine.
 
-Per CLAUDE.md ModalScreen rule: brief blocking choice — dismiss to
+Per the project ModalScreen convention: brief blocking choice — dismiss to
 return.  BugReportScreen is the multi-step content-heavy counterpart
 that carries the Sidebar.
 """

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -255,7 +255,7 @@ class FleetScanSummaryModal(ModalScreen[None]):
         """Format succeeded + failed lists for the modal body."""
         # _s: scrub PII (IPs, hostnames, paths) from exception messages BEFORE
         # escape() so malformed IPs are never visible in demo recordings.
-        # Order: scrub → escape → embed (CLAUDE.md anti-pattern rule).
+        # Order: scrub → escape → embed (avoids Rich-markup injection).
         def _s(x: str) -> str:
             try:
                 if self.app.demo_mode and self.app.redaction_service:

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -259,7 +259,7 @@ class InstanceListScreen(Screen):
             if event.worker.error:
                 # markup=False because the worker error message can
                 # include server-controlled text (Hetzner names, label
-                # values, error strings). CLAUDE.md mandates the flag
+                # values, error strings). The project mandates the flag
                 # for any notify with server-controlled interpolation.
                 self.app.notify(
                     f"Hetzner refresh error: {event.worker.error}",

--- a/src/servonaut/screens/memory_consent_modal.py
+++ b/src/servonaut/screens/memory_consent_modal.py
@@ -9,7 +9,7 @@ This is a step DOWN from Memory Sync (E2E encrypted, server can never
 read) so the consent decision is captured separately and persisted to
 ``config.chat_inject_server_memory_decision``.
 
-Per CLAUDE.md ModalScreen rule: a brief blocking choice ("allow this or
+Per the project ModalScreen convention: a brief blocking choice ("allow this or
 not") lives in a Modal.  The "show me what'll be sent" affordance opens
 a non-blocking detail panel.
 """

--- a/src/servonaut/screens/secrets.py
+++ b/src/servonaut/screens/secrets.py
@@ -1,6 +1,6 @@
 """SecretsScreen — in-TUI control for the secrets-management feature.
 
-UX Step 9 (kickoff doc + agent-bus thread ``secrets-management-kickoff``).
+Part of the secrets-management feature.
 Five state variants share one screen layout; the body card swaps based
 on :class:`SecretsStatusSummary`.
 

--- a/src/servonaut/screens/secrets_list.py
+++ b/src/servonaut/screens/secrets_list.py
@@ -1,8 +1,8 @@
 """SecretsListScreen — read-only list of names in the active provider.
 
-Step 9 sub-screen reached via ``[l]`` from :class:`SecretsScreen`.
+Sub-screen reached via ``[l]`` from :class:`SecretsScreen`.
 
-**Hard invariant** (kickoff doc §MCP boundary, audit-fix 7):
+**Hard invariant** (the MCP boundary):
     NAMES are listed; VALUES are never read or rendered. The screen
     only calls :meth:`SecretProviderInterface.list_secrets`, never
     :meth:`get_secret`. Pinned by a test that mocks a provider whose

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -54,7 +54,7 @@ class ConfirmSshVerifyModal(ModalScreen[bool]):
     """Brief blocking confirmation for the SSH probe action.
 
     Returns True on Confirm, False on Cancel (including Escape).
-    Per CLAUDE.md: ModalScreen for brief blocking prompts.
+    Per the project convention: ModalScreen for brief blocking prompts.
     Per style constraints: round $accent border, fixed height, Cancel button.
     """
 

--- a/src/servonaut/screens/tool_confirm_modal.py
+++ b/src/servonaut/screens/tool_confirm_modal.py
@@ -7,7 +7,7 @@ Two ModalScreen flavours, sized by the tool's ``guard_level``:
 - :class:`DangerousToolConfirmModal` — typed-confirm "RUN" for
   ``dangerous`` tools (``deploy``, ``provision``, ``security_scan``).
 
-Per CLAUDE.md "ModalScreen vs Screen rule of thumb": both fit the
+Per the "ModalScreen vs Screen" convention: both fit the
 "brief blocking choice" pattern (small surface, single decision, dim
 background returns to chat). All user-influenced strings (tool names,
 arg values from the model) are passed through ``rich.markup.escape``

--- a/src/servonaut/services/api_client.py
+++ b/src/servonaut/services/api_client.py
@@ -123,8 +123,7 @@ class PaymentRequiredError(APIError):
     entitlement-gated surface) to give the CLI a structured way to
     surface "upgrade your plan" UX rather than a raw 4xx.
 
-    The server-side body shape (locked on agent-bus thread
-    ``secrets-management-kickoff``) is the flat-envelope variant::
+    The server-side body shape is the flat-envelope variant::
 
         {
           "error": "payment_required",
@@ -227,8 +226,7 @@ class APIClient(APIClientInterface):
                 details = err_obj.get("details")
             elif isinstance(err_obj, str):
                 # Flat envelope (introduced for the secrets-management
-                # 402/403 responses; locked on agent-bus thread
-                # ``secrets-management-kickoff``):
+                # 402/403 responses):
                 #   { "error": "payment_required",
                 #     "message": "...",
                 #     "upgrade_url": "...",
@@ -423,9 +421,7 @@ class APIClient(APIClientInterface):
     ) -> Optional[Dict[str, Any]]:
         """Fetch the team's effective :class:`SecretsConfig` from the API.
 
-        Wire contract (locked on agent-bus thread
-        ``secrets-management-kickoff``; slug-not-id confirmed by
-        servonaut-dev's W5 delta at 2026-05-16 17:58 UTC because
+        Wire contract (the endpoint is keyed on slug, not id, because
         the rest of ``/api/v1/teams/{slug}/*`` already uses slug —
         Team::$id is a UUID anyway):
 
@@ -434,9 +430,8 @@ class APIClient(APIClientInterface):
           ``{"provider": "...", "config": {...}, "updated_at": "..."}``.
         - ``404`` → return ``None``. The CLI's calling layer falls
           back to the LocalProvider and clears its cached payload.
-          ``not_found`` is NOT exceptional here; the kickoff doc
-          §API endpoint lists this as the explicit "no team config
-          on file" path.
+          ``not_found`` is NOT exceptional here; this is the explicit
+          "no team config on file" path.
         - ``402`` → raises :class:`PaymentRequiredError`; the CLI
           surfaces the response's ``upgrade_url`` to the user.
         - ``403`` → raises :class:`ForbiddenError` (not a team

--- a/src/servonaut/services/auth_service.py
+++ b/src/servonaut/services/auth_service.py
@@ -32,7 +32,7 @@ def _api_base() -> str:
 ENTITLEMENT_TTL = 3600  # 1 hour cache
 # Stale-while-revalidate window for the per-team
 # ``GET /api/v1/teams/{slug}/secrets-config`` response. Deliberately
-# the same as ``ENTITLEMENT_TTL`` (kickoff doc §Cache): one timer
+# the same as ``ENTITLEMENT_TTL``: one timer
 # rather than two unrelated TTL knobs for state that admins rotate
 # at the same human cadence (team-settings UI updates both).
 SECRETS_CACHE_TTL = 3600
@@ -51,8 +51,7 @@ SECRETS_PAYLOAD_MAX_BYTES = 16 * 1024
 # entitlement + secrets-config TTL so all three "cheap admin
 # metadata" caches share the same staleness window — one mental
 # model for operators ("data is at most an hour out of date").
-# Servonaut-dev's call on the kickoff thread (2026-05-17 15:39 UTC):
-# acceptable that newly-accepted team invites take up to an hour to
+# It is acceptable that newly-accepted team invites take up to an hour to
 # appear in ``active_team_slug()`` bootstrap, since the alternative
 # (no cache, list_teams per CLI invocation) is wasteful and a user
 # in that exact race can run ``servonaut auth refresh`` to skip the
@@ -78,7 +77,7 @@ class AuthToken:
     allow_dangerous_ai_tools: bool = False  # F4 cache from entitlements
     last_used_provider: str = ""  # T4.5 lapse fallback ranking
     settings_last_visited_at: float = 0.0  # T4.5 paying-twice banner gating
-    # Secrets-management cache (kickoff doc §Cache). Persisted as a raw
+    # Secrets-management cache. Persisted as a raw
     # dict so it round-trips through ``json.dump`` without bespoke
     # serialisation; consumers wrap it in
     # :class:`servonaut.config.schema.SecretsConfig` via
@@ -271,9 +270,7 @@ class AuthService(AuthServiceInterface):
     async def active_team_slug(self) -> Optional[str]:
         """Return the slug of the team this CLI session operates against.
 
-        Resolution order (kickoff doc + agent-bus
-        ``secrets-management-kickoff`` 2026-05-17 — agreed model
-        D + bootstrap-from-B):
+        Resolution order:
 
         1. **Cached team_slug** — if the secrets-config response
            body carried ``team_slug`` (additive server change
@@ -345,7 +342,7 @@ class AuthService(AuthServiceInterface):
             - Past the TTL window.
             - On logout (the whole token is dropped).
 
-        Edge case servonaut-dev flagged on the kickoff thread:
+        Edge case:
             A user accepting a new team invite won't see the new team
             in ``active_team_slug()`` bootstrap until the cache expires.
             Acceptable for the MVP — same staleness as entitlements,
@@ -401,7 +398,7 @@ class AuthService(AuthServiceInterface):
             "memory_team_share": False,
             "memory_ai_summary": False,
             "memory_compliance_export": False,
-            # Secrets management (kickoff §Tier gating: Solo+).
+            # Secrets management (tier gating: Solo+).
             # LocalProvider available to Solo + Teams; team-shared
             # secrets are Teams-only.
             "secrets_management": True,
@@ -618,8 +615,8 @@ class AuthService(AuthServiceInterface):
         """Exchange the stored refresh_token for a fresh pair.
 
         Refresh tokens are single-use server-side — the moment the server
-        issues a new pair it revokes the one we presented (confirmed by
-        servonaut-web-backend on agent-bus thread 0ab60c52). Without
+        issues a new pair it revokes the one we presented (confirmed
+        server-side). Without
         serialisation, two concurrent 401-retries would both present the
         same ``R_0``: the first succeeds, the second hits a revoked
         token and gets ``400 invalid_grant`` → session killed mid-flight.
@@ -835,8 +832,7 @@ class AuthService(AuthServiceInterface):
         # ``_token`` already clears it from memory. Nothing extra to do
         # — but if ``auth.json`` is recreated by a subsequent login, the
         # new ``AuthToken`` starts with the default empty cache thanks
-        # to the dataclass defaults (kickoff doc §Cache, point on cold
-        # cache after re-login).
+        # to the dataclass defaults (cold cache after re-login).
         logger.info("Logged out")
 
     async def fetch_entitlements(self) -> Optional[dict]:
@@ -1078,7 +1074,7 @@ class AuthService(AuthServiceInterface):
         return self._token.entitlements
 
     # ------------------------------------------------------------------
-    # Secrets-management cache (kickoff doc §Cache)
+    # Secrets-management cache
     #
     # Stale-while-revalidate model:
     #   - Callers always get an immediate answer from the cache via

--- a/src/servonaut/services/bitwarden_provider.py
+++ b/src/servonaut/services/bitwarden_provider.py
@@ -8,8 +8,7 @@ backends transparently per the active :class:`SecretsConfig`.
 
 Why subprocess instead of a Python SDK?
     Bitwarden ships ``bws`` (Rust) but does NOT publish a stable
-    Python SDK at the time of writing (kickoff doc §Provider config
-    schemas confirms this). Shelling out keeps us on the supported
+    Python SDK at the time of writing. Shelling out keeps us on the supported
     surface and means a future ``bws`` upgrade lands without a CLI
     release on our side. The performance hit (one fork+exec per
     operation, ~30-80ms) is negligible against the network round-trip
@@ -462,8 +461,8 @@ class BitwardenProvider(SecretProviderInterface):
         """Find a secret in this project by its ``key`` field.
 
         Returns the first match (Bitwarden allows duplicate keys
-        within a project but the team-secrets-management UX in the
-        kickoff doc treats names as unique; if you have duplicates,
+        within a project but the team-secrets-management UX
+        treats names as unique; if you have duplicates,
         the first wins deterministically since :meth:`_list_raw`
         preserves bws' response ordering).
         """

--- a/src/servonaut/services/dangerous_tool_floor.py
+++ b/src/servonaut/services/dangerous_tool_floor.py
@@ -8,7 +8,7 @@ escalated to ``dangerous`` regardless of what the server claims,
 and the escalation is audit-logged.
 
 Patterns are compiled once at module import. Order matches the
-agent-bus thread d59dd956 spec.
+dangerous-tool classification spec.
 """
 from __future__ import annotations
 

--- a/src/servonaut/services/entitlement_guard.py
+++ b/src/servonaut/services/entitlement_guard.py
@@ -27,8 +27,7 @@ FEATURE_PLANS = {
     "rbac": "teams",
     "team_audit": "teams",
     "sso": "teams",
-    # Secrets management — locked on agent-bus thread
-    # ``secrets-management-kickoff``. LocalProvider available to Solo+,
+    # Secrets management. LocalProvider available to Solo+,
     # team-shared (Bitwarden / future Vault) is Teams-only and gated
     # separately at the api_client layer where the server's 402
     # tells us so.

--- a/src/servonaut/services/fake_secrets_config_client.py
+++ b/src/servonaut/services/fake_secrets_config_client.py
@@ -1,9 +1,8 @@
 """In-memory stand-in for the secrets-management API client.
 
-While servonaut-web's
+While the server's
 ``GET /api/v1/teams/{slug}/secrets-config`` endpoint is still under
-development (kickoff doc Step W5 → security review → Playwright E2E
-→ staging deploy), Steps 5 and 6 on the CLI side need *something*
+development, the CLI side needs *something*
 to call. :class:`FakeSecretsConfigClient` is that something: it
 implements the same callable signature as
 :meth:`APIClient.get_team_secrets_config` so consumers can swap one
@@ -13,20 +12,19 @@ Scope:
     Lives in ``src/`` rather than ``tests/`` because dev runs of the
     CLI (``servonaut --debug`` against an in-memory team) want to
     exercise the BitwardenProvider path BEFORE the real endpoint is
-    live. The fake is opt-in — production wiring (Step 6) selects
+    live. The fake is opt-in — production wiring selects
     between :class:`APIClient.get_team_secrets_config` and this fake
     via the env var :data:`SERVONAUT_SECRETS_FAKE` (off by default).
 
 Removal plan:
-    The kickoff doc Step 7 (joint E2E) will remove the env var and
+    The joint E2E pass will remove the env var and
     the fake's references from the wiring code. The class itself
     stays in the codebase as a test-support utility — the unit
     tests for Step 5 and 6 will keep using it.
 
 Team identifier model:
     The real endpoint is keyed on team SLUG (URL-safe identifier),
-    not integer id — locked in the kickoff doc and re-confirmed by
-    servonaut-dev's W5 contract delta. This fake follows suit so
+    not integer id — confirmed server-side. This fake follows suit so
     test code reads like production code.
 """
 from __future__ import annotations

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -1222,9 +1222,7 @@ class SecretProviderInterface(ABC):
         machine-readable hook so the check survives every refactor
         without relying on developers remembering a docstring rule.
 
-    Contract (locked with servonaut-web-backend on agent-bus thread
-    ``secrets-management-kickoff``, doc at
-    ``~/.dotfiles/org/org/servonaut/plans/kickoff-secrets-management.org``):
+    The server-side contract is:
 
     - **Async by default** so providers that talk to a remote backend
       (Bitwarden, future Vault) don't block the TUI event loop. The

--- a/src/servonaut/services/memory/summariser.py
+++ b/src/servonaut/services/memory/summariser.py
@@ -84,7 +84,7 @@ def _render_value(
 
     Returns:
         A string like ``"v20.11.0"`` when they match, or
-        ``"observed=v20.11.0 declared=v22.0.0 (pinned by zoltan at 2026-04-10T09:00Z)"``
+        ``"observed=v20.11.0 declared=v22.0.0 (pinned by operator at 2026-04-10T09:00Z)"``
         when they differ.
     """
     if declared_entry is None:

--- a/src/servonaut/services/relay_manager.py
+++ b/src/servonaut/services/relay_manager.py
@@ -43,7 +43,7 @@ def derive_relay_urls(api_base: str) -> Tuple[str, str]:
 
     Examples:
         ``https://api.servonaut.dev``      → mercure on ``servonaut.dev``
-        ``https://staging.servonaut.dev``  → mercure on ``staging.servonaut.dev``
+        ``https://staging.example.com``  → mercure on ``staging.example.com``
     """
     parts = urlsplit(api_base)
     if not parts.scheme or not parts.netloc:

--- a/src/servonaut/services/secret_provider_resolver.py
+++ b/src/servonaut/services/secret_provider_resolver.py
@@ -1,7 +1,6 @@
 """Resolve the active :class:`SecretProviderInterface` for a session.
 
-Step 6 of the kickoff plan
-(``~/.dotfiles/org/org/servonaut/plans/kickoff-secrets-management.org``).
+Part of the secrets-management feature.
 
 The resolver collapses the moving parts — auth state, entitlements,
 cached team :class:`SecretsConfig`, environment env-var seam — into
@@ -95,7 +94,7 @@ def resolve_secret_provider(
        ``None``. The user is effectively logged-out from the secrets
        backend's POV; don't try to use a stale Bitwarden token they
        have no way of refreshing.
-    3. **Free tier** → ``None`` (kickoff doc §Tier gating: Solo + Teams
+    3. **Free tier** → ``None`` (tier gating: Solo + Teams
        only). Surfacing an "upgrade your plan" prompt belongs at the
        UI layer; the resolver just doesn't hand out a provider.
     4. **No team config cached + no local-only opt-in** → return
@@ -244,8 +243,7 @@ async def fetch_and_apply_secrets_config(
         auth_service.clear_secrets_cache()
         return True
 
-    # Defensive slug-consistency check (servonaut-dev's suggestion on
-    # the kickoff thread 2026-05-17 15:39 UTC). When the server adds
+    # Defensive slug-consistency check. When the server adds
     # the additive ``team_slug`` echo to the response body, verify it
     # matches the slug we used in the URL. Mismatch = potential
     # server-side mapping bug → log WARNING but do NOT raise; the URL

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -2052,7 +2052,7 @@ class ChatPanel(Widget):
         if isinstance(result_summary, str) and result_summary.strip():
             # Demo-mode: scrub tool result content BEFORE escape so IPs /
             # ARNs / secrets are never visible on screen. Order: scrub →
-            # escape → embed (CLAUDE.md anti-pattern rule).
+            # escape → embed (avoids Rich-markup injection).
             raw_body = result_summary.strip()
             try:
                 _app = self.app
@@ -2066,7 +2066,7 @@ class ChatPanel(Widget):
             except Exception:
                 pass  # Not mounted or app not available — skip redaction gracefully
             # Server-controlled string — escape every byte before
-            # interpolating into Rich markup (CLAUDE.md A2 rule).
+            # interpolating into Rich markup (markup-injection guard).
             safe_body = _rich_escape(raw_body)
             body = f"\n{safe_body}"
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from servonaut.config.schema import (
 # to run. Absent → auto-skip with a clear reason so CI logs explain WHY a
 # test didn't execute (silent skips are worse than failures).
 #
-# Markers (per servonaut-dev's 2026-05-17 01:22 UTC suggestion):
+# Markers:
 #
 #   requires_e2e_oauth   — joint contract test against staging endpoint
 #                          (E2E #5). Stubs out bws + Hetzner; only needs

--- a/tests/test_active_team_slug.py
+++ b/tests/test_active_team_slug.py
@@ -1,13 +1,12 @@
-"""Tests for ``AuthService.active_team_slug()`` (UX Step 9 helper).
+"""Tests for ``AuthService.active_team_slug()`` helper.
 
-Resolution policy locked with servonaut-dev on agent-bus thread
-``secrets-management-kickoff`` 2026-05-17:
+Resolution policy:
 
 1. Cached team_slug from the secrets-config payload — wins.
 2. Bootstrap from :meth:`list_teams` — owner role first, else first.
 3. None when user has no teams or isn't authenticated.
 
-Plus the edge case servonaut-dev flagged:
+Plus the edge case:
 
 - Stale cached slug for a team the user no longer has access to →
   403/404 path inside ``fetch_and_apply_secrets_config`` clears the
@@ -60,7 +59,7 @@ def authed_service(tmp_path, monkeypatch) -> AuthService:
 class TestCachedSlug:
     def test_returns_cached_team_slug_when_present(self, authed_service):
         # Simulate the server having sent the additive team_slug field.
-        # Once servonaut-dev's patch ships, the production
+        # Once the server change ships, the production
         # apply_secrets_config persists it through the same dict.
         authed_service.apply_secrets_config({
             "provider": "bitwarden",
@@ -161,7 +160,7 @@ class TestUnauthenticated:
 
 
 # ---------------------------------------------------------------------------
-# Stale-cache edge case (servonaut-dev's catch)
+# Stale-cache edge case
 # ---------------------------------------------------------------------------
 
 
@@ -196,7 +195,7 @@ class TestStaleCacheReBootstrap:
         ok = run(fetch_and_apply_secrets_config(
             authed_service, client, slug="old-team-revoked",
         ))
-        assert ok is True  # 403 returns True per the kickoff contract
+        assert ok is True  # 403 returns True per the server contract
         assert not authed_service.is_secrets_cache_present()
 
         # 3. list_teams now returns the user's CURRENT team.

--- a/tests/test_ai_conversations_screen.py
+++ b/tests/test_ai_conversations_screen.py
@@ -15,7 +15,7 @@ mountable widget tree), we exercise the screen at two levels:
 
 We use ``MagicMock(spec=AIConversationsClient)`` so positional misuse of
 its async methods fails at test time — matching the convention called
-out in the Memory Sync section of CLAUDE.md.
+out in the project's Memory Sync conventions.
 """
 from __future__ import annotations
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -151,8 +151,7 @@ class TestAuthTokenPersistence:
         The server is the source of truth — the 401-retry-refresh path heals
         a stale access_token transparently. Returning False here is the bug
         that caused users to be kicked out mid-session even though their
-        refresh_token was still valid (servonaut-web-backend confirmed on
-        agent-bus thread 0ab60c52).
+        refresh_token was still valid (confirmed server-side).
         """
         auth_file = tmp_path / "auth.json"
         token_data = {
@@ -486,7 +485,6 @@ def test_await_post_topup_refresh_swallows_fetch_failures():
 
 # ---------------------------------------------------------------------------
 # Refresh-race + smart failure classification
-# (servonaut-web-backend agent-bus thread 0ab60c52)
 # ---------------------------------------------------------------------------
 
 
@@ -523,7 +521,7 @@ def test_refresh_skips_network_when_disk_already_rotated(tmp_path, monkeypatch):
     """Concurrent-refresh dedup: if another task rotated while we waited
     for the lock, adopt the disk token without hitting the network.
 
-    This is the exact race servonaut-web-backend pointed at: two parallel
+    This is the exact race the server contract guards against: two parallel
     401-retries each call refresh with the same R_0; without the lock +
     disk re-read, the second one would present a now-revoked token and
     get 400 invalid_grant, killing the session.

--- a/tests/test_e2e_secrets_staging.py
+++ b/tests/test_e2e_secrets_staging.py
@@ -1,21 +1,22 @@
-"""Joint web↔CLI end-to-end tests for the secrets-management feature.
+"""Joint server↔CLI end-to-end tests for the secrets-management feature.
 
-THIS FILE IS SKELETON-MODE until servonaut-dev posts the seeded
-staging bundle on agent-bus thread ``secrets-management-kickoff``.
-The constants in :class:`StagingBundle` are placeholders; the
-moment the bundle lands, fill them in and the tests run.
+THIS FILE IS A SKIP-BY-DEFAULT SKELETON. The constants in
+:class:`StagingBundle` are neutral placeholders; the gated test bodies
+only run when the corresponding env vars point at a seeded staging
+environment. With no env vars set (e.g. in CI) every gated test
+auto-skips and only :class:`TestSkeletonPlumbing` executes.
 
 Two test surfaces, two markers (see ``tests/conftest.py`` for the
 auto-skip plumbing):
 
 - :class:`TestJointE2E5_ContractHandshake` — pinned by
-  ``@pytest.mark.requires_e2e_oauth``. Hits the real staging
+  ``@pytest.mark.requires_e2e_oauth``. Hits a real staging
   endpoint with a service-account OAuth bearer, verifies the CLI
   fetches the team's :class:`SecretsConfig`, parses it, and the
   resolver flips :class:`SSHService` from
   :class:`LocalProvider` to :class:`BitwardenProvider` with the
   right project_id + token_env_var. bws subprocess is STUBBED here
-  — we're validating the contract between web and CLI, not bws.
+  — we're validating the contract between server and CLI, not bws.
 
 - :class:`TestFullE2E3_RealStackSmoke` — pinned by
   ``@pytest.mark.requires_e2e_bws + requires_e2e_hetzner``
@@ -24,20 +25,15 @@ auto-skip plumbing):
 
 Operational notes:
 
-- The OAuth token in :data:`StagingBundle.oauth_token_env_var`
-  rotates every 7 days. servonaut-dev ships
-  ``bin/console app:e2e-secrets:seed --rotate-token`` for easy
-  rotation; this file's constants don't change.
+- The OAuth token in :data:`StagingBundle.oauth_token` rotates on a
+  fixed cadence; rotation is handled out of band and this file's
+  constants don't change.
 - All credentials read from env vars, never hardcoded. The
   ``StagingBundle.from_env()`` helper produces a tidy bundle
   object the tests destructure from.
 
-When you fill in the placeholders:
-- :data:`StagingBundle.team_slug` — the seeded team slug
-- :data:`StagingBundle.bws_project_id` — the Bitwarden project ID
-- :data:`StagingBundle.seeded_secret_name` — the SSH key stored in
-  BWS for E2E #3 (servonaut-dev suggested ``e2e-secrets-hetzner-key``)
-
+To run the gated tests against a seeded staging environment, set the
+``SERVONAUT_E2E_*`` env vars described in ``StagingBundle.from_env``.
 Everything else is wire-format-driven and shouldn't need a touch.
 """
 from __future__ import annotations
@@ -52,35 +48,33 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# Bundle skeleton — filled in when servonaut-dev posts on the bus
+# Bundle defaults — neutral placeholders, overridable by env var
 # ---------------------------------------------------------------------------
 
-# The seeded team slug — bundle posted by servonaut-dev on
-# agent-bus thread ``secrets-management-kickoff`` 2026-05-17 14:30 UTC.
-# If servonaut-dev re-seeds with a different slug, update this single
-# constant — the rest of the file is wire-format-driven.
-SEEDED_TEAM_SLUG = "e2e-secrets-test-team"
+# The seeded team slug. Overridable via SERVONAUT_E2E_TEAM_SLUG so a
+# staging seed can use a different slug — the rest of the file is
+# wire-format-driven.
+SEEDED_TEAM_SLUG = "example-team"
 
-# Seeded Bitwarden project UUID — also from the bundle. Compared to
-# the value the server returns in the 200 body so a future server-side
+# Seeded Bitwarden project UUID — also overridable from the env. Compared
+# to the value the server returns in the 200 body so a future server-side
 # project rotation is observable in CI.
-SEEDED_BWS_PROJECT_ID = "e2e-staging-bws-project-uuid"
+SEEDED_BWS_PROJECT_ID = "example-bws-project-uuid"
 
 # Env var the team config tells the CLI to look in for the BWS access
 # token. Matches DEFAULT_TOKEN_ENV_VAR on the CLI side; pinned here
 # so a future server-side override surfaces in CI.
 SEEDED_TOKEN_ENV_VAR = "BWS_ACCESS_TOKEN"
 
-# Name of the SSH key stored in the seeded BWS project. Proposed by
-# servonaut-dev for E2E #3. Only the BWS path uses this; the contract
-# (E2E #5) doesn't touch real bws.
-SEEDED_KEY_NAME = "e2e-secrets-hetzner-key"
+# Name of the SSH key stored in the seeded BWS project. Only the BWS
+# path uses this; the contract test (E2E #5) doesn't touch real bws.
+SEEDED_KEY_NAME = "e2e-test-key"
 
 # Staging API base — overridable by env var so a developer can point
 # the tests at a local dev instance without editing this file.
 STAGING_API_BASE = os.environ.get(
     "SERVONAUT_E2E_API_BASE",
-    "https://staging.servonaut.dev",
+    "https://staging.example.com",
 )
 
 
@@ -94,14 +88,13 @@ class StagingBundle:
         - Frozen dataclass so tests can't accidentally mutate state
           that should round-trip identically across cases.
 
-    Basic auth gotcha (servonaut-dev 2026-05-17 14:30 UTC):
-        staging.servonaut.dev sits behind shared-Caddy basic_auth for
-        the whole site EXCEPT a narrow public allowlist. The
+    Basic auth note:
+        A staging deployment may sit behind a site-wide basic_auth gate
+        with a narrow public allowlist. If the
         ``/api/v1/teams/<slug>/secrets-config`` path is NOT in that
-        allowlist, so the request needs basic_auth credentials in
+        allowlist, the request needs basic_auth credentials in
         addition to the OAuth Bearer. We thread them through
-        :data:`basic_auth` and url-embed them in
-        :attr:`api_base_with_auth` so httpx picks both up.
+        :data:`basic_auth` for that case.
     """
 
     api_base: str
@@ -150,24 +143,17 @@ class StagingBundle:
     def api_base_with_auth(self) -> str:
         """``api_base`` ready to point :class:`APIClient` at.
 
-        Live verification on the bundled staging endpoint shows that
-        Bearer alone passes Caddy's basic_auth gate — the API allow-
-        list pattern accepts any ``Authorization`` header, regardless
-        of scheme. Empirical evidence:
+        When the staging endpoint is fronted by a basic_auth gate that
+        accepts any ``Authorization`` header, the Bearer alone passes
+        and we must NOT url-embed basic auth — httpx would parse it into
+        an ``Authorization: Basic`` header that overrides our Bearer,
+        and the app would then see no Bearer and reject with 403.
 
-        - ``curl -u 'staging:…' -H 'Authorization: Bearer …' …`` →
-          200 (curl's -H overrides -u, sending Bearer ONLY).
-        - URL-embedding basic-auth in the httpx URL gets parsed by
-          httpx into an ``Authorization: Basic`` header that wins
-          over our explicitly-set Bearer → Symfony app sees no
-          Bearer → 403.
-
-        So: don't url-embed basic auth. Send Bearer alone via
-        :meth:`APIClient._get_headers`. ``basic_auth`` is still
-        captured on the bundle in case a future Caddy policy
-        tightens — we'd then thread it via a non-conflicting
-        mechanism (e.g. ``Proxy-Authorization`` or a custom Caddy
-        bypass header).
+        So: send Bearer alone via :meth:`APIClient._get_headers`.
+        ``basic_auth`` is still captured on the bundle in case a future
+        gateway policy tightens — we'd then thread it via a
+        non-conflicting mechanism (e.g. ``Proxy-Authorization`` or a
+        custom bypass header).
         """
         return self.api_base
 
@@ -203,7 +189,7 @@ class TestJointE2E5_ContractHandshake:
 
     Failure-mode taxonomy worth pinning so a future failure surface
     points at the right side:
-    - 200 with wrong shape → wire-format drift (web side ships).
+    - 200 with wrong shape → wire-format drift (server side ships).
     - 401/403 → service-account token expired or scope revoked.
     - 404 → seed command didn't run / team got wiped.
     - 5xx → staging incident; this isn't a CLI bug.
@@ -213,10 +199,9 @@ class TestJointE2E5_ContractHandshake:
         """End-to-end: real staging endpoint → CLI parses → resolver
         instantiates the right provider.
 
-        Validates the contract Step W5 shipped against the parser
-        Step 4 wrote. The 402 / 403 / 404 paths are covered by unit
-        tests; this test is specifically the 200 success path with a
-        live wire payload.
+        Validates the server-side contract against the CLI parser. The
+        402 / 403 / 404 paths are covered by unit tests; this test is
+        specifically the 200 success path with a live wire payload.
         """
         bundle = StagingBundle.from_env()
 
@@ -235,10 +220,9 @@ class TestJointE2E5_ContractHandshake:
         monkeypatch.setattr(
             "servonaut.services.auth_service.AUTH_FILE", auth_file,
         )
-        # Point APIClient at the staging base. URL-embedded basic auth
-        # so Caddy's basic_auth gate doesn't reject us (Bearer alone
-        # SHOULD pass per servonaut-dev's smoke test, but layering is
-        # defensive against a future Caddy policy tightening).
+        # Point APIClient at the staging base. Bearer alone passes the
+        # gateway's basic_auth gate; basic auth is layered only as a
+        # defensive fallback against a future policy tightening.
         monkeypatch.setenv("SERVONAUT_API_URL", bundle.api_base_with_auth)
 
         auth = AuthService()
@@ -269,8 +253,7 @@ class TestJointE2E5_ContractHandshake:
         assert ok, (
             "fetch_and_apply_secrets_config must succeed against the seeded "
             "team. If this assertion fails, check (a) OAuth token "
-            "expiry (1h from issue per servonaut-dev's bundle note), "
-            "(b) Caddy basic_auth policy on the endpoint, "
+            "expiry, (b) any basic_auth policy on the endpoint, "
             "(c) staging-side seed health."
         )
 
@@ -285,7 +268,7 @@ class TestJointE2E5_ContractHandshake:
             f"seed={bundle.bws_project_id!r}"
         )
         assert cfg.config.get("token_env_var") == bundle.bws_token_env_var
-        # updated_at is an ATOM datetime per servonaut-dev's smoke output.
+        # updated_at is an ATOM datetime in the server response.
         assert cfg.updated_at, "updated_at must be non-empty on a 200"
 
         # 3. Resolver flips to BitwardenProvider with the right args.
@@ -300,12 +283,13 @@ class TestJointE2E5_ContractHandshake:
     def test_response_body_includes_team_slug_matching_url(self, tmp_path, monkeypatch):
         """Pin the additive ``team_slug`` echo as a frozen contract.
 
-        Servonaut-dev shipped the additive field on 2026-05-17 16:33
-        UTC. This test is a separate explicit assertion (rather than
-        rolled into ``test_endpoint_returns_locked_contract_shape``)
-        so a future regression names the new field specifically in
-        the failure message — future-debugger sees ``team_slug``
-        verbatim, knows exactly which contract slot drifted.
+        The server includes an additive ``team_slug`` field in the
+        response body. This test is a separate explicit assertion
+        (rather than rolled into
+        ``test_endpoint_returns_locked_contract_shape``) so a future
+        regression names the new field specifically in the failure
+        message — a future debugger sees ``team_slug`` verbatim and
+        knows exactly which contract slot drifted.
 
         Failure mode taxonomy if this trips:
 
@@ -355,10 +339,9 @@ class TestJointE2E5_ContractHandshake:
         )
         assert "team_slug" in payload, (
             "Additive contract regression: response body missing the "
-            "team_slug echo. servonaut-dev shipped this on 2026-05-17 "
-            "16:33 UTC; if it's gone, the CLI's cached "
+            "team_slug echo. If it's gone, the CLI's cached "
             "active_team_slug() path silently falls back to list_teams "
-            "bootstrap. Check the recent web-side commits."
+            "bootstrap. Check the recent server-side changes."
         )
         assert payload["team_slug"] == bundle.team_slug, (
             f"team_slug echo mismatch: server returned "
@@ -379,13 +362,13 @@ class TestJointE2E5_ContractHandshake:
         TestGetTeamSecretsConfig404::test_404_with_envelope_returns_none
         which mocks the response.
 
-        NB: servonaut-dev's note says "non-member 403 collapses
-        unknown-slug into 403 to prevent enumeration". Since our
-        service-account token is a MEMBER of the seeded team only,
-        an unknown slug from this token's POV may surface as 404
-        (no-config-on-existing-team) or 403 (token not a member of
-        slug-that-doesn't-exist). The test accepts EITHER outcome —
-        both cause the same caller-side fallback to LocalProvider.
+        NB: the server collapses an unknown slug into a 403 to prevent
+        enumeration. Since our service-account token is a MEMBER of the
+        seeded team only, an unknown slug from this token's POV may
+        surface as 404 (no-config-on-existing-team) or 403 (token not a
+        member of slug-that-doesn't-exist). The test accepts EITHER
+        outcome — both cause the same caller-side fallback to
+        LocalProvider.
         """
         bundle = StagingBundle.from_env()
 
@@ -458,10 +441,10 @@ class TestJointE2E5_ContractHandshake:
         the server collapses unknown-slug into 403 to prevent
         enumeration. CLI surfaces :class:`ForbiddenError`.
 
-        Needs a SECOND service-account token from servonaut-dev —
-        one that ISN'T a member of the seeded team. The test below
-        is wired to read SERVONAUT_E2E_OAUTH_TOKEN_NONMEMBER if
-        present; otherwise it auto-skips. Unit test
+        Needs a SECOND service-account token that ISN'T a member of the
+        seeded team. The test below is wired to read
+        SERVONAUT_E2E_OAUTH_TOKEN_NONMEMBER if present; otherwise it
+        auto-skips. Unit test
         TestGetTeamSecretsConfig403::test_403_raises_forbidden
         already pins the wire format, so this is belt+braces.
         """
@@ -480,7 +463,7 @@ class TestJointE2E5_ContractHandshake:
         # an explicit TODO when the second token is wired in.
         pytest.skip(
             "Bundle includes a single OAuth token (the team member). "
-            "When servonaut-dev mints a non-member companion, fill in "
+            "When a non-member companion token is provisioned, fill in "
             "the live assertion: fetch must raise ForbiddenError."
         )
 
@@ -511,22 +494,22 @@ class TestFullE2E3_RealStackSmoke:
     for staging deploy.
 
     Cost reality check: each run provisions + tears down a Hetzner
-    instance (~€0.01 / run depending on type). Nightly cadence is
-    £3/year, well within "smoke testing budget".
+    instance (cents per run depending on type), well within a
+    smoke-testing budget.
     """
 
     def test_end_to_end_ssh_using_bws_supplied_key(self):
         """Resolve → fetch BWS-stored private key → SSH into Hetzner.
 
-        TODO(servonaut): fill in once bundle lands. Needs:
+        TODO: fill in once a seeded staging environment is wired. Needs:
         - Hetzner test server type + region pinned (cheapest = cx22
           / hel1 currently).
         - Tear-down on finally (regardless of test outcome).
         - 30s timeout on the SSH connect.
         """
         pytest.skip(
-            "Full-stack E2E pending staging bundle. Costs cents per "
-            "run; gated on three env vars by design."
+            "Full-stack E2E pending a seeded staging environment. Costs "
+            "cents per run; gated on three env vars by design."
         )
 
 
@@ -564,12 +547,12 @@ class TestSkeletonPlumbing:
     def test_staging_bundle_seeded_slug_passes_cli_slug_regex(self):
         """The slug the CLI sends must satisfy
         :class:`APIClient`'s own validation regex — caught
-        client-side before any network call. servonaut-dev
-        confirmed the server-side TeamSlug grammar is a strict
-        subset; verifying here too is belt + braces."""
+        client-side before any network call. The server-side TeamSlug
+        grammar is a strict subset; verifying here too is belt +
+        braces."""
         from servonaut.services.api_client import _TEAM_SLUG_RE
         assert _TEAM_SLUG_RE.match(SEEDED_TEAM_SLUG), (
             f"Seeded slug {SEEDED_TEAM_SLUG!r} doesn't match CLI's "
-            "team-slug regex — coordinate with servonaut-dev before "
-            "the bundle drops, NOT after."
+            "team-slug regex — ensure the seeded slug conforms before "
+            "wiring the bundle, NOT after."
         )

--- a/tests/test_mcp_api_request.py
+++ b/tests/test_mcp_api_request.py
@@ -28,7 +28,7 @@ from servonaut.mcp import tools as tools_module
 from servonaut.mcp.tools import ServonautTools
 
 
-BASE_URL = "https://staging.servonaut.dev"
+BASE_URL = "https://staging.example.com"
 
 
 def _run(coro):

--- a/tests/test_mcp_relay_reconnect.py
+++ b/tests/test_mcp_relay_reconnect.py
@@ -21,7 +21,7 @@ from servonaut.mcp.guards import CommandGuard, GuardLevel
 from servonaut.mcp.tools import ServonautTools
 
 
-BASE_URL = "https://staging.servonaut.dev"
+BASE_URL = "https://staging.example.com"
 
 
 def _run(coro):

--- a/tests/test_mcp_relay_status_and_tool_call.py
+++ b/tests/test_mcp_relay_status_and_tool_call.py
@@ -16,8 +16,8 @@ from servonaut.mcp.guards import CommandGuard, GuardLevel
 from servonaut.mcp.tools import ServonautTools
 
 
-API_BASE = "https://api.staging.servonaut.dev"
-MCP_BASE = "https://mcp.staging.servonaut.dev"
+API_BASE = "https://api.staging.example.com"
+MCP_BASE = "https://mcp.staging.example.com"
 
 
 def _run(coro):

--- a/tests/test_mcp_whoami.py
+++ b/tests/test_mcp_whoami.py
@@ -86,10 +86,10 @@ class TestWhoamiLoggedOut:
 
 class TestWhoamiLoggedIn:
     def test_returns_expected_fields_without_leaking_token(self, monkeypatch):
-        monkeypatch.setenv("SERVONAUT_API_URL", "https://staging.servonaut.dev")
+        monkeypatch.setenv("SERVONAUT_API_URL", "https://staging.example.com")
         expires = time.time() + 3600
         svc = _authenticated_stub(
-            email="zashboy@gmail.com", plan="solo", expires_at=expires
+            email="user@example.com", plan="solo", expires_at=expires
         )
         tools, _ = _make_tools(auth_service=svc)
 
@@ -97,9 +97,9 @@ class TestWhoamiLoggedIn:
         result = json.loads(raw)
 
         assert result["logged_in"] is True
-        assert result["email"] == "zashboy@gmail.com"
+        assert result["email"] == "user@example.com"
         assert result["plan"] == "solo"
-        assert result["base_url"] == "https://staging.servonaut.dev"
+        assert result["base_url"] == "https://staging.example.com"
         assert result["token_expires_in_seconds"] > 3500
         assert result["token_expires_at"].startswith(
             time.strftime("%Y", time.gmtime(expires))
@@ -109,7 +109,7 @@ class TestWhoamiLoggedIn:
         assert "SECRET-ACCESS-TOKEN" not in raw
 
     def test_expired_token_returns_negative_expires_in(self, monkeypatch):
-        monkeypatch.setenv("SERVONAUT_API_URL", "https://staging.servonaut.dev")
+        monkeypatch.setenv("SERVONAUT_API_URL", "https://staging.example.com")
         expires = time.time() - 600
         svc = _authenticated_stub(
             email="expired@example.com", plan="free", expires_at=expires

--- a/tests/test_memory_crypto.py
+++ b/tests/test_memory_crypto.py
@@ -11,7 +11,7 @@ Covers:
 - Frozen fixture snapshot (catches accidental wire-format regressions)
 
 Fixture regeneration:
-  cd /home/zashboy/projects/servonaut
+  cd /path/to/servonaut
   PYTHONPATH=src python3 -c "
 import base64, json, sys
 sys.path.insert(0, 'src')

--- a/tests/test_memory_summariser.py
+++ b/tests/test_memory_summariser.py
@@ -143,7 +143,7 @@ class TestFullMvpFixture:
                     "go": "go1.21.5",
                 },
                 declared={
-                    "node": {"value": "v20.11.0", "pinned_by": "zoltan", "at": "2026-04-10T09:00Z"},
+                    "node": {"value": "v20.11.0", "pinned_by": "operator", "at": "2026-04-10T09:00Z"},
                 },
                 ttl_seconds=604800,
             ),
@@ -282,7 +282,7 @@ class TestObservedVsDeclaredRendering:
             "runtimes": _make_module(
                 "runtimes",
                 observed={"node": "v20.11.0"},
-                declared={"node": {"value": "v20.11.0", "pinned_by": "zoltan", "at": "2026-04-10T09:00Z"}},
+                declared={"node": {"value": "v20.11.0", "pinned_by": "operator", "at": "2026-04-10T09:00Z"}},
             )
         }
         s = Summariser()
@@ -297,14 +297,14 @@ class TestObservedVsDeclaredRendering:
             "runtimes": _make_module(
                 "runtimes",
                 observed={"node": "v20.11.0"},
-                declared={"node": {"value": "v22.0.0", "pinned_by": "zoltan", "at": "2026-04-10T09:00Z"}},
+                declared={"node": {"value": "v22.0.0", "pinned_by": "operator", "at": "2026-04-10T09:00Z"}},
             )
         }
         s = Summariser()
         result = s.summarise(_INSTANCE_META, modules, now=_NOW)
         assert "observed=v20.11.0" in result
         assert "declared=v22.0.0" in result
-        assert "pinned by zoltan" in result
+        assert "pinned by operator" in result
         assert "2026-04-10T09:00Z" in result
 
     def test_no_declared_just_shows_observed(self) -> None:
@@ -1291,7 +1291,7 @@ class TestRenderLogsDeclaredMerge:
                 declared={
                     "probed_paths": {
                         "value": ["/var/log/myapp.log"],
-                        "pinned_by": "zoltan",
+                        "pinned_by": "operator",
                         "at": "2026-04-10T09:00Z",
                     }
                 },
@@ -1312,7 +1312,7 @@ class TestRenderLogsDeclaredMerge:
                 declared={
                     "/var/log/app.log": {
                         "value": True,
-                        "pinned_by": "zoltan",
+                        "pinned_by": "operator",
                         "at": "2026-04-10T09:00Z",
                     }
                 },

--- a/tests/test_relay_manager.py
+++ b/tests/test_relay_manager.py
@@ -56,8 +56,8 @@ def _make_auth(*, authenticated: bool = True, mcp_connections: int = 5,
     return svc
 
 
-def _make_config(*, base_url="https://staging.servonaut.dev",
-                 mercure_url="https://staging.servonaut.dev/.well-known/mercure"):
+def _make_config(*, base_url="https://staging.example.com",
+                 mercure_url="https://staging.example.com/.well-known/mercure"):
     cfg = AppConfig(relay=RelayConfig(
         base_url=base_url, mercure_url=mercure_url, heartbeat_interval=30,
     ))
@@ -180,9 +180,9 @@ class TestDeriveRelayUrls:
         assert mercure == "https://servonaut.dev/.well-known/mercure"
 
     def test_staging_keeps_host_for_mercure(self):
-        base, mercure = derive_relay_urls("https://staging.servonaut.dev")
-        assert base == "https://staging.servonaut.dev"
-        assert mercure == "https://staging.servonaut.dev/.well-known/mercure"
+        base, mercure = derive_relay_urls("https://staging.example.com")
+        assert base == "https://staging.example.com"
+        assert mercure == "https://staging.example.com/.well-known/mercure"
 
     def test_trailing_slash_dropped_on_base(self):
         base, _ = derive_relay_urls("https://api.servonaut.dev/")

--- a/tests/test_secret_provider.py
+++ b/tests/test_secret_provider.py
@@ -1,7 +1,6 @@
 """Tests for :class:`LocalProvider` and the :class:`SecretProviderInterface`.
 
-These tests pin down the Step 1 contract from the kickoff org
-``~/.dotfiles/org/org/servonaut/plans/kickoff-secrets-management.org``:
+These tests pin down the secrets-management contract:
 
 - LocalProvider is the foundation backend; every CLI install gets
   one regardless of plan/entitlement state.

--- a/tests/test_secret_provider_resolver.py
+++ b/tests/test_secret_provider_resolver.py
@@ -1,12 +1,12 @@
-"""Tests for the Step 6 wiring — :mod:`servonaut.services.secret_provider_resolver`.
+"""Tests for the resolver — :mod:`servonaut.services.secret_provider_resolver`.
 
 The resolver is the single source of truth for "which
 :class:`SecretProvider` is active right now". Every branch maps to
-a kickoff-doc-locked semantic that we don't want a future refactor
+a locked semantic that we don't want a future refactor
 to silently change:
 
 - Unauthenticated → None (legacy ~/.ssh).
-- Free tier → None (kickoff §Tier gating).
+- Free tier → None (tier gating).
 - Solo / Teams with no cached config → LocalProvider.
 - Solo / Teams with cached provider="bitwarden" + project_id →
   BitwardenProvider.

--- a/tests/test_secrets_audit_fixes.py
+++ b/tests/test_secrets_audit_fixes.py
@@ -1,5 +1,5 @@
-"""Tests pinning the 8 audit fixes applied after zoltan's
-2026-05-16 "zero-tolerance" directive.
+"""Tests pinning the 8 audit fixes applied after a
+"zero-tolerance" security review.
 
 One test class per audit-fix item so a future regression points
 directly back at the security concern it guards.

--- a/tests/test_secrets_config_api_client.py
+++ b/tests/test_secrets_config_api_client.py
@@ -16,7 +16,7 @@ will surface ``upgrade_url`` directly — a future server-side rename
 must trip these tests before it ships.
 
 Team identifier is a slug string (matches the rest of
-``/api/v1/teams/{slug}/*`` — confirmed by servonaut-dev's W5 delta).
+``/api/v1/teams/{slug}/*`` — confirmed server-side).
 """
 from __future__ import annotations
 
@@ -37,10 +37,8 @@ from servonaut.services.api_client import (
 from servonaut.services.fake_secrets_config_client import FakeSecretsConfigClient
 
 
-# servonaut-dev will spin up a stable seeded ``cli-integration-test-team``
-# on staging (kickoff doc heartbeat 2026-05-16 17:59 UTC). Until then,
-# tests use this same slug locally so the path the CLI sends matches
-# the path the eventual joint E2E will hit.
+# Tests use this slug locally so the path the CLI sends matches
+# the path the eventual joint E2E will hit against a seeded staging team.
 TEST_TEAM_SLUG = "cli-integration-test-team"
 
 
@@ -121,8 +119,8 @@ class TestGetTeamSecretsConfig200:
     def test_returns_local_provider_shape_when_team_uses_local(self, api_client):
         """A team admin can legitimately set provider=local — the
         endpoint still returns 200, NOT 404. Distinguishing this
-        from "no row exists" is the whole point of the kickoff
-        doc's 200-vs-404 split."""
+        from "no row exists" is the whole point of the
+        200-vs-404 split."""
         payload = {
             "provider": "local",
             "config": {},
@@ -133,7 +131,7 @@ class TestGetTeamSecretsConfig200:
         assert result == payload
 
     def test_url_path_uses_slug_not_id(self, api_client):
-        """The endpoint is keyed on slug per servonaut-dev's W5 delta;
+        """The endpoint is keyed on slug (confirmed server-side);
         pin that the path matches so a future refactor can't silently
         drift back to integer ids."""
         with _patch_httpx_with(_FakeResponse(200, {
@@ -233,7 +231,7 @@ class TestGetTeamSecretsConfig403:
     """Not a team member (or unknown slug) → 403 with code=forbidden,
     distinct from forbidden_entitlement which is feature-gating.
 
-    Note: servonaut-dev's W5 endpoint intentionally collapses
+    Note: the endpoint intentionally collapses
     'non-member' and 'unknown slug' into the same 403 to prevent
     slug enumeration through error-shape. CLI doesn't distinguish."""
 

--- a/tests/test_secrets_config_cache.py
+++ b/tests/test_secrets_config_cache.py
@@ -1,8 +1,8 @@
-"""Tests for the secrets-management Step 2 cache wiring.
+"""Tests for the secrets-management cache wiring.
 
 Covers:
 - :class:`servonaut.config.schema.SecretsConfig` round-trip parse / dump
-  against the locked wire format (kickoff doc §Contract → API endpoint).
+  against the locked wire format (the server's API endpoint contract).
 - :class:`AuthToken` gains ``secrets_config`` + ``secrets_fetched_at``
   with defaults that don't break legacy on-disk auth.json files.
 - :class:`AuthService` cache helpers: ``cached_secrets_config`` falls
@@ -44,9 +44,8 @@ class TestSecretsConfigDataclass:
         assert cfg.updated_at == ""
 
     def test_from_wire_parses_contract_shape(self):
-        """The exact shape locked with servonaut-web-backend on
-        thread secrets-management-kickoff. If this test changes,
-        notify the web side on the same thread BEFORE landing."""
+        """The exact shape of the server-side contract. If this test
+        changes, the server-side wire format must be updated in lockstep."""
         wire = {
             "provider": "bitwarden",
             "config": {

--- a/tests/test_secrets_followups.py
+++ b/tests/test_secrets_followups.py
@@ -1,4 +1,4 @@
-"""Tests for the UX Step 9 follow-ups servonaut-dev signed off on:
+"""Tests for the secrets-management follow-ups:
 
 1. Slug-consistency WARNING — if the server's response body
    includes ``team_slug`` AND it doesn't match the URL slug we used,
@@ -7,9 +7,6 @@
 2. ``AuthService.list_teams`` cached with :data:`TEAMS_CACHE_TTL`
    (3600s, matching entitlements + secrets-config). Cache hit
    within the TTL skips the network. ``force_refresh=True`` bypasses.
-
-Both kicked off by the kickoff-thread message from servonaut-dev
-on 2026-05-17 15:39 UTC.
 """
 from __future__ import annotations
 

--- a/tests/test_secrets_screen.py
+++ b/tests/test_secrets_screen.py
@@ -14,7 +14,7 @@ Two test surfaces:
    keypress.
 
 The "secret values never leak into rendered text" invariant is the
-audit-pinned guarantee (kickoff doc §MCP boundary). A mocked provider
+audit-pinned guarantee (the MCP boundary). A mocked provider
 returns a known sentinel value; the test asserts the sentinel never
 appears in the screen's rendered text.
 """

--- a/tests/test_team_config_share.py
+++ b/tests/test_team_config_share.py
@@ -20,7 +20,7 @@ def _seeded_config() -> AppConfig:
     cfg = AppConfig()
     cfg.connection_profiles = [
         ConnectionProfile(name="prod-bastion", bastion_host="bastion.example.com",
-                          bastion_user="zoltan", bastion_key="/home/zoltan/.ssh/bastion_key"),
+                          bastion_user="operator", bastion_key="/home/operator/.ssh/bastion_key"),
         ConnectionProfile(name="staging", username="ec2-user"),
     ]
     cfg.connection_rules = [
@@ -32,7 +32,7 @@ def _seeded_config() -> AppConfig:
     ]
     cfg.custom_servers = [
         CustomServer(name="db-1", host="10.0.0.1", username="ubuntu",
-                     ssh_key="/home/zoltan/.ssh/db_key", port=22),
+                     ssh_key="/home/operator/.ssh/db_key", port=22),
         CustomServer(name="cache-1", host="10.0.0.2", username="root", port=22),
     ]
     return cfg

--- a/tests/test_team_management_screen.py
+++ b/tests/test_team_management_screen.py
@@ -41,7 +41,7 @@ def _make_team_service(teams: list[dict] | None = None) -> MagicMock:
                     "role": "member",
                     "is_accepted": False,
                     "invitation_expires_at": "2099-01-01T00:00:00+00:00",
-                    "accept_url": "https://staging.servonaut.dev/invite/abc123",
+                    "accept_url": "https://staging.example.com/invite/abc123",
                 },
             ],
         }
@@ -673,7 +673,7 @@ class TestTeamManagementCopyAcceptUrl:
                     "invitation_email": "bob@example.com",
                     "role": "member",
                     "is_accepted": False,
-                    "accept_url": "https://staging.servonaut.dev/invite/xyz",
+                    "accept_url": "https://staging.example.com/invite/xyz",
                 },
             ]
             tbl = screen.query_one("#members_table", DataTable)
@@ -683,7 +683,7 @@ class TestTeamManagementCopyAcceptUrl:
             app.copy_to_clipboard = lambda text: copied.append(text)  # type: ignore[method-assign]
             screen._action_copy_accept_url()
             await pilot.pause()
-            assert copied == ["https://staging.servonaut.dev/invite/xyz"]
+            assert copied == ["https://staging.example.com/invite/xyz"]
 
     @pytest.mark.asyncio
     async def test_copy_accept_url_noop_when_url_missing(self):


### PR DESCRIPTION
## Why

A review pass identified internal detail in tracked files of this **public** repo. This is a forward-hygiene sweep that genericizes the affected prose. (No git history is rewritten; that would break clones/forks and the leak window is already past.)

## Scope

33 tracked files. **Comments, docstrings, and docs/markdown prose only — no code logic, identifiers, env-var names, or behavior changed.** Where a flagged value was test-fixture data, it was renamed consistently (inputs + asserts) so tests still pass.

What was genericized:
- Internal coordination metadata and dated attributions → neutral "server-side contract" / "integration spec" wording (the technical contracts the comments document are fully preserved).
- Private local filesystem paths removed from docstrings.
- Personal identifiers and a real email in fixtures → `user@example.com` / `operator` / `/home/user`.
- An internal staging hostname in docs, a docstring, and several test fixtures → `staging.example.com` (the override-via-env-var mechanism is unchanged).
- `CONTRIBUTING.md` and the PR template now link to this repository instead of a stale repo name.

Deliberately left intact:
- Functional legacy config-migration code/paths (real behavior, not a leak).
- Public product URLs (`servonaut.dev`, `api.`/`mcp.servonaut.dev`).
- Redaction-test fixtures (example AWS keys / fake tokens).

## Verification
- Marker sweep across `src/`, `tests/`, `docs/`, `.github/`, `*.md` returns clean.
- Changed-line review confirms only prose/fixtures changed.
- Full test suite green (the only failures are pre-existing, env-gated tests needing an optional extra not installed locally; CI installs it).

Pairs with the Leak Guard CI check (separate PR) which will block this class of issue on future PRs.