### PR TITLE
fix(cli): align AI chat/top-up with live gateway; buffered chat defaults tools off

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,7 +42,7 @@ All `servonaut ai *` commands use these exit codes:
 Send a single prompt to the AI gateway and print the response.
 
 ```
-servonaut ai chat <prompt> [--stream] [--no-tools] [--ai-provider <name>]
+servonaut ai chat <prompt> [--stream] [--no-tools] [--tools] [--ai-provider <name>]
 ```
 
 **Arguments:**
@@ -52,6 +52,7 @@ servonaut ai chat <prompt> [--stream] [--no-tools] [--ai-provider <name>]
 | `<prompt>` | string | required | The user message. Wrap in quotes for multi-word prompts. |
 | `--stream` | flag | off | Stream tokens to stdout as they arrive (SSE mode). Without this flag the command waits for the full response and prints it at once (buffered mode). |
 | `--no-tools` | flag | off | Disable tool execution; server will not emit `tool_call` events. Use when you want a read-only, non-interactive chat for scripting. |
+| `--tools` | flag | off | Re-enable tool execution in buffered mode. Buffered chat defaults tools **off** — tool calls are executed by the TUI chat panel, so a headless buffered request with tools would block until the server's wall-clock cap and return no answer. `--no-tools` wins if both are given. |
 | `--ai-provider <name>` | string | from config | Override the provider for this invocation only. |
 
 **Examples:**

--- a/src/servonaut/cli/ai.py
+++ b/src/servonaut/cli/ai.py
@@ -11,7 +11,7 @@ Mirrors the shape of :mod:`servonaut.cli.memory`:
 
 Subcommand tree (per plan T9 + architect plan §T9):
 
-    servonaut ai chat <prompt>           [--stream] [--no-tools]
+    servonaut ai chat <prompt>           [--stream] [--no-tools] [--tools]
                                           [--ai-provider X] [--task TASK]
     servonaut ai quota                    [--json]
     servonaut ai conversations list       [--limit N] [--before ISO]
@@ -231,6 +231,21 @@ def _handle_chat(args: argparse.Namespace) -> int:
     )
     allow_tools = not no_tools
 
+    # Buffered mode defaults tools OFF: tool calls are executed by the TUI
+    # chat panel (and, soon, the relay listener) — a headless buffered
+    # request has no executor, so a tool-requiring prompt would block for
+    # the server's full wall-clock cap and come back empty. --tools opts
+    # back in; --no-tools always wins.
+    use_stream = bool(getattr(args, "stream", False))
+    if not use_stream and allow_tools and not bool(getattr(args, "tools", False)):
+        allow_tools = False
+        print(
+            "Note: tool execution is disabled in buffered headless chat "
+            "(no executor outside the TUI yet). Pass --tools to opt in, "
+            "or use --stream / the TUI chat panel.",
+            file=sys.stderr,
+        )
+
     # Per-session provider override is resolved + threaded into env var so
     # the chat-panel TUI (sister Agent G) honours it without a side-channel.
     # For the headless CLI we currently only call the Servonaut provider —
@@ -257,7 +272,6 @@ def _handle_chat(args: argparse.Namespace) -> int:
             messages.append({"role": "user", "content": memory_block})
 
     messages.append({"role": "user", "content": prompt})
