### PR TITLE
fix(cli): graceful Ctrl+C — Cancelled. + exit 130 instead of tracebacks

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,6 +14,13 @@ configuration see [Configuration Guide](configuration.md).
 `SERVONAUT_AI_PROVIDER` environment variable has the same effect as `--ai-provider`
 and is honoured by all `servonaut ai *` subcommands.
 
+**Cancelling:** Ctrl+C cancels any running command with a one-line
+`Cancelled.` and exit code `130` (the shell convention for SIGINT) — never a
+traceback. Some commands handle it more specifically: interrupting the
+post-top-up wait skips only the courtesy balance refresh (the purchase is
+unaffected, exit `0`), and interrupting `servonaut login` prints
+`Sign-in aborted.` (exit `130`).
+
 ---
 
 ## `servonaut ai`

--- a/src/servonaut/cli/ai.py
+++ b/src/servonaut/cli/ai.py
@@ -928,9 +928,10 @@ def _handle_topup(args: argparse.Namespace) -> int:
         except Exception:  # noqa: BLE001
             opened = False
 
-        print(f"Opening checkout for {pack!r} pack: {url}")
+        print(f"Opening checkout for {pack!r} pack: {url}", flush=True)
         if not opened:
-            print("(could not auto-launch browser; copy the URL above)")
+            print("(could not auto-launch browser; copy the URL above)",
+                  flush=True)
 
     # B3 — block inline for the post-checkout entitlements refresh. The
     # TUI variant (:meth:`schedule_post_topup_refresh`) uses
@@ -944,6 +945,15 @@ def _handle_topup(args: argparse.Namespace) -> int:
     if callable(await_refresh):
         try:
             _run_async(await_refresh(lambda msg: print(msg)))
+        except KeyboardInterrupt:
+            # The purchase is already done — interrupting the courtesy
+            # wait is not a failure.
+            print(
+                "\nSkipping the entitlement refresh (your top-up is "
+                "unaffected). Run `servonaut ai quota` in ~60s to see "
+                "the new balance.",
+                file=sys.stderr,
+            )
         except Exception:  # noqa: BLE001
             logger.debug(
                 "await_post_topup_refresh raised; continuing.",

--- a/src/servonaut/cli/login.py
+++ b/src/servonaut/cli/login.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _EXIT_SUCCESS = 0
 _EXIT_ERROR = 1
+_EXIT_CANCELLED = 130  # 128 + SIGINT, matching the shell convention
 
 # Upper bound on how long we wait for the user to approve in a browser.
 # The server's device-code lifetime (``expires_in``) is the real budget;
@@ -105,7 +106,7 @@ def handle_login_command(args: argparse.Namespace) -> int:
         )
     except KeyboardInterrupt:
         print("\nSign-in aborted.", file=sys.stderr)
-        return _EXIT_ERROR
+        return _EXIT_CANCELLED
 
 
 async def _do_login(auth: Any, *, no_browser: bool) -> int:

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -639,7 +639,22 @@ def _run_connect(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    """Entry point for servonaut command."""
+    """Entry point for the ``servonaut`` command.
+
+    Thin wrapper that turns an unhandled Ctrl+C anywhere in the CLI into
+    a one-line "Cancelled." and exit code 130 (128+SIGINT) instead of a
+    traceback. Handlers that want a friendlier outcome catch
+    KeyboardInterrupt themselves before it reaches this backstop.
+    """
+    try:
+        _main()
+    except KeyboardInterrupt:
+        print("\nCancelled.", file=sys.stderr)
+        sys.exit(130)
+
+
+def _main() -> None:
+    """Parse arguments and dispatch to the selected command."""
     parser = argparse.ArgumentParser(
         description='Servonaut — Interactive TUI for managing AWS EC2 SSH connections'
     )

--- a/src/servonaut/services/api_client.py
+++ b/src/servonaut/services/api_client.py
@@ -246,9 +246,19 @@ class APIClient(APIClientInterface):
                     "error field missing or unsupported envelope shape"
                 )
         except Exception:
+            # Non-JSON error body. An HTML error page (LB/proxy 502/503,
+            # maintenance page) is noise to a CLI user — summarise it
+            # instead of printing 500 chars of markup.
+            text = (response.text or "").strip()
+            if "text/html" in content_type or text[:15].lower().startswith(
+                ("<!doctype", "<html")
+            ):
+                message = f"HTTP {status} — service returned an error page"
+            else:
+                message = text[:200] or f"HTTP {status}"
             return APIError(
                 code="unknown",
-                message=response.text[:500],
+                message=message,
                 status=status,
                 response_headers=headers_dict,
             )

--- a/tests/test_api_client_errors.py
+++ b/tests/test_api_client_errors.py
@@ -130,6 +130,24 @@ class TestParseError:
         assert err.code == "unknown"
         assert err.status == 500
 
+    def test_html_error_page_summarised_not_dumped(self):
+        """A proxy/LB HTML error page (e.g. 503 maintenance) must become a
+        one-line message, never 500 chars of markup on the user's terminal."""
+        client = _make_client()
+        html = "<!DOCTYPE html>\n<html lang=\"en\">\n<head><title>Service Unavailable</title></head>..."
+        resp = _make_response(503, raw_text=html, content_type="text/html")
+        err = client._parse_error(resp)
+        assert isinstance(err, APIError)
+        assert err.code == "unknown"
+        assert err.message == "HTTP 503 — service returned an error page"
+        assert "<" not in err.message
+
+    def test_plain_text_error_body_truncated(self):
+        client = _make_client()
+        resp = _make_response(500, raw_text="x" * 999, content_type="text/plain")
+        err = client._parse_error(resp)
+        assert len(err.message) <= 200
+
     def test_response_headers_lowercased(self):
         client = _make_client()
         resp = MagicMock()

