### PR TITLE
feat(relay): execute AI chat tool calls in the headless connect listener

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -347,6 +347,22 @@ servonaut connect --reconnect   # heal a stale connection
 servonaut connect --stop        # stop
 ```
 
+**Authentication:** the listener uses your stored `servonaut login`
+session (with automatic token refresh). Setting both
+`SERVONAUT_RELAY_TOKEN` and `SERVONAUT_USER_ID` overrides the session
+(legacy/CI mode).
+
+**AI chat tool execution:** when started with a logged-in session, the
+listener also executes tool calls dispatched by Servonaut AI chats
+(headless `servonaut ai chat --tools`, web-originated conversations).
+Approval is policy-driven because no human is present to confirm:
+`relay.ai_tool_auto_approve` in `~/.servonaut/config.json` sets the
+maximum guard tier executed without confirmation — `"readonly"`,
+`"standard"` (default), or `"dangerous"` (additionally requires the
+dangerous-AI-tools entitlement). Tools above the tier return a denial
+the model can relay to the user. Every execution is written to
+`~/.servonaut/mcp_audit.jsonl` with `source="ai_chat"`.
+
 ---
 
 ## `servonaut login`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,8 +329,8 @@ These environment variables override hardcoded API endpoints. Useful for pointin
 |----------|---------|-------------|
 | `SERVONAUT_API_URL` | `https://api.servonaut.dev` | Base URL for the Servonaut API (auth, config sync, teams, entitlements) |
 | `SERVONAUT_MCP_URL` | `https://mcp.servonaut.dev` | Base URL for the hosted MCP server (premium tools) |
-| `SERVONAUT_RELAY_TOKEN` | — | Auth token for the CLI relay listener (`servonaut --connect`) |
-| `SERVONAUT_USER_ID` | — | User ID for the CLI relay listener |
+| `SERVONAUT_RELAY_TOKEN` | — | Legacy/CI override: auth token for `servonaut connect` (the stored `servonaut login` session is used when unset) |
+| `SERVONAUT_USER_ID` | — | Legacy/CI override: user ID for `servonaut connect` |
 
 These can be set inline, exported, or added to `~/.secrets/servonaut.env`:
 
@@ -339,6 +339,29 @@ These can be set inline, exported, or added to `~/.secrets/servonaut.env`:
 SERVONAUT_API_URL=https://staging.example.com
 SERVONAUT_MCP_URL=https://staging.example.com
 ```
+
+## Relay Listener (`relay`)
+
+Settings for the Mercure SSE relay used by `servonaut connect` and the
+TUI's in-process listener:
+
+```json
+{
+  "relay": {
+    "base_url": "https://api.servonaut.dev",
+    "mercure_url": "https://servonaut.dev/.well-known/mercure",
+    "heartbeat_interval": 30,
+    "ai_tool_auto_approve": "standard"
+  }
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | _(derived from API base)_ | REST API for heartbeats, Mercure JWTs, and results |
+| `mercure_url` | _(derived from API base)_ | The Mercure hub URL |
+| `heartbeat_interval` | `30` | Seconds between heartbeats |
+| `ai_tool_auto_approve` | `"standard"` | Max guard tier a headless listener auto-approves for AI chat tool calls: `"readonly"`, `"standard"`, or `"dangerous"`. `"dangerous"` additionally requires the dangerous-AI-tools entitlement. Tools above the tier are denied with an explanatory message. |
 
 ## Supported Terminals
 

--- a/src/servonaut/cli/ai.py
+++ b/src/servonaut/cli/ai.py
@@ -232,17 +232,17 @@ def _handle_chat(args: argparse.Namespace) -> int:
     allow_tools = not no_tools
 
     # Buffered mode defaults tools OFF: tool calls are executed by the TUI
-    # chat panel (and, soon, the relay listener) — a headless buffered
-    # request has no executor, so a tool-requiring prompt would block for
-    # the server's full wall-clock cap and come back empty. --tools opts
-    # back in; --no-tools always wins.
+    # chat panel or a running `servonaut connect` listener — without one,
+    # a tool-requiring prompt blocks for the server's full wall-clock cap
+    # and comes back degraded. --tools opts back in; --no-tools always wins.
     use_stream = bool(getattr(args, "stream", False))
     if not use_stream and allow_tools and not bool(getattr(args, "tools", False)):
         allow_tools = False
         print(
-            "Note: tool execution is disabled in buffered headless chat "
-            "(no executor outside the TUI yet). Pass --tools to opt in, "
-            "or use --stream / the TUI chat panel.",
+            "Note: tool execution is disabled in buffered headless chat by "
+            "default. Start `servonaut connect` (the relay listener "
+            "executes dispatched tools) and pass --tools to opt in, or use "
+            "the TUI chat panel.",
             file=sys.stderr,
         )
 

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -379,6 +379,14 @@ class RelayConfig:
     base_url: str = ""            # e.g. https://api.servonaut.dev
     mercure_url: str = ""         # e.g. https://servonaut.dev/.well-known/mercure
     heartbeat_interval: int = 30
+    # Maximum guard tier a headless `servonaut connect` listener may
+    # auto-approve when executing AI-chat tool calls dispatched over the
+    # relay (no human is present to confirm). One of: "readonly",
+    # "standard", "dangerous". Tools above this tier are refused with
+    # status="denied". "dangerous" additionally requires the
+    # allow_dangerous_ai_tools entitlement — the config alone never
+    # unlocks it.
+    ai_tool_auto_approve: str = "standard"
 
 
 @dataclass

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -204,12 +204,41 @@ def _relay_run_foreground() -> None:
     auth_token = os.environ.get('SERVONAUT_RELAY_TOKEN', '')
     user_id = os.environ.get('SERVONAUT_USER_ID', '')
 
-    if not auth_token:
-        print("Error: SERVONAUT_RELAY_TOKEN environment variable is required.")
-        sys.exit(1)
-    if not user_id:
-        print("Error: SERVONAUT_USER_ID environment variable is required.")
-        sys.exit(1)
+    # The stored OAuth session (`servonaut login`) is the primary auth
+    # source; the env-var pair is the legacy/CI override and wins when
+    # BOTH are set. The session is also what enables AI tool execution —
+    # tool results POST to the API with the bearer.
+    auth_service = None
+    try:
+        from servonaut.services.auth_service import AuthService
+        candidate = AuthService()
+        if candidate.is_authenticated:
+            auth_service = candidate
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "AuthService unavailable for relay: %s", exc,
+        )
+
+    token_source = auth_token  # str (legacy) or callable (OAuth session)
+    refresh_callback = None
+    if not (auth_token and user_id):
+        if auth_service is None:
+            print(
+                "Error: no Servonaut session found. Run `servonaut login` "
+                "first, or set both SERVONAUT_RELAY_TOKEN and "
+                "SERVONAUT_USER_ID."
+            )
+            sys.exit(1)
+        from servonaut.services.relay_manager import _extract_user_id
+        token_source = lambda: auth_service.access_token  # noqa: E731
+        refresh_callback = auth_service.refresh_token
+        user_id = _extract_user_id(auth_service) or ''
+        if not user_id:
+            print(
+                "Error: could not determine your user id from the stored "
+                "session. Re-run `servonaut login`."
+            )
+            sys.exit(1)
 
     # Auto-fill relay URLs from the API base if missing (same logic the TUI
     # runs at mount), so a bg listener launched before the user has ever
@@ -270,18 +299,61 @@ def _relay_run_foreground() -> None:
         config_manager, aws_service, custom_server_service,
         ssh_service, connection_service, scp_service,
     )
