### PR TITLE
Configurable max_tool_rounds for hosted AI + dangerous-confirm modal hardening

### DIFF
--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -894,6 +894,11 @@ class AppConfig:
     chat_max_history_messages: int = 20
     chat_system_prompt: str = ""
     chat_max_tool_iterations: int = 10
+    # Hosted Servonaut AI only: max agentic tool rounds per chat turn,
+    # sent as ``max_tool_rounds`` on the chat request and clamped
+    # server-side. None = use the server's default. Local/user-keyed
+    # providers use ``chat_max_tool_iterations`` above instead.
+    chat_max_tool_rounds: Optional[int] = None
     chat_tool_guard_level: str = "standard"  # readonly, standard, dangerous
     # When True (default), tool-result rows are persisted in the local
     # chat session so they re-appear when the session is reloaded — useful

--- a/src/servonaut/screens/tool_confirm_modal.py
+++ b/src/servonaut/screens/tool_confirm_modal.py
@@ -213,6 +213,16 @@ class DangerousToolConfirmModal(ModalScreen[bool]):
         margin-bottom: 1;
     }
 
+    DangerousToolConfirmModal #dangerous_confirm_error {
+        color: $error;
+        margin-bottom: 1;
+        display: none;
+    }
+
+    DangerousToolConfirmModal #dangerous_confirm_error.visible {
+        display: block;
+    }
+
     DangerousToolConfirmModal #dangerous_confirm_buttons {
         height: auto;
         align: center middle;
@@ -248,6 +258,7 @@ class DangerousToolConfirmModal(ModalScreen[bool]):
                 placeholder=f"Type {_DANGEROUS_CONFIRM_WORD} to confirm",
                 id="dangerous_confirm_input",
             ),
+            Static("", id="dangerous_confirm_error"),
             Horizontal(
                 Button("Confirm", id="btn_dangerous_confirm", variant="error"),
                 Button("Cancel", id="btn_dangerous_cancel", variant="default"),
@@ -269,16 +280,41 @@ class DangerousToolConfirmModal(ModalScreen[bool]):
             value = self.query_one("#dangerous_confirm_input", Input).value
         except Exception:  # pragma: no cover - defensive
             return False
-        return value == _DANGEROUS_CONFIRM_WORD
+        # Tolerate surrounding whitespace (a trailing space from the user
+        # or a paste is not intent to cancel) but keep the word match
+        # case-sensitive — the typed-confirm is a deliberate friction.
+        return value.strip() == _DANGEROUS_CONFIRM_WORD
+
+    def _confirm_or_reprompt(self) -> None:
+        """Approve on an exact ``RUN``; otherwise keep the modal open.
+
+        A wrong/empty value must NEVER silently dismiss the modal — Enter
+        is the universal "submit" reflex and a silent cancel here looks
+        like the confirm was lost. Only Escape / Cancel deny; everything
+        else either confirms or re-prompts with a visible hint.
+        """
+        if self._typed_run():
+            self.dismiss(True)
+            return
+        try:
+            err = self.query_one("#dangerous_confirm_error", Static)
+            err.update(
+                f"Type [bold]{_DANGEROUS_CONFIRM_WORD}[/bold] exactly to confirm, "
+                "or press Escape to cancel."
+            )
+            err.add_class("visible")
+            self.query_one("#dangerous_confirm_input", Input).focus()
+        except Exception:  # pragma: no cover - defensive
+            pass
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        # Pressing Enter inside the input is equivalent to clicking
-        # Confirm — only succeeds when the value matches exactly.
-        self.dismiss(self._typed_run())
+        # Pressing Enter inside the input confirms on an exact match and
+        # otherwise re-prompts — it does not deny.
+        self._confirm_or_reprompt()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn_dangerous_confirm":
-            self.dismiss(self._typed_run())
+            self._confirm_or_reprompt()
         elif event.button.id == "btn_dangerous_cancel":
             self.dismiss(False)
 

--- a/src/servonaut/services/ai_analysis_service.py
+++ b/src/servonaut/services/ai_analysis_service.py
@@ -655,6 +655,7 @@ class AIAnalysisService(AIAnalysisServiceInterface):
         self._providers['servonaut'] = ServonautProvider(
             api_client=api_client,  # type: ignore[arg-type]
             auth_service=auth_service,  # type: ignore[arg-type]
+            config_manager=self._config_manager,
         )
 
     async def analyze_text(self, text: str, system_prompt: str = "") -> dict:

--- a/src/servonaut/services/ai_providers/servonaut_provider.py
+++ b/src/servonaut/services/ai_providers/servonaut_provider.py
@@ -96,9 +96,11 @@ class ServonautProvider(AIProviderInterface):
         self,
         api_client: "APIClient",
         auth_service: "AuthService",
+        config_manager: Optional[object] = None,
     ) -> None:
         self._api_client = api_client
         self._auth_service = auth_service
