### PR TITLE
fix(mcp): route ovh_monitoring for manually registered OVH servers

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -534,7 +534,12 @@ class ServonautTools:
                             f"matching OVH discovery (include_vps / "
                             f"include_dedicated / include_cloud) and make "
                             f"sure its public IP or name matches the OVH "
-                            f"service so it can be correlated."
+                            f"service so it can be correlated. Note: a "
+                            f"custom entry whose host is a DNS name rather "
+                            f"than an IPv4 address never matches by IP — "
+                            f"set host to the server's primary IPv4 or "
+                            f"align the entry name with the discovered "
+                            f"service name."
                         )
                     return f"Error: Cannot determine project_id for instance {instance_id}. Provider type: {provider_type!r}"
                 data = await self._ovh_monitoring_service.get_cloud_monitoring(project_id, name, period)

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -488,6 +488,15 @@ class ServonautTools:
             return f"Instance not found: {instance_id}"
 
         provider_type = instance.get('provider_type', '')
+        if not provider_type and self._ovh_service is not None:
+            # Custom-server entries (e.g. an OVH VPS registered manually)
+            # carry no provider_type, so route via the discovered OVH
+            # inventory instead — matched by public IP, then name.
+            correlated = await self._correlate_ovh_instance(instance)
+            if correlated is not None:
+                instance = correlated
+                provider_type = instance.get('provider_type', '')
+
         name = instance.get('id', '') or instance.get('name', '')
 
         try:
@@ -513,6 +522,20 @@ class ServonautTools:
                 # Public Cloud instance: needs project_id
                 project_id = instance.get('project_id', '')
                 if not project_id:
+                    if not provider_type:
+                        # Uncorrelated custom entry — explain what the
+                        # tool supports instead of a bare project_id error.
+                        return (
+                            f"Error: Cannot determine the OVH product type "
+                            f"for {instance_id}. ovh_monitoring supports "
+                            f"OVH VPS, dedicated, and Public Cloud "
+                            f"instances discovered via the OVH API. If "
+                            f"this server is a custom entry, enable the "
+                            f"matching OVH discovery (include_vps / "
+                            f"include_dedicated / include_cloud) and make "
+                            f"sure its public IP or name matches the OVH "
+                            f"service so it can be correlated."
+                        )
                     return f"Error: Cannot determine project_id for instance {instance_id}. Provider type: {provider_type!r}"
                 data = await self._ovh_monitoring_service.get_cloud_monitoring(project_id, name, period)
                 lines = [f"Cloud Instance Monitoring: {name} (project={project_id}, period={period})"]
@@ -3018,6 +3041,31 @@ class ServonautTools:
                     or inst.get('name') == instance_id
                     or inst.get('name', '').lower() == instance_id_lower):
                 return inst
+        return None
+
+    async def _correlate_ovh_instance(self, instance: Dict) -> Optional[Dict]:
+        """Match an instance without provider_type to a discovered OVH one.
+
+        Custom-server entries are matched in :meth:`_find_instance` before
+        the OVH inventory, so a manually registered OVH box resolves to a
+        dict without ``provider_type`` and OVH-specific tools cannot route
+        it. Correlate by public IP first (strongest signal), then by
+        case-insensitive name.
+        """
+        try:
+            ovh_instances = await self._ovh_service.fetch_instances_cached()
+        except Exception:
+            return None
+        public_ip = instance.get('public_ip') or ''
+        name = (instance.get('name') or '').lower()
+        if public_ip:
+            for inst in ovh_instances:
+                if inst.get('public_ip') == public_ip:
+                    return inst
+        if name:
+            for inst in ovh_instances:
+                if (inst.get('name') or '').lower() == name:
+                    return inst
         return None
 
     def _format_instances(self, instances: List[Dict]) -> str:

--- a/tests/test_ovh_tools.py
+++ b/tests/test_ovh_tools.py
@@ -281,11 +281,15 @@ class TestOVHMonitoringCorrelation:
     def test_custom_entry_correlates_by_public_ip(self):
         # Custom entry matched first by _find_instance; the tool must
         # re-route via the discovered VPS and use its OVH service name.
