### PR TITLE
fix(ovh): per-type VPS monitoring calls + loud failure on empty metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -24,7 +24,7 @@ jobs:
   leak-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Resolve scanner from base branch (anti-tamper)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -52,7 +52,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # The version in the committed server.json is informational; the
       # release tag is the source of truth at publish time.

--- a/src/servonaut/services/ovh_monitoring_service.py
+++ b/src/servonaut/services/ovh_monitoring_service.py
@@ -22,6 +22,15 @@ _DEDICATED_CHART_TYPES = [
     ("net_tx", "net:tx:max"),
 ]
 
+# /vps/{serviceName}/monitoring requires one call per statistic type
+# (vps.VpsStatisticTypeEnum); omitting `type` is a 400.
+_VPS_STAT_TYPES = [
+    ("cpu", "cpu:used"),
+    ("ram", "mem:used"),
+    ("net_in", "net:rx"),
+    ("net_out", "net:tx"),
+]
+
 
 def _validate_period(period: str) -> None:
     """Raise ValueError if period is not one of the accepted values."""
@@ -54,6 +63,9 @@ def _normalise_series(raw: object) -> List[dict]:
                 {"timestamp": ts, "value": v}
                 for ts, v in zip(timestamps, values)
             ]
+        # vps.VpsMonitoringData: {"unit": ..., "values": [{timestamp, value}]}
+        if values and isinstance(values[0], dict):
+            return values
         # Single-point dict
         return [raw]
     return []
@@ -80,7 +92,9 @@ class OVHMonitoringService:
     ) -> dict:
         """Fetch CPU, RAM, and network monitoring data for a VPS.
 
-        Calls GET /vps/{serviceName}/monitoring?period={period}.
+        Calls GET /vps/{serviceName}/monitoring once per statistic type
+        (``cpu:used``, ``mem:used``, ``net:rx``, ``net:tx``) — the
+        endpoint rejects requests without a ``type`` parameter.
 
         Args:
             vps_name: VPS service name (e.g. ``vps-abc123.ovh.net``).
@@ -89,36 +103,51 @@ class OVHMonitoringService:
 
         Returns:
             Dict with keys ``cpu``, ``ram``, ``net_in``, ``net_out``.
-            Each value is a list of ``{timestamp, value}`` dicts.
+            Each value is a list of ``{timestamp, value}`` dicts. A key
+            whose individual fetch failed is an empty list.
 
         Raises:
             ValueError: If *period* or *vps_name* is invalid.
+            RuntimeError: If every statistic type fails — the caller must
+                see a loud failure rather than empty-but-successful data.
         """
         _validate_period(period)
         _validate_name(vps_name, "vps_name")
 
         client = self._ovh_service.client
-        try:
-            raw = await asyncio.to_thread(
-                client.get,
-                f"/vps/{vps_name}/monitoring",
-                period=period,
-            )
-        except Exception as exc:
-            logger.error(
-                "Error fetching VPS monitoring for %s (period=%s): %s",
-                vps_name,
-                period,
-                exc,
-            )
-            raw = {}
+        result: dict = {}
+        errors: list = []
 
