### PR TITLE
Glama listing prep: MCP Dockerfile + claimable maintainer in glama.json

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+tests
+docs
+.playwright-mcp
+__pycache__
+*.pyc
+.pytest_cache
+.venv
+local
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for the Servonaut MCP server (stdio transport).
+#
+# Built so directories like Glama can start the server and run an
+# introspection handshake (initialize + tools/list) without any cloud
+# credentials — the tool catalogue is static, so `servonaut --mcp`
+# answers introspection on a bare container. Live AWS/OVH/Hetzner calls
+# still require credentials mounted at runtime; introspection does not.
+#
+#   docker build -t servonaut-mcp .
+#   docker run --rm -i servonaut-mcp           # speaks MCP over stdio
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install the package with the MCP extra from the source tree.
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install --no-cache-dir '.[mcp]'
+
+# stdio MCP server: clients (and Glama's introspector) talk over stdin/stdout.
+ENTRYPOINT ["servonaut", "--mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["zb-ss"]
+  "maintainers": ["zashboy"]
 }


### PR DESCRIPTION
Prep so the Servonaut MCP server can be listed on Glama and pass its quality checks. Two small pieces:

## 1. `Dockerfile` (+ `.dockerignore`)

Builds an image running the MCP server over stdio (`servonaut --mcp`). MCP directories and CI can build and introspect the server without provisioning cloud credentials — the tool catalogue is static, so the server answers `initialize` + `tools/list` on a bare container. Live AWS/OVH/Hetzner calls still require credentials mounted at runtime.

Verified end-to-end (mimics a directory's quality check):

```
docker build -t servonaut-mcp .
docker run --rm -i servonaut-mcp   # pipe initialize + notifications/initialized + tools/list
```

- `initialize` → OK (server `servonaut`, protocol `2024-11-05`)
- `tools/list` → 57 tools
- no credentials required

## 2. `glama.json` maintainer fix

The file listed the owning organization as the sole maintainer. Glama's claim flow verifies the signed-in GitHub **user** against this list, and an organization account can't sign in to claim — so the listing was unclaimable. Pointed it at the personal maintainer username instead.