+        self._config_manager = config_manager
 
     def is_available(self) -> bool:
         """Return True iff caller is authenticated AND has the ``premium_ai`` feature.
@@ -328,6 +330,18 @@ class ServonautProvider(AIProviderInterface):
             "allow_tools": allow_tools,
             "stream": stream,
         }
+        # Optional cap on agentic tool rounds (server-clamped). Only sent
+        # when the user explicitly configured chat_max_tool_rounds —
+        # absent means the server's admin default applies. Unknown to
+        # pre-support servers, which ignore the extra key harmlessly.
+        max_rounds = None
+        if self._config_manager is not None:
+            try:
+                max_rounds = self._config_manager.get().chat_max_tool_rounds
+            except Exception:  # noqa: BLE001 — config access must not break chat
+                max_rounds = None
+        if max_rounds:
+            body["max_tool_rounds"] = int(max_rounds)
         if conversation_id:
             body["conversation_id"] = conversation_id
         if context:

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -400,6 +400,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "dangerous_confirm_body",
         "dangerous_confirm_buttons",
         "dangerous_confirm_container",
+        "dangerous_confirm_error",  # Reason: styled in DangerousToolConfirmModal.DEFAULT_CSS (hidden until .visible)
         "dangerous_confirm_input",
         "dangerous_confirm_title",
         # ---- Generic description/text ----

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -89,6 +89,13 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes a static UI hint ('No output yet') — "
                    "no user/server data involved."),
 
+    # tool_confirm_modal.py — _confirm_or_reprompt updates the error Static
+    # with a fixed 'Type RUN to confirm' hint. The string is a code constant
+    # with no user/model/server data, so redaction is a no-op.
+    AllowlistEntry("screens/tool_confirm_modal.py", "_confirm_or_reprompt", "update",
+                   "Writes a static 'Type RUN to confirm' hint constant — "
+                   "no user/model/server-origin data to redact."),
+
     # ip_ban.py — _load_audit_log: the line `audit_log.write(...)` that
     # writes the '[dim]No audit log entries yet.[/dim]' placeholder is safe.
     # The writes with real IP/msg data are guarded by the demo-mode check.

--- a/tests/test_servonaut_provider.py
+++ b/tests/test_servonaut_provider.py
@@ -478,3 +478,42 @@ def test_stream_chat_synthesises_done_event_at_end():
     # Exactly one ``done`` event — never duplicated.
     done_events = [e for e in events if e["event"] == "done"]
     assert len(done_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# max_tool_rounds wiring (hosted agentic-loop cap).
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_with_config(chat_max_tool_rounds):
+    """Provider with a mocked config_manager exposing chat_max_tool_rounds."""
+    api = MagicMock(spec=APIClient)
+    api.post = AsyncMock(return_value=dict(_CANONICAL_RESPONSE))
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.has_feature = MagicMock(return_value=True)
+    cfg = MagicMock()
+    cfg.get.return_value = MagicMock(chat_max_tool_rounds=chat_max_tool_rounds)
+    return ServonautProvider(api_client=api, auth_service=auth, config_manager=cfg), api
+
+
+def test_chat_body_includes_max_tool_rounds_when_configured():
+    provider, api = _make_provider_with_config(150)
+    run(provider.chat([{"role": "user", "content": "hi"}], "system", _ai_config()))
+    body = api.post.call_args.kwargs["json"]
+    assert body["max_tool_rounds"] == 150
+
+
+def test_chat_body_omits_max_tool_rounds_when_unset():
+    provider, api = _make_provider_with_config(None)
+    run(provider.chat([{"role": "user", "content": "hi"}], "system", _ai_config()))
+    body = api.post.call_args.kwargs["json"]
+    assert "max_tool_rounds" not in body
+
+
+def test_chat_body_omits_max_tool_rounds_without_config_manager():
+    """Construction sites that don't inject config keep the old wire shape."""
+    provider, api, _ = _make_provider()
+    run(provider.chat([{"role": "user", "content": "hi"}], "system", _ai_config()))
+    body = api.post.call_args.kwargs["json"]
+    assert "max_tool_rounds" not in body