+
+    # AI chat tool executor — lets headless sessions answer tool calls the
+    # hosted AI dispatches on /cli/{uid}/ai-tool-calls. Needs the OAuth
+    # session (tool results POST to the API); in env-token-only mode it
+    # stays disabled and tool dispatches time out server-side as before.
+    ai_tool_executor = None
+    ai_tool_note = "disabled (run `servonaut login` to enable)"
+    if auth_service is not None:
+        try:
+            from servonaut.services.api_client import APIClient
+            from servonaut.services.ai_tool_bridge import AIToolBridge
+            from servonaut.services.ip_ban_service import IPBanService
+            from servonaut.services.relay_tool_executor import (
+                RelayAIToolExecutor, build_headless_confirm,
+            )
+            from servonaut.mcp.audit import AuditTrail
+            from servonaut.mcp.server import build_headless_tools
+
+            bridge = AIToolBridge(
+                api_client=APIClient(auth_service),
+                relay_executors=executors,
+                mcp_audit=AuditTrail(config.mcp.audit_path),
+                confirm_callback=build_headless_confirm(config_manager),
+                auth_service=auth_service,
+                servonaut_tools=build_headless_tools(config_manager),
+                ip_ban_service=IPBanService(config_manager),
+            )
+            ai_tool_executor = RelayAIToolExecutor(bridge)
+            ai_tool_note = (
+                f"enabled (auto-approve up to: "
+                f"{config.relay.ai_tool_auto_approve})"
+            )
+        except ImportError as exc:
+            ai_tool_note = f"disabled (missing dependency: {exc})"
+        except Exception as exc:
+            ai_tool_note = f"disabled (init failed: {exc})"
+            logging.getLogger(__name__).exception(
+                "AI tool executor init failed",
+            )
+
     listener = RelayListener(
         executors=executors,
         base_url=relay_cfg.base_url,
         mercure_url=relay_cfg.mercure_url,
-        auth_token=auth_token,
+        auth_token=token_source,
         user_id=user_id,
         heartbeat_interval=relay_cfg.heartbeat_interval,
+        refresh_callback=refresh_callback,
+        ai_tool_executor=ai_tool_executor,
     )
 
     print(f"Starting Servonaut relay listener (user: {user_id})")
     print(f"  Hub: {relay_cfg.mercure_url}")
     print(f"  API: {relay_cfg.base_url}")
+    print(f"  AI chat tools: {ai_tool_note}")
     print("Press Ctrl+C to stop.")
     log_relay_event("starting", mode="bg", client_id=listener.client_id)
 

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -12,15 +12,15 @@ import sys
 logger = logging.getLogger(__name__)
 
 
-def create_mcp_server():
-    """Create and configure the MCP server."""
-    try:
-        from mcp.server import Server
-        from mcp.types import Tool, TextContent
-    except ImportError:
-        logger.error("MCP SDK not installed. Install with: pip install 'servonaut[mcp]'")
-        sys.exit(1)
+def build_headless_tools(config_manager=None):
+    """Construct a fully wired :class:`ServonautTools` with no TUI.
 
+    Single source of truth for headless service construction — shared by
+    the MCP server (stdio transport) and the ``servonaut connect`` relay
+    listener's AI-tool executor. Optional providers (Hetzner, OVH, object
+    storage, memory, secret provider) degrade to ``None`` exactly as the
+    MCP server always has.
+    """
     from servonaut.config.manager import ConfigManager
     from servonaut.services.cache_service import CacheService
     from servonaut.services.aws_service import AWSService
@@ -35,7 +35,8 @@ def create_mcp_server():
     from servonaut.mcp.tools import ServonautTools
 
     # Initialize services (headless — no TUI)
-    config_manager = ConfigManager()
+    if config_manager is None:
+        config_manager = ConfigManager()
     config = config_manager.get()
     cache_service = CacheService(ttl_seconds=config.cache_ttl_seconds)
     aws_service = AWSService(cache_service)
@@ -223,6 +224,23 @@ def create_mcp_server():
         secret_provider=secret_provider,
         ip_enrichment_service=ip_enrichment_service,
     )