--- a/tests/test_cli_ai.py
+++ b/tests/test_cli_ai.py
@@ -478,6 +478,28 @@ def test_ai_topup_opens_browser_and_schedules_refresh(monkeypatch, capsys):
     auth.await_post_topup_refresh.assert_awaited_once()
 
 
+def test_ai_topup_ctrl_c_during_refresh_wait_is_graceful(monkeypatch, capsys):
+    """Ctrl+C during the post-checkout wait is not a failure: the purchase
+    already happened. Expect exit 0 + a 'top-up is unaffected' note, never
+    a traceback."""
+    services = _make_services()
+    _patch_init(monkeypatch, services)
+    _config, auth, _api, provider, _convs, _pref = services
+
+    provider.topup_checkout.return_value = (
+        "https://checkout.stripe.com/pay/cs_test_abc"
+    )
+    auth.await_post_topup_refresh = AsyncMock(side_effect=KeyboardInterrupt)
+    monkeypatch.setattr(cli_ai.webbrowser, "open", lambda url: True)
+
+    rc = cli_ai.handle_ai_command(_ns(ai_command="topup", pack="small"))
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "top-up is unaffected" in err
+    assert "servonaut ai quota" in err
+
+
 def test_ai_topup_blocks_for_post_checkout_refresh(monkeypatch):
     """B3 — the CLI handler awaits the refresh; the entitlements actually fetch.
 

--- a/tests/test_cli_login.py
+++ b/tests/test_cli_login.py
@@ -153,6 +153,18 @@ def test_login_opens_browser_unless_no_browser(monkeypatch, capsys):
     assert opened == []
 
 
+def test_login_ctrl_c_aborts_with_130(monkeypatch, capsys):
+    """Ctrl+C while waiting for approval → 'Sign-in aborted.' + exit 130."""
+    auth = _make_auth()
+    auth.start_device_flow = AsyncMock(side_effect=KeyboardInterrupt)
+    _patch_auth(monkeypatch, auth)
+
+    rc = cli_login.handle_login_command(_ns())
+
+    assert rc == 130
+    assert "aborted" in capsys.readouterr().err
+
+
 def test_login_loads_secrets_env_overrides(monkeypatch):
     """login/logout must load ~/.secrets/servonaut.env (SERVONAUT_API_URL
     et al.) — they build no ConfigManager, which is where every other entry

--- a/tests/test_main_entry.py
+++ b/tests/test_main_entry.py
@@ -1,0 +1,35 @@
+"""Tests for the ``main()`` entry-point wrapper.
+
+Ctrl+C anywhere in the CLI must produce a one-line "Cancelled." and exit
+code 130 (128+SIGINT) — never a raw KeyboardInterrupt traceback. Ctrl+C is
+the only cancellation mechanism a headless invocation has, so it has to
+read as a normal outcome, not a crash.
+"""
+from __future__ import annotations
+
+import pytest
+
+import servonaut.main as main_mod
+
+
+def test_keyboard_interrupt_exits_130_without_traceback(monkeypatch, capsys):
+    monkeypatch.setattr(main_mod, "_main", lambda: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main()
+
+    assert excinfo.value.code == 130
+    err = capsys.readouterr().err
+    assert "Cancelled." in err
+    assert "Traceback" not in err
+
+
+def test_normal_exit_passes_through(monkeypatch):
+    """SystemExit from a handler propagates untouched (wrapper only owns
+    KeyboardInterrupt)."""
+    monkeypatch.setattr(main_mod, "_main", lambda: (_ for _ in ()).throw(SystemExit(3)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main()
+
+    assert excinfo.value.code == 3


### PR DESCRIPTION
## Summary

Ctrl+C is the only cancellation mechanism a headless invocation has, but interrupting any in-flight command dumped a raw `KeyboardInterrupt` traceback. This makes cancellation a designed outcome:

- **Global backstop in `main()`**: any unhandled Ctrl+C prints a one-line `Cancelled.` and exits `130` (the 128+SIGINT shell convention). Cleanup still runs (`finally:` blocks, e.g. the relay lock release, execute before the backstop fires).
- **Post-top-up wait**: interrupting the ~45s entitlement-refresh wait is not a failure — the purchase already happened. Prints "your top-up is unaffected, run `servonaut ai quota` in ~60s" and exits `0`.
- **`servonaut login` abort** now exits `130` (was `1`) to match the convention.
- **Bonus polish found while testing**: non-JSON API error bodies are summarised — an HTML error page from a proxy/LB (502/503/maintenance window) becomes `HTTP <status> — service returned an error page` instead of 500 characters of markup on the terminal; plain-text bodies truncate to 200 chars. Top-up checkout prints are flushed so they appear immediately under redirection.
- CLI reference documents the cancellation contract.

## Tests

- `tests/test_main_entry.py` (new): backstop exits 130 with no traceback; SystemExit passes through untouched.
- Top-up interrupt → exit 0 + note; login interrupt → exit 130; HTML error page summarisation; plain-text truncation.
- Live-verified with real SIGINT delivery (`timeout -s INT`): top-up interrupted mid-wait → graceful skip, exit 0; login interrupted mid-poll → "Sign-in aborted.", exit 130.
