### PR TITLE
feat(mcp): list server in the official MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,50 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  mcp-registry:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The version in the committed server.json is informational; the
+      # release tag is the source of truth at publish time.
+      - name: Set version in server.json from release tag
+        run: |
+          VERSION="${TAG#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.tmp && mv server.tmp server.json
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
+      # Registry validation fetches the package from PyPI (version must
+      # exist and the README must contain the mcp-name marker), so wait
+      # for the index to serve the release published by the previous job.
+      - name: Wait for PyPI to serve the new version
+        run: |
+          VERSION="${TAG#v}"
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/servonaut/${VERSION}/json" > /dev/null; then
+              echo "PyPI serves servonaut ${VERSION}"
+              exit 0
+            fi
+            echo "Attempt ${i}: not available yet, retrying in 10s..."
+            sleep 10
+          done
+          echo "PyPI never served servonaut ${VERSION}" >&2
+          exit 1
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (DNS, servonaut.dev)
+        run: ./mcp-publisher login dns --domain servonaut.dev --private-key "$MCP_PRIVATE_KEY"
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Servonaut
 
+<!-- mcp-name: dev.servonaut/servonaut -->
+
 **Your servers. Your terminal. Your AI agent. One TUI.**
 
 Manage AWS, Hetzner, OVH, and custom servers from one terminal — with a built-in AI assistant and MCP server.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -1,0 +1,31 @@
+# MCP Registry Listing
+
+Servonaut's MCP server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io)
+as **`dev.servonaut/servonaut`**, so MCP clients and registry aggregators can
+discover and install it directly.
+
+## How the listing works
+
+- [`server.json`](../server.json) at the repo root is the registry manifest.
+  It describes the PyPI package, the stdio transport, and the launch command
+  (`uvx --from 'servonaut[mcp]' servonaut --mcp`).
+- The README contains an `mcp-name` marker (an HTML comment near the top)
+  that the registry uses to verify PyPI package ownership. Don't remove it.
+- The `dev.servonaut` namespace is verified via a DNS TXT record on
+  `servonaut.dev` (Ed25519 public key, `v=MCPv1` format).
+
+## Publishing flow
+
+Registry publishing is automated in `.github/workflows/publish.yml`
+(`mcp-registry` job). On each GitHub release it:
+
+1. Sets the version in `server.json` from the release tag (the committed
+   version is informational only).
+2. Waits until PyPI serves the new package version (the registry validates
+   the package exists and its README carries the `mcp-name` marker).
+3. Authenticates with `mcp-publisher login dns` using the `MCP_PRIVATE_KEY`
+   repository secret and publishes the manifest.
+
+No manual step is needed for a normal release. To publish manually, install
+[`mcp-publisher`](https://github.com/modelcontextprotocol/registry/releases),
+authenticate the same way, and run `mcp-publisher publish` from the repo root.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "dev.servonaut/servonaut",
+  "title": "Servonaut",
+  "description": "Manage AWS, Hetzner, OVH and SSH servers: status, logs, CloudWatch, IP bans, safe command exec.",
+  "repository": {
+    "url": "https://github.com/zb-ss/servonaut",
+    "source": "github"
+  },
+  "websiteUrl": "https://servonaut.dev",
+  "version": "2.19.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "servonaut",
+      "version": "2.19.1",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "servonaut[mcp]",
+          "description": "Install the MCP extra alongside the base package"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "--mcp",
+          "description": "Start the MCP server on stdio transport"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Lists Servonaut's MCP server in the [official MCP Registry](https://registry.modelcontextprotocol.io) as **`dev.servonaut/servonaut`**, making it discoverable by MCP clients and registry aggregators.

- **`server.json`** — registry manifest: PyPI package, stdio transport, launched as `uvx --from 'servonaut[mcp]' servonaut --mcp` (the `--from` runtime argument pulls in the MCP extra so the install works out of the box)
- **`README.md`** — adds the `mcp-name` ownership marker (HTML comment, invisible when rendered) that the registry uses to verify PyPI package ownership
- **`.github/workflows/publish.yml`** — new `mcp-registry` job that runs after the PyPI publish on each release: sets the version from the release tag, waits until PyPI serves the new version, then authenticates via DNS and publishes the manifest
- **`docs/mcp-registry.md`** — documents how the listing and the automated publishing flow work

Namespace ownership is verified via an Ed25519 DNS TXT record on the `servonaut.dev` apex.

## Notes

- The first registry publish will happen on the **next release** — registry validation reads the README as served by PyPI, and the marker only lands there with the next published version.
- The registry is currently in preview, so the first `mcp-registry` job run is worth a glance.

## Testing

- `server.json` validated against the 2025-12-11 server schema (name pattern, length constraints)
- Workflow YAML parses cleanly
- DNS TXT record verified live on the apex from multiple resolvers
- `mcp-publisher login dns` dry-run against servonaut.dev succeeded with the stored key