+    return tools
+
+
+def create_mcp_server():
+    """Create and configure the MCP server."""
+    try:
+        from mcp.server import Server
+        from mcp.types import Tool, TextContent
+    except ImportError:
+        logger.error("MCP SDK not installed. Install with: pip install 'servonaut[mcp]'")
+        sys.exit(1)
+
+    from servonaut.config.manager import ConfigManager
+
+    config_manager = ConfigManager()
+    config = config_manager.get()
+    tools = build_headless_tools(config_manager)
 
     _instructions = (
         "Agents: BEFORE issuing any read or exec tool against a managed "
@@ -286,13 +304,13 @@ def create_mcp_server():
     server = Server("servonaut", instructions=_instructions)
 
     from servonaut.mcp.tool_schemas import mcp_tool_list
-    have_ovh = ovh_service is not None
-    have_hetzner = hetzner_service is not None
+    have_ovh = tools.has_ovh
+    have_hetzner = tools.has_hetzner
     # IP-ban tools are only useful once at least one ban target is defined.
-    have_ip_ban = ip_ban_service is not None and bool(config.ip_ban_configs)
+    have_ip_ban = tools.has_ip_ban and bool(config.ip_ban_configs)
     # Memory tools need the subsystem wired AND enabled in config — when
     # memory.enabled is false every memory tool just returns an opt-out error.
-    have_memory = memory_service is not None and config.memory.enabled
+    have_memory = tools.has_memory and config.memory.enabled
 
     @server.list_tools()
     async def list_tools():

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -155,6 +155,26 @@ class ServonautTools:
         reuse our MCP config without reaching into private attributes."""
         return self._config_manager
 
+    # Capability flags — public so construction sites (MCP server, relay
+    # AI-tool executor) can gate tool listings without reaching into
+    # private attributes.
+
+    @property
+    def has_ovh(self) -> bool:
+        return self._ovh_service is not None
+
+    @property
+    def has_hetzner(self) -> bool:
+        return self._hetzner_service is not None
+
+    @property
+    def has_ip_ban(self) -> bool:
+        return self._ip_ban_service is not None
+
+    @property
+    def has_memory(self) -> bool:
+        return self._memory_service is not None
+
     def set_secret_provider(self, provider) -> None:
         """Bind/rebind the active secret store used by the DB tools.
 

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -505,6 +505,22 @@ class ToolResult:
 ConfirmCallback = Callable[[ToolCall], Awaitable[bool]]
 
 
+class ToolConfirmDenied(Exception):
+    """Raised by a confirm callback to deny with a specific reason + message.
+
+    Returning ``False`` from the callback produces the generic
+    ``user_declined`` audit row — correct for an interactive modal, but
+    misleading for policy-driven denials (e.g. the headless relay
+    executor refusing a tool above ``relay.ai_tool_auto_approve``).
+    Raising this instead lets the callback control both the audit
+    ``reason`` code and the message the model sees in the tool result.
+    """
+
+    def __init__(self, message: str, *, reason: str = "confirm_denied") -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 # ---------------------------------------------------------------------------
 # Dangerous-tool name-pattern floor (defense-in-depth for PR5')
 # ---------------------------------------------------------------------------
@@ -664,6 +680,12 @@ class AIToolBridge(_FloorDangerousMixin):
         if call.guard_level != "readonly":
             try:
                 allowed = await self._confirm(call)
+            except ToolConfirmDenied as exc:
+                return self._deny_with_audit(
+                    call,
+                    reason=exc.reason,
+                    error_message=str(exc),
+                )
             except Exception as exc:  # noqa: BLE001 — defensive
                 logger.exception("confirm_callback raised; treating as denied")
                 return self._deny_with_audit(
@@ -1196,6 +1218,7 @@ __all__ = [
     "AIToolBridge",
     "ConfirmCallback",
     "ToolCall",
+    "ToolConfirmDenied",
     "ToolResult",
     "_escalate_guard",
     "_FloorDangerousMixin",

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -145,7 +145,8 @@ class RelayListener:
                  refresh_callback: Optional[
                      Callable[[], Awaitable[bool]]
                  ] = None,
-                 providers_configured: Optional[List[str]] = None) -> None:
+                 providers_configured: Optional[List[str]] = None,
+                 ai_tool_executor=None) -> None:
         if not HAS_HTTPX_SSE:
             raise ImportError(
                 "httpx-sse required. Install with: pip install 'servonaut[relay]'"
@@ -200,6 +201,13 @@ class RelayListener:
         # Tracks whether the initial handshake has been posted; we fire
         # it exactly once on the first iteration of the heartbeat loop.
         self._handshake_sent: bool = False
+        # Optional RelayAIToolExecutor. When set, AI chat tool calls
+        # dispatched on /cli/{uid}/ai-tool-calls are executed here
+        # (headless `servonaut connect` sessions). When None — the TUI's
+        # in-process listener — those events are skipped, because the
+        # chat panel already executes them from the chat-stream SSE
+        # ``tool_call`` event; wiring both would double-execute.
+        self._ai_tool_executor = ai_tool_executor
 
     @property
     def client_id(self) -> str:
@@ -521,16 +529,48 @@ class RelayListener:
             except (TypeError, ValueError):
                 ttl = 60
 
-            # AI tool calls (ssh_exec_readonly, tail_log, etc.) are handled by
-            # services/ai_tool_bridge.py via the chat-stream / tool-result HTTP
-            # path — NOT by this relay listener. The backend currently mirrors
-            # them onto /cli/{user_id}/commands too, so we receive them here and
-            # must skip cleanly instead of erroring. CommandType only covers the
-            # 8 web-originated relay verbs; anything else belongs elsewhere.
             raw_type = raw.get("type")
+
+            # AI chat tool calls are discriminated FIRST, before the
+            # CommandType parse: the dispatch envelope carries a
+            # ``tool_call_id`` (web-console CommandRequests never do), and
+            # several AI tool names collide with the 8 relay verbs
+            # (run_command, get_logs, transfer_file, deploy, …). Without
+            # this check a colliding AI dispatch would execute down the
+            # web-console path — skipping the AI guard policy + audit and
+            # posting its result to the wrong endpoint (the command-result
+            # route only matches web-console v4 ids), so the AI turn would
+            # time out despite the command having run.
+            #
+            # With an executor wired (headless `servonaut connect`), the
+            # call executes here; without one (the TUI's in-process
+            # listener), it's skipped — the chat panel executes its own
+            # conversations from the chat-stream SSE ``tool_call`` event,
+            # and executing the Mercure copy too would double-run the tool.
+            if self._carries_tool_call_id(raw):
+                if self._ai_tool_executor is not None:
+                    await self._handle_ai_tool_call(raw)
+                else:
+                    logger.debug(
+                        "Skipping AI tool-call event type=%r (no executor "
+                        "wired; chat panel owns execution): id=%s",
+                        raw_type, raw.get("id"),
+                    )
+                return
+
             try:
                 command_type = CommandType(raw_type)
             except ValueError:
+                # Legacy (pre-enrichment) AI dispatches carry no
+                # tool_call_id; a non-CommandType name + an id is the
+                # remaining marker.
+                if self._ai_tool_executor is not None:
+                    from servonaut.services.relay_tool_executor import (
+                        is_ai_tool_call_event,
+                    )
+                    if is_ai_tool_call_event(raw):
+                        await self._handle_ai_tool_call(raw)
+                        return
                 logger.debug(
                     "Skipping non-relay event type=%r on commands channel "
                     "(handled by ai_tool_bridge): id=%s",
@@ -560,6 +600,36 @@ class RelayListener:
             await self._post_result(response)
         except Exception as e:
             logger.error("Failed to handle event: %s — data length: %d", e, len(data))
+
+    @staticmethod
+    def _carries_tool_call_id(raw: dict) -> bool:
+        """True when the event carries a ``tool_call_id`` (top-level or in
+        payload) — the definitive marker of an AI chat tool dispatch."""
+        if isinstance(raw.get("tool_call_id"), str) and raw["tool_call_id"]:
+            return True
+        payload = raw.get("payload")
+        if isinstance(payload, dict):
+            nested = payload.get("tool_call_id")
+            return isinstance(nested, str) and bool(nested)
+        return False
+
+    async def _handle_ai_tool_call(self, raw: dict) -> None:
+        """Execute an AI chat tool call via the wired executor.
+
+        The executor owns the parse → bridge → tool-result-POST round
+        trip and never raises; this wrapper just adds the foreground
+        status line that relay commands already get.
+        """
+        start = time.monotonic()
+        result = await self._ai_tool_executor.execute(raw)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        if result is None:
+            return
+        status_icon = "v" if result.status == "ok" else "x"
+        msg = (f"[ai:{raw.get('tool') or raw.get('type')}] "
+               f"{result.status} {status_icon} ({elapsed_ms}ms)")
+        logger.info("Relay AI tool call: %s", msg)
+        print(f"  {msg}")
 
     async def _post_result(self, response: CommandResponse) -> None:
         """POST the command result back to the backend."""

--- a/src/servonaut/services/relay_tool_executor.py
+++ b/src/servonaut/services/relay_tool_executor.py
@@ -1,0 +1,321 @@
+"""Headless executor for AI tool calls dispatched over the Mercure relay.
+
+The hosted AI's ``ToolDispatcher`` publishes every CLI-bound tool call to
+``/cli/{user_id}/ai-tool-calls`` (mirrored on ``/cli/{user_id}/commands``
+during the dual-publish transition window). In the TUI those calls are
+executed by the chat panel from the chat-stream ``tool_call`` SSE event;
+a headless ``servonaut connect`` session has no chat panel, so until this
+module existed the dispatch sat unanswered for the full 60s tool-await
+TTL and the model resumed tool-less.
+
+This executor closes that gap: :class:`RelayListener` hands it any
+relay event that is not a :class:`CommandType` verb but carries a
+``tool_call_id``; it adapts the envelope into an
+:class:`~servonaut.services.ai_tool_bridge.ToolCall`, drives the shared
+:class:`~servonaut.services.ai_tool_bridge.AIToolBridge` (guard
+escalation, dangerous floor, entitlement gate, audit trail with
+``source="ai_chat"``), and POSTs the result back to
+``/api/ai/chat/tool-result``.
+
+Headless approval policy
+------------------------
+
+There is no human present to confirm. ``relay.ai_tool_auto_approve``
+(``~/.servonaut/config.json``) sets the maximum guard tier the listener
+may approve on its own:
+
+- ``"readonly"``  → only read-only tools execute; everything else is denied.
+- ``"standard"``  → (default) read-only + standard tools execute. This is
+  the same trust model as the relayed web-console commands the listener
+  already executes without local confirmation.
+- ``"dangerous"`` → everything the server dispatches executes, PROVIDED
+  the account also has the ``allow_dangerous_ai_tools`` entitlement —
+  the bridge's entitlement gate runs first and is not bypassed.
+
+Denied calls return ``status="denied"`` with an actionable message, so
+the model can tell the user how to enable the tool instead of stalling.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+from servonaut.services.ai_tool_bridge import (
+    AIToolBridge,
+    ToolCall,
+    ToolConfirmDenied,
+    ToolResult,
+    # Relay-bound tool names — used to decide whether CommandRequest-style
+    # top-level fields (target_server_id) should be folded into args.
+    _RELAY_TOOL_TO_TYPE,
+)
+
+if TYPE_CHECKING:
+    from servonaut.services.config_manager import ConfigManager
+
+logger = logging.getLogger(__name__)
+
+_GUARD_RANK: Dict[str, int] = {"readonly": 0, "standard": 1, "dangerous": 2}
+
+_VALID_AUTO_APPROVE = frozenset(_GUARD_RANK)
+
+# Keys the bridge's _build_command_request reads to resolve the relay target.
+_TARGET_ARG_KEYS = ("instance_id", "server_id", "target_server_id")
+
+
+def is_ai_tool_call_event(raw: Dict[str, Any]) -> bool:
+    """True when a relay event is an AI chat tool call.
+
+    Callers only invoke this for events whose ``type`` is NOT one of the
+    8 :class:`CommandType` web-console verbs, so the check here is "does
+    this look like a dispatched tool call at all":
+
+    - ``tool_call_id`` (top-level or nested in ``payload``) — the
+      forward-looking marker; or
+    - ``id`` + a ``type`` string — the envelope observed on the wire
+      today (staging, 2026-06-11): ``{id, user_id, type=<tool name>,
+      target_server_id, payload, created_at, ttl_seconds}`` with NO
+      tool_call_id. The ``id`` doubles as the idempotency key.
+
+    Unknown tool names are safe to route: the bridge synthesises a
+    structured ``tool_unavailable`` error instead of executing anything.
+    """
+    if isinstance(raw.get("tool_call_id"), str) and raw["tool_call_id"]:
+        return True
+    payload = raw.get("payload")
+    if isinstance(payload, dict):
+        nested = payload.get("tool_call_id")
+        if isinstance(nested, str) and nested:
+            return True
+    return (
+        isinstance(raw.get("id"), str) and bool(raw["id"])
+        and isinstance(raw.get("type"), str) and bool(raw["type"])
+    )
+
+
+def parse_mercure_tool_call(raw: Dict[str, Any]) -> Optional[ToolCall]:
+    """Adapt a Mercure AI-tool-call envelope into a :class:`ToolCall`.
+
+    Tolerates both wire shapes in the field today:
+
+    - SSE-style 4-key dict: ``{tool_call_id, tool, args, guard_level}``
+      (+ ``user_id``/``conversation_id`` added for the Mercure publish).
+    - CommandRequest-style: ``{id, user_id, type=<tool name>,
+      target_server_id, payload=<args>, ttl_seconds, tool_call_id}`` —
+      the shape ``ToolDispatcher`` historically published to
+      ``/cli/{uid}/commands``.
+
+    Returns ``None`` when no tool name or no ``tool_call_id`` can be
+    resolved — the caller logs and skips (never guess an execution).
+
+    Note: the server serialises an empty args payload as a JSON array
+    (PHP ``[]``), not an object — observed on the wire 2026-06-11.
+    Anything that isn't a dict is treated as "no args".
+    """
+    payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
+
+    tool = raw.get("tool") or raw.get("type") or ""
+    if not isinstance(tool, str) or not tool:
+        return None
+
+    tool_call_id = (
+        raw.get("tool_call_id")
+        or payload.get("tool_call_id")
+        or raw.get("id")
+        or ""
+    )
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        return None
+
+    # Args: SSE shape puts them in ``args``; CommandRequest shape in
+    # ``payload``. A payload that only wrapped metadata (tool_call_id,
+    # conversation_id) still passes through — the bridge's per-tool arg
+    # handling tolerates extras for relay tools and TypeErrors cleanly
+    # (reason="bad_args") for local handlers.
+    raw_args = raw.get("args")
+    if isinstance(raw_args, dict):
+        args = dict(raw_args)
+    elif isinstance(raw_args, str) and raw_args.strip():
+        try:
+            decoded = json.loads(raw_args)
+            args = decoded if isinstance(decoded, dict) else {}
+        except (ValueError, TypeError):
+            logger.warning(
+                "ai-tool-call args was a non-JSON string for tool=%s call=%s",
+                tool, tool_call_id,
+            )
+            args = {}
+    elif payload:
+        args = {
+            k: v for k, v in payload.items()
+            if k not in ("tool_call_id", "conversation_id", "guard_level")
+        }
+    else:
+        args = {}
+
+    # CommandRequest-style target: fold into args for relay-bound tools so
+    # the bridge's target resolution finds it. Local ServonautTools
+    # handlers get their args untouched (an unexpected kwarg would
+    # TypeError as reason="bad_args").
+    target = raw.get("target_server_id")
+    if (
+        tool in _RELAY_TOOL_TO_TYPE
+        and isinstance(target, str) and target
+        and not any(k in args for k in _TARGET_ARG_KEYS)
+    ):
+        args["target_server_id"] = target
+
+    conversation_id = (
+        raw.get("conversation_id")
+        or payload.get("conversation_id")
+        or ""
+    )
+    if not conversation_id:
+        logger.warning(
+            "ai-tool-call %s arrived without conversation_id — the "
+            "tool-result POST will be rejected with validation_failed",
+            tool_call_id,
+        )
+
+    # Guard: prefer the server-supplied level; fall back to the client
+    # mirror (NOT a blanket "standard") so a readonly tool dispatched by
+    # an older server without guard_level isn't denied under a
+    # readonly-only auto-approve policy. The bridge re-escalates against
+    # the mirror + dangerous floor regardless, so this can never relax
+    # the effective tier.
+    guard_level = (
+        raw.get("guard_level")
+        or payload.get("guard_level")
+        or AIToolBridge.guard_for(tool)
+    )
+
+    return ToolCall(
+        tool_call_id=str(tool_call_id),
+        tool=tool,
+        args=args,
+        guard_level=str(guard_level),  # type: ignore[arg-type]
+        conversation_id=str(conversation_id),
+    )
+
+
+def build_headless_confirm(config_manager: "ConfigManager"):
+    """Confirm callback for headless sessions — policy, not a prompt.
+
+    Reads ``relay.ai_tool_auto_approve`` live on every call (config edits
+    apply without restarting the listener). Approves calls at or below
+    the configured tier; raises :class:`ToolConfirmDenied` above it so
+    the audit row carries a distinct reason code instead of the
+    interactive ``user_declined``.
+    """
+
+    async def _confirm(call: ToolCall) -> bool:
+        cfg = config_manager.get().relay
+        auto_approve = (cfg.ai_tool_auto_approve or "standard").strip().lower()
+        if auto_approve not in _VALID_AUTO_APPROVE:
+            logger.warning(
+                "Invalid relay.ai_tool_auto_approve=%r — treating as 'readonly'",
+                cfg.ai_tool_auto_approve,
+            )
+            auto_approve = "readonly"
+        call_rank = _GUARD_RANK.get(call.guard_level, _GUARD_RANK["standard"])
+        if call_rank <= _GUARD_RANK[auto_approve]:
+            logger.info(
+                "headless auto-approve: tool=%s guard=%s policy=%s call=%s",
+                call.tool, call.guard_level, auto_approve, call.tool_call_id,
+            )
+            return True
+        raise ToolConfirmDenied(
+            f"Tool {call.tool!r} requires {call.guard_level!r} approval, but "
+            f"this headless relay listener auto-approves up to "
+            f"{auto_approve!r} only. Run the tool from the Servonaut TUI "
+            f"chat (interactive confirmation), or raise "
+            f"relay.ai_tool_auto_approve in ~/.servonaut/config.json.",
+            reason="headless_policy_denied",
+        )
+
+    return _confirm
+
+
+class RelayAIToolExecutor:
+    """Executes AI tool calls received by a headless relay listener.
+
+    Owns the parse → bridge → post-result round trip for one event. The
+    listener calls :meth:`execute` from its event loop; every path POSTs
+    a tool result (the server's turn stays open until it lands), and no
+    exception escapes back into the listener's SSE loop.
+    """
+
+    def __init__(self, bridge: AIToolBridge) -> None:
+        self._bridge = bridge
+
+    async def execute(self, raw: Dict[str, Any]) -> Optional[ToolResult]:
+        """Run one AI tool call end-to-end. Returns the posted result.
+
+        Returns ``None`` only when the envelope is unparseable (no tool
+        name / tool_call_id) — there is nothing to POST a result for.
+        """
+        call = parse_mercure_tool_call(raw)
+        if call is None:
+            logger.warning(
+                "Unparseable ai-tool-call event (keys: %s) — skipping",
+                sorted(raw.keys()),
+            )
+            return None
+
+        logger.info(
+            "relay ai-tool-call received: tool=%s call=%s guard=%s conv=%s",
+            call.tool, call.tool_call_id, call.guard_level,
+            call.conversation_id or "<empty>",
+        )
+
+        try:
+            result = await self._bridge.handle_tool_call(call)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            # Mirror of the chat panel's C4 fallback: the bridge raised
+            # before producing a ToolResult; synthesise an error envelope
+            # so the server's turn closes instead of burning the await TTL.
+            logger.exception(
+                "AIToolBridge.handle_tool_call raised for %s", call.tool_call_id,
+            )
+            message = f"Tool execution failed: {exc}"
+            result = ToolResult(
+                tool_call_id=call.tool_call_id,
+                conversation_id=call.conversation_id,
+                status="error",
+                result=message,
+                error=str(exc),
+                bytes=len(message.encode("utf-8")),
+            )
+
+        try:
+            await self._bridge.post_tool_result(result)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            # post_tool_result already logged specifics; the listener loop
+            # must survive (the server will time the await out gracefully).
+            hint = ""
+            if not result.conversation_id:
+                hint = (
+                    " (the dispatch envelope carried no conversation_id, "
+                    "which /api/ai/chat/tool-result requires — known "
+                    "server-side contract gap)"
+                )
+            logger.warning(
+                "tool-result POST failed for %s status=%s — server will "
+                "time out the await%s",
+                result.tool_call_id, result.status, hint,
+            )
+        return result
+
+
+__all__ = [
+    "RelayAIToolExecutor",
+    "build_headless_confirm",
+    "is_ai_tool_call_event",
+    "parse_mercure_tool_call",
+]

--- a/tests/test_connect_command.py
+++ b/tests/test_connect_command.py
@@ -203,8 +203,21 @@ class TestHTTPSEnforcement:
         )
         assert exc.code != 0
 
+    def _unauthenticated_auth(self):
+        """AuthService stand-in for 'no stored session'.
+
+        The env-var pair is incomplete in these tests, so the code falls
+        back to the stored OAuth session — patching it to unauthenticated
+        keeps the tests hermetic on a developer machine with a real
+        ~/.servonaut/auth.json (otherwise the fallback would find the
+        live session and start a real listener loop).
+        """
+        auth = MagicMock()
+        auth.is_authenticated = False
+        return auth
+
     def test_missing_token_causes_exit(self):
-        """Missing SERVONAUT_RELAY_TOKEN must also cause sys.exit."""
+        """Missing SERVONAUT_RELAY_TOKEN and no stored session → sys.exit."""
         from servonaut.config.schema import AppConfig, RelayConfig
         relay_cfg = RelayConfig(
             base_url="https://app.example.com",
@@ -216,13 +229,15 @@ class TestHTTPSEnforcement:
 
         env = {"SERVONAUT_USER_ID": "user-1"}
         with patch("servonaut.config.manager.ConfigManager", return_value=config_manager), \
+             patch("servonaut.services.auth_service.AuthService",
+                   return_value=self._unauthenticated_auth()), \
              patch.dict(os.environ, env, clear=False):
             os.environ.pop("SERVONAUT_RELAY_TOKEN", None)
             with pytest.raises(SystemExit):
                 _relay_run_foreground()
 
     def test_missing_user_id_causes_exit(self):
-        """Missing SERVONAUT_USER_ID must also cause sys.exit."""
+        """Missing SERVONAUT_USER_ID and no stored session → sys.exit."""
         from servonaut.config.schema import AppConfig, RelayConfig
         relay_cfg = RelayConfig(
             base_url="https://app.example.com",
@@ -234,6 +249,8 @@ class TestHTTPSEnforcement:
 
         env = {"SERVONAUT_RELAY_TOKEN": "tok-abc"}
         with patch("servonaut.config.manager.ConfigManager", return_value=config_manager), \
+             patch("servonaut.services.auth_service.AuthService",
+                   return_value=self._unauthenticated_auth()), \
              patch.dict(os.environ, env, clear=False):
             os.environ.pop("SERVONAUT_USER_ID", None)
             with pytest.raises(SystemExit):
@@ -287,6 +304,102 @@ class TestHTTPSEnforcement:
              patch.dict(os.environ, env, clear=False):
             with pytest.raises(SystemExit):
                 _relay_run_foreground()
+
+
+# ---------------------------------------------------------------------------
+# OAuth-session fallback (no env vars) + AI tool executor wiring
+# ---------------------------------------------------------------------------
+
+class TestOAuthSessionFallback:
+    def test_session_fallback_builds_listener_with_token_provider(self):
+        """Without env vars, the stored session drives the listener:
+        callable token source, refresh callback, user id from the token,
+        and the AI tool executor wired in."""
+        from servonaut.config.schema import AppConfig, RelayConfig
+        relay_cfg = RelayConfig(
+            base_url="https://app.example.com",
+            mercure_url="https://hub.example.com/.well-known/mercure",
+        )
+        config = AppConfig(relay=relay_cfg)
+        config_manager = MagicMock()
+        config_manager.get.return_value = config
+
+        auth = MagicMock()
+        auth.is_authenticated = True
+        auth.access_token = "bearer-1"
+
+        listener = MagicMock()
+
+        async def _noop_run():
+            return None
+
+        listener.run = _noop_run
+        listener.client_id = "client-test"
+
+        lock = MagicMock()
+        lock.acquire.return_value = lock
+
+        with patch("servonaut.config.manager.ConfigManager", return_value=config_manager), \
+             patch("servonaut.services.auth_service.AuthService", return_value=auth), \
+             patch("servonaut.services.relay_manager._extract_user_id", return_value="42"), \
+             patch("servonaut.services.relay_lock.RelayLock", return_value=lock), \
+             patch("servonaut.mcp.server.build_headless_tools", return_value=MagicMock()), \
+             patch("servonaut.services.relay_listener.RelayListener",
+                   return_value=listener) as listener_cls, \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SERVONAUT_RELAY_TOKEN", None)
+            os.environ.pop("SERVONAUT_USER_ID", None)
+            _relay_run_foreground()
+
+        kwargs = listener_cls.call_args.kwargs
+        assert callable(kwargs["auth_token"])
+        assert kwargs["auth_token"]() == "bearer-1"
+        assert kwargs["user_id"] == "42"
+        assert kwargs["refresh_callback"] is auth.refresh_token
+        assert kwargs["ai_tool_executor"] is not None
+        lock.release.assert_called_once()
+
+    def test_env_pair_still_wins_over_session(self):
+        """Both env vars set → legacy string token, no refresh callback;
+        the executor still wires (it POSTs with the session bearer)."""
+        from servonaut.config.schema import AppConfig, RelayConfig
+        relay_cfg = RelayConfig(
+            base_url="https://app.example.com",
+            mercure_url="https://hub.example.com/.well-known/mercure",
+        )
+        config = AppConfig(relay=relay_cfg)
+        config_manager = MagicMock()
+        config_manager.get.return_value = config
+
+        auth = MagicMock()
+        auth.is_authenticated = True
+        auth.access_token = "bearer-1"
+
+        listener = MagicMock()
+
+        async def _noop_run():
+            return None
+
+        listener.run = _noop_run
+        listener.client_id = "client-test"
+
+        lock = MagicMock()
+        lock.acquire.return_value = lock
+
+        env = {"SERVONAUT_RELAY_TOKEN": "tok-legacy", "SERVONAUT_USER_ID": "9"}
+        with patch("servonaut.config.manager.ConfigManager", return_value=config_manager), \
+             patch("servonaut.services.auth_service.AuthService", return_value=auth), \
+             patch("servonaut.services.relay_lock.RelayLock", return_value=lock), \
+             patch("servonaut.mcp.server.build_headless_tools", return_value=MagicMock()), \
+             patch("servonaut.services.relay_listener.RelayListener",
+                   return_value=listener) as listener_cls, \
+             patch.dict(os.environ, env, clear=False):
+            _relay_run_foreground()
+
+        kwargs = listener_cls.call_args.kwargs
+        assert kwargs["auth_token"] == "tok-legacy"
+        assert kwargs["user_id"] == "9"
+        assert kwargs["refresh_callback"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relay_tool_executor.py
+++ b/tests/test_relay_tool_executor.py
@@ -1,0 +1,530 @@
+"""Tests for the headless relay AI-tool executor.
+
+Covers:
+
+1. Envelope classifier (``is_ai_tool_call_event``) — tool_call_id
+   top-level, nested in payload, absent.
+2. Envelope parser — SSE-style 4-key shape, CommandRequest-style shape,
+   JSON-string args, target_server_id folding (relay tools only),
+   guard_level fallback to the client mirror, unparseable → None.
+3. Headless approval policy — guard × ai_tool_auto_approve matrix,
+   invalid config value treated as readonly, denial raises
+   ``ToolConfirmDenied`` with reason ``headless_policy_denied``.
+4. Executor round trip — bridge driven, result POSTed; bridge crash →
+   synthetic error result still POSTed; POST failure swallowed;
+   unparseable envelope → no POST.
+5. RelayListener routing — non-CommandType event with a tool_call_id
+   goes to the executor when wired, is skipped when not; CommandRequest
+   events never touch the executor.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from servonaut.services.ai_tool_bridge import (
+    AIToolBridge,
+    ToolCall,
+    ToolConfirmDenied,
+    ToolResult,
+)
+from servonaut.services.relay_tool_executor import (
+    RelayAIToolExecutor,
+    build_headless_confirm,
+    is_ai_tool_call_event,
+    parse_mercure_tool_call,
+)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_top_level_tool_call_id():
+    assert is_ai_tool_call_event({"tool_call_id": "tc-1", "type": "tail_log"})
+
+
+def test_classifier_nested_tool_call_id():
+    assert is_ai_tool_call_event(
+        {"type": "tail_log", "payload": {"tool_call_id": "tc-1"}}
+    )
+
+
+def test_classifier_accepts_id_plus_type_shape():
+    # The envelope observed on the wire (staging, 2026-06-11) has no
+    # tool_call_id at all — id + type is the marker. (The caller only
+    # consults the classifier for non-CommandType events, so a
+    # CommandRequest never reaches it.)
+    assert is_ai_tool_call_event({
+        "id": "evt-7b17-dispatch-1",
+        "user_id": 7,
+        "type": "list_instances",
+        "target_server_id": None,
+        "payload": [],
+        "created_at": "2026-06-11T10:31:06+00:00",
+        "ttl_seconds": 60,
+    })
+
+
+def test_classifier_rejects_event_without_any_id():
+    assert not is_ai_tool_call_event({"tool_call_id": "", "type": "tail_log"})
+    assert not is_ai_tool_call_event({"type": "tail_log"})
+    assert not is_ai_tool_call_event({"id": "x"})  # no type
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sse_style_envelope():
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-9",
+        "tool": "list_instances",
+        "args": {"region": "eu-west-1"},
+        "guard_level": "readonly",
+        "conversation_id": "conv-1",
+        "user_id": 7,
+    })
+    assert call is not None
+    assert call.tool == "list_instances"
+    assert call.tool_call_id == "tc-9"
+    assert call.args == {"region": "eu-west-1"}
+    assert call.guard_level == "readonly"
+    assert call.conversation_id == "conv-1"
+
+
+def test_parse_command_request_style_envelope():
+    call = parse_mercure_tool_call({
+        "id": "tc-7",
+        "user_id": 7,
+        "type": "ssh_exec_readonly",
+        "target_server_id": "web-1",
+        "payload": {
+            "command": "uptime",
+            "tool_call_id": "tc-7",
+            "conversation_id": "conv-2",
+        },
+        "ttl_seconds": 60,
+    })
+    assert call is not None
+    assert call.tool == "ssh_exec_readonly"
+    assert call.tool_call_id == "tc-7"
+    assert call.conversation_id == "conv-2"
+    assert call.args["command"] == "uptime"
+    # Metadata keys are stripped from args.
+    assert "tool_call_id" not in call.args
+    assert "conversation_id" not in call.args
+    # target_server_id folded in for relay-bound tools.
+    assert call.args["target_server_id"] == "web-1"
+
+
+def test_parse_json_string_args():
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-2",
+        "tool": "tail_log",
+        "args": json.dumps({"log_path": "/var/log/nginx/error.log"}),
+    })
+    assert call is not None
+    assert call.args == {"log_path": "/var/log/nginx/error.log"}
+
+
+def test_parse_bad_json_string_args_falls_back_empty():
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-3",
+        "tool": "tail_log",
+        "args": "{not json",
+    })
+    assert call is not None
+    assert call.args == {}
+
+
+def test_parse_target_not_folded_for_local_tools():
+    # list_instances runs via ServonautTools locally; an injected
+    # target_server_id kwarg would TypeError there.
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-4",
+        "tool": "list_instances",
+        "target_server_id": "web-1",
+        "args": {},
+    })
+    assert call is not None
+    assert "target_server_id" not in call.args
+
+
+def test_parse_target_not_folded_when_args_already_target():
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-5",
+        "tool": "run_command",
+        "target_server_id": "web-1",
+        "args": {"instance_id": "i-123", "command": "uptime"},
+    })
+    assert call is not None
+    assert call.args["instance_id"] == "i-123"
+    assert "target_server_id" not in call.args
+
+
+def test_parse_guard_falls_back_to_client_mirror():
+    # No guard_level on the wire → use the client mirror, not a blanket
+    # "standard", so readonly tools stay readonly under strict policies.
+    call = parse_mercure_tool_call({
+        "tool_call_id": "tc-6",
+        "tool": "list_instances",
+        "args": {},
+    })
+    assert call is not None
+    assert call.guard_level == AIToolBridge.guard_for("list_instances") == "readonly"
+
+
+def test_parse_observed_wire_envelope():
+    # Golden-master for the literal bytes captured from staging Mercure
+    # on 2026-06-11 — payload is a JSON ARRAY when empty (PHP []), there
+    # is no tool_call_id / conversation_id / guard_level, and id is the
+    # only idempotency key.
+    call = parse_mercure_tool_call({
+        "id": "evt-7b17-dispatch-1",
+        "user_id": 7,
+        "type": "list_instances",
+        "target_server_id": None,
+        "payload": [],
+        "created_at": "2026-06-11T10:31:06+00:00",
+        "ttl_seconds": 60,
+    })
+    assert call is not None
+    assert call.tool == "list_instances"
+    assert call.tool_call_id == "evt-7b17-dispatch-1"
+    assert call.args == {}
+    assert call.guard_level == "readonly"  # client-mirror fallback
+    assert call.conversation_id == ""
+
+
+def test_parse_enriched_envelope():
+    # The enriched publish (server-side fix, 2026-06-11): `id` stays the
+    # relay correlation id (dedup key), `tool_call_id` is the server row
+    # id that must be echoed to /api/ai/chat/tool-result, and payload is
+    # always an object. The parser must prefer tool_call_id over id.
+    call = parse_mercure_tool_call({
+        "id": "corr-model-1",
+        "tool_call_id": "row-id-1",
+        "conversation_id": "conv-9",
+        "guard_level": "readonly",
+        "user_id": 7,
+        "type": "list_instances",
+        "target_server_id": None,
+        "payload": {},
+        "created_at": "2026-06-11T11:00:00+00:00",
+        "ttl_seconds": 60,
+    })
+    assert call is not None
+    assert call.tool == "list_instances"
+    assert call.tool_call_id == "row-id-1"
+    assert call.conversation_id == "conv-9"
+    assert call.guard_level == "readonly"
+    assert call.args == {}
+
+
+def test_parse_returns_none_without_tool_name():
+    assert parse_mercure_tool_call({"tool_call_id": "tc-1", "args": {}}) is None
+
+
+def test_parse_returns_none_without_tool_call_id():
+    assert parse_mercure_tool_call({"tool": "tail_log", "args": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# Headless approval policy
+# ---------------------------------------------------------------------------
+
+
+def _config_manager(auto_approve: str):
+    cfg = SimpleNamespace(relay=SimpleNamespace(ai_tool_auto_approve=auto_approve))
+    manager = MagicMock()
+    manager.get.return_value = cfg
+    return manager
+
+
+def _call(guard: str) -> ToolCall:
+    return ToolCall(
+        tool_call_id="tc-1", tool="run_command", args={},
+        guard_level=guard, conversation_id="conv-1",
+    )
+
+
+@pytest.mark.parametrize("policy,guard,approved", [
+    ("readonly", "readonly", True),
+    ("readonly", "standard", False),
+    ("readonly", "dangerous", False),
+    ("standard", "readonly", True),
+    ("standard", "standard", True),
+    ("standard", "dangerous", False),
+    ("dangerous", "readonly", True),
+    ("dangerous", "standard", True),
+    ("dangerous", "dangerous", True),
+])
+def test_policy_matrix(policy, guard, approved):
+    confirm = build_headless_confirm(_config_manager(policy))
+    if approved:
+        assert run(confirm(_call(guard))) is True
+    else:
+        with pytest.raises(ToolConfirmDenied) as exc_info:
+            run(confirm(_call(guard)))
+        assert exc_info.value.reason == "headless_policy_denied"
+        assert "ai_tool_auto_approve" in str(exc_info.value)
+
+
+def test_policy_invalid_config_treated_as_readonly():
+    confirm = build_headless_confirm(_config_manager("yolo"))
+    with pytest.raises(ToolConfirmDenied):
+        run(confirm(_call("standard")))
+    assert run(confirm(_call("readonly"))) is True
+
+
+def test_policy_unknown_guard_treated_as_standard():
+    confirm = build_headless_confirm(_config_manager("standard"))
+    assert run(confirm(_call("weird-tier"))) is True
+    confirm_ro = build_headless_confirm(_config_manager("readonly"))
+    with pytest.raises(ToolConfirmDenied):
+        run(confirm_ro(_call("weird-tier")))
+
+
+# ---------------------------------------------------------------------------
+# Bridge integration: ToolConfirmDenied → status="denied" + reason
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_maps_confirm_denied_to_denied_status():
+    api = MagicMock()
+    api.post = AsyncMock(return_value={})
+    audit = MagicMock()
+    auth = MagicMock()
+    auth.has_dangerous_ai_tools = True
+
+    async def _confirm(call):
+        raise ToolConfirmDenied("nope, policy", reason="headless_policy_denied")
+
+    bridge = AIToolBridge(
+        api_client=api,
+        relay_executors=MagicMock(),
+        mcp_audit=audit,
+        confirm_callback=_confirm,
+        auth_service=auth,
+    )
+    result = run(bridge.handle_tool_call(_call("standard")))
+    assert result.status == "denied"
+    assert "nope, policy" in result.result
+    reasons = [c.args[4] for c in audit.log.call_args_list]
+    assert "headless_policy_denied" in reasons
+
+
+# ---------------------------------------------------------------------------
+# Executor round trip
+# ---------------------------------------------------------------------------
+
+
+def _executor(handle_result=None, handle_raises=None, post_raises=None):
+    bridge = MagicMock(spec=AIToolBridge)
+    if handle_raises is not None:
+        bridge.handle_tool_call = AsyncMock(side_effect=handle_raises)
+    else:
+        bridge.handle_tool_call = AsyncMock(
+            return_value=handle_result or ToolResult(
+                tool_call_id="tc-1", conversation_id="conv-1",
+                status="ok", result="fine", bytes=4,
+            )
+        )
+    if post_raises is not None:
+        bridge.post_tool_result = AsyncMock(side_effect=post_raises)
+    else:
+        bridge.post_tool_result = AsyncMock(return_value=None)
+    return RelayAIToolExecutor(bridge), bridge
+
+
+_EVENT = {
+    "tool_call_id": "tc-1",
+    "tool": "list_instances",
+    "args": {},
+    "guard_level": "readonly",
+    "conversation_id": "conv-1",
+    "user_id": 7,
+}
+
+
+def test_executor_executes_and_posts():
+    executor, bridge = _executor()
+    result = run(executor.execute(dict(_EVENT)))
+    assert result is not None and result.status == "ok"
+    bridge.handle_tool_call.assert_awaited_once()
+    call = bridge.handle_tool_call.await_args.args[0]
+    assert isinstance(call, ToolCall)
+    assert call.tool == "list_instances"
+    bridge.post_tool_result.assert_awaited_once_with(result)
+
+
+def test_executor_posts_synthetic_error_when_bridge_raises():
+    executor, bridge = _executor(handle_raises=RuntimeError("boom"))
+    result = run(executor.execute(dict(_EVENT)))
+    assert result is not None
+    assert result.status == "error"
+    assert "boom" in (result.error or "")
+    bridge.post_tool_result.assert_awaited_once_with(result)
+
+
+def test_executor_swallows_post_failure():
+    executor, bridge = _executor(post_raises=RuntimeError("api down"))
+    result = run(executor.execute(dict(_EVENT)))
+    assert result is not None and result.status == "ok"
+
+
+def test_executor_skips_unparseable_event():
+    executor, bridge = _executor()
+    result = run(executor.execute({"something": "else"}))
+    assert result is None
+    bridge.handle_tool_call.assert_not_awaited()
+    bridge.post_tool_result.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# RelayListener routing
+# ---------------------------------------------------------------------------
+
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("httpx_sse")
+
+from servonaut.services.relay_listener import RelayListener  # noqa: E402
+
+
+def _listener(ai_tool_executor=None, user_id="7"):
+    executors = MagicMock()
+    executors.execute = AsyncMock()
+    listener = RelayListener(
+        executors=executors,
+        base_url="https://app.example.com",
+        mercure_url="https://hub.example.com/.well-known/mercure",
+        auth_token="tok",
+        user_id=user_id,
+        ai_tool_executor=ai_tool_executor,
+    )
+    listener._client = MagicMock()
+    listener._client.post = AsyncMock(
+        return_value=MagicMock(status_code=200, text="")
+    )
+    return listener, executors
+
+
+def test_listener_routes_ai_tool_call_to_executor():
+    executor = MagicMock()
+    executor.execute = AsyncMock(return_value=ToolResult(
+        tool_call_id="tc-1", conversation_id="conv-1",
+        status="ok", result="fine", bytes=4,
+    ))
+    listener, executors = _listener(ai_tool_executor=executor)
+    event = dict(_EVENT, type="list_instances")
+    run(listener._handle_event(json.dumps(event)))
+    executor.execute.assert_awaited_once()
+    assert executor.execute.await_args.args[0]["tool_call_id"] == "tc-1"
+    executors.execute.assert_not_awaited()
+
+
+def test_listener_skips_ai_tool_call_without_executor():
+    listener, executors = _listener(ai_tool_executor=None)
+    event = dict(_EVENT, type="list_instances")
+    run(listener._handle_event(json.dumps(event)))
+    executors.execute.assert_not_awaited()
+
+
+def test_listener_rejects_mismatched_user_id_before_executor():
+    executor = MagicMock()
+    executor.execute = AsyncMock()
+    listener, _ = _listener(ai_tool_executor=executor, user_id="7")
+    event = dict(_EVENT, type="list_instances", user_id=42)
+    run(listener._handle_event(json.dumps(event)))
+    executor.execute.assert_not_awaited()
+
+
+def test_listener_command_request_never_touches_executor():
+    executor = MagicMock()
+    executor.execute = AsyncMock()
+    listener, executors = _listener(ai_tool_executor=executor)
+    from servonaut.models.relay_messages import CommandResponse
+    executors.execute = AsyncMock(return_value=CommandResponse(
+        request_id="req-1", status="success", output="ok",
+    ))
+    event = {
+        "id": "req-1", "user_id": 7, "type": "run_command",
+        "target_server_id": "web-1", "payload": {"command": "ls"},
+        "ttl_seconds": 60,
+    }
+    run(listener._handle_event(json.dumps(event)))
+    executors.execute.assert_awaited_once()
+    executor.execute.assert_not_awaited()
+
+
+def test_listener_routes_colliding_tool_name_to_executor():
+    # run_command is BOTH an AI tool name and a web-console CommandType
+    # verb. An AI dispatch (marked by tool_call_id) must go to the
+    # executor — running it down the web-console path skips the AI guard
+    # policy/audit and posts the result to the wrong endpoint, so the AI
+    # turn times out despite the command executing (observed live
+    # 2026-06-11).
+    executor = MagicMock()
+    executor.execute = AsyncMock(return_value=ToolResult(
+        tool_call_id="row-1", conversation_id="conv-1",
+        status="ok", result="fine", bytes=4,
+    ))
+    listener, executors = _listener(ai_tool_executor=executor)
+    event = {
+        "id": "corr-1",
+        "tool_call_id": "row-1",
+        "conversation_id": "conv-1",
+        "guard_level": "standard",
+        "user_id": 7,
+        "type": "run_command",
+        "target_server_id": "web-1",
+        "payload": {"command": "uptime"},
+        "ttl_seconds": 60,
+    }
+    run(listener._handle_event(json.dumps(event)))
+    executor.execute.assert_awaited_once()
+    executors.execute.assert_not_awaited()
+
+
+def test_listener_skips_colliding_ai_dispatch_without_executor():
+    # The TUI's in-process listener (no executor) must NOT execute an AI
+    # dispatch whose name collides with a CommandType verb — the chat
+    # panel executes its own conversations from the SSE stream, and
+    # running the Mercure copy too would double-execute the tool.
+    listener, executors = _listener(ai_tool_executor=None)
+    event = {
+        "id": "corr-2",
+        "tool_call_id": "row-2",
+        "conversation_id": "conv-1",
+        "user_id": 7,
+        "type": "run_command",
+        "target_server_id": "web-1",
+        "payload": {"command": "uptime"},
+        "ttl_seconds": 60,
+    }
+    run(listener._handle_event(json.dumps(event)))
+    executors.execute.assert_not_awaited()
+
+
+def test_listener_dedups_dual_published_tool_call():
+    executor = MagicMock()
+    executor.execute = AsyncMock(return_value=ToolResult(
+        tool_call_id="tc-1", conversation_id="conv-1",
+        status="ok", result="fine", bytes=4,
+    ))
+    listener, _ = _listener(ai_tool_executor=executor)
+    event = json.dumps(dict(_EVENT, type="list_instances"))
+    run(listener._handle_event(event))
+    run(listener._handle_event(event))
+    executor.execute.assert_awaited_once()


### PR DESCRIPTION
## Summary

The relay listener (`servonaut connect`) now executes tool calls dispatched by Servonaut AI chats, closing the gap where headless sessions (`servonaut ai chat --tools`, web-originated conversations) had no executor and every tool round burned the server-side await timeout.

## Changes

- **New `services/relay_tool_executor.py`** — adapts the dispatch envelope (tolerates both the legacy and the enriched wire shapes) into the existing `AIToolBridge` flow: guard escalation, dangerous-tool name floor, entitlement gate, audit trail (`source="ai_chat"`), and the tool-result POST.
- **Headless approval policy** — new config `relay.ai_tool_auto_approve` (`readonly` | `standard` | `dangerous`, default `standard`) sets the maximum guard tier executed without interactive confirmation. `dangerous` additionally requires the account entitlement. Above-tier calls return an instant, actionable denial instead of timing out.
- **Collision routing** — AI tool names that overlap the web-console relay verbs (`run_command`, `get_logs`, `transfer_file`, `deploy`) are discriminated by the `tool_call_id` the dispatch envelope carries, so they execute through the AI guard policy + audit rather than the web-console path. Listeners without an executor (the TUI's in-process listener) skip these events — the TUI chat panel owns execution for its own conversations.
- **`servonaut connect` session auth** — the listener authenticates from the stored `servonaut login` session (with automatic token refresh) when the legacy `SERVONAUT_RELAY_TOKEN`/`SERVONAUT_USER_ID` pair is absent; the env pair still wins when both are set (CI use).
- **`AIToolBridge`** — confirm callbacks can raise `ToolConfirmDenied` to deny with a distinct audit reason code and message.
- **`build_headless_tools()`** extracted from the MCP server as the single shared headless service factory.
- Docs: `cli-reference.md` connect section, `configuration.md` relay block.

## Testing

- 38 new unit tests (`tests/test_relay_tool_executor.py`) covering the envelope parser (both wire shapes pinned), the classifier, the approval-policy matrix, executor round-trip including crash/POST-failure paths, and listener routing incl. the verb-collision cases.
- `tests/test_connect_command.py` extended for the session fallback and env-override precedence.
- Full suite green locally.
- Verified live end-to-end: read-only tools execute and close the model turn with real results; denied calls return immediately with a graceful tool result; dangerous-tier execution works when both the entitlement and the `dangerous` policy are set.
