### PR TITLE
docs: add Glama card badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,12 @@ Logs are always written to `~/.servonaut/logs/servonaut.log`. Use `--debug` for 
 
 When SSH fails, the terminal window stays open showing the error and exit code.
 
+## Listed on
+
+[![servonaut MCP server](https://glama.ai/mcp/servers/zb-ss/servonaut/badges/card.svg)](https://glama.ai/mcp/servers/zb-ss/servonaut)
+
+Also published to the official [MCP Registry](https://registry.modelcontextprotocol.io) as `dev.servonaut/servonaut`.
+
 ## License
 
 This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Adds a `## Listed on` section near the end of the README with the Glama score **card** badge (the large promotional variant) and a pointer to the official MCP Registry listing.

- Card badge → our README (large, shows score + stats).
- The compact **score** badge variant goes in third-party lists (already added to the awesome-mcp-servers PR).

Placed at the bottom so it doesn't compete with the demo GIF / install hero; trivially movable if a more prominent spot is preferred.