### PR TITLE
feat(cli): headless device-flow login/logout; fail-loud empty AI chat responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ All screenshots and the launch video were recorded with `--demo` active, which r
 - **Server memory** — persistent per-server cache of OS/runtime/service/web-stack/log/database/container/network/git/disk facts. Agents call `get_server_memory(id)` before SSH round-trips; CLI has `servonaut memory build|refresh|show|export|annotate|pin|clear`. [Full docs](docs/memory.md)
 - **Memory Sync** — Solo+ feature that backs up your fleet memory to servonaut.dev with end-to-end encryption (X25519 keypair + AES-256-GCM envelopes wrapped to a passphrase you control). Drift detection across re-probes, cross-device history, and AI-queryable fact cache. The TUI's `☁ Memory Sync` sidebar entry is the unified setup / unlock / status hub.
 - **MCP server for AI agents** — Claude Code, Cursor, Windsurf, etc. ~60 tools covering instance ops, AWS EC2 lifecycle + describe helpers, S3 / object storage on AWS, Hetzner, OVH, AWS log analysis & IP banning (CloudWatch / CloudTrail / WAF / Security Group / NACL), full Hetzner + OVH lifecycle (create / start / stop / reboot / delete), SSH-key registry CRUD, server-memory queries, session introspection, and authenticated REST proxy. Three-tier guard system (`readonly` / `standard` / `dangerous`), confirmation-protocol prompt baked into every mutating tool's description, and a JSONL audit trail.
-- **Servonaut Cloud account** — optional; sign in from the TUI (Account → Login) to unlock config sync across machines and the MCP relay
+- **Servonaut Cloud account** — optional; run `servonaut login` (or TUI → Account → Login) to unlock config sync across machines and the MCP relay
 - **MCP relay** — `servonaut connect` (or the TUI autostart) keeps a Mercure SSE connection open so AI agents and team-mates can dispatch MCP tool calls to this machine over the internet. Tokens never leave the CLI; heartbeats every 30 s with automatic Mercure JWT refresh.
 - **Config sync** — client-side-encrypted snapshots of your config.json pushed/pulled from servonaut.dev, paired with a passphrase you control
 - **Bastion host / jump server support** via ProxyJump or ProxyCommand
@@ -269,8 +269,11 @@ servonaut --mcp-install claude   # or cursor, windsurf, opencode, vscode, all
 
 Configure credentials and servers the same way as a TUI install (
 `~/.servonaut/config.json`, `$ENV_VAR` / `file:` secret syntax — see
-[Configuration Guide](docs/configuration.md)). Everything an agent does goes
-through the same guard levels and is logged to `~/.servonaut/mcp_audit.jsonl`.
+[Configuration Guide](docs/configuration.md)). For Servonaut Cloud features
+(relay, config sync, hosted AI), `servonaut login` runs the device-flow
+sign-in fully headless — approve from a browser on any device. Everything an
+agent does goes through the same guard levels and is logged to
+`~/.servonaut/mcp_audit.jsonl`.
 
 **Available tools:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,7 +20,7 @@ and is honoured by all `servonaut ai *` subcommands.
 
 The `ai` subcommand tree gives headless (non-TUI) access to the Servonaut AI
 gateway. All subcommands require a valid login session — see