--- a/tests/test_tool_confirm_modal.py
+++ b/tests/test_tool_confirm_modal.py
@@ -1,0 +1,134 @@
+"""Tests for the AI tool-call confirmation modals.
+
+Uses Textual's ``App.run_test`` pilot pattern (matches
+``tests/test_ai_picker_modal.py``) so we exercise real widget IDs and
+dismiss values rather than introspecting ``compose()`` output.
+
+Regression focus: the dangerous typed-confirm modal must NEVER silently
+deny on Enter — a wrong/empty value re-prompts and stays open; only
+Escape / Cancel deny; an exact (whitespace-tolerant) ``RUN`` confirms.
+"""
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Input, Static
+
+from servonaut.screens.tool_confirm_modal import (
+    DangerousToolConfirmModal,
+    ToolConfirmModal,
+)
+
+
+class _WrapperApp(App):
+    """Minimal host app to push a modal and capture its dismiss value."""
+
+    def __init__(self, modal) -> None:
+        super().__init__()
+        self._modal = modal
+        self.dismissed = []
+
+    def on_mount(self) -> None:
+        self.push_screen(self._modal, callback=self.dismissed.append)
+
+
+# ---------------------------------------------------------------------------
+# Dangerous typed-confirm modal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_confirms_on_exact_run():
+    app = _WrapperApp(DangerousToolConfirmModal("deploy", {"target": "prod"}))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._modal.query_one("#dangerous_confirm_input", Input).value = "RUN"
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.dismissed == [True]
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_tolerates_surrounding_whitespace():
+    """A trailing space is not intent to cancel — it still confirms."""
+    app = _WrapperApp(DangerousToolConfirmModal("deploy"))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._modal.query_one("#dangerous_confirm_input", Input).value = "RUN "
+        await pilot.press("enter")
+        await pilot.pause()
+    assert app.dismissed == [True]
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_enter_on_empty_does_not_dismiss():
+    """The core regression: Enter with an empty box must NOT silently deny."""
+    app = _WrapperApp(DangerousToolConfirmModal("deploy"))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        # Modal stayed open (no dismiss) and surfaced the hint.
+        assert app.dismissed == []
+        err = app._modal.query_one("#dangerous_confirm_error", Static)
+        assert "visible" in err.classes
+    # After the test block the app tears down; the key assertion is that
+    # no dismiss value was recorded while the modal was live.
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_enter_on_wrong_word_reprompts():
+    app = _WrapperApp(DangerousToolConfirmModal("deploy"))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        app._modal.query_one("#dangerous_confirm_input", Input).value = "run"  # wrong case
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.dismissed == []
+        assert "visible" in app._modal.query_one("#dangerous_confirm_error", Static).classes
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_escape_denies():
+    app = _WrapperApp(DangerousToolConfirmModal("deploy"))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.dismissed == [False]
+
+
+@pytest.mark.asyncio
+async def test_dangerous_modal_cancel_button_denies():
+    app = _WrapperApp(DangerousToolConfirmModal("deploy"))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn_dangerous_cancel")
+        await pilot.pause()
+    assert app.dismissed == [False]
+
+
+# ---------------------------------------------------------------------------
+# Standard y/n modal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_standard_modal_approves_on_y():
+    app = _WrapperApp(ToolConfirmModal("run_command", {"command": "uptime"}))
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+        await pilot.press("y")
+        await pilot.pause()
+    assert app.dismissed == [True]
+
+
+@pytest.mark.asyncio
+async def test_standard_modal_denies_on_n_and_escape():
+    for key in ("n", "escape"):
+        app = _WrapperApp(ToolConfirmModal("run_command", {"command": "uptime"}))
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.press(key)
+            await pilot.pause()
+        assert app.dismissed == [False], f"key {key!r} should deny"


### PR DESCRIPTION
Two small, independent AI-chat fixes.

## 1. Configurable `max_tool_rounds` for hosted AI

Hosted Servonaut AI runs the agentic tool loop server-side and caps it at an admin default. The client had no way to raise that cap for a long investigation — the existing `chat_max_tool_iterations` config only governs the *local/user-keyed* provider loop, so setting it expecting it to apply to hosted AI had no effect.

- New config key `chat_max_tool_rounds` (`Optional[int]`, `None` = use the server default), sent as `max_tool_rounds` on the chat request and clamped server-side.
- Deliberately a **new** key, not a reuse of `chat_max_tool_iterations`: that field is persisted as `10` in existing configs, so reusing it would have silently lowered the hosted cap.
- `ServonautProvider` gains an optional `config_manager`; the field is only included in the request body when explicitly set, so servers that don't support it ignore the unknown key harmlessly.

## 2. Dangerous-tool confirm modal must not silently deny

On the typed-confirm "RUN" modal, pressing Enter with a wrong or empty value dismissed the modal as a **denial**. Enter is the universal submit reflex, so an accidental press — or a correct `RUN` with a stray trailing space — read as a silent cancel with no feedback.

- The only ways to deny are now Escape or Cancel.
- An exact `RUN` (tolerant of surrounding whitespace, still case-sensitive) confirms.
- Any other submitted value keeps the modal open and surfaces an inline hint instead of dismissing.

## Testing

- New pilot-driven modal tests: confirm, whitespace tolerance, empty/wrong-value re-prompt, escape/cancel deny, plus the standard y/n modal's key paths.
- New provider tests: `max_tool_rounds` present when configured, omitted when unset, omitted without a config manager.
- 181 passed across the modal, chat-panel, bridge, provider, and demo suites; the only failures in the full run are the pre-existing `hcloud`-not-installed cases in `test_hetzner_service.py`.