-        return {
-            "cpu": _normalise_series(raw.get("cpu") or []),
-            "ram": _normalise_series(raw.get("ram") or []),
-            "net_in": _normalise_series(raw.get("net_in") or []),
-            "net_out": _normalise_series(raw.get("net_out") or []),
-        }
+        for result_key, stat_type in _VPS_STAT_TYPES:
+            try:
+                raw = await asyncio.to_thread(
+                    client.get,
+                    f"/vps/{vps_name}/monitoring",
+                    period=period,
+                    type=stat_type,
+                )
+                result[result_key] = _normalise_series(raw)
+            except Exception as exc:
+                logger.error(
+                    "Error fetching VPS stat %s for %s (period=%s): %s",
+                    stat_type,
+                    vps_name,
+                    period,
+                    exc,
+                )
+                errors.append(f"{stat_type}: {exc}")
+                result[result_key] = []
+
+        if len(errors) == len(_VPS_STAT_TYPES):
+            raise RuntimeError(
+                f"OVH returned no monitoring data for VPS {vps_name}: all "
+                f"{len(errors)} statistic types failed (last: {errors[-1]}). "
+                "The legacy /vps monitoring API may not serve metrics for "
+                "current-generation VPS ranges — collect host-level metrics "
+                "on the server instead."
+            )
+
+        return result
 
     async def get_dedicated_monitoring(
         self, server_name: str, period: str = "lastday"

--- a/tests/test_ovh_monitoring_service.py
+++ b/tests/test_ovh_monitoring_service.py
@@ -123,66 +123,81 @@ class TestInputValidation:
 
 class TestGetVpsMonitoring:
 
-    def test_returns_structured_data_with_all_keys(self, monitoring_service, mock_ovh_client):
+    def test_fetches_all_four_stat_types(self, monitoring_service, mock_ovh_client):
+        # One API call per statistic type — the endpoint 400s without
+        # an explicit `type` parameter.
         mock_ovh_client.get.return_value = {
-            "cpu": [{"timestamp": "2024-01-01T00:00:00Z", "value": 12.5}],
-            "ram": [{"timestamp": "2024-01-01T00:00:00Z", "value": 512.0}],
-            "net_in": [{"timestamp": "2024-01-01T00:00:00Z", "value": 1024.0}],
-            "net_out": [{"timestamp": "2024-01-01T00:00:00Z", "value": 256.0}],
+            "unit": "%",
+            "values": [{"timestamp": 1704067200, "value": 12.5}],
         }
 
         result = asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
 
+        assert mock_ovh_client.get.call_count == 4
+        types_called = [
+            kwargs["type"] for _, kwargs in mock_ovh_client.get.call_args_list
+        ]
+        assert types_called == ["cpu:used", "mem:used", "net:rx", "net:tx"]
         assert set(result.keys()) == {"cpu", "ram", "net_in", "net_out"}
-        assert len(result["cpu"]) == 1
         assert result["cpu"][0]["value"] == 12.5
-        assert len(result["net_in"]) == 1
 
-    def test_empty_api_response_returns_empty_lists(self, monitoring_service, mock_ovh_client):
-        mock_ovh_client.get.return_value = {}
-
-        result = asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
-
-        assert result["cpu"] == []
-        assert result["ram"] == []
-        assert result["net_in"] == []
-        assert result["net_out"] == []
-
-    def test_api_error_returns_empty_lists(self, monitoring_service, mock_ovh_client):
-        mock_ovh_client.get.side_effect = Exception("404 Not Found")
-
-        result = asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
-
-        assert result["cpu"] == []
-        assert result["ram"] == []
-        assert result["net_in"] == []
-        assert result["net_out"] == []
-
-    def test_correct_api_path_called(self, monitoring_service, mock_ovh_client):
-        mock_ovh_client.get.return_value = {}
+    def test_correct_api_path_and_period(self, monitoring_service, mock_ovh_client):
+        mock_ovh_client.get.return_value = {"unit": "%", "values": []}
 
         asyncio.run(monitoring_service.get_vps_monitoring("vps-test.ovh.net", "lastweek"))
 
-        mock_ovh_client.get.assert_called_once_with(
-            "/vps/vps-test.ovh.net/monitoring",
-            period="lastweek",
-        )
+        for args, kwargs in mock_ovh_client.get.call_args_list:
+            assert args[0] == "/vps/vps-test.ovh.net/monitoring"
+            assert kwargs["period"] == "lastweek"
 
     def test_default_period_is_lastday(self, monitoring_service, mock_ovh_client):
-        mock_ovh_client.get.return_value = {}
+        mock_ovh_client.get.return_value = {"unit": "%", "values": []}
 
         asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
 
         _, kwargs = mock_ovh_client.get.call_args
         assert kwargs["period"] == "lastday"
 
-    def test_multiple_data_points_returned(self, monitoring_service, mock_ovh_client):
-        points = [{"timestamp": f"2024-01-01T0{i}:00:00Z", "value": float(i)} for i in range(5)]
-        mock_ovh_client.get.return_value = {"cpu": points}
+    def test_partial_failure_keeps_successful_keys(self, monitoring_service, mock_ovh_client):
+        # cpu succeeds, the rest fail — result keeps cpu and empties the
+        # failed keys without raising.
+        ok = {"unit": "%", "values": [{"timestamp": 1704067200, "value": 12.5}]}
+        mock_ovh_client.get.side_effect = [
+            ok,
+            Exception("500 Internal server error"),
+            Exception("500 Internal server error"),
+            Exception("500 Internal server error"),
+        ]
+
+        result = asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
+
+        assert result["cpu"][0]["value"] == 12.5
+        assert result["ram"] == []
+        assert result["net_in"] == []
+        assert result["net_out"] == []
+
+    def test_all_types_failing_raises_loudly(self, monitoring_service, mock_ovh_client):
+        # Silent-empty is indistinguishable from "no load" — when every
+        # statistic type fails the caller must see an error.
+        mock_ovh_client.get.side_effect = Exception("500 Internal server error")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
+
+        msg = str(exc_info.value)
+        assert "no monitoring data" in msg
+        assert "500 Internal server error" in msg
+        assert "legacy /vps monitoring API" in msg
+
+    def test_vps_monitoring_data_shape_normalised(self, monitoring_service, mock_ovh_client):
+        # vps.VpsMonitoringData: {"unit": ..., "values": [{timestamp, value}]}
+        points = [{"timestamp": 1704067200 + i, "value": float(i)} for i in range(5)]
+        mock_ovh_client.get.return_value = {"unit": "%", "values": points}
 
         result = asyncio.run(monitoring_service.get_vps_monitoring("vps-abc123.ovh.net"))
 
         assert len(result["cpu"]) == 5
+        assert result["cpu"][2] == {"timestamp": 1704067202, "value": 2.0}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Field testing of the v2.19.2 `ovh_monitoring` correlation fix surfaced two further problems in the VPS metrics fetch itself. This PR fixes both, plus a housekeeping chore.

### fix(ovh): VPS monitoring requires one API call per statistic type

- `GET /vps/{serviceName}/monitoring` **requires a `type` parameter** — the previous single call (period only) was rejected with a 400, and the error was swallowed into empty-but-successful series, so the tool reported "no data" indistinguishably from an idle box.
- Now fetches each statistic type separately (`cpu:used`, `mem:used`, `net:rx`, `net:tx`), mirroring the per-chart-type pattern `get_dedicated_monitoring` already uses.
- Normalises the `vps.VpsMonitoringData` response shape (`{"unit": …, "values": [{timestamp, value}]}`).
- **Loud failure**: when *every* statistic type fails, `get_vps_monitoring` now raises with a clear message (the legacy VPS monitoring API does not serve data for some current-generation VPS ranges) instead of returning silent-empty metrics. Partial failures keep the successful series and empty the failed keys. Both consumers (MCP tool, monitoring screen) already surface exceptions properly.

### chore(ci): update GitHub Actions to current Node 24 majors

`actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7 across `ci.yml`, `publish.yml`, `leak-guard.yml`. Node 20 action runtimes are deprecated (forced to Node 24 from 2026-06-16, removed 2026-09-16).

## Testing

`TestGetVpsMonitoring` rewritten for the per-type contract: 4 calls with correct types/path/period, partial-failure keeps successful keys, all-types-failing raises with the explanatory message, and `VpsMonitoringData`-shape normalisation. 165 tests across the affected files pass. Workflow YAML validated; action majors verified against latest releases.