-[Signing in](#signing-in).
+[`servonaut login`](#servonaut-login).
 
 ### Exit codes
 
@@ -30,7 +30,7 @@ All `servonaut ai *` commands use these exit codes:
 |------|---------|
 | `0` | Success |
 | `1` | Other / unknown error |
-| `2` | Unauthenticated — sign in from the TUI (Account → Login) |
+| `2` | Unauthenticated — run `servonaut login` |
 | `3` | Insufficient entitlement — Solo or Teams plan required |
 | `4` | Quota exhausted — run `servonaut ai topup` |
 | `5` | Budget (cost-cap) exhausted — run `servonaut ai topup` |
@@ -341,15 +341,38 @@ servonaut connect --stop        # stop
 
 ---
 
-## Signing in
+## `servonaut login`
 
-There is currently no `login` subcommand — authentication happens in the TUI.
-Launch `servonaut`, open **Account → Login** in the sidebar, and approve the
-device-flow OAuth2 prompt at servonaut.dev. Tokens are stored at
-`~/.servonaut/auth.json` (mode `0600`) and are shared by every CLI subcommand
-and the MCP server, so you only sign in once per machine. After signing in,
-entitlements are fetched and cached — the `premium_ai` and
-`allow_dangerous_ai_tools` flags become available immediately.
+Sign in to servonaut.dev via the OAuth2 device flow — works headless, no
+TUI needed.
+
+```bash
+servonaut login                # prints a URL + code, waits for approval
+servonaut login --no-browser   # never try to open a local browser
+servonaut login --force        # re-authenticate over an existing session
+```
+
+The command prints a verification URL and a short code; open the URL in any
+browser **on any device**, enter the code, and the CLI completes sign-in
+automatically. Tokens are stored at `~/.servonaut/auth.json` (mode `0600`)
+and are shared by every CLI subcommand, the MCP server, and the TUI — you
+only sign in once per machine. After signing in, entitlements are fetched
+and cached — the `premium_ai` and `allow_dangerous_ai_tools` flags become
+available immediately.
+
+Prefer the TUI? **Account → Login** in the sidebar runs the same flow.
+
+---
+
+## `servonaut logout`
+
+Sign out: revoke the session at servonaut.dev (best-effort — local sign-out
+proceeds even if the server is unreachable) and delete
+`~/.servonaut/auth.json`.
+
+```bash
+servonaut logout
+```
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -456,7 +456,7 @@ Top-up packs: `small`, `medium`, `large` (canonical names; pricing at
 |------|---------|
 | `0` | Success |
 | `1` | Other / unknown error |
-| `2` | Unauthenticated — sign in from the TUI (Account → Login) |
+| `2` | Unauthenticated — run `servonaut login` |
 | `3` | Insufficient entitlement — requires Solo or Teams plan |
 | `4` | Quota exhausted — run `servonaut ai topup` |
 | `5` | Budget exhausted — cost cap reached; run `servonaut ai topup` |

--- a/src/servonaut/cli/ai.py
+++ b/src/servonaut/cli/ai.py
@@ -74,7 +74,7 @@ _VALID_TASKS = ("chat", "analyze_logs", "security_audit",
 # Valid conversation statuses (mirrors AIConversationsClient).
 _VALID_STATUSES = ("active", "archived", "deleted")
 
-_LOGIN_HINT = "Log in first: run `servonaut --login`"
+_LOGIN_HINT = "Log in first: run `servonaut login`"
 _UPGRADE_HINT = (
     "Servonaut AI requires the Solo or Teams plan: "
     "https://servonaut.dev/pricing"
@@ -398,10 +398,31 @@ async def _do_chat_buffered(
         print(f"Error: {exc}", file=sys.stderr)
         return _EXIT_GENERIC_ERROR
 
-    content = (result or {}).get("content", "") or ""
+    result = result or {}
+    warning = result.get("warning", "") or ""
+    if warning:
+        print(f"Warning: {warning}", file=sys.stderr)
+
+    content = result.get("content", "") or ""
     if content:
         print(content)
-    return _EXIT_SUCCESS
+        return _EXIT_SUCCESS
+
+    # Empty content is never a success for a one-shot CLI. The common cause:
+    # the model answered with a tool call, which only the TUI chat panel can
+    # confirm and execute — buffered headless chat has no tool bridge.
+    tool_calls_count = int(result.get("tool_calls_count") or 0)
+    if tool_calls_count > 0 or result.get("stop_reason") == "tool_use":
+        print(
+            "Error: the model requested a tool call to answer this prompt, "
+            "but headless chat cannot execute tools. Ask in the TUI chat "
+            "panel (F2) where tools run with confirmation, or re-run with "
+            "--no-tools for a text-only answer.",
+            file=sys.stderr,
+        )
+    else:
+        print("Error: the server returned an empty response.", file=sys.stderr)
+    return _EXIT_GENERIC_ERROR
 
 
 async def _do_chat_stream(

--- a/src/servonaut/cli/login.py
+++ b/src/servonaut/cli/login.py
@@ -1,0 +1,170 @@
+"""``servonaut login`` — headless device-flow sign-in (RFC 8628).
+
+Drives the same OAuth2 device-flow endpoints the TUI login screen uses
+(``POST /api/oauth/device`` → user verifies in any browser on any device →
+poll ``POST /api/oauth/token``), so headless boxes (CI runners, agent-only
+MCP installs) can authenticate without ever opening the TUI. Tokens land in
+``~/.servonaut/auth.json`` exactly as with a TUI login and are shared by
+every CLI subcommand and the MCP server.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_EXIT_SUCCESS = 0
+_EXIT_ERROR = 1
+
+# Upper bound on how long we wait for the user to approve in a browser.
+# The server's device-code lifetime (``expires_in``) is the real budget;
+# this only caps a pathologically large value.
+_MAX_POLL_WAIT_SECONDS = 900
+
+
+def add_login_parser(subparsers: Any) -> None:
+    """Register the ``login`` subcommand on the top-level parser."""
+    parser = subparsers.add_parser(
+        'login',
+        help='Sign in to servonaut.dev via device flow — works headless, '
+             'no TUI needed.',
+    )
+    parser.add_argument(
+        '--no-browser', action='store_true',
+        help="Don't try to open the verification URL locally; just print it "
+             "(default behaviour on boxes without a browser).",
+    )
+    parser.add_argument(
+        '--force', action='store_true',
+        help='Run the device flow even if a valid session already exists.',
+    )
+
+
+def add_logout_parser(subparsers: Any) -> None:
+    """Register the ``logout`` subcommand on the top-level parser."""
+    subparsers.add_parser(
+        'logout',
+        help='Sign out: revoke the session at servonaut.dev (best-effort) '
+             'and delete ~/.servonaut/auth.json.',
+    )
+
+
+def handle_logout_command(args: argparse.Namespace) -> int:
+    """Implement ``servonaut logout``. Returns a process exit code."""
+    from servonaut.services.auth_service import AuthService
+
+    _load_env_overrides()
+    auth = AuthService()
+    if not auth.is_authenticated:
+        print("Not signed in — nothing to do.")
+        return _EXIT_SUCCESS
+
+    try:
+        asyncio.run(auth.logout())
+    except Exception as exc:  # noqa: BLE001 — single-line CLI error
+        print(f"Error: {exc}", file=sys.stderr)
+        return _EXIT_ERROR
+
+    print("Signed out — session revoked and ~/.servonaut/auth.json removed.")
+    return _EXIT_SUCCESS
+
+
+def _load_env_overrides() -> None:
+    """Load ``~/.secrets/servonaut.env`` into the environment.
+
+    ``AuthService`` reads ``SERVONAUT_API_URL`` at request time, and other
+    entry points get the env file loaded as a side effect of constructing
+    ``ConfigManager``. login/logout never build a ConfigManager, so without
+    this call they would target the production API even when the user has
+    overridden the URL (e.g. to staging) in the secrets env file.
+    """
+    from servonaut.config.secrets import load_secrets_env
+    load_secrets_env()
+
+
+def handle_login_command(args: argparse.Namespace) -> int:
+    """Implement ``servonaut login``. Returns a process exit code."""
+    from servonaut.services.auth_service import AuthService
+
+    _load_env_overrides()
+    auth = AuthService()
+    if auth.is_authenticated and not getattr(args, 'force', False):
+        print(
+            f"Already signed in (plan: {auth.plan}). "
+            "Run `servonaut login --force` to re-authenticate."
+        )
+        return _EXIT_SUCCESS
+
+    try:
+        return asyncio.run(
+            _do_login(auth, no_browser=bool(getattr(args, 'no_browser', False)))
+        )
+    except KeyboardInterrupt:
+        print("\nSign-in aborted.", file=sys.stderr)
+        return _EXIT_ERROR
+
+
+async def _do_login(auth: Any, *, no_browser: bool) -> int:
+    """Run the device flow: print URL + code, poll until approved."""
+    try:
+        flow = await auth.start_device_flow()
+    except Exception as exc:  # noqa: BLE001 — single-line CLI error
+        print(f"Error: {exc}", file=sys.stderr)
+        return _EXIT_ERROR
+
+    device_code = flow.get("device_code", "")
+    user_code = flow.get("user_code", "")
+    verification_uri = flow.get("verification_uri", "")
+    verification_uri_complete = flow.get("verification_uri_complete", "")
+    interval = int(flow.get("interval") or 5)
+    expires_in = int(flow.get("expires_in") or 300)
+
+    if not device_code or not user_code or not verification_uri:
+        print(
+            "Error: device-flow response was missing device_code, "
+            "user_code, or verification_uri.",
+            file=sys.stderr,
+        )
+        return _EXIT_ERROR
+
+    print("To sign in, open this URL in any browser (any device works):")
+    print(f"\n    {verification_uri}\n")
+    print(f"and enter the code: {user_code}\n")
+
+    # Best-effort convenience on desktop; the printed URL is the real path
+    # on headless boxes. Only ever auto-open URLs our own API returned over
+    # https — never an http or scheme-less value.
+    open_target = verification_uri_complete or verification_uri
+    if not no_browser and open_target.startswith("https://"):
+        try:
+            import webbrowser
+            if webbrowser.open(open_target):
+                print("(Opened the verification page in your local browser.)")
+        except Exception:  # noqa: BLE001 — no browser is the expected case
+            pass
+
+    wait_seconds = max(interval, min(expires_in, _MAX_POLL_WAIT_SECONDS))
+    print(
+        f"Waiting for approval (up to {wait_seconds // 60} min, "
+        "Ctrl+C to abort)..."
+    )
+
+    success = await auth.poll_for_token(
+        device_code, interval=interval, max_wait_seconds=wait_seconds,
+    )
+    if not success:
+        print(
+            "Sign-in was not completed (denied, expired, or timed out). "
+            "Run `servonaut login` to try again.",
+            file=sys.stderr,
+        )
+        return _EXIT_ERROR
+
+    print(f"Signed in successfully (plan: {auth.plan}).")
+    print("Tokens saved to ~/.servonaut/auth.json — all CLI subcommands "
+          "and the MCP server now share this session.")
+    return _EXIT_SUCCESS

--- a/src/servonaut/cli/servers.py
+++ b/src/servonaut/cli/servers.py
@@ -305,7 +305,7 @@ async def _cmd_verify(args: Any) -> int:
 
     if not auth_service.is_authenticated:
         print(
-            "Not logged in. Run `servonaut --login` first.",
+            "Not logged in. Run `servonaut login` first.",
             file=sys.stderr,
         )
         return _EXIT_FATAL

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -843,6 +843,11 @@ def main() -> None:
     from servonaut.cli.db import add_db_parser
     add_db_parser(subparsers)
 
+    # ---- login / logout subcommands (headless device-flow sign-in) ----
+    from servonaut.cli.login import add_login_parser, add_logout_parser
+    add_login_parser(subparsers)
+    add_logout_parser(subparsers)
+
     args = parser.parse_args()
 
     # Top-level --ai-provider / --no-tools flags propagate via env vars so
@@ -883,6 +888,16 @@ def main() -> None:
         _setup_logging(debug=args.debug)
         from servonaut.cli.memory import run_memory
         sys.exit(run_memory(args))
+
+    if getattr(args, 'subcommand', None) == 'login':
+        _setup_logging(debug=args.debug)
+        from servonaut.cli.login import handle_login_command
+        sys.exit(handle_login_command(args))
+
+    if getattr(args, 'subcommand', None) == 'logout':
+        _setup_logging(debug=args.debug)
+        from servonaut.cli.login import handle_logout_command
+        sys.exit(handle_logout_command(args))
 
     if args.subcommand == 'connect':
         _setup_logging(debug=args.debug)

--- a/src/servonaut/mcp/remote_client.py
+++ b/src/servonaut/mcp/remote_client.py
@@ -64,7 +64,7 @@ class RemoteMCPClient:
 
         token = self._auth.access_token
         if not token:
-            raise RuntimeError("Not authenticated. Run 'servonaut --login' first.")
+            raise RuntimeError("Not authenticated. Run 'servonaut login' first.")
 
         try:
             async with httpx.AsyncClient(timeout=None) as client:

--- a/src/servonaut/services/auth_service.py
+++ b/src/servonaut/services/auth_service.py
@@ -542,15 +542,26 @@ class AuthService(AuthServiceInterface):
                 )
             return response.json()
 
-    async def poll_for_token(self, device_code: str, interval: int = 5) -> bool:
-        """Poll until user authorizes or timeout. Returns True on success."""
+    async def poll_for_token(
+        self,
+        device_code: str,
+        interval: int = 5,
+        max_wait_seconds: int = 120,
+    ) -> bool:
+        """Poll until user authorizes or timeout. Returns True on success.
+
+        ``max_wait_seconds`` bounds the total poll budget (default 120 —
+        the TUI's historical window). Headless ``servonaut login`` passes
+        the device code's ``expires_in`` so users have the full lifetime
+        to approve from another device.
+        """
         if not HAS_HTTPX:
             raise RuntimeError("httpx not installed")
 
         import asyncio
 
-        max_attempts = 120 // interval  # 2 minute timeout
-        for _ in range(max_attempts):
+        deadline = time.monotonic() + max(max_wait_seconds, interval)
+        while time.monotonic() < deadline:
             await asyncio.sleep(interval)
             try:
                 async with httpx.AsyncClient(timeout=30) as client:

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -872,7 +872,12 @@ class AuthServiceInterface(ABC):
         pass
 
     @abstractmethod
-    async def poll_for_token(self, device_code: str, interval: int = 5) -> bool:
+    async def poll_for_token(
+        self,
+        device_code: str,
+        interval: int = 5,
+        max_wait_seconds: int = 120,
+    ) -> bool:
         pass
 
     @abstractmethod

--- a/tests/test_cli_ai.py
+++ b/tests/test_cli_ai.py
@@ -146,6 +146,70 @@ def test_ai_chat_buffered(monkeypatch, capsys):
     assert kwargs["task"] == "chat"
 
 
+def _chat_args(**overrides) -> argparse.Namespace:
+    base = dict(
+        ai_command="chat",
+        prompt="how many instances?",
+        stream=False,
+        no_tools=False,
+        ai_provider=None,
+        task="chat",
+    )
+    base.update(overrides)
+    return _ns(**base)
+
+
+def test_ai_chat_buffered_tool_use_empty_content_errors(monkeypatch, capsys):
+    """Empty content + tool_use must NOT exit 0 silently — the field bug:
+    a prompt needing a tool returned content="" and the CLI printed nothing."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, _auth, _api, provider, _convs, _pref = services
+    provider.chat.return_value = {
+        "content": "",
+        "tool_calls_count": 1,
+        "stop_reason": "tool_use",
+    }
+
+    rc = cli_ai.handle_ai_command(_chat_args())
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "tool call" in captured.err
+    assert "--no-tools" in captured.err
+
+
+def test_ai_chat_buffered_empty_content_errors(monkeypatch, capsys):
+    """Empty content without tool calls is still an error, not a silent 0."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, _auth, _api, provider, _convs, _pref = services
+    provider.chat.return_value = {"content": ""}
+
+    rc = cli_ai.handle_ai_command(_chat_args())
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "empty response" in captured.err
+
+
+def test_ai_chat_buffered_warning_surfaced(monkeypatch, capsys):
+    """A non-empty `warning` field is printed to stderr alongside content."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, _auth, _api, provider, _convs, _pref = services
+    provider.chat.return_value = {"content": "hi back!", "warning": "fallback model used"}
+
+    rc = cli_ai.handle_ai_command(_chat_args())
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "hi back!" in captured.out
+    assert "fallback model used" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # 3. --no-tools propagation
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -1,0 +1,198 @@
+"""Tests for ``servonaut login`` / ``servonaut logout`` CLI handlers.
+
+Drives :func:`servonaut.cli.login.handle_login_command` and
+:func:`handle_logout_command` directly with constructed Namespaces, patching
+``AuthService`` at the module seam so no network or filesystem I/O happens.
+"""
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.cli import login as cli_login
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    base = {"no_browser": True, "force": False}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _make_auth(
+    *,
+    authenticated: bool = False,
+    flow: dict | None = None,
+    poll_result: bool = True,
+):
+    auth = MagicMock()
+    auth.is_authenticated = authenticated
+    auth.plan = "solo"
+    auth.start_device_flow = AsyncMock(
+        return_value=flow if flow is not None else {
+            "device_code": "dev-123",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://servonaut.dev/activate",
+            "interval": 1,
+            "expires_in": 60,
+        }
+    )
+    auth.poll_for_token = AsyncMock(return_value=poll_result)
+    auth.logout = AsyncMock(return_value=None)
+    return auth
+
+
+def _patch_auth(monkeypatch, auth):
+    import servonaut.services.auth_service as auth_mod
+    monkeypatch.setattr(auth_mod, "AuthService", lambda: auth)
+
+
+# ---------------------------------------------------------------------------
+# login
+# ---------------------------------------------------------------------------
+
+
+def test_login_already_authenticated_short_circuits(monkeypatch, capsys):
+    auth = _make_auth(authenticated=True)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Already signed in" in out
+    assert "--force" in out
+    auth.start_device_flow.assert_not_awaited()
+
+
+def test_login_force_runs_flow_despite_session(monkeypatch, capsys):
+    auth = _make_auth(authenticated=True)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns(force=True))
+
+    assert rc == 0
+    auth.start_device_flow.assert_awaited_once()
+    auth.poll_for_token.assert_awaited_once()
+
+
+def test_login_success_prints_url_code_and_plan(monkeypatch, capsys):
+    auth = _make_auth()
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "https://servonaut.dev/activate" in out
+    assert "ABCD-EFGH" in out
+    assert "plan: solo" in out
+    # expires_in (60s) bounds the poll budget, not the 120s default.
+    kwargs = auth.poll_for_token.call_args.kwargs
+    assert kwargs["max_wait_seconds"] == 60
+    assert kwargs["interval"] == 1
+
+
+def test_login_denied_or_timeout_exits_1(monkeypatch, capsys):
+    auth = _make_auth(poll_result=False)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 1
+    assert "not completed" in capsys.readouterr().err
+
+
+def test_login_initiation_failure_exits_1(monkeypatch, capsys):
+    auth = _make_auth()
+    auth.start_device_flow = AsyncMock(
+        side_effect=RuntimeError("Device flow initiation failed: HTTP 503")
+    )
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 1
+    assert "HTTP 503" in capsys.readouterr().err
+
+
+def test_login_malformed_flow_response_exits_1(monkeypatch, capsys):
+    auth = _make_auth(flow={"interval": 5})
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 1
+    assert "missing" in capsys.readouterr().err
+
+
+def test_login_opens_browser_unless_no_browser(monkeypatch, capsys):
+    auth = _make_auth(flow={
+        "device_code": "dev-123",
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://servonaut.dev/activate",
+        "verification_uri_complete": "https://servonaut.dev/activate?code=ABCD-EFGH",
+        "interval": 1,
+        "expires_in": 60,
+    })
+    _patch_auth(monkeypatch, auth)
+    opened: list[str] = []
+    import webbrowser
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+
+    rc = cli_login.handle_login_command(_ns(no_browser=False))
+
+    assert rc == 0
+    # Prefers verification_uri_complete when the server provides it.
+    assert opened == ["https://servonaut.dev/activate?code=ABCD-EFGH"]
+
+    opened.clear()
+    rc = cli_login.handle_login_command(_ns(no_browser=True))
+    assert rc == 0
+    assert opened == []
+
+
+def test_login_loads_secrets_env_overrides(monkeypatch):
+    """login/logout must load ~/.secrets/servonaut.env (SERVONAUT_API_URL
+    et al.) — they build no ConfigManager, which is where every other entry
+    point gets it. Regression: device flow targeted production despite a
+    staging override in the env file."""
+    import servonaut.config.secrets as secrets_mod
+    calls: list[str] = []
+    monkeypatch.setattr(
+        secrets_mod, "load_secrets_env", lambda *a, **k: calls.append("loaded")
+    )
+    auth = _make_auth(authenticated=True)
+    _patch_auth(monkeypatch, auth)
+
+    assert cli_login.handle_login_command(_ns()) == 0
+    assert cli_login.handle_logout_command(_ns()) == 0
+    assert calls == ["loaded", "loaded"]
+
+
+# ---------------------------------------------------------------------------
+# logout
+# ---------------------------------------------------------------------------
+
+
+def test_logout_not_signed_in_is_noop(monkeypatch, capsys):
+    auth = _make_auth(authenticated=False)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_logout_command(_ns())
+
+    assert rc == 0
+    assert "Not signed in" in capsys.readouterr().out
+    auth.logout.assert_not_awaited()
+
+
+def test_logout_revokes_and_reports(monkeypatch, capsys):
+    auth = _make_auth(authenticated=True)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_logout_command(_ns())
+
+    assert rc == 0
+    assert "Signed out" in capsys.readouterr().out
+    auth.logout.assert_awaited_once()

--- a/tests/test_cli_servers.py
+++ b/tests/test_cli_servers.py
@@ -203,7 +203,7 @@ class TestNotLoggedIn:
 
         assert rc == _EXIT_FATAL
         out = capsys.readouterr()
-        assert "servonaut --login" in out.err
+        assert "servonaut login" in out.err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two changes that close gaps in headless (no-TUI) usage:

### `servonaut login` / `servonaut logout` (new)

Headless boxes (CI runners, agent-only MCP installs) previously needed one interactive TUI session to authenticate. `servonaut login` now runs the OAuth2 device flow (RFC 8628) end-to-end from the terminal:

- Prints the verification URL + user code — approve from a browser on **any** device; best-effort opens a local browser when one exists (https-only, prefers `verification_uri_complete`).
- Polls until approved, writes `~/.servonaut/auth.json` (shared by every CLI subcommand, the MCP server, and the TUI), fetches entitlements.
- `--no-browser`, `--force`; already-signed-in is a friendly no-op.
- `servonaut logout` revokes the session (best-effort) and removes `auth.json`.
- `AuthService.poll_for_token` gains `max_wait_seconds` (default 120 preserves TUI behaviour); login passes the device code's `expires_in` so users have its full lifetime to approve from another device.
- login/logout load `~/.secrets/servonaut.env` before any request — they construct no `ConfigManager` (where other entry points get it as a side effect), so a `SERVONAUT_API_URL` override would otherwise be silently ignored.
- All user-facing "run `servonaut login`" hints across CLI/MCP output are now real commands (previously the command didn't exist; `--login` variants normalized).

### `servonaut ai chat` buffered mode fails loudly (fix)

Buffered chat printed nothing and exited 0 when the server returned empty content — exactly what happens when the model answers with a tool call, since tool execution lives in the TUI chat panel and headless chat has no tool bridge. Now:

- Empty content + `stop_reason=tool_use` → actionable error (use the TUI chat panel or `--no-tools`), exit 1.
- Any other empty response also errors instead of silently succeeding.
- A non-empty `warning` field from the server is surfaced to stderr.

## Tests

- `tests/test_cli_login.py` (new): already-authed short-circuit, `--force`, success output, denied/timeout, malformed flow response, browser-open preference + `--no-browser`, env-override loading regression, logout paths.
- `tests/test_cli_ai.py`: 3 new cases for the empty/tool-call/warning behaviours.
- Live-verified: device-flow initiation (URL + response shape), already-signed-in and logout no-op paths, and the original failing chat prompt now produces the actionable error. The approve-click loop is mock-covered (same `poll_for_token` the TUI login screen uses).
- Doc-lint guard validates the new subcommands; full suite green apart from the known local-env `hcloud` absences (CI installs the extra).