-    use_stream = bool(getattr(args, "stream", False))
 
     if use_stream:
         return _run_async(
@@ -395,7 +409,9 @@ async def _do_chat_buffered(
         return _EXIT_GENERIC_ERROR
     except Exception as exc:  # noqa: BLE001 — last-resort defence
         logger.exception("Buffered chat failed")
-        print(f"Error: {exc}", file=sys.stderr)
+        # str() of some httpx exceptions (e.g. ReadTimeout) is empty —
+        # fall back to the class name so the user never sees "Error: ".
+        print(f"Error: {exc or type(exc).__name__}", file=sys.stderr)
         return _EXIT_GENERIC_ERROR
 
     result = result or {}
@@ -1026,6 +1042,16 @@ def add_ai_parser(subparsers: Any) -> argparse.ArgumentParser:
         "--no-tools",
         action="store_true",
         help="Disable tool execution (sets allow_tools:false on the request).",
+    )
+    chat_parser.add_argument(
+        "--tools",
+        action="store_true",
+        help=(
+            "Enable tool execution in buffered mode (off by default there: "
+            "no headless executor exists yet, so a tool-requiring prompt "
+            "would block until the server's wall-clock cap). --no-tools "
+            "wins if both are given."
+        ),
     )
     chat_parser.add_argument(
         "--ai-provider",

--- a/src/servonaut/cli/login.py
+++ b/src/servonaut/cli/login.py
@@ -131,9 +131,14 @@ async def _do_login(auth: Any, *, no_browser: bool) -> int:
         )
         return _EXIT_ERROR
 
-    print("To sign in, open this URL in any browser (any device works):")
-    print(f"\n    {verification_uri}\n")
-    print(f"and enter the code: {user_code}\n")
+    # flush=True throughout the pre-poll output: when stdout is redirected
+    # (CI logs, `servonaut login | tee`), block buffering would otherwise
+    # hold back the URL + code until process exit — after the user needed
+    # them.
+    print("To sign in, open this URL in any browser (any device works):",
+          flush=True)
+    print(f"\n    {verification_uri}\n", flush=True)
+    print(f"and enter the code: {user_code}\n", flush=True)
 
     # Best-effort convenience on desktop; the printed URL is the real path
     # on headless boxes. Only ever auto-open URLs our own API returned over
@@ -143,14 +148,16 @@ async def _do_login(auth: Any, *, no_browser: bool) -> int:
         try:
             import webbrowser
             if webbrowser.open(open_target):
-                print("(Opened the verification page in your local browser.)")
+                print("(Opened the verification page in your local browser.)",
+                      flush=True)
         except Exception:  # noqa: BLE001 — no browser is the expected case
             pass
 
     wait_seconds = max(interval, min(expires_in, _MAX_POLL_WAIT_SECONDS))
     print(
         f"Waiting for approval (up to {wait_seconds // 60} min, "
-        "Ctrl+C to abort)..."
+        "Ctrl+C to abort)...",
+        flush=True,
     )
 
     success = await auth.poll_for_token(

--- a/src/servonaut/services/ai_providers/servonaut_provider.py
+++ b/src/servonaut/services/ai_providers/servonaut_provider.py
@@ -46,6 +46,11 @@ _DEFAULT_TASK = "chat"
 _ANALYZE_TASK = "analyze_logs"
 _REQUIRED_FEATURE = "premium_ai"
 _CHAT_PATH = "/api/ai/chat"
+
+# Buffered chat blocks server-side while the tool loop runs (the server
+# caps a turn at 120s wall-clock); allow that plus headroom before the
+# HTTP read times out. The default 30s client timeout is too short.
+_CHAT_BUFFERED_TIMEOUT_SECONDS = 150
 _TOPUP_PATH = "/api/ai/topup/checkout"
 
 # Rate-limit retry budget (T5). Buffered chat retries up to this many
@@ -239,7 +244,10 @@ class ServonautProvider(AIProviderInterface):
         last_error: Optional[RateLimitedError] = None
         for attempt in range(_RATE_LIMIT_MAX_ATTEMPTS):
             try:
-                return await self._api_client.post(path, json=body)
+                return await self._api_client.post(
+                    path, json=body,
+                    timeout=_CHAT_BUFFERED_TIMEOUT_SECONDS,
+                )
             except RateLimitedError as exc:
                 last_error = exc
                 # Don't sleep after the last attempt — surface the error.
@@ -533,9 +541,12 @@ class ServonautProvider(AIProviderInterface):
             )
         body = {"pack": pack}
         response = await self._api_client.post(_TOPUP_PATH, json=body)
-        # Defensive: server contract says ``checkout_url`` is always set
-        # on 2xx, but we'd rather fail loud than ``webbrowser.open("")``.
-        url = response.get("checkout_url", "") if isinstance(response, dict) else ""
+        # Defensive: we'd rather fail loud than ``webbrowser.open("")``.
+        # The live API returns the session URL as ``url``; ``checkout_url``
+        # was the originally specced name — accept either.
+        url = ""
+        if isinstance(response, dict):
+            url = response.get("checkout_url") or response.get("url") or ""
         if not url or not isinstance(url, str):
             raise RuntimeError(
                 "Top-up server did not return a valid checkout_url"

--- a/tests/test_cli_ai.py
+++ b/tests/test_cli_ai.py
@@ -140,10 +140,40 @@ def test_ai_chat_buffered(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "hi back!" in captured.out
     provider.chat.assert_awaited_once()
-    # allow_tools defaults to True when --no-tools is absent.
+    # Buffered mode defaults tools OFF (no headless executor exists) and
+    # says so on stderr; --tools opts back in.
     kwargs = provider.chat.call_args.kwargs
-    assert kwargs["allow_tools"] is True
+    assert kwargs["allow_tools"] is False
+    assert "tool execution is disabled" in captured.err
     assert kwargs["task"] == "chat"
+
+
+def test_ai_chat_buffered_tools_flag_opts_in(monkeypatch, capsys):
+    """`--tools` re-enables tool execution in buffered mode."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, _auth, _api, provider, _convs, _pref = services
+    provider.chat.return_value = {"content": "ok"}
+
+    rc = cli_ai.handle_ai_command(_chat_args(tools=True))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert provider.chat.call_args.kwargs["allow_tools"] is True
+    assert "tool execution is disabled" not in captured.err
+
+
+def test_ai_chat_no_tools_beats_tools_flag(monkeypatch):
+    """`--no-tools` wins when both flags are given."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, _auth, _api, provider, _convs, _pref = services
+    provider.chat.return_value = {"content": "ok"}
+
+    rc = cli_ai.handle_ai_command(_chat_args(tools=True, no_tools=True))
+
+    assert rc == 0
+    assert provider.chat.call_args.kwargs["allow_tools"] is False
 
 
 def _chat_args(**overrides) -> argparse.Namespace:


### PR DESCRIPTION
## Summary

Client-side alignment with the live AI gateway behaviour, found by exercising the real endpoints end-to-end:

- **Buffered chat HTTP timeout 30s → 150s** — the server now executes the tool loop inside the request (wall-clock cap 120s), so the default timeout produced an instant `ReadTimeout` with an empty error message. The error printer also falls back to the exception class name when `str()` is empty.
- **Buffered headless chat defaults `allow_tools: false`** — tool calls are executed by the TUI chat panel; with no headless executor, a tool-requiring prompt blocked for the full wall-clock cap and returned no answer. Buffered mode now sends tools-off with a stderr note; new `--tools` flag opts back in (`--no-tools` still wins). Stream mode unchanged. Verified live: a tool-shaped prompt now answers in seconds instead of hanging 120s and exiting empty.
- **Top-up checkout URL field** — accept the session URL under `url` (what the live endpoint returns) as well as the originally specced `checkout_url` (now also sent).
- **`servonaut login` output flushing** — the verification URL + user code are flushed before polling so they appear immediately when stdout is redirected (CI logs, `tee`).

## Tests

- New: buffered default tools-off + stderr note, `--tools` opt-in, `--no-tools` precedence.
- Updated: buffered chat default assertion.
- Live-verified against the deployed gateway: buffered chat (tools-off note + text answer), top-up checkout end-to-end, full `servonaut login` device flow including pre-filled one-click approve.
