### PR TITLE
feat(config): store SSH key paths as home-relative for portable configs

### DIFF
--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -32,6 +32,7 @@ from .schema import (
     CONFIG_VERSION,
 )
 from .migration import migrate_to_latest, create_backup
+from .paths import normalize_config_paths
 from .secrets import load_secrets_env
 
 logger = logging.getLogger(__name__)
@@ -545,6 +546,11 @@ class ConfigManager:
     def _serialize(self, config: AppConfig) -> Dict[str, Any]:
         """Convert AppConfig to JSON-serializable dictionary.
 
+        User-entered SSH key paths are collapsed to ``~/…`` literals when they
+        live under the current user's home directory, so the resulting config
+        is portable across machines, usernames, and OSes (the read path already
+        expands ``~`` per-OS). Paths outside home are left untouched.
+
         Args:
             config: AppConfig instance
 
@@ -552,6 +558,7 @@ class ConfigManager:
             Dictionary ready for JSON serialization
         """
         data = asdict(config)
+        normalize_config_paths(data)
         return data
 
     def _deserialize(self, raw_data: Dict[str, Any]) -> AppConfig:

--- a/src/servonaut/config/paths.py
+++ b/src/servonaut/config/paths.py
@@ -1,0 +1,114 @@
+"""Home-relative path normalisation for portable config files.
+
+User-entered SSH key paths (``default_key``, ``custom_servers[].ssh_key`` …)
+are stored as whatever string the user typed or a file-picker handed back —
+typically a machine-specific absolute path like ``/home/<user>/.ssh/id_rsa``.
+That makes ``config.json`` non-portable: a different username, a different OS,
+or a teammate's machine all resolve that path to something that doesn't exist.
+
+The fix is symmetric:
+
+* On **save**, :func:`tildify` collapses any absolute path that lives under the
+  current user's home directory back to a ``~/…`` literal (with forward
+  slashes, so a Windows-authored config stays readable on macOS/Linux).
+* On **read**, every consumption site already calls ``os.path.expanduser`` /
+  ``Path.expanduser``, which expands ``~`` per-OS — ``$HOME`` on POSIX,
+  ``%USERPROFILE%`` on Windows. Nothing to change there.
+
+Paths *outside* the home directory (``/etc/ssh/keys/foo``, ``D:\\keys\\foo``)
+are genuinely machine-specific and are left untouched. Distributing the key
+*files* themselves across machines/teams is a separate concern handled by the
+secrets layer, not by path rewriting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+# Prefixes that already denote a portable / indirected value and must never be
+# rewritten: ``~`` (already home-relative), ``$VAR`` (env-var indirection), and
+# ``file:`` (secret-store reference resolved elsewhere).
+_NON_FS_PREFIXES = ("~", "$", "file:")
+
+
+def tildify(path: str) -> str:
+    """Collapse a home-prefixed absolute path to a ``~/…`` literal.
+
+    Returns *path* unchanged when it is empty, already portable (starts with
+    ``~``/``$``/``file:``), or points outside the current user's home
+    directory. Otherwise returns the home-relative form using forward slashes.
+
+    Examples (with ``$HOME`` = ``/home/<user>``)::
+
+        tildify("/home/<user>/.ssh/id_rsa")  -> "~/.ssh/id_rsa"
+        tildify("~/.ssh/id_rsa")            -> "~/.ssh/id_rsa"   # unchanged
+        tildify("/etc/ssh/keys/foo")        -> "/etc/ssh/keys/foo"  # outside home
+        tildify("$HOME/.ssh/id_rsa")        -> "$HOME/.ssh/id_rsa"  # unchanged
+        tildify("")                         -> ""
+    """
+    if not path or path.startswith(_NON_FS_PREFIXES):
+        return path
+    try:
+        home = Path.home()
+        # Resolve only ``~`` (already excluded above) — do NOT call resolve(),
+        # which would follow symlinks and dereference relative segments,
+        # changing the stored value in surprising ways.
+        candidate = Path(path)
+        relative = candidate.relative_to(home)
+    except (ValueError, OSError):
+        # ValueError: not under home. OSError: home is unresolvable. Either
+        # way the original string is the safe thing to keep.
+        return path
+    # ``as_posix`` guarantees forward slashes so a Windows-authored config
+    # ("~/.ssh/id_rsa", not "~\\.ssh\\id_rsa") round-trips on POSIX too.
+    rel = relative.as_posix()
+    return "~" if rel == "." else f"~/{rel}"
+
+
+def normalize_config_paths(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Tildify every user-entered path field in a serialised config dict.
+
+    Mutates and returns *data* (already the product of ``dataclasses.asdict``).
+    Only fields that hold a **local filesystem path the user supplies** are
+    touched. App-managed ``*_path`` fields already default to ``~/…`` literals
+    and Hetzner/OVH *remote* key identifiers (``default_hetzner_ssh_key``) are
+    deliberately excluded — they are not local paths.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    # Top-level scalar key path.
+    if isinstance(data.get("default_key"), str):
+        data["default_key"] = tildify(data["default_key"])
+
+    # Per-instance key map: {instance_id: key_path}.
+    instance_keys = data.get("instance_keys")
+    if isinstance(instance_keys, dict):
+        data["instance_keys"] = {
+            k: tildify(v) if isinstance(v, str) else v
+            for k, v in instance_keys.items()
+        }
+
+    # Connection profiles: bastion key path.
+    for profile in data.get("connection_profiles", []) or []:
+        if isinstance(profile, dict) and isinstance(profile.get("bastion_key"), str):
+            profile["bastion_key"] = tildify(profile["bastion_key"])
+
+    # Custom servers: ssh_key path.
+    for server in data.get("custom_servers", []) or []:
+        if isinstance(server, dict) and isinstance(server.get("ssh_key"), str):
+            server["ssh_key"] = tildify(server["ssh_key"])
+
+    # Provider-level local key paths. ``default_hetzner_ssh_key`` is a
+    # Hetzner-side identifier (NOT a local path) and is intentionally skipped.
+    hetzner = data.get("hetzner")
+    if isinstance(hetzner, dict) and isinstance(hetzner.get("default_local_ssh_key"), str):
+        hetzner["default_local_ssh_key"] = tildify(hetzner["default_local_ssh_key"])
+
+    ovh = data.get("ovh")
+    if isinstance(ovh, dict) and isinstance(ovh.get("default_ssh_key"), str):
+        ovh["default_ssh_key"] = tildify(ovh["default_ssh_key"])
+
+    return data

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -1,0 +1,123 @@
+"""Tests for home-relative config path normalisation (tildify)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from servonaut.config import paths as config_paths
+from servonaut.config.manager import ConfigManager
+from servonaut.config.paths import normalize_config_paths, tildify
+from servonaut.config.schema import (
+    AppConfig,
+    ConnectionProfile,
+    CustomServer,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Pin ``Path.home()`` to a temp dir for deterministic tildify tests."""
+    home = tmp_path / "home" / "alice"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(config_paths.Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+class TestTildify:
+    def test_collapses_path_under_home(self, fake_home):
+        abs_path = str(fake_home / ".ssh" / "id_rsa")
+        assert tildify(abs_path) == "~/.ssh/id_rsa"
+
+    def test_leaves_already_tilde_unchanged(self, fake_home):
+        assert tildify("~/.ssh/id_rsa") == "~/.ssh/id_rsa"
+
+    def test_leaves_env_var_unchanged(self, fake_home):
+        assert tildify("$HOME/.ssh/id_rsa") == "$HOME/.ssh/id_rsa"
+
+    def test_leaves_file_ref_unchanged(self, fake_home):
+        assert tildify("file:/run/secrets/key") == "file:/run/secrets/key"
+
+    def test_leaves_path_outside_home_absolute(self, fake_home):
+        assert tildify("/etc/ssh/keys/foo") == "/etc/ssh/keys/foo"
+
+    def test_empty_string_unchanged(self, fake_home):
+        assert tildify("") == ""
+
+    def test_home_root_itself(self, fake_home):
+        assert tildify(str(fake_home)) == "~"
+
+    def test_windows_style_path_uses_forward_slashes(self, monkeypatch):
+        """A Windows home path must serialise with forward slashes."""
+        win_home = "C:/Users/alice"
+        monkeypatch.setattr(
+            config_paths.Path, "home", classmethod(lambda cls: Path(win_home))
+        )
+        # PurePosixPath stand-in: on a POSIX test host, Path is PosixPath, so a
+        # value like "C:/Users/alice/.ssh/id_rsa" is treated as a normal path
+        # under the (also POSIX-rendered) home and collapses with "/" output.
+        result = tildify("C:/Users/alice/.ssh/id_rsa")
+        assert result == "~/.ssh/id_rsa"
+        assert "\\" not in result
+
+    def test_home_unresolvable_returns_original(self, monkeypatch):
+        def _boom(cls):
+            raise OSError("no home")
+
+        monkeypatch.setattr(config_paths.Path, "home", classmethod(_boom))
+        assert tildify("/some/abs/path") == "/some/abs/path"
+
+
+class TestNormalizeConfigPaths:
+    def test_normalizes_all_user_path_fields(self, fake_home):
+        key = str(fake_home / ".ssh" / "id_rsa")
+        bastion = str(fake_home / ".ssh" / "bastion")
+        custom = str(fake_home / "keys" / "srv")
+        data = {
+            "default_key": key,
+            "instance_keys": {"i-abc": key, "i-def": "/etc/ssh/x"},
+            "connection_profiles": [{"name": "p", "bastion_key": bastion}],
+            "custom_servers": [{"name": "s", "ssh_key": custom}],
+            "hetzner": {"default_local_ssh_key": key, "default_hetzner_ssh_key": "my-hz-key"},
+            "ovh": {"default_ssh_key": key},
+        }
+        normalize_config_paths(data)
+
+        assert data["default_key"] == "~/.ssh/id_rsa"
+        assert data["instance_keys"]["i-abc"] == "~/.ssh/id_rsa"
+        assert data["instance_keys"]["i-def"] == "/etc/ssh/x"  # outside home
+        assert data["connection_profiles"][0]["bastion_key"] == "~/.ssh/bastion"
+        assert data["custom_servers"][0]["ssh_key"] == "~/keys/srv"
+        assert data["hetzner"]["default_local_ssh_key"] == "~/.ssh/id_rsa"
+        # Hetzner-side identifier must NOT be touched.
+        assert data["hetzner"]["default_hetzner_ssh_key"] == "my-hz-key"
+        assert data["ovh"]["default_ssh_key"] == "~/.ssh/id_rsa"
+
+    def test_tolerates_missing_and_malformed_sections(self, fake_home):
+        # Should not raise on empty / wrong-typed sections.
+        normalize_config_paths({})
+        normalize_config_paths({"connection_profiles": None, "custom_servers": None})
+        normalize_config_paths({"default_key": None})
+        normalize_config_paths({"instance_keys": "not-a-dict"})
+
+
+class TestSaveIntegration:
+    def test_save_writes_tildified_paths(self, tmp_path, fake_home):
+        manager = ConfigManager()
+        manager._config_path = tmp_path / "config.json"
+
+        key = str(fake_home / ".ssh" / "id_rsa")
+        config = AppConfig(
+            default_key=key,
+            connection_profiles=[ConnectionProfile(name="p", bastion_key=key)],
+            custom_servers=[CustomServer(name="s", host="h", ssh_key=key)],
+        )
+        manager.save(config)
+
+        on_disk = json.loads((tmp_path / "config.json").read_text())
+        assert on_disk["default_key"] == "~/.ssh/id_rsa"
+        assert on_disk["connection_profiles"][0]["bastion_key"] == "~/.ssh/id_rsa"
+        assert on_disk["custom_servers"][0]["ssh_key"] == "~/.ssh/id_rsa"


### PR DESCRIPTION
## Problem

User-entered SSH key paths were persisted to `config.json` as whatever absolute string the user typed or a file picker returned (e.g. `/home/<user>/.ssh/id_rsa`). That makes the config non-portable — a different username, a different OS, or a teammate's machine all resolve that path to something that doesn't exist.

## Change

Collapse any absolute path that lives **under the current user's home directory** to a `~/…` literal at config-serialization time. The fix is symmetric with what the read side already does:

- **Save** — new `config/paths.py::tildify()` rewrites home-prefixed absolute paths to `~/…`; `normalize_config_paths()` applies it to the user-entered path fields in `_serialize`.
- **Read** — every consumption site already calls `expanduser()`, which expands `~` per-OS (`$HOME` on POSIX, `%USERPROFILE%` on Windows). No read-path change needed; existing configs self-heal on their next save.

Fields normalized: `default_key`, `instance_keys` values, `connection_profiles[].bastion_key`, `custom_servers[].ssh_key`, `hetzner.default_local_ssh_key`, `ovh.default_ssh_key`.

Deliberately **not** touched: `hetzner.default_hetzner_ssh_key` (a provider-side identifier, not a local path), `proxy_command` (free-form), and the app-managed `*_path` fields (already `~/…`).

### Notable design points
- Paths **outside** home (`/etc/ssh/keys/foo`, `D:\keys\foo`) are left absolute — they are genuinely machine-specific.
- Already-portable values (`~/…`, `$VAR/…`, `file:…`) pass through unchanged.
- Output uses `as_posix()` so a Windows-authored config serializes with forward slashes and stays readable on macOS/Linux.
- No schema bump, no migration — purely additive on the write path.

### Scope
This makes paths portable when a teammate keeps their key at the same home-relative location. Distributing the key **files** themselves across machines is a separate concern handled by the secrets layer, not by path rewriting.

## Tests
- `tests/test_config_paths.py` — 12 cases: under-home collapse, env-var/`file:`/already-`~` passthrough, outside-home preservation, home-root edge, Windows forward-slash output, unresolvable-home fallback, malformed-section tolerance, and a save-to-disk round trip.
- Verified end-to-end through the TUI: added a custom server with an absolute key path under `$HOME` → saved as `~/.ssh/…`; added one with a path outside `$HOME` → preserved absolute.
- Full suite green (`1662 passed`).