+        # The names deliberately DIFFER: operators often label a custom
+        # entry differently from the provider-side display name, so the
+        # IP-first pass must hit on its own without the name fallback.
+        custom = dict(_CUSTOM_ENTRY, name='edge-1')
         monitoring = _monitoring_mock()
         tools = _make_tools(
             ovh_service=_ovh_service_mock([_OVH_VPS]),
             ovh_monitoring_service=monitoring,
-            custom_instances=[_CUSTOM_ENTRY],
+            custom_instances=[custom],
         )
         out = _run(tools.ovh_monitoring("custom-web-1"))
         monitoring.get_vps_monitoring.assert_awaited_once_with(

--- a/tests/test_ovh_tools.py
+++ b/tests/test_ovh_tools.py
@@ -33,13 +33,16 @@ def _make_tools(
     guard_level: str = GuardLevel.DANGEROUS,
     ovh_service=None,
     ovh_cloud_service=None,
+    ovh_monitoring_service=None,
+    custom_instances=None,
 ):
     """Construct a ServonautTools wired with mocked services.
 
     ``ovh_service`` covers start/stop/reboot (those route through
     ``OVHService``). ``ovh_cloud_service`` covers create/delete
     (those route through ``OVHCloudService``). They're independent —
-    each test wires only what it needs.
+    each test wires only what it needs. ``custom_instances`` seeds
+    the custom-server inventory used by ``_find_instance``.
     """
     config = AppConfig(mcp=MCPConfig(guard_level=guard_level))
     config_manager = MagicMock()
@@ -48,7 +51,7 @@ def _make_tools(
     aws_service = MagicMock()
     aws_service.fetch_instances_cached = AsyncMock(return_value=[])
     custom_server_service = MagicMock()
-    custom_server_service.list_as_instances.return_value = []
+    custom_server_service.list_as_instances.return_value = custom_instances or []
     cache_service = MagicMock()
     ssh_service = MagicMock()
     connection_service = MagicMock()
@@ -63,6 +66,7 @@ def _make_tools(
         guard, audit,
         ovh_service=ovh_service,
         ovh_cloud_service=ovh_cloud_service,
+        ovh_monitoring_service=ovh_monitoring_service,
     )
 
 
@@ -231,3 +235,133 @@ class TestOVHPowerTools:
         out = _run(getattr(tools, tool_name)("i-1", "cloud"))
         assert out.startswith("Blocked: ")
         getattr(svc, service_method).assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tool: ovh_monitoring — custom-server correlation
+# ---------------------------------------------------------------------------
+
+_OVH_VPS = {
+    'id': 'vps-abc123.vps.ovh.net',
+    'name': 'web-1',
+    'public_ip': '1.1.1.1',
+    'provider': 'OVH',
+    'provider_type': 'vps',
+    'is_ovh': True,
+}
+
+# A manually registered custom server pointing at the same box: no
+# provider_type, so ovh_monitoring cannot route it without correlation.
+_CUSTOM_ENTRY = {
+    'id': 'custom-web-1',
+    'name': 'web-1',
+    'public_ip': '1.1.1.1',
+    'provider': 'ovh',
+    'is_custom': True,
+}
+
+
+def _monitoring_mock():
+    svc = MagicMock()
+    svc.get_vps_monitoring = AsyncMock(return_value={
+        'cpu:used': [{'timestamp': 1, 'value': 12.5}],
+    })
+    svc.get_cloud_monitoring = AsyncMock(return_value={})
+    svc.get_dedicated_monitoring = AsyncMock(return_value={})
+    return svc
+
+
+def _ovh_service_mock(instances):
+    svc = MagicMock()
+    svc.fetch_instances_cached = AsyncMock(return_value=instances)
+    return svc
+
+
+class TestOVHMonitoringCorrelation:
+    def test_custom_entry_correlates_by_public_ip(self):
+        # Custom entry matched first by _find_instance; the tool must
+        # re-route via the discovered VPS and use its OVH service name.
+        monitoring = _monitoring_mock()
+        tools = _make_tools(
+            ovh_service=_ovh_service_mock([_OVH_VPS]),
+            ovh_monitoring_service=monitoring,
+            custom_instances=[_CUSTOM_ENTRY],
+        )
+        out = _run(tools.ovh_monitoring("custom-web-1"))
+        monitoring.get_vps_monitoring.assert_awaited_once_with(
+            'vps-abc123.vps.ovh.net', 'lastday',
+        )
+        assert "VPS Monitoring: vps-abc123.vps.ovh.net" in out
+        assert "cpu:used" in out
+
+    def test_custom_entry_correlates_by_name_when_ip_differs(self):
+        custom = dict(_CUSTOM_ENTRY, public_ip='')
+        monitoring = _monitoring_mock()
+        tools = _make_tools(
+            ovh_service=_ovh_service_mock([_OVH_VPS]),
+            ovh_monitoring_service=monitoring,
+            custom_instances=[custom],
+        )
+        out = _run(tools.ovh_monitoring("web-1"))
+        monitoring.get_vps_monitoring.assert_awaited_once_with(
+            'vps-abc123.vps.ovh.net', 'lastday',
+        )
+        assert "VPS Monitoring" in out
+
+    def test_no_correlation_returns_clear_error(self):
+        # No discovered OVH instance matches: the error must explain the
+        # supported product types instead of a bare project_id message.
+        monitoring = _monitoring_mock()
+        tools = _make_tools(
+            ovh_service=_ovh_service_mock([]),
+            ovh_monitoring_service=monitoring,
+            custom_instances=[_CUSTOM_ENTRY],
+        )
+        out = _run(tools.ovh_monitoring("custom-web-1"))
+        assert "supports OVH VPS, dedicated" in out
+        monitoring.get_vps_monitoring.assert_not_called()
+        monitoring.get_cloud_monitoring.assert_not_called()
+
+    def test_correlation_skipped_without_ovh_service(self):
+        # Monitoring service wired but no OVHService: must not crash,
+        # must surface the clear error.
+        monitoring = _monitoring_mock()
+        tools = _make_tools(
+            ovh_service=None,
+            ovh_monitoring_service=monitoring,
+            custom_instances=[_CUSTOM_ENTRY],
+        )
+        out = _run(tools.ovh_monitoring("custom-web-1"))
+        assert "supports OVH VPS, dedicated" in out
+
+    def test_correlation_survives_ovh_fetch_failure(self):
+        # First fetch (inside _find_instance) succeeds empty; the
+        # correlation re-fetch raises — the helper must swallow it and
+        # fall through to the clear error instead of crashing the tool.
+        ovh = MagicMock()
+        ovh.fetch_instances_cached = AsyncMock(
+            side_effect=[[], RuntimeError("api down")],
+        )
+        monitoring = _monitoring_mock()
+        tools = _make_tools(
+            ovh_service=ovh,
+            ovh_monitoring_service=monitoring,
+            custom_instances=[_CUSTOM_ENTRY],
+        )
+        out = _run(tools.ovh_monitoring("custom-web-1"))
+        assert "supports OVH VPS, dedicated" in out
+
+    def test_discovered_vps_still_routes_directly(self):
+        # Regression guard: instances that already carry provider_type
+        # must not go through correlation.
+        monitoring = _monitoring_mock()
+        ovh = _ovh_service_mock([_OVH_VPS])
+        tools = _make_tools(
+            ovh_service=ovh,
+            ovh_monitoring_service=monitoring,
+        )
+        out = _run(tools.ovh_monitoring("vps-abc123.vps.ovh.net"))
+        monitoring.get_vps_monitoring.assert_awaited_once_with(
+            'vps-abc123.vps.ovh.net', 'lastday',
+        )
+        assert "VPS Monitoring" in out


### PR DESCRIPTION
## Summary

`ovh_monitoring` failed with `Cannot determine project_id` when pointed at an OVH VPS that is registered as a **custom server** entry. The VPS/dedicated routing already existed — the real bug was instance resolution: `_find_instance` matches custom entries before the discovered OVH inventory, and custom dicts carry no `provider_type`, so the tool fell into the Public Cloud branch and died on the missing `project_id`.

## Changes

- **Correlation fallback**: when the matched instance has no `provider_type` and OVH is configured, correlate it against the discovered OVH inventory — by public IP first (strongest signal), then case-insensitive name — and route monitoring via the discovered entry (real OVH service name, correct product endpoint).
- **Clear error**: when nothing correlates, the error now explains the supported product types (VPS / dedicated / Public Cloud) and how to fix it (enable `include_vps` / `include_dedicated` / `include_cloud`, match IP or name) instead of a bare `project_id` message.
- **Preserved behavior**: discovered cloud instances missing `project_id` keep the original specific error; discovered VPS/dedicated instances route directly without correlation.

## Testing

6 new tests in `test_ovh_tools.py`: IP correlation, name-fallback correlation, no-match clear error, missing-OVHService safety, correlation fetch-failure resilience, and a regression guard for direct discovered-VPS routing. Full suite: 5260 passed; the 8 `test_hetzner_service.py` failures are pre-existing on master and environmental (local env lacks the `hcloud` extra — CI installs it).