### PR TITLE
feat(memory): background fleet auto-scan + server-backed auto-sync + live scan indicators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ test = [
 mcp = ["mcp>=1.0.0"]
 ovh = ["ovh"]
 hetzner = ["hcloud>=2.0"]
+keyring = ["keyring>=24"]
 # Deprecated aliases kept for compatibility — deps are now required.
 ai = []
 sync = []
-all = ["mcp>=1.0.0", "ovh", "hcloud>=2.0"]
+all = ["mcp>=1.0.0", "ovh", "hcloud>=2.0", "keyring>=24"]
 
 [project.urls]
 Homepage = "https://github.com/zb-ss/ec2-ssh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pynacl>=1.5",
     "httpx>=0.25.0",
     "httpx-sse>=0.4",
+    "keyring>=24",
 ]
 
 [project.optional-dependencies]
@@ -46,10 +47,10 @@ test = [
 mcp = ["mcp>=1.0.0"]
 ovh = ["ovh"]
 hetzner = ["hcloud>=2.0"]
-keyring = ["keyring>=24"]
 # Deprecated aliases kept for compatibility — deps are now required.
 ai = []
 sync = []
+keyring = []
 all = ["mcp>=1.0.0", "ovh", "hcloud>=2.0", "keyring>=24"]
 
 [project.urls]

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -836,6 +836,17 @@ class ServonautApp(App):
                 self.memory_sync_service.set_key_material_listener(
                     self._propagate_memory_key_material
                 )
+            # SEC-3: gate enqueue_module on the memory_sync entitlement so an
+            # enrolled-but-lapsed user's background auto-scan doesn't accumulate
+            # plaintext JSONL envelopes that can never be drained to the server.
+            # auth_service is guaranteed non-None here (checked at method entry).
+            if hasattr(self.memory_sync_service, "set_entitlement_check"):
+                self.memory_sync_service.set_entitlement_check(
+                    lambda: (
+                        self.auth_service is not None
+                        and self.auth_service.has_feature("memory_sync")
+                    )
+                )
         except Exception as exc:
             logger.debug("MemorySyncService init failed: %s", exc)
 

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -101,6 +101,7 @@ class ServonautApp(App):
     memory_retrieval_service = None
     memory_settings_service = None
     fleet_service = None
+    fleet_scan_service = None
     drift_service = None
     anomaly_service = None
     ai_summary_service = None
@@ -125,6 +126,15 @@ class ServonautApp(App):
 
     # Latest version found by the background update check (None = not checked yet)
     _latest_version: Optional[str] = None
+
+    # Timestamp of the last successful auto-scan cycle (epoch seconds).
+    # Zero means no cycle has completed yet this session.
+    _fleet_auto_scan_last_run: float = 0.0
+
+    # True while the app-owned manual fleet scan worker is running.
+    # Set before run_worker returns, cleared in the finally block of
+    # _do_fleet_manual_scan.  Guards against double-spawning.
+    _fleet_manual_scan_in_progress: bool = False
 
     # Relay connection status, reactive so widgets can bind and re-render on change.
     # Carries the RelayState enum value (starts as None until the manager inits).
@@ -242,6 +252,9 @@ class ServonautApp(App):
                 name="relay_autostart",
                 exclusive=True,
             )
+        # Start background fleet auto-scan loop (sleeps first, so safe to
+        # call here even before the instance list is fully populated).
+        self._start_fleet_auto_scan_loop()
 
     def _init_services(self) -> None:
         """Create all service instances."""
@@ -876,6 +889,15 @@ class ServonautApp(App):
             logger.debug("FleetService init failed: %s", exc)
 
         try:
+            from servonaut.services.memory.fleet_scan_service import FleetScanService
+            if self.memory_service is not None:
+                self.fleet_scan_service = FleetScanService(
+                    self.memory_service, max_parallel=4
+                )
+        except Exception as exc:
+            logger.debug("FleetScanService init failed: %s", exc)
+
+        try:
             from servonaut.services.memory.settings_service import MemorySettingsService
             self.memory_settings_service = MemorySettingsService(
                 api_client=self.api_client,
@@ -936,17 +958,35 @@ class ServonautApp(App):
             passphrase_provider=self._prompt_memory_passphrase,
         )
         self._propagate_memory_key_material()
-        self._start_memory_sync_loop()
+        # Fetch the server-side auto_sync_enabled flag before spawning the loop.
+        auto_sync = False
+        try:
+            if self.memory_settings_service and self.auth_service and self.auth_service.has_feature("memory_sync"):
+                settings = await self.memory_settings_service.get_settings()
+                auto_sync = bool(getattr(settings, "auto_sync_enabled", False))
+        except Exception:
+            auto_sync = False
+        self._start_memory_sync_loop(auto_sync)
 
-    def _start_memory_sync_loop(self) -> None:
+    def _start_memory_sync_loop(self, auto_sync_enabled: bool) -> None:
         """Spawn the long-running sync drain loop as a background worker.
 
         Idempotent + decoupled from setup so the setup coroutine can return
         promptly. Uses a distinct worker group from setup so cancelling a
         retry doesn't accidentally tear down the active sync loop.
+
+        Args:
+            auto_sync_enabled: Value of the server-side auto_sync_enabled flag,
+                fetched from MemorySettingsService before this call.
         """
         sync = self.memory_sync_service
         if sync is None or not getattr(sync, "is_configured", False):
+            return
+        entitled = (
+            self.auth_service is not None
+            and self.auth_service.has_feature("memory_sync")
+        )
+        if not (auto_sync_enabled and entitled):
             return
         self.run_worker(
             sync.start_background_loop(interval_s=60),
@@ -954,6 +994,250 @@ class ServonautApp(App):
             group="memory_sync_background",
             exclusive=True,
         )
+
+    async def _refresh_memory_sync_loop(self) -> None:
+        """Re-evaluate the drain loop after the server-side auto_sync flag changes.
+
+        Called by MemorySyncPanel after a successful patch_settings save.
+        Re-fetches the server flag and either spawns the drain worker (if
+        auto_sync_enabled AND entitled AND is_configured) or stops it.
+
+        Stop mechanism: we use Textual's ``workers.cancel_group`` on the
+        ``"memory_sync_background"`` group.  The loop was started via
+        ``run_worker(..., group="memory_sync_background", exclusive=True)``
+        which means it lives as a Textual worker, NOT as a bare asyncio Task
+        (``_loop_task`` is only set when the coroutine is scheduled directly
+        via ``asyncio.create_task``).  Calling ``sync.stop()`` sets
+        ``_stopped=True`` but would NOT cancel the worker coroutine because
+        the ``_loop_task`` handle is None in this path.  ``cancel_group``
+        cancels the actual Textual worker and propagates CancelledError into
+        ``start_background_loop``, which catches it and exits cleanly.
+        """
+        sync = getattr(self, "memory_sync_service", None)
+        if sync is None:
+            return
+
+        entitled = (
+            self.auth_service is not None
+            and self.auth_service.has_feature("memory_sync")
+        )
+        is_configured = bool(getattr(sync, "is_configured", False))
+
+        auto_sync = False
+        try:
+            if self.memory_settings_service and entitled:
+                settings = await self.memory_settings_service.get_settings(force_refresh=True)
+                auto_sync = bool(getattr(settings, "auto_sync_enabled", False))
+        except Exception:
+            auto_sync = False
+
+        if auto_sync and entitled and is_configured:
+            self._start_memory_sync_loop(auto_sync)
+        else:
+            # Cancel the worker group so the running loop coroutine receives
+            # CancelledError on its next asyncio.sleep and exits cleanly.
+            try:
+                self.workers.cancel_group(self, "memory_sync_background")
+            except Exception:
+                pass
+
+    def _refresh_fleet_auto_scan_loop(self) -> None:
+        """Re-evaluate the fleet auto-scan loop after the config flag changes.
+
+        Analogous to ``_refresh_memory_sync_loop``.  Reads the current config
+        and either spawns the loop (when both ``enabled`` and
+        ``auto_scan_enabled`` are True) or cancels the running worker group
+        promptly so the loop stops within one asyncio tick rather than waiting
+        up to ``auto_scan_interval_seconds``.
+
+        Called by ``FleetMemoryScreen.action_toggle_auto_scan`` after persisting
+        the new flag, and by ``MemoryPanel.persist`` so toggling auto-scan in
+        Settings starts/stops the loop immediately.
+        """
+        cfg = self.config_manager.get().memory
+        if cfg.enabled and cfg.auto_scan_enabled:
+            self._start_fleet_auto_scan_loop()
+        else:
+            try:
+                self.workers.cancel_group(self, "memory_auto_scan")
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _start_fleet_auto_scan_loop(self) -> None:
+        """Spawn the background fleet auto-scan loop as a worker.
+
+        No-op when ``config.memory.auto_scan_enabled`` is ``False`` or when
+        either ``memory_service`` or ``fleet_scan_service`` is unavailable.
+        The worker sleeps for the configured interval before the FIRST scan,
+        so calling this in ``on_mount`` is safe regardless of instance-list
+        readiness.
+
+        The worker group ``memory_auto_scan`` is exclusive and distinct from
+        ``memory_refresh`` and ``memory_sync_background`` so cancelling one
+        loop does not tear down the others.
+        """
+        cfg = self.config_manager.get().memory
+        if not (cfg.enabled and cfg.auto_scan_enabled):
+            return
+        if self.fleet_scan_service is None or self.memory_service is None:
+            return
+        self.run_worker(
+            self._fleet_auto_scan_loop(),
+            name="fleet_auto_scan_loop",
+            group="memory_auto_scan",
+            exclusive=True,
+        )
+
+    async def _fleet_auto_scan_loop(self) -> None:
+        """Long-running background fleet auto-scan coroutine.
+
+        Sleeps for ``auto_scan_interval_seconds`` (minimum 60 s), then
+        probes eligible instances via ``FleetScanService``.  Re-reads config
+        before each cycle so operators can disable the loop without a restart.
+        Exceptions inside a scan cycle are logged and swallowed so the loop
+        survives transient SSH failures — ``asyncio.CancelledError`` is
+        always re-raised.
+        """
+        import asyncio
+        import time
+
+        while True:
+            cfg = self.config_manager.get().memory
+            if not (cfg.enabled and cfg.auto_scan_enabled):
+                return
+            interval = max(60, cfg.auto_scan_interval_seconds)
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                return
+            # Re-read config after the sleep in case it changed.
+            cfg = self.config_manager.get().memory
+            if not (cfg.enabled and cfg.auto_scan_enabled):
+                return
+            try:
+                await self.fleet_scan_service.scan(
+                    self.instances or [],
+                    stale_only=cfg.auto_scan_stale_only,
+                )
+                self._fleet_auto_scan_last_run = time.time()
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                logger.exception("fleet auto-scan cycle failed")
+                # Loop MUST survive individual cycle failures.
+
+    # ------------------------------------------------------------------
+    # App-owned manual fleet scan (survives screen navigation)
+    # ------------------------------------------------------------------
+
+    def start_fleet_manual_scan(
+        self,
+        instances: list,
+        *,
+        stale_only: bool,
+    ) -> bool:
+        """Spawn the app-owned manual fleet scan worker.
+
+        Returns ``True`` when the worker was successfully spawned, ``False``
+        when a scan is already in progress (caller should notify the user).
+
+        The worker runs in group ``memory_manual_scan`` — a dedicated group
+        distinct from ``memory_auto_scan``, ``memory_refresh``,
+        ``memory_fleet``, and ``memory_sync_background`` — so it is never
+        cancelled by navigation or by any other worker group.
+        """
+        if self._fleet_manual_scan_in_progress:
+            return False
+        self._fleet_manual_scan_in_progress = True
+        self.run_worker(
+            self._do_fleet_manual_scan(list(instances), stale_only),
+            name="fleet_manual_scan",
+            group="memory_manual_scan",
+            exclusive=True,
+        )
+        return True
+
+    async def _do_fleet_manual_scan(
+        self,
+        instances: list,
+        stale_only: bool,
+    ) -> None:
+        """App-owned coroutine that drives the manual fleet scan.
+
+        Survives screen navigation because it is a worker on the *app*, not
+        on any screen.  Progress callbacks and completion hooks are routed to
+        whichever ``FleetMemoryScreen`` is currently mounted via duck-typing
+        — they are silent no-ops when the user has navigated elsewhere.
+
+        On completion the current screen's ``on_fleet_manual_scan_done``
+        method is called (if present) so the screen can repopulate the table,
+        push the summary modal, and clear its in-progress indicator.
+        """
+        import asyncio as _asyncio
+
+        try:
+            fleet_scan_service = getattr(self, "fleet_scan_service", None)
+            if fleet_scan_service is None:
+                self.notify("Fleet scan service not available.", severity="error")
+                return
+
+            result = await fleet_scan_service.scan(
+                instances,
+                stale_only=stale_only,
+                on_progress=self._fleet_manual_scan_progress,
+            )
+        except _asyncio.CancelledError:
+            # Worker cancelled (app quit, etc.) — exit quietly.
+            logger.info("Fleet manual scan cancelled")
+            return
+        except Exception:
+            logger.exception("Fleet manual scan crashed")
+            self.notify(
+                "Fleet scan crashed — check logs for details.",
+                severity="error",
+                markup=False,
+            )
+            return
+        finally:
+            self._fleet_manual_scan_in_progress = False
+            # Tell the current screen (if it's a Fleet Memory screen) to
+            # refresh its in-progress indicator regardless of outcome.
+            screen = getattr(self, "screen", None)
+            set_progress = getattr(screen, "_set_progress", None)
+            if callable(set_progress):
+                try:
+                    set_progress("")
+                except Exception:
+                    pass
+
+        # Success path: notify and hand off to the screen.
+        self.notify(
+            f"Fleet scan done: {len(result.succeeded)} ok, "
+            f"{len(result.failed)} failed.",
+            markup=False,
+        )
+        screen = getattr(self, "screen", None)
+        done_hook = getattr(screen, "on_fleet_manual_scan_done", None)
+        if callable(done_hook):
+            try:
+                done_hook(result)
+            except Exception:
+                logger.exception("on_fleet_manual_scan_done raised")
+
+    def _fleet_manual_scan_progress(self, progress: object) -> None:
+        """Route a scan progress event to the currently mounted Fleet Memory screen.
+
+        Uses duck-typing to avoid importing the screen class (which would
+        create a circular import).  The call is a safe no-op when the user
+        has navigated to a different screen.
+        """
+        screen = getattr(self, "screen", None)
+        cb = getattr(screen, "_on_scan_progress", None)
+        if callable(cb):
+            try:
+                cb(progress)
+            except Exception:
+                logger.debug("_fleet_manual_scan_progress: _on_scan_progress raised", exc_info=True)
 
     def _propagate_memory_key_material(self) -> None:
         """Mirror keypair material from MemorySyncService onto the app.

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -1139,168 +1139,204 @@ class ServonautApp(App):
             except Exception:
                 pass
 
-    async def _reactivate_memory_sync(self) -> None:
-        """Attempt to reactivate Memory Sync silently or via prompt on startup.
+    def _remember_passphrase_expired(self, cfg) -> bool:
+        """Return ``True`` when the remembered passphrase has passed its TTL.
 
-        Runs as a background worker immediately after the relay autostart in
-        ``on_mount``.  Early-returns quickly when the conditions for
-        reactivation are not met so there is no startup cost for users who
-        have not enrolled.
+        Reads ``config.memory.sync_remember_expires_at`` (ISO-8601 UTC).  An
+        empty value means "no expiry recorded" (legacy enrolment from before
+        the TTL feature) and is treated as NOT expired so existing users are
+        not surprised by a sudden re-prompt; the timestamp is stamped the next
+        time they re-enter the passphrase.  Unparseable values fail open
+        (not expired) — a malformed timestamp should not lock a user out.
+        """
+        raw = getattr(cfg.memory, "sync_remember_expires_at", "") or ""
+        if not raw:
+            return False
+        try:
+            from datetime import datetime, timezone
+            exp = datetime.fromisoformat(raw)
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=timezone.utc)
+            return datetime.now(timezone.utc) >= exp
+        except Exception:
+            return False
 
-        Startup reactivation flow
-        --------------------------
-        1. Guard checks (all fast, no network):
-           - Memory Sync service is wired and not already configured.
-           - A local passphrase-encrypted keypair cache (``keys.json``) exists
-             (i.e. the user has enrolled on this device before).
-           - The user is authenticated and has the ``memory_sync`` entitlement
-             (checked from the persisted auth token — no network needed).
+    def _clear_remember_device(self, *, drop_cache: bool = False) -> None:
+        """Forget the device-remembered passphrase (keychain + config flags).
 
-        2. Silent path (no modal):
-           If ``config.memory.sync_remember_device`` is ``True`` and the OS
-           keychain is available and contains a passphrase, bootstrap is
-           attempted with that passphrase.  If it succeeds, sync reactivates
-           without user interaction.  If it fails (stale/wrong passphrase),
-           the keychain entry is cleared and the prompt path runs.
+        Always clears the OS keychain entry and resets
+        ``sync_remember_device`` / ``sync_remember_expires_at`` in config.
+        When *drop_cache* is ``True`` the local passphrase-encrypted keypair
+        cache (``keys.json``) is also removed — used when the stored passphrase
+        no longer unwraps the cache (rotated elsewhere).  Never raises.
+        """
+        import logging as _log
+        _logger = _log.getLogger(__name__)
+        try:
+            from servonaut.services.memory import passphrase_store as _ps
+            _ps.clear_passphrase()
+        except Exception:
+            pass
+        if drop_cache:
+            sync = getattr(self, "memory_sync_service", None)
+            if sync is not None:
+                try:
+                    sync.clear_local_keypair_cache()
+                except Exception:
+                    pass
+        try:
+            import dataclasses as _dc
+            cfg = self.config_manager.get()
+            updated_mem = _dc.replace(
+                cfg.memory,
+                sync_remember_device=False,
+                sync_remember_expires_at="",
+            )
+            self.config_manager.update(memory=updated_mem)
+        except Exception as exc:
+            _logger.warning(
+                "_clear_remember_device: could not clear remember flags: %s", exc
+            )
 
-        3. Prompt path (TUI modal):
-           Shows the ``PassphraseEnrolModal`` in unlock mode.  The user can
-           cancel — that leaves sync dormant until they manually unlock from
-           the Memory Sync screen.  A cancel is NOT an error.
+    async def _try_silent_memory_unlock(self) -> bool:
+        """Attempt a no-modal keychain-based Memory Sync unlock.
+
+        Returns ``True`` iff the sync service ends up configured.  Never shows
+        a modal and never raises.  Honours the remember TTL and self-corrects
+        stale state:
+
+        - keychain unavailable / nothing stored / TTL expired → clear the
+          remember flags and return ``False`` (no credential to use);
+        - stored passphrase no longer unwraps the local cache (rotated on
+          another device) → clear keychain + cache + flags, return ``False``;
+        - transient network/backend failure with a VALID passphrase → keep the
+          credential untouched and return ``False`` (retry next launch);
+        - valid passphrase + successful bootstrap → return ``True``.
         """
         import logging as _log
         _logger = _log.getLogger(__name__)
 
         sync = getattr(self, "memory_sync_service", None)
         if sync is None:
-            return
+            return False
         if sync.is_configured:
-            return
-        if not sync.is_enrolled_locally():
-            return
+            return True
 
+        cfg = self.config_manager.get()
+        if not getattr(cfg.memory, "sync_remember_device", False):
+            return False
+
+        try:
+            from servonaut.services.memory import passphrase_store as _ps
+            if not _ps.keyring_available():
+                _logger.debug(
+                    "_try_silent_memory_unlock: keychain unavailable; "
+                    "clearing stale remember flag"
+                )
+                self._clear_remember_device()
+                return False
+            stored_pw = _ps.get_passphrase()
+            if stored_pw is None:
+                _logger.debug(
+                    "_try_silent_memory_unlock: no passphrase in keychain; "
+                    "clearing stale remember flag"
+                )
+                self._clear_remember_device()
+                return False
+            if self._remember_passphrase_expired(cfg):
+                _logger.info(
+                    "_try_silent_memory_unlock: remembered passphrase expired; "
+                    "clearing keychain (user will be re-prompted)"
+                )
+                self._clear_remember_device()
+                return False
+            # MAJOR-1: validate the passphrase LOCALLY before any network call
+            # so a transient backend error is never mistaken for a wrong one.
+            if not sync.can_unwrap_local(stored_pw):
+                _logger.info(
+                    "_try_silent_memory_unlock: stored passphrase no longer "
+                    "unwraps local cache; clearing keychain + cache"
+                )
+                self._clear_remember_device(drop_cache=True)
+                return False
+
+            async def _kc_provider(mode: str) -> str:
+                return stored_pw
+
+            try:
+                await self.bootstrap_memory_cloud(passphrase_provider=_kc_provider)
+                _logger.info("_try_silent_memory_unlock: silent reactivation succeeded")
+                return True
+            except Exception as exc:
+                if sync.is_configured:
+                    return True
+                # Network/backend error — passphrase WAS valid; keep the
+                # credential and retry on the next launch / section open.
+                _logger.warning(
+                    "_try_silent_memory_unlock: transient bootstrap failure "
+                    "(passphrase valid): %s; will retry later", exc
+                )
+                return False
+        except Exception as exc:
+            _logger.warning(
+                "_try_silent_memory_unlock: keychain check failed: %s", exc
+            )
+            return False
+
+    async def _reactivate_memory_sync(self) -> None:
+        """Startup SILENT reactivation of Memory Sync (no modal).
+
+        Runs as a background worker from ``on_mount``.  Only attempts the
+        non-intrusive keychain-based unlock — it NEVER opens a passphrase
+        modal on boot.  When the user has not opted into "Remember on this
+        device" (or the credential is stale/expired), Memory Sync simply stays
+        dormant until the user opens a memory section, at which point
+        :meth:`prompt_memory_sync_unlock` offers the unlock modal in context.
+
+        Early-returns quickly when reactivation is not applicable so there is
+        no startup cost for users who never set up Memory Sync.  Free users
+        (no ``memory_sync`` entitlement) never reach the unlock path at all.
+        """
+        sync = getattr(self, "memory_sync_service", None)
+        if sync is None or sync.is_configured or not sync.is_enrolled_locally():
+            return
         # Auth guard — all cheap (reads from persisted token, no network).
         auth = getattr(self, "auth_service", None)
-        if auth is None or not auth.is_authenticated:
+        if auth is None or not auth.is_authenticated or not auth.has_feature("memory_sync"):
             return
-        if not auth.has_feature("memory_sync"):
+        await self._try_silent_memory_unlock()
+
+    async def prompt_memory_sync_unlock(self) -> None:
+        """Unlock Memory Sync when the user opens a memory section.
+
+        Called from the memory screens' ``on_mount`` (e.g. the fleet memory
+        view) — NOT on app boot — so the passphrase modal only appears in the
+        context the user navigated to.  Tries a silent keychain unlock first
+        (covers the transient-failure-on-boot case), then falls back to the
+        ``PassphraseEnrolModal`` in unlock mode.
+
+        No-op when sync is already active, the user is not enrolled on this
+        device, lacks the ``memory_sync`` entitlement, or already declined the
+        prompt earlier this session.  A cancel is NOT an error — it just leaves
+        sync dormant until the user explicitly unlocks from the Memory Sync
+        screen.
+        """
+        import logging as _log
+        _logger = _log.getLogger(__name__)
+
+        sync = getattr(self, "memory_sync_service", None)
+        if sync is None or sync.is_configured or not sync.is_enrolled_locally():
             return
-
-        # ------------------------------------------------------------------
-        # Silent path: OS keychain
-        # ------------------------------------------------------------------
-        cfg = self.config_manager.get()
-        remember = getattr(cfg.memory, "sync_remember_device", False)
-        if remember:
-            try:
-                from servonaut.services.memory import passphrase_store as _ps
-                if not _ps.keyring_available():
-                    # M4: keychain unavailable but flag is set — self-correct.
-                    _logger.debug(
-                        "_reactivate_memory_sync: keychain unavailable; "
-                        "clearing stale sync_remember_device flag"
-                    )
-                    try:
-                        import dataclasses as _dc
-                        updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
-                        self.config_manager.update(memory=updated_mem)
-                    except Exception as upd_exc:
-                        _logger.warning(
-                            "_reactivate_memory_sync: could not clear "
-                            "sync_remember_device flag: %s", upd_exc
-                        )
-                else:
-                    stored_pw = _ps.get_passphrase()
-                    if stored_pw is None:
-                        # M4: keychain available but nothing stored — stale flag.
-                        _logger.debug(
-                            "_reactivate_memory_sync: no passphrase in keychain; "
-                            "clearing stale sync_remember_device flag"
-                        )
-                        try:
-                            import dataclasses as _dc
-                            updated_mem = _dc.replace(
-                                cfg.memory, sync_remember_device=False
-                            )
-                            self.config_manager.update(memory=updated_mem)
-                        except Exception as upd_exc:
-                            _logger.warning(
-                                "_reactivate_memory_sync: could not clear "
-                                "sync_remember_device flag: %s", upd_exc
-                            )
-                    else:
-                        # MAJOR-1: validate the passphrase LOCALLY before any
-                        # network call so we can distinguish wrong/stale
-                        # passphrase from a transient backend error.
-                        if sync.can_unwrap_local(stored_pw):
-                            # Passphrase is valid — attempt silent bootstrap.
-                            async def _kc_provider(mode: str) -> str:
-                                return stored_pw
-
-                            try:
-                                await self.bootstrap_memory_cloud(
-                                    passphrase_provider=_kc_provider
-                                )
-                                _logger.info(
-                                    "_reactivate_memory_sync: silent reactivation succeeded"
-                                )
-                                return
-                            except Exception as exc:
-                                # Key material check: if bootstrap completed its
-                                # crypto steps before failing, the key is already
-                                # loaded — do not clear the keychain.
-                                if sync.is_configured:
-                                    _logger.info(
-                                        "_reactivate_memory_sync: keypair already loaded "
-                                        "after partial bootstrap; returning"
-                                    )
-                                    return
-                                # Network/backend error — passphrase WAS valid;
-                                # do NOT clear keychain or reset flag.
-                                # Try again on the next app launch.
-                                _logger.warning(
-                                    "_reactivate_memory_sync: silent bootstrap failed "
-                                    "(network/backend — passphrase is valid): %s; "
-                                    "will retry on next launch",
-                                    exc,
-                                )
-                                return  # do NOT fall through to prompt
-                        else:
-                            # Wrong/stale passphrase — clear credential and
-                            # fall through to the TUI prompt path.
-                            _logger.info(
-                                "_reactivate_memory_sync: stored passphrase did not "
-                                "unwrap local cache; clearing keychain and prompting"
-                            )
-                            _ps.clear_passphrase()
-                            try:
-                                sync.clear_local_keypair_cache()
-                            except Exception:
-                                pass
-                            try:
-                                import dataclasses as _dc
-                                updated_mem = _dc.replace(
-                                    cfg.memory, sync_remember_device=False
-                                )
-                                self.config_manager.update(memory=updated_mem)
-                            except Exception as upd_exc:
-                                _logger.warning(
-                                    "_reactivate_memory_sync: could not clear "
-                                    "sync_remember_device flag: %s", upd_exc
-                                )
-                            # Fall through to prompt path
-            except Exception as exc:
-                _logger.warning(
-                    "_reactivate_memory_sync: keychain check failed: %s", exc
-                )
-
-        # ------------------------------------------------------------------
-        # Prompt path: TUI modal (skippable)
-        # ------------------------------------------------------------------
-        # M11: don't re-prompt if the user already cancelled this session.
+        auth = getattr(self, "auth_service", None)
+        if auth is None or not auth.is_authenticated or not auth.has_feature("memory_sync"):
+            return
+        # Don't nag: if the user dismissed the prompt this session, stay quiet.
         if getattr(self, "_memory_sync_prompt_skipped", False):
             return
-        # Skip if already configured (e.g. silent path completed mid-exception).
+
+        # Silent path first (also re-tries a transient boot failure).
+        if await self._try_silent_memory_unlock():
+            return
         if sync.is_configured:
             return
 
@@ -1315,7 +1351,7 @@ class ServonautApp(App):
             # User cancelled the modal — leave sync dormant, no error toast.
             self._memory_sync_prompt_skipped = True
             _logger.info(
-                "_reactivate_memory_sync: user cancelled passphrase prompt; "
+                "prompt_memory_sync_unlock: user cancelled passphrase prompt; "
                 "sync stays dormant"
             )
             self.notify(
@@ -1325,7 +1361,7 @@ class ServonautApp(App):
             )
         except Exception as exc:
             _logger.warning(
-                "_reactivate_memory_sync: prompt path failed: %s", exc
+                "prompt_memory_sync_unlock: prompt path failed: %s", exc
             )
 
     def _refresh_fleet_auto_scan_loop(self) -> None:
@@ -1589,14 +1625,33 @@ class ServonautApp(App):
                 if passphrase_store.keyring_available():
                     if passphrase_store.store_passphrase(result.passphrase):
                         import dataclasses as _dc
+                        from datetime import datetime, timedelta, timezone
+                        from servonaut.config.schema import DEFAULT_REMEMBER_TTL_DAYS
+                        expires_at = (
+                            datetime.now(timezone.utc)
+                            + timedelta(days=DEFAULT_REMEMBER_TTL_DAYS)
+                        ).isoformat()
                         cfg = self.config_manager.get()
                         updated_mem = _dc.replace(
-                            cfg.memory, sync_remember_device=True
+                            cfg.memory,
+                            sync_remember_device=True,
+                            sync_remember_expires_at=expires_at,
                         )
                         self.config_manager.update(memory=updated_mem)
                         logger.info(
-                            "_prompt_memory_passphrase: passphrase stored in keychain"
+                            "_prompt_memory_passphrase: passphrase stored in "
+                            "keychain (expires %s)", expires_at
                         )
+                else:
+                    # The user asked to remember but there is no secure OS
+                    # keychain backend on this machine — be honest rather than
+                    # silently re-prompting on every launch.
+                    self.notify(
+                        "No OS keychain available on this device — couldn't "
+                        "save the passphrase. You'll be asked again next time.",
+                        severity="warning",
+                        timeout=7,
+                    )
             except Exception as exc:
                 logger.warning(
                     "_prompt_memory_passphrase: keychain store failed: %s", exc

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -252,6 +252,24 @@ class ServonautApp(App):
                 name="relay_autostart",
                 exclusive=True,
             )
+        # Reactivate Memory Sync if the user enrolled on a previous session.
+        # Gated entirely on local state (no eager network calls) so it is
+        # safe and fast for users who have never set up Memory Sync.
+        sync = getattr(self, "memory_sync_service", None)
+        _auth = getattr(self, "auth_service", None)
+        if (
+            sync is not None
+            and _auth is not None
+            and _auth.is_authenticated
+            and _auth.has_feature("memory_sync")
+            and sync.is_enrolled_locally()
+        ):
+            self.run_worker(
+                self._reactivate_memory_sync(),
+                name="memory_sync_autostart",
+                group="memory_reactivate",
+                exclusive=True,
+            )
         # Start background fleet auto-scan loop (sleeps first, so safe to
         # call here even before the instance list is fully populated).
         self._start_fleet_auto_scan_loop()
@@ -640,10 +658,46 @@ class ServonautApp(App):
             )
 
     def on_user_logout(self) -> None:
-        """Called by LoginScreen after logout — tear the relay down."""
-        if self.relay_manager is not None:
-            self.run_worker(self.relay_manager.stop(),
+        """Called by LoginScreen after logout — tear down all session state.
+
+        Single source of truth for logout cleanup: relay listener, config-sync
+        session, and Memory Sync key material. (Previously split across two
+        same-named methods, the second of which silently shadowed the first.)
+        """
+        # Relay listener
+        relay = getattr(self, "relay_manager", None)
+        if relay is not None and hasattr(self, "run_worker"):
+            self.run_worker(relay.stop(),
                             name="relay_logout_stop", exclusive=True)
+        # Config-sync session
+        if getattr(self, "config_sync_service", None) is not None:
+            self.config_sync_service.clear_session()
+        # Memory Sync logout cleanup (MAJOR-2): clear the local keypair cache,
+        # OS keychain passphrase, and remember flag so a different account on
+        # the same OS user cannot silently reuse the prior keypair next launch.
+        sync = getattr(self, "memory_sync_service", None)
+        if sync is not None:
+            try:
+                if hasattr(sync, "lock"):
+                    sync.lock()
+            except Exception:
+                pass
+            try:
+                sync.clear_local_keypair_cache()
+            except Exception:
+                pass
+        try:
+            from servonaut.services.memory import passphrase_store as _ps
+            _ps.clear_passphrase()
+        except Exception:
+            pass
+        try:
+            import dataclasses as _dc
+            cfg = self.config_manager.get()
+            updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+            self.config_manager.update(memory=updated_mem)
+        except Exception:
+            pass
 
     async def on_unmount(self) -> None:
         """Cancel the relay listener cleanly as the app exits."""
@@ -847,6 +901,24 @@ class ServonautApp(App):
                         and self.auth_service.has_feature("memory_sync")
                     )
                 )
+            # S-1: cross-device rotation notify — show a user-visible toast
+            # when the background drain loop detects that our local keypair
+            # is no longer registered on the server (another device rotated).
+            if hasattr(self.memory_sync_service, "set_key_mismatch_listener"):
+                def _on_key_mismatch_notify() -> None:
+                    try:
+                        self.notify(
+                            "Memory Sync key changed on another device — "
+                            "re-unlock from the Memory Sync screen to resume sync.",
+                            severity="warning",
+                            timeout=10,
+                            markup=False,
+                        )
+                    except Exception:
+                        pass
+                self.memory_sync_service.set_key_mismatch_listener(
+                    _on_key_mismatch_notify
+                )
         except Exception as exc:
             logger.debug("MemorySyncService init failed: %s", exc)
 
@@ -944,18 +1016,28 @@ class ServonautApp(App):
         # :meth:`bootstrap_memory_cloud` once they explicitly hit "Set up".
         # No auto-modals, no auto network calls.
 
-    async def bootstrap_memory_cloud(self) -> None:
-        """Bootstrap the memory cloud sync layer (user-initiated).
+    async def bootstrap_memory_cloud(
+        self, passphrase_provider=None
+    ) -> None:
+        """Bootstrap the memory cloud sync layer (user-initiated or auto-restart).
 
-        Called from ``MemorySyncSetupScreen`` when the user clicks "Set up".
+        Called from ``MemorySyncSetupScreen`` when the user clicks "Set up",
+        or from ``_reactivate_memory_sync`` on startup when a local keypair
+        cache is present.
+
+        Args:
+            passphrase_provider: Async callable ``(mode: str) -> str`` that
+                returns the passphrase.  Defaults to
+                ``self._prompt_memory_passphrase`` (shows the TUI modal).
+                Pass a custom coroutine factory to supply the passphrase
+                silently (e.g. from the OS keychain) without opening a modal.
+
         Idempotent — safe to call multiple times; the underlying service
         skips the network round-trip if a key is already loaded.
 
-        Exceptions are NOT swallowed — the caller (the setup screen worker)
-        catches them and shows the user a notify with the actual reason
-        (wrong passphrase, backend down, beta-waitlisted, etc.). Swallowing
-        here would leave the user staring at an unchanged screen wondering
-        what went wrong.
+        Exceptions are NOT swallowed — the caller catches them and shows
+        the user a notify with the actual reason (wrong passphrase, backend
+        down, beta-waitlisted, etc.).
 
         The background sync loop is spawned as a *separate* worker so this
         coroutine returns once enrolment completes — otherwise the caller
@@ -964,9 +1046,14 @@ class ServonautApp(App):
         """
         if self.memory_sync_service is None:
             return
+        provider = (
+            passphrase_provider
+            if passphrase_provider is not None
+            else self._prompt_memory_passphrase
+        )
         await self.auth_service.fetch_user_id()
         await self.memory_sync_service.bootstrap(
-            passphrase_provider=self._prompt_memory_passphrase,
+            passphrase_provider=provider,
         )
         self._propagate_memory_key_material()
         # Fetch the server-side auto_sync_enabled flag before spawning the loop.
@@ -1051,6 +1138,195 @@ class ServonautApp(App):
                 self.workers.cancel_group(self, "memory_sync_background")
             except Exception:
                 pass
+
+    async def _reactivate_memory_sync(self) -> None:
+        """Attempt to reactivate Memory Sync silently or via prompt on startup.
+
+        Runs as a background worker immediately after the relay autostart in
+        ``on_mount``.  Early-returns quickly when the conditions for
+        reactivation are not met so there is no startup cost for users who
+        have not enrolled.
+
+        Startup reactivation flow
+        --------------------------
+        1. Guard checks (all fast, no network):
+           - Memory Sync service is wired and not already configured.
+           - A local passphrase-encrypted keypair cache (``keys.json``) exists
+             (i.e. the user has enrolled on this device before).
+           - The user is authenticated and has the ``memory_sync`` entitlement
+             (checked from the persisted auth token — no network needed).
+
+        2. Silent path (no modal):
+           If ``config.memory.sync_remember_device`` is ``True`` and the OS
+           keychain is available and contains a passphrase, bootstrap is
+           attempted with that passphrase.  If it succeeds, sync reactivates
+           without user interaction.  If it fails (stale/wrong passphrase),
+           the keychain entry is cleared and the prompt path runs.
+
+        3. Prompt path (TUI modal):
+           Shows the ``PassphraseEnrolModal`` in unlock mode.  The user can
+           cancel — that leaves sync dormant until they manually unlock from
+           the Memory Sync screen.  A cancel is NOT an error.
+        """
+        import logging as _log
+        _logger = _log.getLogger(__name__)
+
+        sync = getattr(self, "memory_sync_service", None)
+        if sync is None:
+            return
+        if sync.is_configured:
+            return
+        if not sync.is_enrolled_locally():
+            return
+
+        # Auth guard — all cheap (reads from persisted token, no network).
+        auth = getattr(self, "auth_service", None)
+        if auth is None or not auth.is_authenticated:
+            return
+        if not auth.has_feature("memory_sync"):
+            return
+
+        # ------------------------------------------------------------------
+        # Silent path: OS keychain
+        # ------------------------------------------------------------------
+        cfg = self.config_manager.get()
+        remember = getattr(cfg.memory, "sync_remember_device", False)
+        if remember:
+            try:
+                from servonaut.services.memory import passphrase_store as _ps
+                if not _ps.keyring_available():
+                    # M4: keychain unavailable but flag is set — self-correct.
+                    _logger.debug(
+                        "_reactivate_memory_sync: keychain unavailable; "
+                        "clearing stale sync_remember_device flag"
+                    )
+                    try:
+                        import dataclasses as _dc
+                        updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+                        self.config_manager.update(memory=updated_mem)
+                    except Exception as upd_exc:
+                        _logger.warning(
+                            "_reactivate_memory_sync: could not clear "
+                            "sync_remember_device flag: %s", upd_exc
+                        )
+                else:
+                    stored_pw = _ps.get_passphrase()
+                    if stored_pw is None:
+                        # M4: keychain available but nothing stored — stale flag.
+                        _logger.debug(
+                            "_reactivate_memory_sync: no passphrase in keychain; "
+                            "clearing stale sync_remember_device flag"
+                        )
+                        try:
+                            import dataclasses as _dc
+                            updated_mem = _dc.replace(
+                                cfg.memory, sync_remember_device=False
+                            )
+                            self.config_manager.update(memory=updated_mem)
+                        except Exception as upd_exc:
+                            _logger.warning(
+                                "_reactivate_memory_sync: could not clear "
+                                "sync_remember_device flag: %s", upd_exc
+                            )
+                    else:
+                        # MAJOR-1: validate the passphrase LOCALLY before any
+                        # network call so we can distinguish wrong/stale
+                        # passphrase from a transient backend error.
+                        if sync.can_unwrap_local(stored_pw):
+                            # Passphrase is valid — attempt silent bootstrap.
+                            async def _kc_provider(mode: str) -> str:
+                                return stored_pw
+
+                            try:
+                                await self.bootstrap_memory_cloud(
+                                    passphrase_provider=_kc_provider
+                                )
+                                _logger.info(
+                                    "_reactivate_memory_sync: silent reactivation succeeded"
+                                )
+                                return
+                            except Exception as exc:
+                                # Key material check: if bootstrap completed its
+                                # crypto steps before failing, the key is already
+                                # loaded — do not clear the keychain.
+                                if sync.is_configured:
+                                    _logger.info(
+                                        "_reactivate_memory_sync: keypair already loaded "
+                                        "after partial bootstrap; returning"
+                                    )
+                                    return
+                                # Network/backend error — passphrase WAS valid;
+                                # do NOT clear keychain or reset flag.
+                                # Try again on the next app launch.
+                                _logger.warning(
+                                    "_reactivate_memory_sync: silent bootstrap failed "
+                                    "(network/backend — passphrase is valid): %s; "
+                                    "will retry on next launch",
+                                    exc,
+                                )
+                                return  # do NOT fall through to prompt
+                        else:
+                            # Wrong/stale passphrase — clear credential and
+                            # fall through to the TUI prompt path.
+                            _logger.info(
+                                "_reactivate_memory_sync: stored passphrase did not "
+                                "unwrap local cache; clearing keychain and prompting"
+                            )
+                            _ps.clear_passphrase()
+                            try:
+                                sync.clear_local_keypair_cache()
+                            except Exception:
+                                pass
+                            try:
+                                import dataclasses as _dc
+                                updated_mem = _dc.replace(
+                                    cfg.memory, sync_remember_device=False
+                                )
+                                self.config_manager.update(memory=updated_mem)
+                            except Exception as upd_exc:
+                                _logger.warning(
+                                    "_reactivate_memory_sync: could not clear "
+                                    "sync_remember_device flag: %s", upd_exc
+                                )
+                            # Fall through to prompt path
+            except Exception as exc:
+                _logger.warning(
+                    "_reactivate_memory_sync: keychain check failed: %s", exc
+                )
+
+        # ------------------------------------------------------------------
+        # Prompt path: TUI modal (skippable)
+        # ------------------------------------------------------------------
+        # M11: don't re-prompt if the user already cancelled this session.
+        if getattr(self, "_memory_sync_prompt_skipped", False):
+            return
+        # Skip if already configured (e.g. silent path completed mid-exception).
+        if sync.is_configured:
+            return
+
+        try:
+            await self.bootstrap_memory_cloud()
+            self.notify(
+                "Memory Sync unlocked.",
+                severity="information",
+                timeout=4,
+            )
+        except RuntimeError:
+            # User cancelled the modal — leave sync dormant, no error toast.
+            self._memory_sync_prompt_skipped = True
+            _logger.info(
+                "_reactivate_memory_sync: user cancelled passphrase prompt; "
+                "sync stays dormant"
+            )
+            self.notify(
+                "Memory Sync locked — open Memory Sync to unlock.",
+                severity="information",
+                timeout=5,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "_reactivate_memory_sync: prompt path failed: %s", exc
+            )
 
     def _refresh_fleet_auto_scan_loop(self) -> None:
         """Re-evaluate the fleet auto-scan loop after the config flag changes.
@@ -1278,6 +1554,11 @@ class ServonautApp(App):
         the appropriate ``mode`` (``"enrol"`` for first-time setup,
         ``"unlock"`` when the keypair already exists server-side).
 
+        When the user checks "Remember on this device" in the modal AND the
+        OS keychain is available, the passphrase is stored in the keychain
+        and ``config.memory.sync_remember_device`` is set to ``True`` so
+        the startup reactivation path can silently unlock on the next launch.
+
         Args:
             mode: ``"enrol"`` (default — confirm field shown) or
                 ``"unlock"`` (single passphrase input). The sync service
@@ -1296,11 +1577,31 @@ class ServonautApp(App):
             return env
         from servonaut.screens.memory_keys import PassphraseEnrolModal
         result = await self.push_screen_wait(PassphraseEnrolModal(mode=mode))
-        if not result:
+        if result is None:
             raise RuntimeError(
                 f"Memory keypair {mode} cancelled by user"
             )
-        return result
+        # Honor the "Remember on this device" opt-in: store the passphrase
+        # in the OS keychain and flag it in config for startup reactivation.
+        if result.remember:
+            try:
+                from servonaut.services.memory import passphrase_store
+                if passphrase_store.keyring_available():
+                    if passphrase_store.store_passphrase(result.passphrase):
+                        import dataclasses as _dc
+                        cfg = self.config_manager.get()
+                        updated_mem = _dc.replace(
+                            cfg.memory, sync_remember_device=True
+                        )
+                        self.config_manager.update(memory=updated_mem)
+                        logger.info(
+                            "_prompt_memory_passphrase: passphrase stored in keychain"
+                        )
+            except Exception as exc:
+                logger.warning(
+                    "_prompt_memory_passphrase: keychain store failed: %s", exc
+                )
+        return result.passphrase
 
     def on_text_selected(self) -> None:
         """Auto-copy selected text to clipboard when user highlights with mouse.
@@ -1683,8 +1984,3 @@ class ServonautApp(App):
                 self.screen._update_table()
         except Exception:
             pass
-
-    def on_user_logout(self) -> None:
-        """Called after a successful logout to clean up session state."""
-        if hasattr(self, "config_sync_service") and self.config_sync_service is not None:
-            self.config_sync_service.clear_session()

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -598,6 +598,12 @@ DEFAULT_FIRST_CONNECT_REPROMPT_SECONDS = 14 * 86400  # 14 days
 # instances.  Users can override via config.memory.auto_scan_interval_seconds.
 DEFAULT_AUTO_SCAN_INTERVAL_SECONDS = 86400  # 24 hours
 
+# How long a "Remember on this device" passphrase stays valid before the user
+# is asked to re-enter it.  Silent reactivation stops working once the stored
+# passphrase is older than this, balancing convenience against the risk of an
+# indefinitely-remembered credential on a shared or lost machine.
+DEFAULT_REMEMBER_TTL_DAYS = 30
+
 
 @dataclass
 class MemoryConfig:
@@ -693,6 +699,14 @@ class MemoryConfig:
     # silent keychain-based bootstrap on startup.  The actual passphrase
     # is NEVER stored in this config file — only this boolean flag.
     sync_remember_device: bool = False
+
+    # ISO-8601 UTC timestamp (e.g. ``"2026-07-25T12:00:00+00:00"``) after which
+    # the remembered passphrase is considered expired.  Silent reactivation
+    # refuses to use the keychain passphrase past this instant and the user is
+    # asked to re-enter it the next time they open a memory section.  Empty
+    # string means "no expiry recorded" (legacy / not remembered).  Refreshed
+    # every time the passphrase is successfully (re-)stored.
+    sync_remember_expires_at: str = ""
 
     # ------------------------------------------------------------------
     # Helpers used by MemoryService / MemoryStore

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -685,6 +685,16 @@ class MemoryConfig:
     auto_scan_stale_only: bool = True
 
     # ------------------------------------------------------------------
+    # Device passphrase remember flag (ADDITIVE — no migration needed)
+    # ------------------------------------------------------------------
+    # When True, the Memory Sync passphrase has been stored in the OS
+    # keychain (via opt-in "Remember on this device" in the unlock modal).
+    # Used by _reactivate_memory_sync to decide whether to attempt a
+    # silent keychain-based bootstrap on startup.  The actual passphrase
+    # is NEVER stored in this config file — only this boolean flag.
+    sync_remember_device: bool = False
+
+    # ------------------------------------------------------------------
     # Helpers used by MemoryService / MemoryStore
     # ------------------------------------------------------------------
 

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -593,6 +593,11 @@ DEFAULT_SNAPSHOT_STALE_SECONDS = 7 * 86400  # 7 days
 # this (servers with no memory at all are always prompted).
 DEFAULT_FIRST_CONNECT_REPROMPT_SECONDS = 14 * 86400  # 14 days
 
+# Default interval for the background fleet auto-scan loop.  24 hours keeps
+# the fleet memory reasonably fresh without hammering SSH on short-lived
+# instances.  Users can override via config.memory.auto_scan_interval_seconds.
+DEFAULT_AUTO_SCAN_INTERVAL_SECONDS = 86400  # 24 hours
+
 
 @dataclass
 class MemoryConfig:
@@ -615,7 +620,10 @@ class MemoryConfig:
             "redaction_enabled": true,
             "per_server_overrides": {
               "i-critical-prod": { "memory_disabled": true }
-            }
+            },
+            "auto_scan_enabled": false,
+            "auto_scan_interval_seconds": 86400,
+            "auto_scan_stale_only": true
           }
         }
 
@@ -638,6 +646,14 @@ class MemoryConfig:
         first_connect_reprompt_seconds: Age in seconds beyond which a server
             that already has memory is re-prompted by the first-connect
             "Build memory" banner. Servers with no memory are always prompted.
+        auto_scan_enabled: When ``True`` the background fleet auto-scan loop
+            runs on startup (after ``_init_services``) and re-scans on every
+            ``auto_scan_interval_seconds`` tick.  Requires ``enabled=True``.
+        auto_scan_interval_seconds: Interval between background fleet scans in
+            seconds.  Minimum enforced at runtime: 60 s.  Defaults to 24 h.
+        auto_scan_stale_only: When ``True`` the auto-scan loop probes only
+            instances whose memory is stale or missing, skipping fresh ones.
+            Set to ``False`` to force a full fleet re-probe on every tick.
     """
 
     enabled: bool = True
@@ -660,6 +676,13 @@ class MemoryConfig:
     # Maximum characters budgeted for the findings title index when building
     # a summary or injector context block.
     findings_index_char_cap: int = 1200
+
+    # ------------------------------------------------------------------
+    # Auto-scan / auto-sync feature flags (ADDITIVE — no migration needed)
+    # ------------------------------------------------------------------
+    auto_scan_enabled: bool = False
+    auto_scan_interval_seconds: int = DEFAULT_AUTO_SCAN_INTERVAL_SECONDS
+    auto_scan_stale_only: bool = True
 
     # ------------------------------------------------------------------
     # Helpers used by MemoryService / MemoryStore

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -328,6 +328,20 @@ class FleetMemoryScreen(Screen):
         table.add_column("Last probed", key="age", width=14)
         self._refresh_auto_scan_status()
         self._launch_populate()
+        # Memory Sync unlock is offered HERE (on entering a memory section),
+        # not on app boot — a passphrase modal on startup is too intrusive.
+        # The app method is a no-op for free users, the unentitled, those who
+        # never enrolled, and anyone who declined the prompt this session.
+        # Run it as an app-owned worker so the modal survives navigating away
+        # from this screen.
+        prompt_unlock = getattr(self.app, "prompt_memory_sync_unlock", None)
+        if prompt_unlock is not None:
+            self.app.run_worker(
+                prompt_unlock(),
+                name="memory_sync_unlock_prompt",
+                group="memory_reactivate",
+                exclusive=True,
+            )
         # If an app-owned manual scan is still running (e.g. the user left
         # this panel mid-scan and came back), surface it — the scan keeps
         # going in the background and routes progress here while mounted.

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -14,7 +14,9 @@ to hunt row-by-row for failures.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
@@ -25,6 +27,7 @@ from rich.markup import escape
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, VerticalScroll
+from textual.coordinate import Coordinate
 from textual.screen import ModalScreen, Screen
 from textual.widgets import Button, DataTable, Footer, Header, Static
 
@@ -325,6 +328,7 @@ class FleetMemoryScreen(Screen):
         Binding("f", "refresh_stale", "Refresh Stale", show=True),
         Binding("enter", "open_selected", "Open", show=True),
         Binding("x", "clear_selected", "Clear", show=True),
+        Binding("a", "toggle_auto_scan", "Toggle Auto-scan", show=True),
     ]
 
     @property
@@ -366,6 +370,9 @@ class FleetMemoryScreen(Screen):
                     id="fleet-memory-help",
                 ),
                 Static("", id="fleet-memory-status"),
+                # Auto-scan state indicator — updated on mount, after
+                # manual scans, and after a refresh-view.
+                Static("", id="fleet-auto-scan-status"),
                 # Live progress line for bulk scans — hidden when idle so
                 # it never competes with the status summary above.
                 Static("", id="fleet-memory-progress", classes="hidden"),
@@ -379,8 +386,10 @@ class FleetMemoryScreen(Screen):
                 Horizontal(
                     Button("s. Scan All", id="btn_scan_all", variant="primary"),
                     Button("f. Refresh Stale", id="btn_refresh_stale"),
+                    Button("r. Refresh", id="btn_refresh_view"),
                     Button("enter. Open", id="btn_open"),
                     Button("x. Clear", id="btn_clear", variant="error"),
+                    Button("a. Toggle Auto-scan", id="btn_toggle_auto_scan"),
                     id="memory-actions",
                 ),
                 id="memory-container",
@@ -398,7 +407,14 @@ class FleetMemoryScreen(Screen):
         table.add_column("Modules", key="modules", width=10)
         table.add_column("Drift 7d", key="drift_7d", width=6)
         table.add_column("Last probed", key="age", width=14)
+        self._refresh_auto_scan_status()
         self._launch_populate()
+        # If an app-owned manual scan is still running (e.g. the user left
+        # this panel mid-scan and came back), surface it — the scan keeps
+        # going in the background and routes progress here while mounted.
+        if getattr(self.app, "_fleet_manual_scan_in_progress", False):
+            self._scanning = True
+            self._set_progress("[cyan]Fleet scan in progress…[/cyan]")
 
     # ------------------------------------------------------------------
     # Data / populate
@@ -478,8 +494,6 @@ class FleetMemoryScreen(Screen):
             return _rs.redact_provider(v) if _demo else v
 
         self._rows = []
-        fresh = stale = none_count = opt_out = 0
-        source_counts = {"local": 0, "remote": 0, "merged": 0}
 
         for fleet_row in merged:
             # Keep raw values for internal lookups (inst_by_id, memory_service)
@@ -503,17 +517,6 @@ class FleetMemoryScreen(Screen):
             })
             status = compute_memory_status(inst, memory_service)
 
-            if status == STATUS_FRESH:
-                fresh += 1
-            elif status == STATUS_STALE:
-                stale += 1
-            elif status == STATUS_OPT_OUT:
-                opt_out += 1
-            else:
-                none_count += 1
-
-            source_counts[source] = source_counts.get(source, 0) + 1
-
             modules_count = fleet_row.get("modules", 0)
             age_text = "—"
             if memory_service is not None and status in (STATUS_FRESH, STATUS_STALE):
@@ -532,6 +535,11 @@ class FleetMemoryScreen(Screen):
                 "id": iid,
                 "name": iname,
                 "provider": provider,
+                # raw_id / raw_provider preserve the un-redacted keys for
+                # memory-store lookups and for matching incoming progress
+                # events (which carry the real instance_id).
+                "raw_id": raw_iid,
+                "raw_provider": raw_provider,
                 "source": source,
                 "status": status,
                 "modules": modules_count,
@@ -554,15 +562,9 @@ class FleetMemoryScreen(Screen):
                 row["age"],
             )
 
-        total = len(self._rows)
-        status_line = (
-            f"[dim]{total} instances  ·  "
-            f"[green]{fresh} fresh[/green]  ·  "
-            f"[yellow]{stale} stale[/yellow]  ·  "
-            f"{none_count} not probed  ·  "
-            f"[red]{opt_out} opted-out[/red][/dim]"
+        self.query_one("#fleet-memory-status", Static).update(
+            self._summary_line_from_rows(self._rows)
         )
-        self.query_one("#fleet-memory-status", Static).update(status_line)
 
     def _populate_table(self) -> None:
         """Rebuild table rows + status footer from local app state (no remote)."""
@@ -570,20 +572,11 @@ class FleetMemoryScreen(Screen):
         instances = self.app.instances or []
 
         self._rows = []
-        fresh = stale = none_count = opt_out = 0
         for inst in instances:
             iid = inst.get("id") or inst.get("name", "")
             iname = inst.get("name", iid)
             provider = inst.get("provider", "custom") or "custom"
             status = compute_memory_status(inst, memory_service)
-            if status == STATUS_FRESH:
-                fresh += 1
-            elif status == STATUS_STALE:
-                stale += 1
-            elif status == STATUS_OPT_OUT:
-                opt_out += 1
-            else:
-                none_count += 1
 
             modules_count = 0
             age_text = "—"
@@ -600,6 +593,14 @@ class FleetMemoryScreen(Screen):
                 "id": iid,
                 "name": iname,
                 "provider": provider,
+                # raw_id / raw_provider are the un-redacted keys used for
+                # memory-store lookups (keyed by real IDs, not display IDs).
+                # In the local path the instance dict is never redacted in-
+                # place, so raw == display; we record them explicitly so the
+                # live-update helper can always use the right key regardless
+                # of which populate path populated the row.
+                "raw_id": iid,
+                "raw_provider": provider,
                 "source": "local",
                 "status": status,
                 "modules": modules_count,
@@ -622,14 +623,40 @@ class FleetMemoryScreen(Screen):
             )
 
         # Status footer — one glance tells the operator where to act.
-        status_line = (
-            f"[dim]{len(instances)} instances  ·  "
+        self.query_one("#fleet-memory-status", Static).update(
+            self._summary_line_from_rows(self._rows)
+        )
+
+    # ------------------------------------------------------------------
+    # Summary helpers (shared between populate paths and live updater)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summary_line_from_rows(rows: List[Dict[str, Any]]) -> str:
+        """Return the Rich-markup summary footer from the current ``_rows`` list.
+
+        Counts statuses directly from the rows so the live-update path and
+        the post-populate path can't drift.
+        """
+        fresh = stale = none_count = opt_out = 0
+        for row in rows:
+            s = row.get("status", STATUS_NONE)
+            if s == STATUS_FRESH:
+                fresh += 1
+            elif s == STATUS_STALE:
+                stale += 1
+            elif s == STATUS_OPT_OUT:
+                opt_out += 1
+            else:
+                none_count += 1
+        total = len(rows)
+        return (
+            f"[dim]{total} instances  ·  "
             f"[green]{fresh} fresh[/green]  ·  "
             f"[yellow]{stale} stale[/yellow]  ·  "
             f"{none_count} not probed  ·  "
             f"[red]{opt_out} opted-out[/red][/dim]"
         )
-        self.query_one("#fleet-memory-status", Static).update(status_line)
 
     def _selected_row(self) -> Optional[Dict[str, Any]]:
         table = self.query_one("#fleet-memory-table", DataTable)
@@ -647,6 +674,7 @@ class FleetMemoryScreen(Screen):
 
     def action_refresh_view(self) -> None:
         """Rebuild the table from cached memory state — no SSH probing."""
+        self._refresh_auto_scan_status()
         self._launch_populate()
         self.app.notify("Fleet memory view refreshed.")
 
@@ -697,9 +725,9 @@ class FleetMemoryScreen(Screen):
         try:
             memory_service.clear(row["id"], provider=row["provider"])
         except Exception as exc:  # noqa: BLE001 — UI helper, always recover
-            self.app.notify(f"Clear failed: {exc}", severity="error")
+            self.app.notify(f"Clear failed: {exc}", severity="error", markup=False)
             return
-        self.app.notify(f"Cleared memory for {row['name']}.")
+        self.app.notify(f"Cleared memory for {row['name']}.", markup=False)
         self._populate_table()
 
     def action_scan_all(self) -> None:
@@ -712,8 +740,10 @@ class FleetMemoryScreen(Screen):
         mapping = {
             "btn_scan_all": self.action_scan_all,
             "btn_refresh_stale": self.action_refresh_stale,
+            "btn_refresh_view": self.action_refresh_view,
             "btn_open": self.action_open_selected,
             "btn_clear": self.action_clear_selected,
+            "btn_toggle_auto_scan": self.action_toggle_auto_scan,
         }
         handler = mapping.get(event.button.id or "")
         if handler:
@@ -721,18 +751,47 @@ class FleetMemoryScreen(Screen):
             handler()
 
     # ------------------------------------------------------------------
-    # Bulk scan worker
+    # Bulk scan worker (C6: delegates to FleetScanService)
     # ------------------------------------------------------------------
+
+    def _eligible_instances(
+        self, stale_only: bool, memory_service: Any
+    ) -> List[Dict[str, Any]]:
+        """Return instances the scan should actually probe.
+
+        Delegates to ``FleetScanService.eligible_instances`` when the service
+        is available so the screen and service can't diverge on eligibility
+        rules.  Falls back to an inline computation (same logic) when the
+        service is not wired — used by pre-scan count display and legacy paths.
+        """
+        fleet_scan_service = getattr(self.app, "fleet_scan_service", None)
+        instances = self.app.instances or []
+        if fleet_scan_service is not None:
+            return fleet_scan_service.eligible_instances(
+                instances, stale_only=stale_only
+            )
+        # Inline fallback that mirrors the service logic.
+        eligible: List[Dict[str, Any]] = []
+        for inst in instances:
+            status = compute_memory_status(inst, memory_service)
+            if status == STATUS_OPT_OUT:
+                continue
+            if stale_only and status != STATUS_STALE:
+                continue
+            eligible.append(inst)
+        return eligible
 
     def _launch_bulk_scan(self, stale_only: bool) -> None:
         memory_service = getattr(self.app, "memory_service", None)
         if memory_service is None:
             self.app.notify("Memory subsystem not wired.", severity="error")
             return
-        if self._scanning:
+        if getattr(self.app, "_fleet_manual_scan_in_progress", False):
             self.app.notify("A fleet scan is already in progress.", severity="warning")
             return
 
+        # Show a pre-scan count using eligible_instances so the user knows
+        # what is about to be probed before the worker starts.
         instances = self._eligible_instances(stale_only, memory_service)
         if not instances:
             msg = (
@@ -743,22 +802,27 @@ class FleetMemoryScreen(Screen):
             self.app.notify(msg)
             return
 
-        self._scanning = True
-        self.app.notify(
-            f"Scanning {len(instances)} instance(s) — watch the progress "
-            "line above the table for updates."
-        )
         self._set_progress(
             f"[cyan]Scanning 0 / {len(instances)}[/cyan]  "
             f"[dim](parallel: {_MAX_PARALLEL_FLEET_PROBES})[/dim]"
         )
         logger.info("Fleet scan launched: %d instance(s), stale_only=%s",
                     len(instances), stale_only)
-        self.run_worker(
-            self._do_bulk_scan(instances, memory_service),
-            name="fleet_memory_scan",
-            group="memory_refresh",
-            exclusive=True,
+        # The scan is APP-owned (group "memory_manual_scan") so it SURVIVES
+        # leaving this panel and finishes in the background; progress and the
+        # completion hook are routed back to whichever Fleet Memory screen is
+        # mounted via the app's _fleet_manual_scan_progress / on_fleet_manual_scan_done.
+        started = self.app.start_fleet_manual_scan(
+            self.app.instances or [], stale_only=stale_only
+        )
+        if not started:
+            self._set_progress("")
+            self.app.notify("A fleet scan is already in progress.", severity="warning")
+            return
+        self._scanning = True
+        self.app.notify(
+            f"Scanning {len(instances)} instance(s) in the background — "
+            "you can leave this panel and it will finish."
         )
 
     def _set_progress(self, markup: str) -> None:
@@ -774,111 +838,143 @@ class FleetMemoryScreen(Screen):
             widget.remove_class("hidden")
             widget.update(markup)
 
-    def _eligible_instances(
-        self, stale_only: bool, memory_service: Any
-    ) -> List[Dict[str, Any]]:
-        """Return instances the scan should actually probe.
-
-        ``stale_only=True`` skips fresh and never-probed servers so refresh
-        does only what the operator intended — targeted, not fleet-wide.
-        Opted-out instances are always skipped.
-        """
-        eligible: List[Dict[str, Any]] = []
-        for inst in (self.app.instances or []):
-            status = compute_memory_status(inst, memory_service)
-            if status == STATUS_OPT_OUT:
-                continue
-            if stale_only and status != STATUS_STALE:
-                continue
-            eligible.append(inst)
-        return eligible
-
-    async def _do_bulk_scan(
+    def _on_scan_progress(
         self,
-        instances: List[Dict[str, Any]],
-        memory_service: Any,
+        progress: Any,  # FleetScanProgress from fleet_scan_service
     ) -> None:
-        """Probe every instance in *instances* concurrently (capped).
+        """Progress callback fired by FleetScanService after each probe.
 
-        Drives ``#fleet-memory-progress`` as each probe finishes so the
-        user sees forward motion even when an individual SSH session
-        takes a minute. ``self._scanning`` is reset in ``finally`` so a
-        crash can't leave the screen permanently "busy".
+        Applies demo-mode name redaction (the service uses raw names; redaction
+        is a UI concern), updates the in-page progress line, and triggers a
+        live cell update for the completed instance's row.
         """
-        semaphore = asyncio.Semaphore(_MAX_PARALLEL_FLEET_PROBES)
-        succeeded: List[str] = []
-        failed: List[Dict[str, Any]] = []
-        total = len(instances)
-        completed = 0
-
-        def refresh_progress(just_finished: str, ok: bool) -> None:
-            colour = "green" if ok else "red"
-            self._set_progress(
-                f"[cyan]Scanning {completed} / {total}[/cyan]  "
-                f"·  [{colour}]last: {escape(just_finished)} "
-                f"{'✓' if ok else '✗'}[/{colour}]"
-            )
-
-        async def scan_one(inst: Dict[str, Any]) -> None:
-            nonlocal completed
-            name = inst.get("name") or inst.get("id") or "unknown"
-            # Scrub at source so every downstream consumer (succeeded/failed
-            # lists, refresh_progress footer, and the modal render) is safe.
-            if self.app.demo_mode and self.app.redaction_service:
+        name = progress.instance_name
+        # Demo-mode: scrub the instance name before displaying it.
+        if self.app.demo_mode and self.app.redaction_service:
+            try:
                 name = self.app.redaction_service.redact_name(name)
-            logger.info("Fleet scan: probing %s", name)
-            async with semaphore:
-                ok = False
-                try:
-                    if hasattr(memory_service, "build_report"):
-                        report = await memory_service.build_report(inst)
-                        if report.has_any_success:
-                            succeeded.append(name)
-                            ok = True
-                        else:
-                            failed.append({
-                                "instance": name,
-                                "reason": report.overall_reason or "unknown",
-                                "failures": [
-                                    {"module": f.module, "reason": f.reason,
-                                     "message": f.message}
-                                    for f in report.failures
-                                ],
-                            })
-                    else:
-                        # Fallback for older service instances.
-                        results = await memory_service.refresh(inst)
-                        if results:
-                            succeeded.append(name)
-                            ok = True
-                        else:
-                            failed.append({
-                                "instance": name,
-                                "reason": "no_modules_returned",
-                                "failures": [],
-                            })
-                except asyncio.CancelledError:
-                    # Propagate so asyncio.gather can unwind cleanly.
-                    raise
-                except Exception as exc:  # noqa: BLE001
-                    logger.exception("Fleet scan probe failed for %s", name)
-                    failed.append({
-                        "instance": name,
-                        "reason": "exception",
-                        "failures": [{
-                            "module": "—",
-                            "reason": "exception",
-                            "message": str(exc)[:240],
-                        }],
-                    })
-                finally:
-                    completed += 1
-                    refresh_progress(name, ok)
+            except Exception:
+                pass
+        colour = "green" if progress.succeeded else "red"
+        self._set_progress(
+            f"[cyan]Scanning {progress.completed} / {progress.total}[/cyan]  "
+            f"·  [{colour}]last: {escape(name)} "
+            f"{'✓' if progress.succeeded else '✗'}[/{colour}]"
+        )
+        # Live row update — flip Memory/Modules/Age cells for the just-probed
+        # instance without waiting for the full scan to complete.
+        self._update_row_for_instance(progress.instance_id)
+
+    def _update_row_for_instance(self, instance_id: str) -> None:
+        """Recompute and live-update the table cells for one instance's row.
+
+        Called from :meth:`_on_scan_progress` after each probe completes so
+        the Memory status column flips from Stale→Fresh (or Not probed→Fresh)
+        in real time rather than waiting for the full scan to rebuild the table.
+
+        Args:
+            instance_id: The raw ``id`` value emitted by :class:`FleetScanProgress`.
+                If empty or not found in ``_rows``, the method is a no-op.
+        """
+        if not instance_id or not self._rows:
+            return
+
+        # Find the row index whose raw_id matches the completed instance.
+        # raw_id is stored un-redacted so matching against the service's
+        # instance_id (also un-redacted) is always correct.
+        row_index: Optional[int] = None
+        for i, row in enumerate(self._rows):
+            if row.get("raw_id", row.get("id", "")) == instance_id:
+                row_index = i
+                break
+        if row_index is None:
+            return
+
+        memory_service = getattr(self.app, "memory_service", None)
+        row = self._rows[row_index]
+        inst = row.get("instance") or {"id": instance_id}
+        raw_id = row.get("raw_id", row.get("id", instance_id))
+        raw_provider = row.get("raw_provider", row.get("provider", "custom"))
+
+        # Recompute status using the same helper as the populate paths.
+        new_status = compute_memory_status(inst, memory_service)
+
+        new_modules: Any = row.get("modules", 0)
+        new_age: str = row.get("age", "—")
+        if memory_service is not None and new_status in (STATUS_FRESH, STATUS_STALE):
+            try:
+                mods = memory_service.get_all_modules(raw_id, raw_provider)
+            except Exception:
+                mods = {}
+            if mods:
+                new_modules = len(mods)
+                new_age = _human_age(_latest_probed_at(mods))
+
+        # Update the in-memory row dict so subsequent summary recomputes and
+        # a later action_refresh_view see the current state.
+        row["status"] = new_status
+        row["modules"] = new_modules
+        row["age"] = new_age
+
+        # Update visible table cells (columns 4=status, 5=modules, 7=age).
+        try:
+            table = self.query_one("#fleet-memory-table", DataTable)
+            table.update_cell_at(
+                Coordinate(row_index, 4),
+                _STATUS_CELL.get(new_status, "—"),
+            )
+            table.update_cell_at(
+                Coordinate(row_index, 5),
+                str(new_modules) if new_modules else "—",
+            )
+            table.update_cell_at(
+                Coordinate(row_index, 7),
+                new_age,
+            )
+        except Exception:
+            # Widget may be gone (screen navigated away during scan) — ignore.
+            pass
+
+        # Recompute the summary count line so fresh/stale totals track live.
+        try:
+            self.query_one("#fleet-memory-status", Static).update(
+                self._summary_line_from_rows(self._rows)
+            )
+        except Exception:
+            pass
+
+    async def _do_bulk_scan(self, stale_only: bool, *_legacy_args: Any) -> None:
+        """Delegate the fleet probe to FleetScanService (screen-scoped variant).
+
+        NOTE: the production "Scan All" path is now app-owned via
+        ``ServonautApp.start_fleet_manual_scan`` (so it survives navigation);
+        this method is retained because the demo-mode redaction coverage test
+        drives it directly to exercise the ``_on_scan_progress`` redaction path.
+
+        The service handles concurrency (semaphore) and per-instance error
+        recovery.  This method owns the screen lifecycle around the scan:
+        progress display, scanning flag, post-scan modal, and table refresh.
+
+        ``*_legacy_args`` is accepted but ignored.  It exists solely so that
+        existing unit tests written against an earlier signature (which took
+        ``instances`` and ``memory_service`` as positional args) continue to
+        pass after the scanning logic was extracted into
+        :class:`~servonaut.services.memory.fleet_scan_service.FleetScanService`.
+        """
+        fleet_scan_service = getattr(self.app, "fleet_scan_service", None)
+        if fleet_scan_service is None:
+            self._scanning = False
+            self.app.notify("Fleet scan service not available.", severity="error")
+            return
 
         try:
-            await asyncio.gather(*(scan_one(i) for i in instances))
+            result = await fleet_scan_service.scan(
+                self.app.instances or [],
+                stale_only=stale_only,
+                on_progress=self._on_scan_progress,
+            )
         except asyncio.CancelledError:
-            logger.info("Fleet scan cancelled after %d/%d", completed, total)
+            logger.info("Fleet scan cancelled")
             self._set_progress("")
             self._scanning = False
             self.app.notify("Fleet scan cancelled.", severity="warning")
@@ -890,6 +986,7 @@ class FleetMemoryScreen(Screen):
             self.app.notify(
                 f"Fleet scan crashed: {exc}",
                 severity="error",
+                markup=False,
             )
             return
         finally:
@@ -898,9 +995,113 @@ class FleetMemoryScreen(Screen):
                 self._scanning = False
 
         self._set_progress("")
+        self._refresh_auto_scan_status()
         self._launch_populate()
         self.app.notify(
-            f"Fleet scan done: {len(succeeded)} ok, {len(failed)} failed."
+            f"Fleet scan done: {len(result.succeeded)} ok, "
+            f"{len(result.failed)} failed."
         )
-        if failed:
-            self.app.push_screen(FleetScanSummaryModal(succeeded, failed))
+        if result.failed:
+            self.app.push_screen(
+                FleetScanSummaryModal(result.succeeded, result.failed)
+            )
+
+    def on_fleet_manual_scan_done(self, result: Any) -> None:
+        """Completion hook invoked by the app-owned manual scan worker.
+
+        The app calls this (duck-typed) when an app-owned manual fleet scan
+        finishes AND this screen is the one currently mounted — so a scan the
+        user launched then navigated away from still updates the table when
+        they return.  The app already emits the "scan done" toast; this only
+        refreshes the view and surfaces the failure summary.
+        """
+        self._scanning = False
+        self._set_progress("")
+        self._refresh_auto_scan_status()
+        self._launch_populate()
+        if getattr(result, "failed", None):
+            self.app.push_screen(
+                FleetScanSummaryModal(result.succeeded, result.failed)
+            )
+
+    # ------------------------------------------------------------------
+    # C5: Auto-scan status indicator + quick toggle
+    # ------------------------------------------------------------------
+
+    def _auto_scan_status_text(self) -> str:
+        """Return the Rich-markup string describing current auto-scan state.
+
+        ON:  ``[green]● Auto-scan on · next in ~Xh[/green]``
+             (or ``· scheduled`` when never run).
+        OFF: ``[dim]○ Auto-scan off[/dim]``.
+
+        No live-ticking timer — recomputed on mount, after refresh-view,
+        and after a manual scan.
+        """
+        config_manager = getattr(self.app, "config_manager", None)
+        if config_manager is None:
+            return "[dim]○ Auto-scan off[/dim]"
+        cfg = config_manager.get()
+        memory_cfg = getattr(cfg, "memory", None)
+        if memory_cfg is None or not memory_cfg.enabled or not memory_cfg.auto_scan_enabled:
+            return "[dim]○ Auto-scan off[/dim]"
+
+        last_run = getattr(self.app, "_fleet_auto_scan_last_run", 0.0)
+        interval = getattr(memory_cfg, "auto_scan_interval_seconds", 86400)
+
+        if last_run == 0.0:
+            return "[green]● Auto-scan on · scheduled[/green]"
+
+        seconds_until = max(0.0, (last_run + interval) - time.time())
+        hours_until = int(seconds_until // 3600)
+        return f"[green]● Auto-scan on · next in ~{hours_until}h[/green]"
+
+    def _refresh_auto_scan_status(self) -> None:
+        """Update the ``#fleet-auto-scan-status`` widget with current state."""
+        try:
+            widget = self.query_one("#fleet-auto-scan-status", Static)
+        except Exception:
+            return
+        widget.update(self._auto_scan_status_text())
+
+    def action_toggle_auto_scan(self) -> None:
+        """Flip ``config.memory.auto_scan_enabled`` and persist.
+
+        On enable: calls ``app._refresh_fleet_auto_scan_loop()`` which spawns
+        the loop worker (idempotent via exclusive=True group).
+        On disable: calls ``app._refresh_fleet_auto_scan_loop()`` which cancels
+        the ``memory_auto_scan`` worker group promptly.
+        """
+        config_manager = getattr(self.app, "config_manager", None)
+        if config_manager is None:
+            self.app.notify("Configuration not available.", severity="error")
+            return
+
+        cfg = config_manager.get()
+        memory_cfg = getattr(cfg, "memory", None)
+        if memory_cfg is None:
+            self.app.notify("Memory config not available.", severity="error")
+            return
+
+        new_enabled = not memory_cfg.auto_scan_enabled
+        updated_memory = dataclasses.replace(
+            memory_cfg, auto_scan_enabled=new_enabled
+        )
+        try:
+            config_manager.update(memory=updated_memory)
+        except Exception as exc:  # noqa: BLE001
+            self.app.notify(f"Failed to save config: {exc}", severity="error", markup=False)
+            return
+
+        if new_enabled:
+            interval_h = max(1, getattr(updated_memory, "auto_scan_interval_seconds", 86400) // 3600)
+            self.app.notify(f"Auto-scan enabled — runs every ~{interval_h}h.")
+        else:
+            self.app.notify("Auto-scan disabled.")
+
+        # Start or cancel the loop promptly based on the new flag.
+        refresh_loop = getattr(self.app, "_refresh_fleet_auto_scan_loop", None)
+        if refresh_loop is not None:
+            refresh_loop()
+
+        self._refresh_auto_scan_status()

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -34,18 +34,25 @@ from textual.widgets import Button, DataTable, Footer, Header, Static
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.widgets.sidebar import Sidebar
 
+# Status constants and classifier live in the dependency-free service module
+# so that both the fleet scan service and this screen share one implementation.
+# Re-exported here so existing importers (widgets/instance_table, tests, …)
+# that do ``from servonaut.screens.fleet_memory import STATUS_*`` keep working.
+from servonaut.services.memory.status import (
+    STATUS_FRESH,
+    STATUS_STALE,
+    STATUS_NONE,
+    STATUS_OPT_OUT,
+    compute_memory_status,
+    snapshot_age_seconds,
+    _latest_probed_at,
+    _resolve_stale_threshold,
+)
+
 if TYPE_CHECKING:  # pragma: no cover
     from servonaut.app import ServonautApp
 
 logger = logging.getLogger(__name__)
-
-
-# Status codes + icons rendered in the Memory column.  Kept as module
-# constants so the instance_list widget can reuse the same vocabulary.
-STATUS_FRESH = "fresh"
-STATUS_STALE = "stale"
-STATUS_NONE = "none"
-STATUS_OPT_OUT = "opted-out"
 
 _STATUS_CELL: Dict[str, str] = {
     STATUS_FRESH: "[green]● Fresh[/green]",
@@ -69,7 +76,7 @@ _MAX_PARALLEL_FLEET_PROBES = 4
 
 
 # ---------------------------------------------------------------------------
-# Helpers (memory status + formatting)
+# Helpers (formatting — screen-local only)
 # ---------------------------------------------------------------------------
 
 
@@ -91,94 +98,6 @@ def _human_age(probed_at_str: str) -> str:
         return f"{int(age // 86400)}d ago"
     except (ValueError, TypeError):
         return "—"
-
-
-def compute_memory_status(
-    instance: Dict[str, Any],
-    memory_service: Any,
-) -> str:
-    """Return one of the STATUS_* codes for *instance*.
-
-    A server's whole memory is reported ``STATUS_STALE`` once its newest
-    probe is older than the server-level threshold
-    (``MemoryService.snapshot_stale_seconds``). This is deliberately
-    decoupled from per-module TTLs — volatile modules (containers, disk)
-    re-probe fast by design and must not drag the whole-server badge.
-
-    Reuses the memory service's public API only — no ``_store`` reach-in.
-    Defensive against missing services so callers (instance_list column,
-    fleet table) never raise from UI code paths.
-    """
-    if memory_service is None:
-        return STATUS_NONE
-
-    iid = instance.get("id") or instance.get("name", "")
-    iname = instance.get("name", "")
-    provider = instance.get("provider", "custom")
-    if not iid:
-        return STATUS_NONE
-
-    try:
-        if memory_service.is_memory_disabled(iid, iname):
-            return STATUS_OPT_OUT
-    except Exception:
-        pass
-
-    try:
-        modules = memory_service.get_all_modules(iid, provider)
-    except Exception:
-        modules = {}
-    if not modules:
-        return STATUS_NONE
-
-    age = snapshot_age_seconds(modules)
-    threshold = _resolve_stale_threshold(memory_service)
-    if age is None or age > threshold:
-        return STATUS_STALE
-    return STATUS_FRESH
-
-
-def _latest_probed_at(modules: Dict[str, Any]) -> str:
-    """Return the most recent ``probed_at`` across *modules*, or ``""``."""
-    latest = ""
-    for mod in modules.values():
-        probed_at = mod.get("probed_at", "") if isinstance(mod, dict) else ""
-        if probed_at and probed_at > latest:
-            latest = probed_at
-    return latest
-
-
-def snapshot_age_seconds(modules: Dict[str, Any]) -> Optional[float]:
-    """Return the age in seconds of the most recent probe across *modules*.
-
-    Returns ``None`` when *modules* is empty or carries no parseable
-    ``probed_at`` timestamp — callers treat that as "stale / unknown".
-    """
-    latest = _latest_probed_at(modules)
-    if not latest:
-        return None
-    try:
-        probed_at = datetime.fromisoformat(latest.rstrip("Z"))
-        if not probed_at.tzinfo:
-            probed_at = probed_at.replace(tzinfo=timezone.utc)
-    except (ValueError, TypeError):
-        return None
-    return (datetime.now(tz=timezone.utc) - probed_at).total_seconds()
-
-
-def _resolve_stale_threshold(memory_service: Any) -> float:
-    """Return the server-level staleness threshold in seconds.
-
-    Reads ``MemoryService.snapshot_stale_seconds`` and falls back to the
-    schema default when the service does not expose a usable numeric value
-    (e.g. lightweight test doubles).
-    """
-    from servonaut.config.schema import DEFAULT_SNAPSHOT_STALE_SECONDS
-
-    val = getattr(memory_service, "snapshot_stale_seconds", None)
-    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
-        return float(val)
-    return float(DEFAULT_SNAPSHOT_STALE_SECONDS)
 
 
 # ---------------------------------------------------------------------------
@@ -792,6 +711,13 @@ class FleetMemoryScreen(Screen):
 
         # Show a pre-scan count using eligible_instances so the user knows
         # what is about to be probed before the worker starts.
+        # NOTE: start_fleet_manual_scan → fleet_scan_service.scan() will
+        # call eligible_instances() a second time internally.  The double
+        # pass is intentional: the count here is purely for the notification
+        # toast; avoiding it would require passing the pre-filtered list
+        # through start_fleet_manual_scan's interface, which adds API surface
+        # for a minor optimisation (disk reads, not SSH).  If this becomes
+        # measurable on very large fleets, hoist the list and thread it through.
         instances = self._eligible_instances(stale_only, memory_service)
         if not instances:
             msg = (
@@ -882,6 +808,11 @@ class FleetMemoryScreen(Screen):
         # Find the row index whose raw_id matches the completed instance.
         # raw_id is stored un-redacted so matching against the service's
         # instance_id (also un-redacted) is always correct.
+        # ASSUMPTION: raw_id is unique across rows.  Two custom servers with
+        # no id and the same name would both have raw_id == name and only the
+        # first would receive the live update.  The instance-list enforces
+        # unique IDs (AWS: instance-id; custom: user-assigned name), so this
+        # degenerate case should never arise in practice.
         row_index: Optional[int] = None
         for i, row in enumerate(self._rows):
             if row.get("raw_id", row.get("id", "")) == instance_id:

--- a/src/servonaut/screens/memory_keys.py
+++ b/src/servonaut/screens/memory_keys.py
@@ -1,20 +1,21 @@
 """PassphraseEnrolModal — prompts the user to choose an encryption passphrase.
 
 Used by ``_prompt_memory_passphrase`` in ``app.py`` when the memory keypair
-has not been enrolled yet.  Returns the passphrase string on confirmation, or
-``None`` on cancellation.
+has not been enrolled yet.  Returns a :class:`PassphraseResult` on
+confirmation, or ``None`` on cancellation.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
 from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Input, Static, Switch
 
 logger = logging.getLogger(__name__)
 
@@ -23,19 +24,37 @@ _STRENGTH_LABEL = ["Very weak", "Weak", "Fair", "Strong", "Very strong"]
 _STRENGTH_COLOR = ["red", "red", "yellow", "green", "green"]
 
 
-class PassphraseEnrolModal(ModalScreen[Optional[str]]):
+@dataclass
+class PassphraseResult:
+    """Result returned by :class:`PassphraseEnrolModal` on confirmation.
+
+    Attributes:
+        passphrase: The confirmed passphrase string.
+        remember: Whether the user opted in to storing the passphrase in
+            the OS keychain (only ever ``True`` when the keychain is
+            actually available on this device).
+    """
+
+    passphrase: str
+    remember: bool = False
+
+
+class PassphraseEnrolModal(ModalScreen[Optional[PassphraseResult]]):
     """Modal dialog for enrolling the memory-sync encryption passphrase.
 
     Compose: title, blurb, two password inputs, live strength readout,
-    Cancel and Enrol buttons.  The Enrol button is disabled until the score
-    is >= 3 AND both inputs match.
+    optional "Remember on this device" switch (keychain opt-in), Cancel
+    and Enrol buttons.  The Enrol button is disabled until the score
+    is >= 3 AND both inputs match (enrol mode) or any input is present
+    (unlock mode).
 
     Args:
         mode: ``"enrol"`` (create new keypair) or ``"unlock"`` (enter
               existing passphrase to unwrap a stored keypair).
 
     Returns via dismiss():
-        Passphrase string on confirmation, or ``None`` on cancellation.
+        :class:`PassphraseResult` on confirmation, or ``None`` on
+        cancellation.
     """
 
     DEFAULT_CSS = """
@@ -80,9 +99,22 @@ class PassphraseEnrolModal(ModalScreen[Optional[str]]):
         color: $error;
     }
 
+    #enrol-remember-row {
+        height: auto;
+        align: left middle;
+        padding: 0 0 1 0;
+    }
+
+    #enrol-remember-label {
+        width: auto;
+        padding: 0 1 0 0;
+        color: $text-muted;
+    }
+
     #enrol-pass2.hidden,
     #enrol-strength.hidden,
-    #enrol-mismatch.hidden {
+    #enrol-mismatch.hidden,
+    #enrol-remember-row.hidden {
         display: none;
         height: 0;
     }
@@ -107,6 +139,13 @@ class PassphraseEnrolModal(ModalScreen[Optional[str]]):
     def __init__(self, mode: str = "enrol") -> None:
         super().__init__()
         self._mode = mode
+        # Lazily check keychain availability at construction time.  Using a
+        # lazy import avoids a hard dep on keyring at module load.
+        try:
+            from servonaut.services.memory import passphrase_store as _ps
+            self._remember_available = _ps.keyring_available()
+        except Exception:
+            self._remember_available = False
 
     def compose(self) -> ComposeResult:
         is_enrol = self._mode == "enrol"
@@ -122,6 +161,7 @@ class PassphraseEnrolModal(ModalScreen[Optional[str]]):
             else "[dim]Enter your passphrase to decrypt the stored keypair.[/dim]"
         )
         btn_label = "Enrol" if is_enrol else "Unlock"
+        remember_classes = "" if self._remember_available else "hidden"
         yield Container(
             Static(title, id="enrol-title"),
             Static(blurb, id="enrol-blurb"),
@@ -134,6 +174,15 @@ class PassphraseEnrolModal(ModalScreen[Optional[str]]):
             ),
             Static("Strength: —", id="enrol-strength", classes="" if is_enrol else "hidden"),
             Static("", id="enrol-mismatch", classes="" if is_enrol else "hidden"),
+            Horizontal(
+                Static(
+                    "Remember on this device (auto-unlock)",
+                    id="enrol-remember-label",
+                ),
+                Switch(value=False, id="enrol-remember"),
+                id="enrol-remember-row",
+                classes=remember_classes,
+            ),
             Horizontal(
                 Button("Cancel", variant="default", id="enrol-btn-cancel"),
                 Button(btn_label, variant="primary", id="enrol-btn-confirm", disabled=True),
@@ -198,7 +247,15 @@ class PassphraseEnrolModal(ModalScreen[Optional[str]]):
         if btn.disabled:
             return
         passphrase = self.query_one("#enrol-pass1", Input).value
-        self.dismiss(passphrase if passphrase else None)
+        if not passphrase:
+            return
+        remember = False
+        if self._remember_available:
+            try:
+                remember = bool(self.query_one("#enrol-remember", Switch).value)
+            except Exception:
+                remember = False
+        self.dismiss(PassphraseResult(passphrase=passphrase, remember=remember))
 
     def action_cancel(self) -> None:
         self.dismiss(None)

--- a/src/servonaut/screens/memory_sync_setup.py
+++ b/src/servonaut/screens/memory_sync_setup.py
@@ -254,6 +254,28 @@ class MemorySyncSetupScreen(Screen):
             except Exception:
                 fingerprint = "loaded"
 
+        # Auto-unlock status — read from config (no network needed).
+        auto_unlock_label = "off"
+        is_remembered = False
+        try:
+            cfg = self.app.config_manager.get()
+            is_remembered = bool(
+                getattr(cfg.memory, "sync_remember_device", False)
+            )
+            auto_unlock_label = "on" if is_remembered else "off"
+        except Exception:
+            pass
+
+        actions_children: list = [
+            Button("Sync now", variant="primary", id="msync_btn_sync_now"),
+            Button("Rotate keypair", id="msync_btn_rotate"),
+            Button("Disable sync", variant="warning", id="msync_btn_disable"),
+        ]
+        if is_remembered:
+            actions_children.append(
+                Button("Forget on this device", id="msync_btn_forget")
+            )
+
         return Container(
             Container(
                 Static("[bold]Status[/bold]", classes="msync_card_title"),
@@ -262,6 +284,7 @@ class MemorySyncSetupScreen(Screen):
                     self._kv_row("Quota used", f"{used} / {soft_cap} envelopes"),
                     self._kv_row("Pending", f"{pending} envelope(s)"),
                     self._kv_row("Key fingerprint", fingerprint),
+                    self._kv_row("Auto-unlock", auto_unlock_label),
                     classes="msync_kv_grid",
                 ),
                 classes="msync_card msync_card_primary",
@@ -269,9 +292,7 @@ class MemorySyncSetupScreen(Screen):
             Container(
                 Static("[bold]Actions[/bold]", classes="msync_card_title"),
                 Horizontal(
-                    Button("Sync now", variant="primary", id="msync_btn_sync_now"),
-                    Button("Rotate keypair", id="msync_btn_rotate"),
-                    Button("Disable sync", variant="warning", id="msync_btn_disable"),
+                    *actions_children,
                     classes="msync_card_actions",
                 ),
                 Static(
@@ -341,6 +362,8 @@ class MemorySyncSetupScreen(Screen):
             )
         elif bid == "msync_btn_disable":
             self._do_disable()
+        elif bid == "msync_btn_forget":
+            self._do_forget()
 
     @staticmethod
     def _open_url(url: str) -> None:
@@ -588,20 +611,46 @@ class MemorySyncSetupScreen(Screen):
         if sync is None or not sync.is_configured:
             return
         from servonaut.screens.memory_keys import PassphraseEnrolModal
-        old_pp = await self.app.push_screen_wait(PassphraseEnrolModal(mode="unlock"))
-        if not old_pp:
+        old_result = await self.app.push_screen_wait(
+            PassphraseEnrolModal(mode="unlock")
+        )
+        if old_result is None:
             return
-        new_pp = await self.app.push_screen_wait(PassphraseEnrolModal(mode="enrol"))
-        if not new_pp:
+        new_result = await self.app.push_screen_wait(
+            PassphraseEnrolModal(mode="enrol")
+        )
+        if new_result is None:
             return
         self._set_busy("Rotating keypair — this re-derives the wrap (~1s)…")
         try:
-            await sync.rotate_keypair(old_pp, new_pp)
+            await sync.rotate_keypair(old_result.passphrase, new_result.passphrase)
         except Exception as exc:
             self._clear_busy()
             self._show_setup_error(exc)
             return
         self._clear_busy()
+        # The old passphrase in the OS keychain (if any) is now invalid —
+        # clear it.  If the user opted to remember the new one, store it.
+        try:
+            import dataclasses as _dc
+            from servonaut.services.memory import passphrase_store
+            passphrase_store.clear_passphrase()
+            if new_result.remember and passphrase_store.keyring_available():
+                passphrase_store.store_passphrase(new_result.passphrase)
+                # MAJOR-3: mirror what _prompt_memory_passphrase does — set the
+                # remember flag in config so the status card and startup path
+                # both see it as enabled.
+                cfg = self.app.config_manager.get()
+                updated_mem = _dc.replace(cfg.memory, sync_remember_device=True)
+                self.app.config_manager.update(memory=updated_mem)
+            else:
+                # Make sure the remember flag is cleared in config so the
+                # stale keychain entry is not attempted on the next startup.
+                cfg = self.app.config_manager.get()
+                updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+                self.app.config_manager.update(memory=updated_mem)
+        except Exception as exc:
+            logger.warning("_do_rotate: keychain update failed: %s", exc)
         self.app.notify("Keypair rotated.", severity="information")
         self._render_state()
 
@@ -615,10 +664,49 @@ class MemorySyncSetupScreen(Screen):
             logger.warning("sync.stop failed: %s", exc)
         # Drop the in-memory keypair so the service flips back to "not configured".
         # The encrypted data on the server is untouched — re-enrol any time.
+        # M12: use the public lock() method instead of poking private attrs
+        # directly (per the project's memory-encapsulation convention).
         try:
-            sync._self_pubkey = None  # type: ignore[attr-defined]
-            sync._self_privkey = None  # type: ignore[attr-defined]
+            if hasattr(sync, "lock"):
+                sync.lock()
+            else:
+                # Fallback for any stub/mock that hasn't been updated yet.
+                sync._self_pubkey = None  # type: ignore[attr-defined]
+                sync._self_privkey = None  # type: ignore[attr-defined]
         except Exception:
             pass
+        # Clear the local keypair cache so the startup reactivation path
+        # does not silently re-unlock sync on the next launch.
+        try:
+            sync.clear_local_keypair_cache()
+        except Exception as exc:
+            logger.warning("_do_disable: clear_local_keypair_cache failed: %s", exc)
+        # Clear keychain passphrase and remember flag so there is no stale
+        # credential left behind.
+        self._do_forget(notify=False)
         self.app.notify("Memory Sync disabled on this device.")
+        self._render_state()
+
+    def _do_forget(self, *, notify: bool = True) -> None:
+        """Clear the stored keychain passphrase and the sync_remember_device flag.
+
+        Called by "Forget on this device" button and as part of ``_do_disable``.
+        """
+        try:
+            from servonaut.services.memory import passphrase_store
+            passphrase_store.clear_passphrase()
+        except Exception as exc:
+            logger.warning("_do_forget: clear_passphrase failed: %s", exc)
+        try:
+            import dataclasses as _dc
+            cfg = self.app.config_manager.get()
+            updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+            self.app.config_manager.update(memory=updated_mem)
+        except Exception as exc:
+            logger.warning("_do_forget: config update failed: %s", exc)
+        if notify:
+            self.app.notify(
+                "Passphrase forgotten — you will be prompted on next launch.",
+                severity="information",
+            )
         self._render_state()

--- a/src/servonaut/screens/memory_sync_setup.py
+++ b/src/servonaut/screens/memory_sync_setup.py
@@ -262,7 +262,26 @@ class MemorySyncSetupScreen(Screen):
             is_remembered = bool(
                 getattr(cfg.memory, "sync_remember_device", False)
             )
-            auto_unlock_label = "on" if is_remembered else "off"
+            if is_remembered:
+                auto_unlock_label = "on"
+                # Surface the remember TTL so the user knows when they'll be
+                # asked to re-enter the passphrase.
+                raw_exp = getattr(cfg.memory, "sync_remember_expires_at", "") or ""
+                if raw_exp:
+                    try:
+                        from datetime import datetime, timezone
+                        exp = datetime.fromisoformat(raw_exp)
+                        if exp.tzinfo is None:
+                            exp = exp.replace(tzinfo=timezone.utc)
+                        days_left = (exp - datetime.now(timezone.utc)).days
+                        if days_left < 0:
+                            auto_unlock_label = "on (expired — will re-prompt)"
+                        else:
+                            auto_unlock_label = f"on (re-prompt in {days_left}d)"
+                    except Exception:
+                        pass
+            else:
+                auto_unlock_label = "off"
         except Exception:
             pass
 
@@ -638,16 +657,30 @@ class MemorySyncSetupScreen(Screen):
             if new_result.remember and passphrase_store.keyring_available():
                 passphrase_store.store_passphrase(new_result.passphrase)
                 # MAJOR-3: mirror what _prompt_memory_passphrase does — set the
-                # remember flag in config so the status card and startup path
-                # both see it as enabled.
+                # remember flag AND refresh the TTL so the status card, startup
+                # path, and expiry check all agree.
+                from datetime import datetime, timedelta, timezone
+                from servonaut.config.schema import DEFAULT_REMEMBER_TTL_DAYS
+                expires_at = (
+                    datetime.now(timezone.utc)
+                    + timedelta(days=DEFAULT_REMEMBER_TTL_DAYS)
+                ).isoformat()
                 cfg = self.app.config_manager.get()
-                updated_mem = _dc.replace(cfg.memory, sync_remember_device=True)
+                updated_mem = _dc.replace(
+                    cfg.memory,
+                    sync_remember_device=True,
+                    sync_remember_expires_at=expires_at,
+                )
                 self.app.config_manager.update(memory=updated_mem)
             else:
                 # Make sure the remember flag is cleared in config so the
                 # stale keychain entry is not attempted on the next startup.
                 cfg = self.app.config_manager.get()
-                updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+                updated_mem = _dc.replace(
+                    cfg.memory,
+                    sync_remember_device=False,
+                    sync_remember_expires_at="",
+                )
                 self.app.config_manager.update(memory=updated_mem)
         except Exception as exc:
             logger.warning("_do_rotate: keychain update failed: %s", exc)
@@ -700,7 +733,11 @@ class MemorySyncSetupScreen(Screen):
         try:
             import dataclasses as _dc
             cfg = self.app.config_manager.get()
-            updated_mem = _dc.replace(cfg.memory, sync_remember_device=False)
+            updated_mem = _dc.replace(
+                cfg.memory,
+                sync_remember_device=False,
+                sync_remember_expires_at="",
+            )
             self.app.config_manager.update(memory=updated_mem)
         except Exception as exc:
             logger.warning("_do_forget: config update failed: %s", exc)

--- a/src/servonaut/screens/settings/panels/memory.py
+++ b/src/servonaut/screens/settings/panels/memory.py
@@ -137,6 +137,18 @@ class MemoryPanel(SettingsPanel):
             classes="setting_row",
         )
 
+        # ---- Background automation -----------------------------------
+        yield Static("Background automation", classes="memory-section-label")
+        yield Horizontal(
+            Static("Background fleet auto-scan", classes="label"),
+            Switch(id="memory_auto_scan_enabled"),
+            classes="setting_row",
+        )
+        yield Horizontal(
+            Static("Auto-scan interval (seconds)", classes="label"),
+            Input(placeholder="86400", id="memory_auto_scan_interval"),
+            classes="setting_row",
+        )
         # ---- Agent findings ------------------------------------------
         yield Static("Agent findings", classes="memory-section-label")
         yield Horizontal(
@@ -209,6 +221,12 @@ class MemoryPanel(SettingsPanel):
             mem.first_connect_reprompt_seconds
         )
 
+        # Background automation
+        self.query_one("#memory_auto_scan_enabled", Switch).value = mem.auto_scan_enabled
+        self.query_one("#memory_auto_scan_interval", Input).value = str(
+            mem.auto_scan_interval_seconds
+        )
+
         # Agent findings
         self.query_one("#memory_findings_sync", Switch).value = mem.findings_sync_enabled
         self.query_one("#memory_findings_confidence", Input).value = str(
@@ -267,6 +285,12 @@ class MemoryPanel(SettingsPanel):
             "findings_index_char_cap": self.query_one(
                 "#memory_findings_index_char_cap", Input
             ).value.strip(),
+            "auto_scan_enabled": self.query_one(
+                "#memory_auto_scan_enabled", Switch
+            ).value,
+            "auto_scan_interval_seconds": self.query_one(
+                "#memory_auto_scan_interval", Input
+            ).value.strip(),
         }
 
     # ------------------------------------------------------------------
@@ -301,6 +325,21 @@ class MemoryPanel(SettingsPanel):
             raise ValidationError(
                 "memory_first_connect_reprompt",
                 f"First-connect reprompt must be at most {_MAX_SECONDS} seconds.",
+            )
+
+        # auto_scan_interval_seconds
+        auto_scan_interval_raw = self.query_one(
+            "#memory_auto_scan_interval", Input
+        ).value.strip()
+        auto_scan_interval = self._parse_non_negative_int(
+            auto_scan_interval_raw,
+            "memory_auto_scan_interval",
+            "Auto-scan interval",
+        )
+        if auto_scan_interval < 60 or auto_scan_interval > _MAX_SECONDS:
+            raise ValidationError(
+                "memory_auto_scan_interval",
+                f"Auto-scan interval must be between 60 and {_MAX_SECONDS} seconds.",
             )
 
         # findings_confidence_threshold
@@ -363,6 +402,10 @@ class MemoryPanel(SettingsPanel):
             ).value,
             "findings_confidence_threshold": confidence,
             "findings_index_char_cap": char_cap,
+            "auto_scan_enabled": self.query_one(
+                "#memory_auto_scan_enabled", Switch
+            ).value,
+            "auto_scan_interval_seconds": auto_scan_interval,
         }
 
     # ------------------------------------------------------------------
@@ -392,6 +435,8 @@ class MemoryPanel(SettingsPanel):
             findings_sync_enabled=fields["findings_sync_enabled"],
             findings_confidence_threshold=fields["findings_confidence_threshold"],
             findings_index_char_cap=fields["findings_index_char_cap"],
+            auto_scan_enabled=fields["auto_scan_enabled"],
+            auto_scan_interval_seconds=fields["auto_scan_interval_seconds"],
             # per_server_overrides is intentionally preserved from existing_mem
         )
 
@@ -399,6 +444,9 @@ class MemoryPanel(SettingsPanel):
             memory=updated_mem,
             sync_encryption_enabled=fields["sync_encryption_enabled"],
         )
+        # Start or cancel the fleet auto-scan loop based on the saved settings
+        # so toggling auto-scan in Settings takes effect immediately.
+        getattr(self.app, "_refresh_fleet_auto_scan_loop", lambda: None)()
         self._finish_save()
 
     # ------------------------------------------------------------------

--- a/src/servonaut/screens/settings/panels/memory_sync.py
+++ b/src/servonaut/screens/settings/panels/memory_sync.py
@@ -133,6 +133,11 @@ class MemorySyncPanel(SettingsPanel):
                 classes="setting_row",
             ),
             Horizontal(
+                Static("Auto-sync memory to cloud", classes="label"),
+                Switch(value=False, id="settings_msync_auto_sync"),
+                classes="setting_row",
+            ),
+            Horizontal(
                 Static("AI Consent Mode", classes="label"),
                 Select(
                     _AI_CONSENT_OPTIONS,
@@ -195,10 +200,12 @@ class MemorySyncPanel(SettingsPanel):
         """
         digest = self.query_one("#settings_msync_digest", Select).value
         mercure = self.query_one("#settings_msync_mercure", Switch).value
+        auto_sync = self.query_one("#settings_msync_auto_sync", Switch).value
         ai_mode = self.query_one("#settings_msync_ai_mode", Select).value
         return {
             "digest": digest if digest is not _SELECT_BLANK else "off",
             "mercure": bool(mercure),
+            "auto_sync": bool(auto_sync),
             "ai_mode": ai_mode if ai_mode is not _SELECT_BLANK else "off",
         }
 
@@ -222,6 +229,7 @@ class MemorySyncPanel(SettingsPanel):
             digest_val = self.query_one("#settings_msync_digest", Select).value
             digest = digest_val if digest_val is not _SELECT_BLANK else "off"
             mercure = bool(self.query_one("#settings_msync_mercure", Switch).value)
+            auto_sync = bool(self.query_one("#settings_msync_auto_sync", Switch).value)
             ai_mode_val = self.query_one("#settings_msync_ai_mode", Select).value
             ai_mode = ai_mode_val if ai_mode_val is not _SELECT_BLANK else "off"
         except Exception:
@@ -229,6 +237,7 @@ class MemorySyncPanel(SettingsPanel):
         return (
             digest != (getattr(orig, "digest_frequency", "off") or "off")
             or mercure != bool(getattr(orig, "mercure_push_enabled", False))
+            or auto_sync != bool(getattr(orig, "auto_sync_enabled", False))
             or ai_mode != (getattr(orig, "ai_consent_mode", "off") or "off")
         )
 
@@ -240,6 +249,7 @@ class MemorySyncPanel(SettingsPanel):
             return {
                 "digest": digest_val if digest_val is not _SELECT_BLANK else "off",
                 "mercure": bool(self.query_one("#settings_msync_mercure", Switch).value),
+                "auto_sync": bool(self.query_one("#settings_msync_auto_sync", Switch).value),
                 "ai_mode": ai_val if ai_val is not _SELECT_BLANK else "off",
             }
         except Exception:
@@ -327,6 +337,7 @@ class MemorySyncPanel(SettingsPanel):
         for widget_id in (
             "#settings_msync_digest",
             "#settings_msync_mercure",
+            "#settings_msync_auto_sync",
             "#settings_msync_ai_mode",
             "#btn_msync_save",
             "#btn_msync_reload",
@@ -387,6 +398,9 @@ class MemorySyncPanel(SettingsPanel):
             self.query_one("#settings_msync_mercure", Switch).value = bool(
                 getattr(settings, "mercure_push_enabled", False)
             )
+            self.query_one("#settings_msync_auto_sync", Switch).value = bool(
+                getattr(settings, "auto_sync_enabled", False)
+            )
             self.query_one("#settings_msync_ai_mode", Select).value = (
                 getattr(settings, "ai_consent_mode", "off") or "off"
             )
@@ -407,6 +421,7 @@ class MemorySyncPanel(SettingsPanel):
             digest_val = self.query_one("#settings_msync_digest", Select).value
             digest = digest_val if digest_val is not _SELECT_BLANK else "off"
             mercure = bool(self.query_one("#settings_msync_mercure", Switch).value)
+            auto_sync = bool(self.query_one("#settings_msync_auto_sync", Switch).value)
             ai_val = self.query_one("#settings_msync_ai_mode", Select).value
             ai_mode = ai_val if ai_val is not _SELECT_BLANK else "off"
         except Exception as exc:
@@ -419,6 +434,8 @@ class MemorySyncPanel(SettingsPanel):
             delta["digest_frequency"] = digest
         if orig is None or bool(getattr(orig, "mercure_push_enabled", False)) != bool(mercure):
             delta["mercure_push_enabled"] = bool(mercure)
+        if auto_sync != bool(getattr(orig, "auto_sync_enabled", False) if orig is not None else False):
+            delta["auto_sync_enabled"] = auto_sync
         if ai_mode and (orig is None or getattr(orig, "ai_consent_mode", None) != ai_mode):
             delta["ai_consent_mode"] = ai_mode
 
@@ -441,6 +458,12 @@ class MemorySyncPanel(SettingsPanel):
         self._populate_from_settings(updated)
         self._set_status("[$success]● Saved[/$success]")
         self.app.notify("Memory Sync settings saved.", severity="information", markup=False)
+
+        # Re-evaluate the drain loop now that auto_sync_enabled may have changed.
+        # guarded with getattr so a test host or older app version can't crash the save.
+        refresh_fn = getattr(self.app, "_refresh_memory_sync_loop", None)
+        if refresh_fn is not None:
+            await refresh_fn()
 
     def _surface_validation_errors(self, exc: Any) -> None:
         """Notify the user of each per-field validation error from the server."""

--- a/src/servonaut/services/memory/__init__.py
+++ b/src/servonaut/services/memory/__init__.py
@@ -64,6 +64,17 @@ except ImportError:  # pragma: no cover — Stream 2 TODO
     FleetService = None  # type: ignore[assignment,misc]
 
 try:
+    from .fleet_scan_service import (  # type: ignore[attr-defined]
+        FleetScanService,
+        FleetScanResult,
+        FleetScanProgress,
+    )
+except ImportError:  # pragma: no cover
+    FleetScanService = None  # type: ignore[assignment,misc]
+    FleetScanResult = None  # type: ignore[assignment,misc]
+    FleetScanProgress = None  # type: ignore[assignment,misc]
+
+try:
     from .settings_service import MemorySettingsService  # type: ignore[attr-defined]  # Stream 2 TODO
 except ImportError:  # pragma: no cover — Stream 2 TODO
     MemorySettingsService = None  # type: ignore[assignment,misc]
@@ -144,6 +155,9 @@ __all__ = [
     "DriftService",
     "AnomalyService",
     "FleetService",
+    "FleetScanService",
+    "FleetScanResult",
+    "FleetScanProgress",
     "MemorySettingsService",
     # Stream 3
     "AISummaryService",

--- a/src/servonaut/services/memory/fleet_scan_service.py
+++ b/src/servonaut/services/memory/fleet_scan_service.py
@@ -1,0 +1,354 @@
+"""Fleet-wide memory scan orchestrator.
+
+UI-agnostic bulk-scan engine used by both the interactive
+``FleetMemoryScreen`` and the background auto-scan loop in ``ServonautApp``.
+Callers own presentation (progress display, demo-mode redaction, modals).
+
+Import-cycle decision
+---------------------
+``screens/fleet_memory.py`` defines ``compute_memory_status`` and the STATUS_*
+constants as module-level reusable helpers.  However, that module also imports
+from ``servonaut.app`` (TYPE_CHECKING only) and several screen helpers.
+Importing it from inside the ``services/`` package would invert the
+conventional services-below-screens layering and risk import cycles that are
+hard to detect at test time.
+
+Instead, this module replicates the *minimal* status classification logic
+using only the memory service's public API
+(``is_memory_disabled``, ``get_all_modules``, ``snapshot_stale_seconds``).
+The classification result matches the screen's ``STATUS_*`` vocabulary
+exactly so callers receive the same codes, but this module has zero
+dependency on ``screens/fleet_memory``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from servonaut.config.schema import DEFAULT_SNAPSHOT_STALE_SECONDS
+
+logger = logging.getLogger(__name__)
+
+# Status codes — must stay in sync with ``screens/fleet_memory.STATUS_*``.
+_STATUS_FRESH = "fresh"
+_STATUS_STALE = "stale"
+_STATUS_NONE = "none"
+_STATUS_OPT_OUT = "opted-out"
+
+
+# ---------------------------------------------------------------------------
+# DTOs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FleetScanProgress:
+    """Emitted by ``FleetScanService.scan`` via *on_progress* after each probe.
+
+    Attributes:
+        instance_name: Display name / id of the instance just probed.
+        succeeded: ``True`` when the probe produced at least one module.
+        completed: Count of instances probed so far (including this one).
+        total: Total number of eligible instances in this scan pass.
+        instance_id: Raw ``id`` key from the instance dict — used by the
+            screen to look up the corresponding table row for a live
+            cell update.  Defaults to ``""`` so existing callers that
+            construct :class:`FleetScanProgress` directly don't break.
+    """
+
+    instance_name: str
+    succeeded: bool
+    completed: int
+    total: int
+    instance_id: str = ""
+
+
+@dataclass
+class FleetScanResult:
+    """Outcome of a ``FleetScanService.scan`` call.
+
+    Matches the shape consumed by ``FleetScanSummaryModal`` in
+    ``screens/fleet_memory``.
+
+    Attributes:
+        succeeded: Display names of instances whose scan produced at least
+            one memory module.
+        failed: Failure entries — each is a dict with keys
+            ``"instance"`` (name), ``"reason"`` (code string), and
+            ``"failures"`` (list of per-module dicts with ``module``,
+            ``reason``, ``message`` keys).
+    """
+
+    succeeded: List[str] = field(default_factory=list)
+    failed: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Internal status helpers (replicated from screens/fleet_memory)
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_age_seconds(modules: Dict[str, Any]) -> Optional[float]:
+    """Return the age of the most recent probe across *modules*, in seconds.
+
+    Returns ``None`` when *modules* is empty or has no parseable timestamp
+    — callers treat that as stale/unknown.
+    """
+    latest = ""
+    for mod in modules.values():
+        probed_at = mod.get("probed_at", "") if isinstance(mod, dict) else ""
+        if probed_at and probed_at > latest:
+            latest = probed_at
+    if not latest:
+        return None
+    try:
+        probed_at_dt = datetime.fromisoformat(latest.rstrip("Z"))
+        if not probed_at_dt.tzinfo:
+            probed_at_dt = probed_at_dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+    return (datetime.now(tz=timezone.utc) - probed_at_dt).total_seconds()
+
+
+def _resolve_stale_threshold(memory_service: Any) -> float:
+    """Return the server-level staleness threshold in seconds from the service."""
+    val = getattr(memory_service, "snapshot_stale_seconds", None)
+    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
+        return float(val)
+    return float(DEFAULT_SNAPSHOT_STALE_SECONDS)
+
+
+def _compute_status(instance: Dict[str, Any], memory_service: Any) -> str:
+    """Return the STATUS_* code for *instance* using the memory service API.
+
+    This is a local reimplementation of ``screens/fleet_memory.compute_memory_status``
+    that avoids a service→screen import dependency.  The logic and return
+    values are identical; keep them in sync when either changes.
+    """
+    if memory_service is None:
+        return _STATUS_NONE
+
+    iid = instance.get("id") or instance.get("name", "")
+    iname = instance.get("name", "")
+    provider = instance.get("provider", "custom")
+    if not iid:
+        return _STATUS_NONE
+
+    try:
+        if memory_service.is_memory_disabled(iid, iname):
+            return _STATUS_OPT_OUT
+    except Exception:  # noqa: BLE001
+        # Fail closed: if the opt-out check errors, treat the instance as
+        # opted out so a broken lookup never accidentally probes a server.
+        logger.warning(
+            "is_memory_disabled check failed for %r — treating as opted out",
+            iid,
+        )
+        return _STATUS_OPT_OUT
+
+    try:
+        modules = memory_service.get_all_modules(iid, provider)
+    except Exception:  # noqa: BLE001
+        modules = {}
+    if not modules:
+        return _STATUS_NONE
+
+    age = _snapshot_age_seconds(modules)
+    threshold = _resolve_stale_threshold(memory_service)
+    if age is None or age > threshold:
+        return _STATUS_STALE
+    return _STATUS_FRESH
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class FleetScanService:
+    """UI-agnostic orchestrator for fleet-wide memory scanning.
+
+    Wraps the concurrent probe logic so both the interactive screen and the
+    background auto-scan loop share one implementation.  Presentation
+    (progress display, demo-mode redaction, post-scan modals) is the
+    caller's responsibility.
+
+    Args:
+        memory_service: The application's ``MemoryService`` instance.
+        max_parallel: Maximum number of concurrent SSH probes.  Mirrors
+            ``_MAX_PARALLEL_FLEET_PROBES`` from ``screens/fleet_memory``.
+    """
+
+    def __init__(
+        self,
+        memory_service: Any,
+        *,
+        max_parallel: int = 4,
+    ) -> None:
+        self._memory_service = memory_service
+        self._max_parallel = max_parallel
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def eligible_instances(
+        self,
+        instances: List[Dict[str, Any]],
+        *,
+        stale_only: bool,
+    ) -> List[Dict[str, Any]]:
+        """Return the subset of *instances* that should be probed.
+
+        Mirrors ``FleetMemoryScreen._eligible_instances``:
+
+        - Opted-out instances are always excluded.
+        - When *stale_only* is ``True``, fresh and never-probed instances
+          are excluded so the scan targets only servers that need refreshing.
+        - When *stale_only* is ``False``, all non-opted-out instances are
+          included for a full fleet re-probe.
+
+        Args:
+            instances: All managed instances (combined AWS + custom list).
+            stale_only: When ``True`` probe only stale instances.
+
+        Returns:
+            Filtered list preserving original order.
+        """
+        eligible: List[Dict[str, Any]] = []
+        for inst in instances:
+            status = _compute_status(inst, self._memory_service)
+            if status == _STATUS_OPT_OUT:
+                continue
+            if stale_only and status != _STATUS_STALE:
+                continue
+            eligible.append(inst)
+        return eligible
+
+    async def scan(
+        self,
+        instances: List[Dict[str, Any]],
+        *,
+        stale_only: bool,
+        on_progress: Optional[Callable[[FleetScanProgress], None]] = None,
+    ) -> FleetScanResult:
+        """Probe eligible instances concurrently and return a summary result.
+
+        Filters via :meth:`eligible_instances`, then runs probes in parallel
+        capped by *max_parallel*.  Fires *on_progress* once per completed
+        instance.  ``asyncio.CancelledError`` is always re-raised so worker
+        cancellation propagates correctly — do NOT catch it in callers without
+        re-raising.
+
+        Args:
+            instances: All managed instances to consider.  Filtering to
+                eligible ones is done internally.
+            stale_only: Passed through to :meth:`eligible_instances`.
+            on_progress: Optional callback invoked after each probe finishes.
+                Receives a :class:`FleetScanProgress` dataclass.  May be
+                called from the asyncio event loop — keep it fast and
+                non-blocking.
+
+        Returns:
+            :class:`FleetScanResult` with ``succeeded`` and ``failed`` lists.
+
+        Raises:
+            asyncio.CancelledError: When the surrounding worker is cancelled.
+                All other exceptions are caught per-instance and collected in
+                the result's ``failed`` list so a single bad SSH connection
+                never aborts the whole scan.
+        """
+        eligible = self.eligible_instances(instances, stale_only=stale_only)
+        if not eligible:
+            logger.debug("FleetScanService.scan: no eligible instances, skipping")
+            return FleetScanResult()
+
+        semaphore = asyncio.Semaphore(self._max_parallel)
+        result = FleetScanResult()
+        total = len(eligible)
+        completed = 0
+
+        async def _probe_one(inst: Dict[str, Any]) -> None:
+            nonlocal completed
+            name = inst.get("name") or inst.get("id") or "unknown"
+            logger.info("FleetScanService: probing %s", name)
+            async with semaphore:
+                ok = False
+                try:
+                    ms = self._memory_service
+                    if hasattr(ms, "build_report"):
+                        report = await ms.build_report(inst)
+                        if report.has_any_success:
+                            result.succeeded.append(name)
+                            ok = True
+                        else:
+                            result.failed.append({
+                                "instance": name,
+                                "reason": report.overall_reason or "unknown",
+                                "failures": [
+                                    {
+                                        "module": f.module,
+                                        "reason": f.reason,
+                                        "message": f.message,
+                                    }
+                                    for f in report.failures
+                                ],
+                            })
+                    else:
+                        # Fallback for older or stubbed service instances.
+                        modules = await ms.refresh(inst)
+                        if modules:
+                            result.succeeded.append(name)
+                            ok = True
+                        else:
+                            result.failed.append({
+                                "instance": name,
+                                "reason": "no_modules_returned",
+                                "failures": [],
+                            })
+                except asyncio.CancelledError:
+                    # Propagate so asyncio.gather unwinds cleanly.
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception(
+                        "FleetScanService: probe failed for %s", name
+                    )
+                    result.failed.append({
+                        "instance": name,
+                        "reason": "exception",
+                        "failures": [
+                            {
+                                "module": "—",
+                                "reason": "exception",
+                                "message": str(exc)[:240],
+                            }
+                        ],
+                    })
+                finally:
+                    completed += 1
+                    if on_progress is not None:
+                        try:
+                            on_progress(
+                                FleetScanProgress(
+                                    instance_name=name,
+                                    succeeded=ok,
+                                    completed=completed,
+                                    total=total,
+                                    instance_id=inst.get("id") or inst.get("name", ""),
+                                )
+                            )
+                        except Exception:  # noqa: BLE001
+                            pass  # never let a progress callback crash the scan
+
+        # CancelledError propagates out of gather and then out of this method.
+        await asyncio.gather(*(_probe_one(i) for i in eligible))
+        logger.info(
+            "FleetScanService.scan complete: %d succeeded, %d failed",
+            len(result.succeeded),
+            len(result.failed),
+        )
+        return result

--- a/src/servonaut/services/memory/fleet_scan_service.py
+++ b/src/servonaut/services/memory/fleet_scan_service.py
@@ -4,21 +4,12 @@ UI-agnostic bulk-scan engine used by both the interactive
 ``FleetMemoryScreen`` and the background auto-scan loop in ``ServonautApp``.
 Callers own presentation (progress display, demo-mode redaction, modals).
 
-Import-cycle decision
+Status classification
 ---------------------
-``screens/fleet_memory.py`` defines ``compute_memory_status`` and the STATUS_*
-constants as module-level reusable helpers.  However, that module also imports
-from ``servonaut.app`` (TYPE_CHECKING only) and several screen helpers.
-Importing it from inside the ``services/`` package would invert the
-conventional services-below-screens layering and risk import cycles that are
-hard to detect at test time.
-
-Instead, this module replicates the *minimal* status classification logic
-using only the memory service's public API
-(``is_memory_disabled``, ``get_all_modules``, ``snapshot_stale_seconds``).
-The classification result matches the screen's ``STATUS_*`` vocabulary
-exactly so callers receive the same codes, but this module has zero
-dependency on ``screens/fleet_memory``.
+The STATUS_* constants and ``compute_memory_status`` classifier live in
+``services/memory/status.py`` — a dependency-free module that both this
+service and ``screens/fleet_memory`` import from.  That module is the
+single source of truth; neither carries its own copy.
 """
 
 from __future__ import annotations
@@ -26,18 +17,17 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from servonaut.config.schema import DEFAULT_SNAPSHOT_STALE_SECONDS
+from servonaut.services.memory.status import (
+    STATUS_FRESH as _STATUS_FRESH,
+    STATUS_STALE as _STATUS_STALE,
+    STATUS_NONE as _STATUS_NONE,
+    STATUS_OPT_OUT as _STATUS_OPT_OUT,
+    compute_memory_status as _compute_status,
+)
 
 logger = logging.getLogger(__name__)
-
-# Status codes — must stay in sync with ``screens/fleet_memory.STATUS_*``.
-_STATUS_FRESH = "fresh"
-_STATUS_STALE = "stale"
-_STATUS_NONE = "none"
-_STATUS_OPT_OUT = "opted-out"
 
 
 # ---------------------------------------------------------------------------
@@ -85,83 +75,6 @@ class FleetScanResult:
 
     succeeded: List[str] = field(default_factory=list)
     failed: List[Dict[str, Any]] = field(default_factory=list)
-
-
-# ---------------------------------------------------------------------------
-# Internal status helpers (replicated from screens/fleet_memory)
-# ---------------------------------------------------------------------------
-
-
-def _snapshot_age_seconds(modules: Dict[str, Any]) -> Optional[float]:
-    """Return the age of the most recent probe across *modules*, in seconds.
-
-    Returns ``None`` when *modules* is empty or has no parseable timestamp
-    — callers treat that as stale/unknown.
-    """
-    latest = ""
-    for mod in modules.values():
-        probed_at = mod.get("probed_at", "") if isinstance(mod, dict) else ""
-        if probed_at and probed_at > latest:
-            latest = probed_at
-    if not latest:
-        return None
-    try:
-        probed_at_dt = datetime.fromisoformat(latest.rstrip("Z"))
-        if not probed_at_dt.tzinfo:
-            probed_at_dt = probed_at_dt.replace(tzinfo=timezone.utc)
-    except (ValueError, TypeError):
-        return None
-    return (datetime.now(tz=timezone.utc) - probed_at_dt).total_seconds()
-
-
-def _resolve_stale_threshold(memory_service: Any) -> float:
-    """Return the server-level staleness threshold in seconds from the service."""
-    val = getattr(memory_service, "snapshot_stale_seconds", None)
-    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
-        return float(val)
-    return float(DEFAULT_SNAPSHOT_STALE_SECONDS)
-
-
-def _compute_status(instance: Dict[str, Any], memory_service: Any) -> str:
-    """Return the STATUS_* code for *instance* using the memory service API.
-
-    This is a local reimplementation of ``screens/fleet_memory.compute_memory_status``
-    that avoids a service→screen import dependency.  The logic and return
-    values are identical; keep them in sync when either changes.
-    """
-    if memory_service is None:
-        return _STATUS_NONE
-
-    iid = instance.get("id") or instance.get("name", "")
-    iname = instance.get("name", "")
-    provider = instance.get("provider", "custom")
-    if not iid:
-        return _STATUS_NONE
-
-    try:
-        if memory_service.is_memory_disabled(iid, iname):
-            return _STATUS_OPT_OUT
-    except Exception:  # noqa: BLE001
-        # Fail closed: if the opt-out check errors, treat the instance as
-        # opted out so a broken lookup never accidentally probes a server.
-        logger.warning(
-            "is_memory_disabled check failed for %r — treating as opted out",
-            iid,
-        )
-        return _STATUS_OPT_OUT
-
-    try:
-        modules = memory_service.get_all_modules(iid, provider)
-    except Exception:  # noqa: BLE001
-        modules = {}
-    if not modules:
-        return _STATUS_NONE
-
-    age = _snapshot_age_seconds(modules)
-    threshold = _resolve_stale_threshold(memory_service)
-    if age is None or age > threshold:
-        return _STATUS_STALE
-    return _STATUS_FRESH
 
 
 # ---------------------------------------------------------------------------

--- a/src/servonaut/services/memory/interfaces.py
+++ b/src/servonaut/services/memory/interfaces.py
@@ -652,6 +652,7 @@ class MemorySettings:
     anomaly_rules: Dict[str, AnomalyRule]
     raw: Dict[str, Any]
     ai_consent_mode: str = "off"
+    auto_sync_enabled: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/servonaut/services/memory/modules/logs.py
+++ b/src/servonaut/services/memory/modules/logs.py
@@ -75,7 +75,10 @@ class LogsProber(ModuleProberInterface):
             A ``ModuleResult`` with ``observed={"probed_paths": [...]}`` and
             a human-readable ``raw_output`` listing what was found.
         """
-        instance = self._instance
+        # Prefer the instance attached to the per-call runner (set by
+        # MemoryService._make_ssh_runner) over the shared _instance field, so
+        # concurrent build_report calls for different instances don't race.
+        instance = getattr(ssh_runner, "instance", None) or self._instance
         if instance is None:
             logger.error("LogsProber.probe() called without setting instance first")
             return ModuleResult(

--- a/src/servonaut/services/memory/passphrase_store.py
+++ b/src/servonaut/services/memory/passphrase_store.py
@@ -1,0 +1,121 @@
+"""OS keychain wrapper for the Memory Sync passphrase (optional dep).
+
+Provides a thin, always-safe API around ``keyring`` so callers never need to
+guard against ``ImportError`` or backend failures.  All functions return
+``False``/``None`` when keyring is unavailable rather than raising.
+
+Only the passphrase is stored here.  The decrypted X25519 private key is
+NEVER written to the keychain or to disk — it lives in RAM only.  The
+passphrase-*encrypted* keypair material is cached separately in the local
+``keys.json`` file managed by :class:`~servonaut.services.memory.sync_service.MemorySyncService`.
+
+Keychain coordinates
+--------------------
+- Service name: ``"servonaut-memory-sync"``
+- Account name: ``"default"`` (one passphrase per OS user)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SERVICE = "servonaut-memory-sync"
+_ACCOUNT = "default"
+
+# Lazy import: keyring is optional.  A hard ImportError at module load would
+# crash the entire app even for users who have no keychain configured.
+try:
+    import keyring as _keyring  # type: ignore[import-untyped]
+    _HAS_KEYRING = True
+except Exception:
+    _keyring = None  # type: ignore[assignment]
+    _HAS_KEYRING = False
+
+
+def keyring_available() -> bool:
+    """Return ``True`` when a known-good OS keychain backend is available.
+
+    Uses an ALLOWLIST of known-good backend module prefixes so that any
+    new or third-party backend that doesn't actually persist secrets is
+    rejected by default.  The previous DENYLIST approach (checking for
+    ``"fail"``/``"null"`` substrings) could silently accept an unknown
+    backend that looks legitimate but loses stored passwords.
+
+    Trusted backends:
+    - ``keyring.backends.SecretService`` / ``secretservice`` — GNOME / DBus (Linux)
+    - ``keyring.backends.kwallet`` — KDE Wallet (Linux)
+    - ``keyring.backends.macOS`` / ``Keyring`` — macOS system keychain
+    - ``keyring.backends.Windows`` / ``CredentialLocker`` — Windows Credential Store
+    - ``keyring.backends.chainer`` — chains multiple backends
+
+    Any backend whose module does NOT start with one of these prefixes is
+    treated as unavailable.  This is the conservative choice: a false negative
+    means "no auto-unlock" while a false positive could silently lose the
+    stored passphrase.
+    """
+    if not _HAS_KEYRING or _keyring is None:
+        return False
+    try:
+        backend = _keyring.get_keyring()
+        module = type(backend).__module__ or ""
+        _ALLOWED_PREFIXES = (
+            "keyring.backends.SecretService",
+            "keyring.backends.secretservice",
+            "keyring.backends.kwallet",
+            "keyring.backends.macOS",
+            "keyring.backends.Keyring",
+            "keyring.backends.Windows",
+            "keyring.backends.CredentialLocker",
+            "keyring.backends.chainer",
+        )
+        return any(module.startswith(pfx) for pfx in _ALLOWED_PREFIXES)
+    except Exception:
+        return False
+
+
+def store_passphrase(passphrase: str) -> bool:
+    """Store *passphrase* in the OS keychain.
+
+    Returns ``True`` on success, ``False`` on any error (including keyring
+    not available).  Never raises.
+    """
+    if not keyring_available():
+        return False
+    try:
+        _keyring.set_password(_SERVICE, _ACCOUNT, passphrase)
+        return True
+    except Exception as exc:
+        logger.warning("passphrase_store.store_passphrase failed: %s", exc)
+        return False
+
+
+def get_passphrase() -> Optional[str]:
+    """Retrieve the stored passphrase from the OS keychain.
+
+    Returns the passphrase string, or ``None`` if nothing is stored or on
+    any error.  Never raises.
+    """
+    if not keyring_available():
+        return None
+    try:
+        return _keyring.get_password(_SERVICE, _ACCOUNT)
+    except Exception as exc:
+        logger.warning("passphrase_store.get_passphrase failed: %s", exc)
+        return None
+
+
+def clear_passphrase() -> None:
+    """Remove the stored passphrase from the OS keychain.
+
+    No-op if nothing is stored or if keyring is unavailable.  Never raises.
+    """
+    if not keyring_available():
+        return
+    try:
+        _keyring.delete_password(_SERVICE, _ACCOUNT)
+    except Exception:
+        # Already absent or backend error — silently ignore.
+        pass

--- a/src/servonaut/services/memory/service.py
+++ b/src/servonaut/services/memory/service.py
@@ -1231,6 +1231,9 @@ class MemoryService(MemoryServiceInterface):
                     "connection_service to MemoryService.__init__ before probing "
                     f"instance {instance.get('id')!r}"
                 )
+            # Attach instance so LogsProber can read it from the runner directly,
+            # eliminating the shared _instance field race in concurrent build_report calls.
+            _stub_runner.instance = instance  # type: ignore[attr-defined]
             return _stub_runner
 
         # Import here to avoid circular imports at module level.
@@ -1314,4 +1317,7 @@ class MemoryService(MemoryServiceInterface):
                 )
                 return "", str(exc), 1
 
+        # Attach instance so LogsProber can read it from the runner directly,
+        # eliminating the shared _instance field race in concurrent build_report calls.
+        _real_runner.instance = instance  # type: ignore[attr-defined]
         return _real_runner

--- a/src/servonaut/services/memory/settings_service.py
+++ b/src/servonaut/services/memory/settings_service.py
@@ -175,6 +175,25 @@ class MemorySettingsService:
             }])
         return await self.patch_settings({"mercure_push_enabled": enabled})
 
+    async def set_auto_sync(self, enabled: bool) -> MemorySettings:
+        """Enable or disable background auto-sync to the cloud.
+
+        Args:
+            enabled: Whether to enable auto-sync.
+
+        Returns:
+            Updated MemorySettings.
+
+        Raises:
+            ValidationFailed: If *enabled* is not a bool (local pre-check).
+        """
+        if not isinstance(enabled, bool):
+            raise ValidationFailed([{
+                "key": "auto_sync_enabled",
+                "error": f"must_be_bool; got {type(enabled).__name__}",
+            }])
+        return await self.patch_settings({"auto_sync_enabled": enabled})
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
@@ -201,4 +220,5 @@ def _parse_settings(data: Dict[str, Any]) -> MemorySettings:
         anomaly_rules=anomaly_rules,
         raw=data,
         ai_consent_mode=str(data.get("ai_consent_mode", "off") or "off"),
+        auto_sync_enabled=bool(data.get("auto_sync_enabled", False)),
     )

--- a/src/servonaut/services/memory/status.py
+++ b/src/servonaut/services/memory/status.py
@@ -1,0 +1,144 @@
+"""Memory status classification helpers — dependency-free service-layer module.
+
+This module carries the STATUS_* constants, the snapshot-age helpers, and
+the ``compute_memory_status`` classifier that both the fleet-scan service
+and the fleet-memory screen need.  It must NOT import from any screen,
+widget, or app module to keep the services layer free of presentation
+dependencies.
+
+``screens/fleet_memory`` re-exports every public symbol from here so that
+existing importers (``widgets/instance_table``, tests, …) that do::
+
+    from servonaut.screens.fleet_memory import STATUS_FRESH, compute_memory_status
+
+continue to work without change.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from servonaut.config.schema import DEFAULT_SNAPSHOT_STALE_SECONDS
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Status codes
+# ---------------------------------------------------------------------------
+
+# These string values are the stable external vocabulary — renderers in
+# ``screens/fleet_memory`` and ``widgets/instance_table`` match on them.
+# Never rename without a migration pass over all callers.
+STATUS_FRESH = "fresh"
+STATUS_STALE = "stale"
+STATUS_NONE = "none"
+STATUS_OPT_OUT = "opted-out"
+
+
+# ---------------------------------------------------------------------------
+# Age / threshold helpers
+# ---------------------------------------------------------------------------
+
+
+def _latest_probed_at(modules: Dict[str, Any]) -> str:
+    """Return the most recent ``probed_at`` across *modules*, or ``""``."""
+    latest = ""
+    for mod in modules.values():
+        probed_at = mod.get("probed_at", "") if isinstance(mod, dict) else ""
+        if probed_at and probed_at > latest:
+            latest = probed_at
+    return latest
+
+
+def snapshot_age_seconds(modules: Dict[str, Any]) -> Optional[float]:
+    """Return the age in seconds of the most recent probe across *modules*.
+
+    Returns ``None`` when *modules* is empty or carries no parseable
+    ``probed_at`` timestamp — callers treat that as "stale / unknown".
+    """
+    latest = _latest_probed_at(modules)
+    if not latest:
+        return None
+    try:
+        probed_at = datetime.fromisoformat(latest.rstrip("Z"))
+        if not probed_at.tzinfo:
+            probed_at = probed_at.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+    return (datetime.now(tz=timezone.utc) - probed_at).total_seconds()
+
+
+def _resolve_stale_threshold(memory_service: Any) -> float:
+    """Return the server-level staleness threshold in seconds.
+
+    Reads ``MemoryService.snapshot_stale_seconds`` and falls back to the
+    schema default when the service does not expose a usable numeric value
+    (e.g. lightweight test doubles).
+    """
+    val = getattr(memory_service, "snapshot_stale_seconds", None)
+    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
+        return float(val)
+    return float(DEFAULT_SNAPSHOT_STALE_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def compute_memory_status(
+    instance: Dict[str, Any],
+    memory_service: Any,
+) -> str:
+    """Return one of the STATUS_* codes for *instance*.
+
+    A server's whole memory is reported ``STATUS_STALE`` once its newest
+    probe is older than the server-level threshold
+    (``MemoryService.snapshot_stale_seconds``).  This is deliberately
+    decoupled from per-module TTLs — volatile modules (containers, disk)
+    re-probe fast by design and must not drag the whole-server badge.
+
+    Reuses the memory service's public API only — no ``_store`` reach-in.
+    Defensive against missing services so callers (instance_list column,
+    fleet table, fleet scan service) never raise from UI or service code
+    paths.
+
+    Opt-out check fails closed: if ``is_memory_disabled`` raises for any
+    reason the instance is treated as opted-out so a broken lookup never
+    accidentally triggers an SSH probe against a server.
+    """
+    if memory_service is None:
+        return STATUS_NONE
+
+    iid = instance.get("id") or instance.get("name", "")
+    iname = instance.get("name", "")
+    provider = instance.get("provider", "custom")
+    if not iid:
+        return STATUS_NONE
+
+    try:
+        if memory_service.is_memory_disabled(iid, iname):
+            return STATUS_OPT_OUT
+    except Exception:  # noqa: BLE001
+        # Fail closed: if the opt-out check errors, treat the instance as
+        # opted out so a broken lookup never accidentally probes a server.
+        logger.warning(
+            "is_memory_disabled check failed for %r — treating as opted out",
+            iid,
+        )
+        return STATUS_OPT_OUT
+
+    try:
+        modules = memory_service.get_all_modules(iid, provider)
+    except Exception:  # noqa: BLE001
+        modules = {}
+    if not modules:
+        return STATUS_NONE
+
+    age = snapshot_age_seconds(modules)
+    threshold = _resolve_stale_threshold(memory_service)
+    if age is None or age > threshold:
+        return STATUS_STALE
+    return STATUS_FRESH

--- a/src/servonaut/services/memory/sync_service.py
+++ b/src/servonaut/services/memory/sync_service.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import random
+import tempfile
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
@@ -104,6 +105,13 @@ _QUOTA_BACKOFF_FACTOR = 10
 
 # Poison-pill envelopes (size-1 batch_too_large) get parked here for triage.
 _POISON_PATH = Path.home() / ".servonaut" / "memory" / "sync_poison.jsonl"
+
+# Local passphrase-encrypted keypair cache.  Stores ONLY the wrapped
+# (passphrase-encrypted) material: public_key, wrapped_private_key, fingerprint.
+# The unwrapped private key and the passphrase are NEVER written here.
+# Path constant; each MemorySyncService instance also stores this as
+# self._key_cache_path so tests can override it.
+_KEY_CACHE_PATH = Path.home() / ".servonaut" / "memory" / "keys.json"
 
 
 def _now_iso() -> str:
@@ -185,6 +193,9 @@ class MemorySyncService:
             Path.home() / ".servonaut" / "memory" / "sync_queue.jsonl"
         )
 
+        # Local keypair cache path (overridable in tests via svc._key_cache_path)
+        self._key_cache_path = _KEY_CACHE_PATH
+
         # Background loop handle
         self._loop_task: Optional[asyncio.Task] = None
         self._stopped = False
@@ -206,6 +217,12 @@ class MemorySyncService:
         # When None (default), the gate is open — preserves current behaviour
         # for headless callers (CLI, MCP) that don't wire the predicate.
         self._entitlement_check: Optional[Callable[[], bool]] = None
+
+        # Optional callback fired when a cross-device key-rotation mismatch
+        # is detected in the drain loop (missing_self_wrap rejection from the
+        # server).  The app wires this to show a user-visible notify so the
+        # user knows to re-unlock from the Memory Sync screen.
+        self._on_key_mismatch: Optional[Callable[[], None]] = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -264,6 +281,82 @@ class MemorySyncService:
             public_key=self._self_pubkey,
             private_key=self._self_privkey,
         )
+
+    def is_enrolled_locally(self) -> bool:
+        """Return ``True`` when the local passphrase-encrypted keypair cache exists.
+
+        The cache stores only ``{public_key, wrapped_private_key, fingerprint}``
+        — never the unwrapped private key or the passphrase.  Its presence is
+        used by the startup reactivation path to decide whether to attempt a
+        bootstrap without prompting the user to go through the Memory Sync setup
+        screen again.
+        """
+        return self._key_cache_path.exists()
+
+    def clear_local_keypair_cache(self) -> None:
+        """Delete the local passphrase-encrypted keypair cache file.
+
+        Safe to call when the cache does not exist.  Called by the "Disable
+        Memory Sync" and "Forget on this device" actions to prevent the
+        startup reactivation path from re-unlocking without user intent.
+        """
+        try:
+            self._key_cache_path.unlink(missing_ok=True)
+        except Exception as exc:
+            logger.warning("clear_local_keypair_cache: %s", exc)
+
+    def lock(self) -> None:
+        """Clear the in-memory private key material.
+
+        Drops ``_self_pubkey`` and ``_self_privkey`` from RAM so
+        ``is_configured`` becomes ``False``.  Used by
+        ``MemorySyncSetupScreen._do_disable`` (instead of poking private
+        attrs directly, per the project's memory-encapsulation convention)
+        and by the cross-device-rotation recovery path.
+        """
+        self._self_pubkey = None
+        self._self_privkey = None
+        self._notify_listeners()
+
+    def can_unwrap_local(self, passphrase: str) -> bool:
+        """Test whether *passphrase* can unwrap the locally cached keypair.
+
+        Reads ``keys.json`` and attempts
+        :func:`~servonaut.services.memory.crypto.unwrap_private_key`;
+        returns ``True`` on success, ``False`` on any failure (wrong
+        passphrase, no cache, corrupt data, crypto unavailable, etc.).
+
+        **No network calls.  No mutation of ``_self_*``.**  Safe to call
+        on the startup reactivation path before ``bootstrap`` so that a
+        wrong/stale cached passphrase is distinguished from a transient
+        backend error without triggering an erroneous keychain clear.
+        """
+        if not _HAS_CRYPTO:
+            return False
+        if not self._key_cache_path.exists():
+            return False
+        try:
+            raw = self._key_cache_path.read_text(encoding="utf-8")
+            cached = json.loads(raw)
+            wrapped_json = cached.get("wrapped_private_key", "")
+            if not wrapped_json:
+                return False
+            wrapped = WrappedPrivateKey.from_json(wrapped_json)
+            unwrap_private_key(wrapped, passphrase)
+            return True
+        except Exception:
+            return False
+
+    def set_key_mismatch_listener(self, fn: Callable[[], None]) -> None:
+        """Register a callback fired when a cross-device key-rotation mismatch is detected.
+
+        Called from the drain loop when the server returns ``missing_self_wrap``
+        (the local keypair cache references a key the server no longer
+        recognises — most likely because the keypair was rotated on another
+        device).  The callback is responsible for showing a user-visible
+        notification so the user knows to re-unlock from the Memory Sync screen.
+        """
+        self._on_key_mismatch = fn
 
     @property
     def is_configured(self) -> bool:
@@ -774,7 +867,17 @@ class MemorySyncService:
             BackendMaintenance: on 503 feature_disabled.
             BetaWaitlist: on 403 feature_not_available.
             UpsellRequired: on 403 forbidden_entitlement.
+
+        M7: idempotent — if a concurrent bootstrap call (e.g. manual setup
+        worker racing the startup autostart worker) has already loaded the
+        keypair, return immediately to avoid a redundant network round-trip
+        or a second passphrase prompt.
         """
+        # M7: already configured — no-op so concurrent bootstrap calls
+        # don't double-prompt the user.
+        if self.is_configured:
+            return
+
         # Guarantee user_id before any crypto. Without it we cannot build
         # the DEK self-wrap (recipient_user_id == caller) and the server
         # would reject every envelope with `missing_self_wrap`.
@@ -1041,6 +1144,10 @@ class MemorySyncService:
                 logger.debug("sync loop: halted (no_active_keypair); skipping drain")
                 continue
 
+            if self._halted_reason == "key_mismatch":
+                logger.debug("sync loop: halted (key_mismatch); exiting loop")
+                break
+
             if self._halted_reason == "quota_exceeded":
                 quota_halt_count += 1
                 if quota_halt_count < _QUOTA_BACKOFF_FACTOR:
@@ -1058,6 +1165,46 @@ class MemorySyncService:
 
             try:
                 await self.drain_now()
+            except MissingSelfWrap:
+                # S-1: cross-device key-rotation recovery.
+                # The server rejected our envelope with missing_self_wrap,
+                # meaning the public key we have cached locally is no longer
+                # the one registered on the server (another device rotated the
+                # keypair after we bootstrapped).
+                #
+                # Action: clear the local keypair cache + lock in-memory key +
+                # clear the OS keychain passphrase + reset the remember flag so
+                # the startup reactivation path re-prompts the user on the next
+                # launch.  Halt the loop so we don't keep burning rate-limit
+                # budget with envelopes that will always be rejected.
+                logger.error(
+                    "sync loop: missing_self_wrap — clearing local keypair cache "
+                    "(cross-device rotation?); halting drain until re-enrolment"
+                )
+                self.clear_local_keypair_cache()
+                self.lock()
+                try:
+                    from servonaut.services.memory import passphrase_store as _ps
+                    _ps.clear_passphrase()
+                except Exception:
+                    pass
+                try:
+                    import dataclasses as _dc
+                    cfg = self._config_manager.get()
+                    _updated = _dc.replace(cfg.memory, sync_remember_device=False)
+                    self._config_manager.update(memory=_updated)
+                except Exception:
+                    pass
+                self._halted_reason = "key_mismatch"
+                self._state = "halted"
+                self._last_error = "Memory Sync key changed — re-unlock to resume sync"
+                self._notify_listeners()
+                if self._on_key_mismatch is not None:
+                    try:
+                        self._on_key_mismatch()
+                    except Exception:
+                        pass
+                break  # exit the loop; user must re-enrol
             except Exception as exc:
                 logger.exception("sync loop: drain_now crashed: %s", exc)
 
@@ -1118,6 +1265,19 @@ class MemorySyncService:
 
         self._self_pubkey = new_kp.public_key
         self._self_privkey = new_kp.private_key
+        # Overwrite the local cache with the new wrapped keypair so that
+        # the next startup can skip the /keys/me network call.  The old
+        # cached passphrase (if any) in the OS keychain is now invalid;
+        # the caller (_do_rotate in the screen) is responsible for clearing
+        # it and optionally storing the new one.  Include user_id so the
+        # cache remains bound to this account after rotation (MAJOR-2).
+        import base64 as _b64
+        self._persist_key_cache(
+            _b64.b64encode(new_kp.public_key).decode(),
+            new_wrapped.to_json(),
+            new_kp.fingerprint,
+            user_id=self._self_user_id,
+        )
         if self._key_material_listener is not None:
             try:
                 self._key_material_listener()
@@ -1128,6 +1288,90 @@ class MemorySyncService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _derive_public_key(self, private_key_bytes: bytes) -> Optional[bytes]:
+        """Derive the X25519 public key from raw *private_key_bytes*.
+
+        Returns the 32-byte public key on success, or ``None`` when PyNaCl
+        is unavailable or derivation fails.  Used by ``_ensure_keypair`` to
+        verify that the cached public key is consistent with the unwrapped
+        private key (M5 pubkey-integrity check).
+        """
+        try:
+            import nacl.public as _nacl_pub
+            return bytes(_nacl_pub.PrivateKey(private_key_bytes).public_key)
+        except Exception:
+            return None
+
+    def _persist_key_cache(
+        self, public_key_b64: str, wrapped_private_key_json: str, fingerprint: str, *, user_id: Optional[int] = None
+    ) -> None:
+        """Write passphrase-encrypted keypair material to the local cache.
+
+        Uses an atomic 0600 write (mirrors ``auth_service._save_token``) so
+        a crash mid-write cannot leave a partial file.
+
+        Security contract:
+        - Only encrypted material is written here.
+        - The unwrapped private key and the passphrase are NEVER stored.
+        - Parent directory is created with mode 0700.
+        - ``user_id`` is stored so the reactivation path can detect a
+          different account on the same OS user and ignore the stale cache.
+
+        Failures are logged as warnings but never re-raised — a missing cache
+        is safe; it just means the next bootstrap must hit the network.
+        """
+        data: Dict[str, Any] = {
+            "public_key": public_key_b64,
+            "wrapped_private_key": wrapped_private_key_json,
+            "fingerprint": fingerprint,
+        }
+        # MAJOR-2: bind cache to the authenticated user_id so a different
+        # account on the same OS user does not silently reuse this cached
+        # keypair on the next launch.
+        if user_id is not None:
+            data["user_id"] = user_id
+        try:
+            parent = self._key_cache_path.parent
+            parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            # M9: mode arg to mkdir is umask-masked and a no-op on existing
+            # dirs, so chmod explicitly to guarantee 0o700 regardless of umask.
+            try:
+                os.chmod(parent, 0o700)
+            except OSError:
+                pass
+            # M8: use a unique temp filename (mkstemp) so concurrent writes
+            # from two app instances don't overwrite each other's temp file.
+            fd, tmp_path_str = tempfile.mkstemp(
+                dir=parent, prefix=".keys_", suffix=".tmp"
+            )
+            tmp_path = Path(tmp_path_str)
+            try:
+                # Restrict to owner-readable immediately after creation
+                # (mkstemp uses mode 0o600 on most platforms; chmod is
+                # belt-and-suspenders in case the platform differs).
+                os.chmod(tmp_path, 0o600)
+                with os.fdopen(fd, "w") as f:
+                    json.dump(data, f)
+                    f.flush()
+                    os.fsync(f.fileno())
+            except Exception:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+                raise
+            os.replace(tmp_path, self._key_cache_path)
+            # Belt-and-suspenders: ensure the final file is 0o600 after replace.
+            try:
+                os.chmod(self._key_cache_path, 0o600)
+            except OSError:
+                pass
+            logger.debug(
+                "_persist_key_cache: wrote cache fingerprint=%s", fingerprint
+            )
+        except Exception as exc:
+            logger.warning("_persist_key_cache: failed to write cache: %s", exc)
 
     def _notify_listeners(self) -> None:
         status = self.status
@@ -1170,7 +1414,101 @@ class MemorySyncService:
     async def _ensure_keypair(
         self, passphrase_provider: Callable[[], Any]
     ) -> None:
-        """Fetch or enrol the caller's X25519 keypair."""
+        """Fetch or enrol the caller's X25519 keypair.
+
+        Fast path (local cache):
+            If ``keys.json`` is present, unwrap the private key from it using
+            the passphrase and return — **no network call is made**.  This
+            avoids consuming one of the server's 3/hour ``/keys/me`` rate-limit
+            slots on every app restart.
+
+            A bad passphrase re-raises the unwrap exception immediately; we do
+            NOT silently fall back to the network, because that would mask the
+            wrong-passphrase error with a misleading "rate-limit" or
+            "key-not-found" message.
+
+        Network path (cache absent):
+            Fetches the wrapped key from ``GET /api/v1/memory/keys/me``,
+            unwraps it, and persists the encrypted material to the cache.
+
+        Enrol path (404 on keys/me):
+            Generates a fresh keypair, wraps it, POSTs to
+            ``POST /api/v1/memory/keys``, and persists to the cache.
+        """
+        import base64
+
+        # ------------------------------------------------------------------
+        # Fast path: local passphrase-encrypted cache
+        # ------------------------------------------------------------------
+        if self._key_cache_path.exists():
+            cached: Optional[Dict[str, Any]] = None
+            try:
+                raw = self._key_cache_path.read_text(encoding="utf-8")
+                cached = json.loads(raw)
+            except Exception as exc:
+                logger.warning(
+                    "_ensure_keypair: cache read/parse failed (%s); "
+                    "falling back to server",
+                    exc,
+                )
+            if cached is not None:
+                pub_b64 = cached.get("public_key", "")
+                wrapped_json = cached.get("wrapped_private_key", "")
+                fingerprint = cached.get("fingerprint", "")
+                if pub_b64 and wrapped_json:
+                    # MAJOR-2: user_id binding — reject cache if it was written
+                    # by a different account on this OS user (e.g. two engineers
+                    # share a laptop with different servonaut.dev accounts).
+                    cached_uid = cached.get("user_id")
+                    if (
+                        cached_uid is not None
+                        and self._self_user_id is not None
+                        and int(cached_uid) != int(self._self_user_id)
+                    ):
+                        logger.warning(
+                            "_ensure_keypair: cached user_id %s != current user_id %s — "
+                            "ignoring cache (different account on same OS user); "
+                            "clearing and falling back to server",
+                            cached_uid, self._self_user_id,
+                        )
+                        self.clear_local_keypair_cache()
+                        # Fall through to network path
+                    else:
+                        # Ask for the passphrase BEFORE touching _self_pubkey so
+                        # that if the provider raises (user cancel) the service
+                        # stays unconfigured and in a clean state.
+                        passphrase = await passphrase_provider("unlock")
+                        wrapped = WrappedPrivateKey.from_json(wrapped_json)
+                        # Bad passphrase raises here — do NOT silently refetch from
+                        # the server, and do NOT swallow the exception.
+                        privkey = unwrap_private_key(wrapped, passphrase)
+                        # M5: derive the public key from the unwrapped private key
+                        # and verify it matches the cached public_key.  A mismatch
+                        # means the cache was corrupted — clear it and fall back to
+                        # the network path so the server's authoritative copy is used.
+                        derived_pub = self._derive_public_key(privkey)
+                        if derived_pub is not None and derived_pub != base64.b64decode(pub_b64):
+                            logger.error(
+                                "_ensure_keypair: derived pubkey does not match cached "
+                                "pubkey — cache is corrupt; clearing and falling back to "
+                                "network path"
+                            )
+                            self.clear_local_keypair_cache()
+                            # Fall through to network path; passphrase_provider
+                            # will be called again from the network/enrol path.
+                        else:
+                            # Only update state AFTER successful unwrap + pubkey check.
+                            self._self_pubkey = base64.b64decode(pub_b64)
+                            self._self_privkey = privkey
+                            logger.info(
+                                "Bootstrap: loaded keypair from local cache fingerprint=%s",
+                                fingerprint,
+                            )
+                            return
+
+        # ------------------------------------------------------------------
+        # Network path: GET /api/v1/memory/keys/me
+        # ------------------------------------------------------------------
         try:
             await self._rate_limiter.acquire(RateLimitKey.KEYS_ME)
             data = await self._api.get(
@@ -1178,15 +1516,22 @@ class MemorySyncService:
             )
             pub_b64 = data.get("public_key", "")
             wrapped_json = data.get("wrapped_private_key", "")
-            import base64
-            pub_bytes = base64.b64decode(pub_b64)
-            self._self_pubkey = pub_bytes
+            fingerprint = data.get("fingerprint", "")
 
-            # Unwrap the private key using the passphrase
             passphrase = await passphrase_provider("unlock")
             wrapped = WrappedPrivateKey.from_json(wrapped_json)
-            self._self_privkey = unwrap_private_key(wrapped, passphrase)
-            logger.info("Bootstrap: loaded existing keypair fingerprint=%s", data.get("fingerprint"))
+            privkey = unwrap_private_key(wrapped, passphrase)
+            # Update state AFTER successful unwrap.
+            self._self_pubkey = base64.b64decode(pub_b64)
+            self._self_privkey = privkey
+            # Persist encrypted material so the next bootstrap skips the
+            # /keys/me rate-limit slot.  Include user_id so the cache is
+            # bound to this account (MAJOR-2).
+            self._persist_key_cache(pub_b64, wrapped_json, fingerprint, user_id=self._self_user_id)
+            logger.info(
+                "Bootstrap: loaded existing keypair fingerprint=%s",
+                fingerprint,
+            )
             return
 
         except RateLimitedError as exc:
@@ -1197,15 +1542,18 @@ class MemorySyncService:
                 endpoint="/api/v1/memory/keys/me", retry_after_s=1200.0
             ) from exc
         except NotFoundError:
-            # No active key — enrol a new one
+            # No active key — enrol a new one (fall through below).
             logger.info("Bootstrap: no active keypair; enrolling new key")
 
+        # ------------------------------------------------------------------
+        # Enrol path: generate fresh keypair + POST /api/v1/memory/keys
+        # ------------------------------------------------------------------
         passphrase = await passphrase_provider("enrol")
         kp = generate_keypair()
         wrapped = wrap_private_key(kp.private_key, passphrase)
-        import base64
+        pub_b64 = base64.b64encode(kp.public_key).decode()
         payload = {
-            "public_key": base64.b64encode(kp.public_key).decode(),
+            "public_key": pub_b64,
             "wrapped_private_key": wrapped.to_json(),
             "fingerprint": kp.fingerprint,
         }
@@ -1214,6 +1562,9 @@ class MemorySyncService:
         )
         self._self_pubkey = kp.public_key
         self._self_privkey = kp.private_key
+        # Persist encrypted material after successful enrolment.  Include
+        # user_id so the cache is bound to this account (MAJOR-2).
+        self._persist_key_cache(pub_b64, wrapped.to_json(), kp.fingerprint, user_id=self._self_user_id)
         logger.info("Bootstrap: enrolled new keypair fingerprint=%s", kp.fingerprint)
 
     async def _post_batch(self, batch: List[SyncEnvelope]) -> SyncBatchResult:

--- a/src/servonaut/services/memory/sync_service.py
+++ b/src/servonaut/services/memory/sync_service.py
@@ -199,6 +199,14 @@ class MemorySyncService:
         # cycle (sync_service ← retrieval_service would be circular).
         self._retrieval_service: Optional["MemoryRetrievalService"] = None
 
+        # Optional entitlement predicate injected by the app after construction.
+        # When set, enqueue_module is a no-op if it returns False.
+        # This prevents enrolled-but-lapsed users from accumulating plaintext
+        # envelopes on the on-disk JSONL queue that can never reach the server.
+        # When None (default), the gate is open — preserves current behaviour
+        # for headless callers (CLI, MCP) that don't wire the predicate.
+        self._entitlement_check: Optional[Callable[[], bool]] = None
+
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
@@ -225,6 +233,23 @@ class MemorySyncService:
         and team services without those services reaching into private attrs.
         """
         self._key_material_listener = listener
+
+    def set_entitlement_check(self, fn: Callable[[], bool]) -> None:
+        """Wire an entitlement predicate for the enqueue gate.
+
+        When *fn* returns ``False``, :meth:`enqueue_module` silently skips
+        enqueuing so enrolled-but-lapsed users don't accumulate plaintext
+        envelopes on disk that can never reach the server.
+
+        The predicate is called on every :meth:`enqueue_module` invocation
+        (i.e. after every successful SSH probe) and should be cheap — a
+        cached boolean attribute on the auth service is ideal.
+
+        Callers that do not call this method get the previous behaviour:
+        ``is_configured`` is the only gate, and any configured user can
+        enqueue regardless of current plan entitlement.
+        """
+        self._entitlement_check = fn
 
     def get_key_material(self) -> Optional[KeyMaterial]:
         """Return the active :class:`KeyMaterial`, or ``None`` if unwired."""
@@ -275,6 +300,16 @@ class MemorySyncService:
         Silently drops if the queue is at capacity (_QUEUE_CAP).
         """
         if not self.is_configured:
+            return
+        # Entitlement gate: if a predicate is wired and returns False (e.g.
+        # plan lapsed), skip enqueuing.  We do NOT want to accumulate plaintext
+        # envelopes on the JSONL queue for users whose subscription no longer
+        # grants access to Memory Sync — those envelopes can never be drained.
+        # When no predicate is set (None) the gate is open to preserve backward
+        # compatibility for callers (CLI, MCP) that don't wire this check.
+        # NOTE: backfill_from_local_store routes all module re-enqueues through
+        # this method, so it inherits the entitlement gate automatically.
+        if self._entitlement_check is not None and not self._entitlement_check():
             return
         if len(self._pending) >= _QUEUE_CAP:
             logger.warning(

--- a/src/servonaut/styles/screens/instance_list.tcss
+++ b/src/servonaut/styles/screens/instance_list.tcss
@@ -93,6 +93,11 @@ FleetMemoryScreen #memory-subtitle {
     color: $accent;
 }
 
+#fleet-auto-scan-status {
+    height: 1;
+    padding: 0 1;
+}
+
 /* Rounded card framing the DataTable so the table reads as an inset
    surface (matches .msync_card on Memory Sync, the IP Ban content
    panels, etc.). DataTable inside takes 1fr to fill the card. */

--- a/tests/test_app_fleet_auto_scan.py
+++ b/tests/test_app_fleet_auto_scan.py
@@ -1,0 +1,654 @@
+"""Tests for the fleet auto-scan loop and memory-sync loop gate in ServonautApp.
+
+Strategy: the Textual App is hard to instantiate headless without a full
+service tree, so we use the same pattern established by
+``test_app_session_expired_toast.py`` — a duck-typed object that provides
+exactly the attributes the methods under test read, then bind the unbound
+methods onto it to call them directly.
+
+For the async loop body ``_fleet_auto_scan_loop``, we monkeypatch
+``asyncio.sleep`` to raise or return quickly, controlling loop cycles.
+
+Note: ``_fleet_auto_scan_loop`` imports ``asyncio`` locally with a bare
+``import asyncio``, so patching must target ``asyncio.sleep`` (not
+``servonaut.app.asyncio.sleep``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from servonaut.app import ServonautApp
+from servonaut.config.schema import AppConfig, MemoryConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal stub
+# ---------------------------------------------------------------------------
+
+def _make_config(
+    *,
+    memory_enabled: bool = True,
+    auto_scan_enabled: bool = True,
+    auto_scan_interval_seconds: int = 300,
+    auto_scan_stale_only: bool = True,
+) -> AppConfig:
+    import dataclasses
+    mem = MemoryConfig(
+        enabled=memory_enabled,
+        auto_scan_enabled=auto_scan_enabled,
+        auto_scan_interval_seconds=auto_scan_interval_seconds,
+        auto_scan_stale_only=auto_scan_stale_only,
+    )
+    return AppConfig(memory=mem)
+
+
+def _make_stub(
+    config: Optional[AppConfig] = None,
+    fleet_scan_service=None,
+    memory_service=None,
+    memory_sync_service=None,
+    auth_service=None,
+) -> SimpleNamespace:
+    """Return a duck-typed stub for ServonautApp method tests.
+
+    Includes a real ``_fleet_auto_scan_loop`` method bound from ``ServonautApp``
+    so ``_start_fleet_auto_scan_loop`` can call ``self._fleet_auto_scan_loop()``.
+    """
+    if config is None:
+        config = _make_config()
+
+    config_manager = MagicMock()
+    config_manager.get = MagicMock(return_value=config)
+
+    # run_worker receives a coroutine object but never awaits it in tests.
+    # Close it immediately so Python doesn't warn about an unawaited coroutine.
+    def _run_worker_closing(coro_or_fn, *, name=None, group=None, exclusive=None):
+        if asyncio.iscoroutine(coro_or_fn):
+            coro_or_fn.close()
+
+    run_worker_mock = MagicMock(side_effect=_run_worker_closing)
+
+    stub = SimpleNamespace(
+        config_manager=config_manager,
+        fleet_scan_service=fleet_scan_service,
+        memory_service=memory_service,
+        memory_sync_service=memory_sync_service,
+        auth_service=auth_service,
+        instances=[],
+        _fleet_auto_scan_last_run=0.0,
+        run_worker=run_worker_mock,
+    )
+    # Bind the real loop coroutine so _start_fleet_auto_scan_loop can call it.
+    stub._fleet_auto_scan_loop = (
+        lambda: ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+    )
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# _start_fleet_auto_scan_loop — guard conditions
+# ---------------------------------------------------------------------------
+
+class TestStartFleetAutoScanLoop:
+    """_start_fleet_auto_scan_loop must be a no-op unless all conditions hold."""
+
+    def test_noop_when_auto_scan_enabled_false(self) -> None:
+        config = _make_config(auto_scan_enabled=False)
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=MagicMock(),
+            memory_service=MagicMock(),
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_memory_enabled_false(self) -> None:
+        config = _make_config(memory_enabled=False, auto_scan_enabled=True)
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=MagicMock(),
+            memory_service=MagicMock(),
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_fleet_scan_service_is_none(self) -> None:
+        config = _make_config()
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=None,
+            memory_service=MagicMock(),
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_memory_service_is_none(self) -> None:
+        config = _make_config()
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=MagicMock(),
+            memory_service=None,
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_calls_run_worker_when_all_conditions_hold(self) -> None:
+        config = _make_config()
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=MagicMock(),
+            memory_service=MagicMock(),
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_called_once()
+
+    def test_run_worker_called_with_correct_group_and_flags(self) -> None:
+        config = _make_config()
+        stub = _make_stub(
+            config=config,
+            fleet_scan_service=MagicMock(),
+            memory_service=MagicMock(),
+        )
+        ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        _, kwargs = stub.run_worker.call_args
+        assert kwargs.get("group") == "memory_auto_scan"
+        assert kwargs.get("exclusive") is True
+        assert kwargs.get("name") == "fleet_auto_scan_loop"
+
+
+# ---------------------------------------------------------------------------
+# _fleet_auto_scan_loop — loop body behaviour
+# ---------------------------------------------------------------------------
+
+class TestFleetAutoScanLoopBody:
+    """Drive _fleet_auto_scan_loop directly by monkeypatching asyncio.sleep.
+
+    ``_fleet_auto_scan_loop`` does ``import asyncio`` locally, so the correct
+    patch target is ``asyncio.sleep`` (the real module attribute), not any
+    ``servonaut.app.*`` path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_loop_exits_when_auto_scan_disabled_before_sleep(self) -> None:
+        """If config has auto_scan_enabled=False on entry, exit immediately."""
+        config = _make_config(auto_scan_enabled=False)
+        stub = _make_stub(config=config)
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_loop_uses_configured_interval(self) -> None:
+        """sleep() must be called with the configured interval (min 60)."""
+        config = _make_config(auto_scan_interval_seconds=180)
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(return_value=MagicMock())
+        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+
+        sleep_calls: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            # After first sleep, flip the flag so the loop exits.
+            off_config = _make_config(auto_scan_enabled=False)
+            stub.config_manager.get = MagicMock(return_value=off_config)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        assert len(sleep_calls) >= 1
+        assert sleep_calls[0] == 180
+
+    @pytest.mark.asyncio
+    async def test_loop_enforces_minimum_interval_of_60(self) -> None:
+        """Interval below 60 is clamped to 60."""
+        config = _make_config(auto_scan_interval_seconds=5)
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(return_value=MagicMock())
+        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+
+        sleep_calls: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            off_config = _make_config(auto_scan_enabled=False)
+            stub.config_manager.get = MagicMock(return_value=off_config)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        assert sleep_calls[0] == 60
+
+    @pytest.mark.asyncio
+    async def test_scan_called_with_stale_only_from_config(self) -> None:
+        """scan() receives stale_only from config.memory.auto_scan_stale_only."""
+        for expected_stale_only in (True, False):
+            config = _make_config(auto_scan_stale_only=expected_stale_only)
+            scan_service = MagicMock()
+            scan_service.scan = AsyncMock(return_value=MagicMock())
+            stub = _make_stub(
+                config=config, fleet_scan_service=scan_service
+            )
+            stub.instances = [{"id": "web-1", "name": "web-1"}]
+
+            # One sleep then exit.
+            cycle_count = 0
+
+            async def _fake_sleep_one_cycle(seconds):
+                nonlocal cycle_count
+                cycle_count += 1
+                if cycle_count == 1:
+                    # First sleep: return normally so the scan runs.
+                    return
+                # Second sleep: flip flag off so loop exits cleanly.
+                off_config = _make_config(auto_scan_enabled=False)
+                stub.config_manager.get = MagicMock(return_value=off_config)
+
+            with patch("asyncio.sleep", side_effect=_fake_sleep_one_cycle):
+                await ServonautApp._fleet_auto_scan_loop(  # type: ignore[arg-type]
+                    stub
+                )
+
+            scan_service.scan.assert_called_with(
+                stub.instances,
+                stale_only=expected_stale_only,
+            )
+
+    @pytest.mark.asyncio
+    async def test_last_run_updated_after_successful_scan(self) -> None:
+        """_fleet_auto_scan_last_run is updated after a scan completes."""
+        config = _make_config()
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(return_value=MagicMock())
+        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+        stub._fleet_auto_scan_last_run = 0.0
+
+        cycle_count = 0
+
+        async def _fake_sleep(seconds):
+            nonlocal cycle_count
+            cycle_count += 1
+            if cycle_count >= 2:
+                off_config = _make_config(auto_scan_enabled=False)
+                stub.config_manager.get = MagicMock(return_value=off_config)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        assert stub._fleet_auto_scan_last_run > 0.0
+
+    @pytest.mark.asyncio
+    async def test_loop_survives_scan_exception_and_continues(self) -> None:
+        """A scan() that raises must not kill the loop — it keeps iterating."""
+        config = _make_config()
+        scan_service = MagicMock()
+        scan_calls: List[int] = []
+
+        async def _scan(instances, *, stale_only):
+            scan_calls.append(1)
+            raise RuntimeError("ssh error")
+
+        scan_service.scan = AsyncMock(side_effect=_scan)
+        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+        stub._fleet_auto_scan_last_run = 0.0
+
+        # Run 2 cycles then exit.
+        cycle_count = 0
+
+        async def _fake_sleep(seconds):
+            nonlocal cycle_count
+            cycle_count += 1
+            if cycle_count >= 3:
+                off_config = _make_config(auto_scan_enabled=False)
+                stub.config_manager.get = MagicMock(return_value=off_config)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        # Should have attempted 2 scans despite both raising.
+        assert len(scan_calls) == 2
+        # last_run NOT updated on failure.
+        assert stub._fleet_auto_scan_last_run == 0.0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_sleep_exits_loop(self) -> None:
+        """CancelledError from asyncio.sleep causes clean loop exit."""
+        config = _make_config()
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+
+        async def _cancel(seconds):
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=_cancel):
+            # _fleet_auto_scan_loop catches CancelledError during sleep and returns.
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        # Reaching here means the loop returned cleanly (did not re-raise).
+
+    @pytest.mark.asyncio
+    async def test_loop_exits_when_flag_toggled_off_after_sleep(self) -> None:
+        """If auto_scan_enabled is flipped to False after the sleep, loop exits."""
+        config = _make_config(auto_scan_enabled=True)
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(return_value=MagicMock())
+        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+
+        async def _fake_sleep(seconds):
+            # After sleeping, flip the flag off so the post-sleep re-read exits.
+            off_config = _make_config(auto_scan_enabled=False)
+            stub.config_manager.get = MagicMock(return_value=off_config)
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        # Loop should have exited before calling scan.
+        scan_service.scan.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _start_memory_sync_loop — gate conditions
+# ---------------------------------------------------------------------------
+
+class TestStartMemorySyncLoop:
+    """_start_memory_sync_loop(self, auto_sync_enabled: bool) must respect the
+    passed flag, the entitlement check, and the is_configured guard.
+
+    The server-side flag is now fetched by the async caller (bootstrap_memory_cloud
+    or _refresh_memory_sync_loop) and passed in as a plain bool parameter,
+    so these tests drive the method directly with the flag value.
+    """
+
+    def _make_sync_service(self, is_configured: bool = True) -> MagicMock:
+        svc = MagicMock()
+        svc.is_configured = is_configured
+        svc.start_background_loop = MagicMock(return_value=AsyncMock())
+        return svc
+
+    def _make_auth(self, has_memory_sync: bool) -> MagicMock:
+        auth = MagicMock()
+        auth.has_feature = MagicMock(
+            side_effect=lambda feat: feat == "memory_sync" and has_memory_sync
+        )
+        return auth
+
+    def test_noop_when_sync_service_is_none(self) -> None:
+        """No sync service — no-op regardless of flag."""
+        stub = _make_stub(
+            memory_sync_service=None,
+            auth_service=self._make_auth(has_memory_sync=True),
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_not_configured(self) -> None:
+        """is_configured=False — no-op even when flag is True."""
+        sync = self._make_sync_service(is_configured=False)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=self._make_auth(has_memory_sync=True),
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_auto_sync_enabled_false(self) -> None:
+        """auto_sync_enabled param=False blocks the loop even when configured."""
+        sync = self._make_sync_service(is_configured=True)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=self._make_auth(has_memory_sync=True),
+        )
+        ServonautApp._start_memory_sync_loop(stub, False)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_noop_when_not_entitled(self) -> None:
+        """has_feature('memory_sync')=False blocks the loop even when flag is True."""
+        sync = self._make_sync_service(is_configured=True)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=self._make_auth(has_memory_sync=False),
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+    def test_spawns_when_configured_enabled_and_entitled(self) -> None:
+        """run_worker is called when all three gates pass."""
+        sync = self._make_sync_service(is_configured=True)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=self._make_auth(has_memory_sync=True),
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        stub.run_worker.assert_called_once()
+
+    def test_run_worker_uses_memory_sync_background_group(self) -> None:
+        """Worker must use the 'memory_sync_background' group with exclusive=True."""
+        sync = self._make_sync_service(is_configured=True)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=self._make_auth(has_memory_sync=True),
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        _, kwargs = stub.run_worker.call_args
+        assert kwargs.get("group") == "memory_sync_background"
+        assert kwargs.get("exclusive") is True
+
+    def test_noop_when_auto_sync_enabled_true_but_auth_service_is_none(self) -> None:
+        """No auth service means has_feature cannot be checked — no-op."""
+        sync = self._make_sync_service(is_configured=True)
+        stub = _make_stub(
+            memory_sync_service=sync,
+            auth_service=None,
+        )
+        ServonautApp._start_memory_sync_loop(stub, True)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _refresh_fleet_auto_scan_loop — Fix C lifecycle helper
+# ---------------------------------------------------------------------------
+
+class TestRefreshFleetAutoScanLoop:
+    """_refresh_fleet_auto_scan_loop must spawn or cancel based on config flags."""
+
+    def _make_stub_with_workers(
+        self,
+        config: Optional[AppConfig] = None,
+        fleet_scan_service=None,
+        memory_service=None,
+    ) -> SimpleNamespace:
+        """Return a stub with a real workers mock that tracks cancel_group calls."""
+        stub = _make_stub(
+            config=config or _make_config(),
+            fleet_scan_service=fleet_scan_service or MagicMock(),
+            memory_service=memory_service or MagicMock(),
+        )
+        workers_mock = MagicMock()
+        workers_mock.cancel_group = MagicMock()
+        stub.workers = workers_mock
+        # Bind _start_fleet_auto_scan_loop so _refresh_fleet_auto_scan_loop can call it.
+        stub._start_fleet_auto_scan_loop = (
+            lambda: ServonautApp._start_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        )
+        return stub
+
+    def test_spawns_loop_when_enabled(self) -> None:
+        """When both enabled and auto_scan_enabled, run_worker is called."""
+        config = _make_config(memory_enabled=True, auto_scan_enabled=True)
+        stub = self._make_stub_with_workers(config=config)
+        ServonautApp._refresh_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_called_once()
+        stub.workers.cancel_group.assert_not_called()
+
+    def test_cancels_group_when_auto_scan_disabled(self) -> None:
+        """When auto_scan_enabled=False, cancel_group is called and run_worker is not."""
+        config = _make_config(memory_enabled=True, auto_scan_enabled=False)
+        stub = self._make_stub_with_workers(config=config)
+        ServonautApp._refresh_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+        stub.workers.cancel_group.assert_called_once_with(stub, "memory_auto_scan")
+
+    def test_cancels_group_when_memory_disabled(self) -> None:
+        """When memory.enabled=False, cancel_group is called promptly."""
+        config = _make_config(memory_enabled=False, auto_scan_enabled=True)
+        stub = self._make_stub_with_workers(config=config)
+        ServonautApp._refresh_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+        stub.run_worker.assert_not_called()
+        stub.workers.cancel_group.assert_called_once_with(stub, "memory_auto_scan")
+
+    def test_cancel_group_exception_is_swallowed(self) -> None:
+        """cancel_group raising must not propagate — graceful degradation."""
+        config = _make_config(memory_enabled=False, auto_scan_enabled=False)
+        stub = self._make_stub_with_workers(config=config)
+        stub.workers.cancel_group.side_effect = RuntimeError("textual gone")
+        # Must not raise.
+        ServonautApp._refresh_fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _auto_scan_status_text — Fix A regression
+# ---------------------------------------------------------------------------
+
+class TestAutoScanStatusText:
+    """_auto_scan_status_text reads config_manager, not the non-existent .config attr."""
+
+    def _make_fleet_screen(self, config: Optional[AppConfig] = None) -> Any:
+        """Return a FleetMemoryScreen-like object with a patched app."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        screen._rows = []
+        screen._scanning = False
+
+        cfg = config or _make_config(memory_enabled=True, auto_scan_enabled=True)
+        config_manager = MagicMock()
+        config_manager.get = MagicMock(return_value=cfg)
+
+        app = MagicMock()
+        app.config_manager = config_manager
+        # _auto_scan_status_text reads _fleet_auto_scan_last_run from app (not screen).
+        app._fleet_auto_scan_last_run = 0.0
+
+        # Patch app property on the screen class shadow.
+        type(screen).app = property(lambda self: app)
+        return screen
+
+    def test_returns_on_string_when_enabled(self) -> None:
+        """When auto_scan_enabled=True, status text contains 'on'."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = self._make_fleet_screen(
+            _make_config(memory_enabled=True, auto_scan_enabled=True)
+        )
+        text = FleetMemoryScreen._auto_scan_status_text(screen)
+        assert "on" in text.lower()
+        assert "off" not in text.lower()
+
+    def test_returns_off_string_when_disabled(self) -> None:
+        """When auto_scan_enabled=False, status text contains 'off'."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = self._make_fleet_screen(
+            _make_config(memory_enabled=True, auto_scan_enabled=False)
+        )
+        text = FleetMemoryScreen._auto_scan_status_text(screen)
+        assert "off" in text.lower()
+
+    def test_returns_off_when_config_manager_is_none(self) -> None:
+        """If config_manager is missing on app, return 'off' gracefully."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        screen._rows = []
+
+        app = MagicMock(spec=[])  # no attributes at all
+        type(screen).app = property(lambda self: app)
+
+        text = FleetMemoryScreen._auto_scan_status_text(screen)
+        assert "off" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# action_toggle_auto_scan — Fix A regression
+# ---------------------------------------------------------------------------
+
+class TestActionToggleAutoScan:
+    """action_toggle_auto_scan reads config_manager (not .config) and persists."""
+
+    def _make_toggle_screen(self, initial_auto_scan: bool) -> Any:
+        """Return a FleetMemoryScreen stub with a writable config_manager."""
+        import dataclasses
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = object.__new__(FleetMemoryScreen)
+        screen._rows = []
+        screen._scanning = False
+
+        cfg = _make_config(memory_enabled=True, auto_scan_enabled=initial_auto_scan)
+
+        # Track config_manager.update calls.
+        config_manager = MagicMock()
+        config_manager.get = MagicMock(return_value=cfg)
+        update_calls: List[Any] = []
+        config_manager.update = MagicMock(side_effect=lambda **kw: update_calls.append(kw))
+
+        app = MagicMock()
+        app.config_manager = config_manager
+        app._refresh_fleet_auto_scan_loop = MagicMock()
+        app.notify = MagicMock()
+
+        type(screen).app = property(lambda self: app)
+        screen._refresh_auto_scan_status = MagicMock()
+
+        screen._update_calls = update_calls
+        screen._config_manager = config_manager
+        return screen
+
+    def test_toggle_off_to_on_persists_enabled(self) -> None:
+        """Toggling from off→on writes auto_scan_enabled=True to config."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = self._make_toggle_screen(initial_auto_scan=False)
+        FleetMemoryScreen.action_toggle_auto_scan(screen)
+
+        assert len(screen._update_calls) == 1
+        updated_mem = screen._update_calls[0]["memory"]
+        assert updated_mem.auto_scan_enabled is True
+
+    def test_toggle_on_to_off_persists_disabled(self) -> None:
+        """Toggling from on→off writes auto_scan_enabled=False to config."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = self._make_toggle_screen(initial_auto_scan=True)
+        FleetMemoryScreen.action_toggle_auto_scan(screen)
+
+        assert len(screen._update_calls) == 1
+        updated_mem = screen._update_calls[0]["memory"]
+        assert updated_mem.auto_scan_enabled is False
+
+    def test_calls_refresh_loop_after_toggle(self) -> None:
+        """_refresh_fleet_auto_scan_loop must be called after persisting."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        screen = self._make_toggle_screen(initial_auto_scan=False)
+        FleetMemoryScreen.action_toggle_auto_scan(screen)
+
+        screen.app._refresh_fleet_auto_scan_loop.assert_called_once()
+
+    def test_status_text_on_after_enabling(self) -> None:
+        """After enabling, _auto_scan_status_text returns an 'on' string."""
+        from servonaut.screens.fleet_memory import FleetMemoryScreen
+
+        # Build screen with enabled=True config (post-toggle state).
+        screen = self._make_toggle_screen(initial_auto_scan=True)
+        # _auto_scan_status_text reads _fleet_auto_scan_last_run from app, not screen.
+        screen.app._fleet_auto_scan_last_run = 0.0
+        text = FleetMemoryScreen._auto_scan_status_text(screen)
+        assert "on" in text.lower()
+        assert "off" not in text.lower()

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,7 +1,7 @@
 """Tests for configuration migration."""
 
 from servonaut.config.migration import migrate_v1_to_v2, migrate_to_latest, create_backup
-from servonaut.config.schema import CONFIG_VERSION
+from servonaut.config.schema import CONFIG_VERSION, DEFAULT_AUTO_SCAN_INTERVAL_SECONDS
 
 
 class TestMigrateV1ToV2:
@@ -83,6 +83,109 @@ class TestMigrateToLatest:
         cfg = {'version': CONFIG_VERSION, 'ai_provider': {}}
         out = migrate_to_latest(cfg)
         assert out['version'] == CONFIG_VERSION
+
+    # ------------------------------------------------------------------
+    # Back-compat: v2, v3, v4, and no-version configs all land at v5
+    # with the new auto-scan fields available at their defaults.
+    # ------------------------------------------------------------------
+
+    def _assert_new_fields_at_defaults(self, out: dict) -> None:
+        """The new MemoryConfig auto-scan fields are additive.
+
+        The migration does NOT write them into the JSON dict — the
+        MemoryConfig dataclass provides defaults when they are absent from
+        disk (the _coerce / AppConfig(**dict) path handles this). What we
+        assert here is that migrate_to_latest does NOT overwrite them with
+        wrong values and that the result is accepted by AppConfig with the
+        expected defaults.
+
+        Note: auto_sync_enabled has been relocated to the server-side
+        MemorySettings and is no longer a MemoryConfig field.
+        """
+        from servonaut.config.manager import ConfigManager
+        import json
+        import tempfile
+        import pathlib
+
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "cfg.json"
+            p.write_text(json.dumps(out))
+            mgr = ConfigManager()
+            mgr._config_path = p
+            mem = mgr.load().memory
+
+        assert mem.auto_scan_enabled is False, (
+            "auto_scan_enabled should default False after migration"
+        )
+        assert mem.auto_scan_interval_seconds == DEFAULT_AUTO_SCAN_INTERVAL_SECONDS, (
+            f"auto_scan_interval_seconds should be {DEFAULT_AUTO_SCAN_INTERVAL_SECONDS}"
+        )
+        assert mem.auto_scan_stale_only is True, (
+            "auto_scan_stale_only should default True after migration"
+        )
+
+    def test_no_version_config_lands_at_v5_with_new_fields(self):
+        """No-version dict (treated as v1) migrates cleanly to v5."""
+        no_version = {'instance_keys': {}, 'default_key': ''}
+        out = migrate_to_latest(no_version)
+        assert out['version'] == 5
+        self._assert_new_fields_at_defaults(out)
+
+    def test_v2_config_lands_at_v5_with_new_fields(self):
+        """v2 on-disk config migrates to v5 preserving new field defaults."""
+        v2 = {
+            'version': 2,
+            'default_username': 'ec2-user',
+            'cache_ttl_seconds': 300,
+        }
+        out = migrate_to_latest(v2)
+        assert out['version'] == 5
+        self._assert_new_fields_at_defaults(out)
+
+    def test_v3_config_lands_at_v5_with_new_fields(self):
+        """v3 on-disk config migrates to v5 preserving new field defaults."""
+        v3 = {
+            'version': 3,
+            'ai_provider': {'provider': 'openai', 'api_key': ''},
+        }
+        out = migrate_to_latest(v3)
+        assert out['version'] == 5
+        self._assert_new_fields_at_defaults(out)
+
+    def test_v4_config_lands_at_v5_with_new_fields(self):
+        """v4 on-disk config migrates to v5 preserving new field defaults."""
+        v4 = {
+            'version': 4,
+            'ai_provider': {
+                'provider': 'openai',
+                'api_key': '',
+                'openai_api_key': 'sk-test',
+                'anthropic_api_key': '',
+                'gemini_api_key': '',
+            },
+        }
+        out = migrate_to_latest(v4)
+        assert out['version'] == 5
+        self._assert_new_fields_at_defaults(out)
+
+    def test_v4_config_with_existing_memory_block_preserves_fields(self):
+        """v4 config with a 'memory' block migrates and preserves memory fields."""
+        v4 = {
+            'version': 4,
+            'ai_provider': {'provider': 'openai'},
+            'memory': {
+                'enabled': False,
+                'redaction_enabled': True,
+                'disabled_modules': ['containers'],
+            },
+        }
+        out = migrate_to_latest(v4)
+        assert out['version'] == 5
+        # Memory fields we put in are still there after migration.
+        assert out.get('memory', {}).get('enabled') is False
+        assert out.get('memory', {}).get('disabled_modules') == ['containers']
+        # New fields absent from disk — defaults picked up via ConfigManager.
+        self._assert_new_fields_at_defaults(out)
 
 
 class TestCreateBackup:

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -417,6 +417,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         # ---- Edit consent ----
         "edit-consent",         # Reason: Button; inherits global Button styling
         "enrol-btn-confirm",    # Reason: Button; inherits global Button styling
+        "enrol-remember",       # Reason: Switch; inherits global Switch styling (row/label have #rules)
         "event_detail_text",    # Reason: Static inside styled #event_detail
         # ---- Export screen ----
         "export-from-input",    # Reason: Input; inherits global Input styling
@@ -580,6 +581,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "msync_btn_disable",
         "msync_btn_learn",
         "msync_btn_login",
+        "msync_btn_forget",
         "msync_btn_rotate",
         "msync_btn_setup",
         "msync_btn_sync_now",

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -239,6 +239,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "btn_refresh_all",
         "btn_refresh_module",
         "btn_refresh_stale",
+        "btn_refresh_view",
         "btn_refresh_zone",
         "btn_reinstall",
         "btn_remove",
@@ -288,6 +289,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "btn_ssh",
         "btn_sync_now",
         "btn_toggle",
+        "btn_toggle_auto_scan",
         "btn_tool_cancel",
         "btn_tool_confirm",
         "btn_topup_cancel",
@@ -661,6 +663,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "settings_chat_inject_server_memory", # Reason: Switch; inherits global Switch styling
         "settings_chat_keep_tool_results",
         "settings_msync_ai_mode",
+        "settings_msync_auto_sync",
         "settings_msync_digest",
         "settings_msync_mercure",
         "settings_msync_status", # Reason: Static status; inherits global Static
@@ -902,6 +905,8 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'mcp_guard_warn',
         'mcp_max_output_lines',
         'memory',
+        'memory_auto_scan_enabled',
+        'memory_auto_scan_interval',
         'memory_disabled_modules',
         'memory_enabled',
         'memory_findings_confidence',

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -496,6 +496,13 @@ _ALLOWLIST: List[AllowlistEntry] = [
     AllowlistEntry("screens/memory_sync_setup.py", "_set_busy", "update",
                    "Writes a busy-state message passed from _do_setup — "
                    "always a code-controlled string constant."),
+    AllowlistEntry("screens/memory_sync_setup.py", "_do_rotate", "update",
+                   "The flagged .update() calls are config_manager.update(memory=...) "
+                   "— config persistence of the remember flag, NOT a widget/UI write; "
+                   "no server-origin data."),
+    AllowlistEntry("screens/memory_sync_setup.py", "_do_forget", "update",
+                   "config_manager.update(memory=...) to reset the remember flag — "
+                   "config write, not a widget/UI write; no server-origin data."),
 
     # ovh_billing.py — current usage and spend history write formatted currency
     # amounts and dates (no customer hostnames or IPs); invoice page writes

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -152,6 +152,17 @@ _ALLOWLIST: List[AllowlistEntry] = [
     AllowlistEntry("screens/fleet_memory.py", "_render_fleet_table", "add_row",
                    "Fleet memory table shows module-count summaries and timestamps "
                    "only — no raw_output values that require scrubbing."),
+    AllowlistEntry("screens/fleet_memory.py", "_update_row_for_instance", "update",
+                   "Live per-row scan update writes the fresh/stale/opted-out count "
+                   "summary line (integers) only; status/module/age cells go through "
+                   "update_cell_at and carry status markup + counts, not server text."),
+    AllowlistEntry("screens/fleet_memory.py", "_refresh_auto_scan_status", "update",
+                   "Writes the auto-scan indicator string derived purely from local "
+                   "config ints (enabled flag, interval, last-run epoch) — no "
+                   "server-origin data."),
+    AllowlistEntry("screens/fleet_memory.py", "action_toggle_auto_scan", "update",
+                   "Refreshes the auto-scan indicator after toggling the local config "
+                   "flag — code/config-derived markup only, no server-origin data."),
 
     # ai_analysis.py — status updates are all hard-coded or contain only
     # token counts and line counts (integers), not raw log content.

--- a/tests/test_fleet_manual_scan.py
+++ b/tests/test_fleet_manual_scan.py
@@ -1,0 +1,133 @@
+"""Tests for the app-owned manual fleet scan (survives screen navigation).
+
+The "Scan All" action is owned by ``ServonautApp`` (group ``memory_manual_scan``)
+rather than by ``FleetMemoryScreen``, so a scan keeps running and finishes even
+when the user leaves the panel. Progress and completion are routed to whichever
+Fleet Memory screen is currently mounted via duck-typing, and are safe no-ops
+when the user has navigated elsewhere.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from servonaut.app import ServonautApp
+
+
+def _make_app():
+    app = ServonautApp.__new__(ServonautApp)
+    app._fleet_manual_scan_in_progress = False
+    app.notify = MagicMock()
+    app.fleet_scan_service = MagicMock()
+    return app
+
+
+def _capture_worker(app):
+    """Replace run_worker with a capture that stores the coroutine + group."""
+    captured = {}
+
+    def run_worker(coro, **kwargs):
+        captured["coro"] = coro
+        captured["group"] = kwargs.get("group")
+        captured["name"] = kwargs.get("name")
+        captured["exclusive"] = kwargs.get("exclusive")
+        return MagicMock()
+
+    app.run_worker = run_worker
+    return captured
+
+
+def test_start_spawns_app_worker_in_dedicated_group():
+    app = _make_app()
+    captured = _capture_worker(app)
+
+    started = app.start_fleet_manual_scan([{"id": "web-1"}], stale_only=False)
+
+    assert started is True
+    assert app._fleet_manual_scan_in_progress is True
+    assert captured["group"] == "memory_manual_scan"
+    assert captured["exclusive"] is True
+    # Close the un-awaited coroutine to avoid a RuntimeWarning.
+    captured["coro"].close()
+
+
+def test_second_start_is_refused_while_in_progress():
+    app = _make_app()
+    captured = _capture_worker(app)
+
+    assert app.start_fleet_manual_scan([{"id": "web-1"}], stale_only=False) is True
+    # A second launch while one is in progress must NOT spawn another worker.
+    spawned_after_first = "coro" in captured
+    captured_count_before = captured.copy()
+    assert app.start_fleet_manual_scan([{"id": "web-2"}], stale_only=False) is False
+    # group/name unchanged — no second spawn occurred.
+    assert captured["name"] == captured_count_before["name"]
+    captured["coro"].close()
+    assert spawned_after_first
+
+
+def test_progress_routes_to_mounted_fleet_screen():
+    app = _make_app()
+    screen = MagicMock()  # has _on_scan_progress
+    with patch.object(ServonautApp, "screen", new_callable=PropertyMock, return_value=screen):
+        progress = MagicMock()
+        app._fleet_manual_scan_progress(progress)
+        screen._on_scan_progress.assert_called_once_with(progress)
+
+
+def test_progress_is_noop_when_current_screen_lacks_hook():
+    app = _make_app()
+    # A screen without _on_scan_progress (user navigated away) must not raise.
+    other_screen = MagicMock(spec=[])
+    with patch.object(ServonautApp, "screen", new_callable=PropertyMock, return_value=other_screen):
+        app._fleet_manual_scan_progress(MagicMock())  # no exception = pass
+
+
+def test_scan_completes_and_clears_flag_even_without_fleet_screen():
+    """The worker finishes in the background and clears the in-progress flag
+    via its finally block, even when no Fleet Memory screen is mounted."""
+    app = _make_app()
+    captured = _capture_worker(app)
+
+    async def fake_scan(instances, *, stale_only, on_progress=None):
+        for i, inst in enumerate(instances, 1):
+            await asyncio.sleep(0)
+            if on_progress:
+                on_progress(MagicMock(instance_id=inst["id"], completed=i,
+                                      total=len(instances), succeeded=True,
+                                      instance_name=inst["id"]))
+        result = MagicMock()
+        result.succeeded = [inst["id"] for inst in instances]
+        result.failed = []
+        return result
+
+    app.fleet_scan_service.scan = fake_scan
+
+    other_screen = MagicMock(spec=[])  # no fleet hooks -> user navigated away
+    with patch.object(ServonautApp, "screen", new_callable=PropertyMock, return_value=other_screen):
+        app.start_fleet_manual_scan([{"id": "web-1"}, {"id": "web-2"}], stale_only=False)
+        assert app._fleet_manual_scan_in_progress is True
+        asyncio.run(captured["coro"])  # drive the background worker to completion
+
+    assert app._fleet_manual_scan_in_progress is False
+    app.notify.assert_called()  # "Fleet scan done: ..." toast fired
+
+
+def test_completion_hook_fires_on_mounted_fleet_screen():
+    app = _make_app()
+    captured = _capture_worker(app)
+
+    async def fake_scan(instances, *, stale_only, on_progress=None):
+        result = MagicMock()
+        result.succeeded = ["web-1"]
+        result.failed = []
+        return result
+
+    app.fleet_scan_service.scan = fake_scan
+
+    screen = MagicMock()  # has on_fleet_manual_scan_done + _set_progress
+    with patch.object(ServonautApp, "screen", new_callable=PropertyMock, return_value=screen):
+        app.start_fleet_manual_scan([{"id": "web-1"}], stale_only=False)
+        asyncio.run(captured["coro"])
+        screen.on_fleet_manual_scan_done.assert_called_once()

--- a/tests/test_fleet_memory_live_update.py
+++ b/tests/test_fleet_memory_live_update.py
@@ -1,0 +1,423 @@
+"""Tests for FleetMemoryScreen live per-row update and summary helper.
+
+Unit-tests for:
+- ``_summary_line_from_rows`` — static helper that builds the fleet status footer.
+- ``_update_row_for_instance`` — live cell updater fired from _on_scan_progress.
+
+These tests construct ``FleetMemoryScreen`` via ``object.__new__`` (skipping
+the full Textual init) and patch ``app`` using the same harness pattern as
+``test_demo_mode_coverage.py``.  The DataTable is mocked so ``update_cell_at``
+assertions run without a running Textual event loop.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from servonaut.screens.fleet_memory import (
+    FleetMemoryScreen,
+    STATUS_FRESH,
+    STATUS_STALE,
+    STATUS_NONE,
+    STATUS_OPT_OUT,
+    _STATUS_CELL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_screen() -> FleetMemoryScreen:
+    """Return a FleetMemoryScreen skipping the Textual widget init."""
+    screen = object.__new__(FleetMemoryScreen)
+    screen._rows = []
+    screen._scanning = False
+    return screen
+
+
+def _make_app(
+    *,
+    memory_service: Any = None,
+    demo_mode: bool = False,
+) -> MagicMock:
+    """Return a minimal mock ServonautApp."""
+    app = MagicMock()
+    app.demo_mode = demo_mode
+    app.redaction_service = None
+    app.memory_service = memory_service
+    app.instances = []
+    return app
+
+
+def _set_app(screen: Any, app: Any) -> None:
+    """Patch the ``app`` property on the screen's class shadow (read-only bypass)."""
+    type(screen).app = property(lambda self: app)
+
+
+def _fresh_modules(age_seconds: float = 60.0) -> Dict[str, Any]:
+    ts = (datetime.now(tz=timezone.utc) - timedelta(seconds=age_seconds)).isoformat()
+    return {"os": {"probed_at": ts}}
+
+
+def _stale_modules(threshold: float = 7 * 86400) -> Dict[str, Any]:
+    ts = (
+        datetime.now(tz=timezone.utc) - timedelta(seconds=threshold + 3600)
+    ).isoformat()
+    return {"os": {"probed_at": ts}}
+
+
+def _make_memory_service(
+    *,
+    module_map: Optional[Dict[str, Dict[str, Any]]] = None,
+    disabled_ids: Optional[List[str]] = None,
+    stale_seconds: float = 7 * 86400,
+) -> MagicMock:
+    """Return a memory service mock.
+
+    ``module_map`` maps raw_id → modules dict returned by ``get_all_modules``.
+    ``disabled_ids`` lists ids for which ``is_memory_disabled`` returns True.
+    """
+    ms = MagicMock()
+    ms.snapshot_stale_seconds = stale_seconds
+    disabled = set(disabled_ids or [])
+
+    def _is_disabled(iid: str, name: str) -> bool:
+        return iid in disabled or name in disabled
+
+    def _get_all_modules(iid: str, provider: str) -> Dict[str, Any]:
+        return (module_map or {}).get(iid, {})
+
+    ms.is_memory_disabled = MagicMock(side_effect=_is_disabled)
+    ms.get_all_modules = MagicMock(side_effect=_get_all_modules)
+    return ms
+
+
+def _row(
+    raw_id: str,
+    raw_provider: str = "aws",
+    status: str = STATUS_STALE,
+    modules: int = 0,
+    age: str = "—",
+    name: str = "",
+) -> Dict[str, Any]:
+    """Build a minimal _rows entry."""
+    return {
+        "instance": {"id": raw_id, "name": name or raw_id, "provider": raw_provider},
+        "id": raw_id,
+        "raw_id": raw_id,
+        "name": name or raw_id,
+        "provider": raw_provider,
+        "raw_provider": raw_provider,
+        "source": "local",
+        "status": status,
+        "modules": modules,
+        "drift_7d": 0,
+        "age": age,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _summary_line_from_rows
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryLineFromRows:
+    def test_empty_rows(self) -> None:
+        line = FleetMemoryScreen._summary_line_from_rows([])
+        assert "0 instances" in line
+        assert "0 not probed" in line
+
+    def test_single_fresh_row(self) -> None:
+        rows = [_row("web-1", status=STATUS_FRESH)]
+        line = FleetMemoryScreen._summary_line_from_rows(rows)
+        assert "1 instances" in line
+        assert "1 fresh" in line
+        assert "0 stale" in line
+
+    def test_mixed_statuses(self) -> None:
+        rows = [
+            _row("web-1", status=STATUS_FRESH),
+            _row("web-2", status=STATUS_STALE),
+            _row("web-3", status=STATUS_NONE),
+            _row("web-4", status=STATUS_OPT_OUT),
+        ]
+        line = FleetMemoryScreen._summary_line_from_rows(rows)
+        assert "4 instances" in line
+        assert "1 fresh" in line
+        assert "1 stale" in line
+        assert "1 not probed" in line
+        assert "1 opted-out" in line
+
+    def test_all_opted_out(self) -> None:
+        rows = [_row(f"web-{i}", status=STATUS_OPT_OUT) for i in range(3)]
+        line = FleetMemoryScreen._summary_line_from_rows(rows)
+        assert "3 opted-out" in line
+        assert "0 fresh" in line
+
+    def test_summary_reflects_updated_row_dict(self) -> None:
+        """After mutating a row's status the helper reads the new value."""
+        row = _row("web-1", status=STATUS_STALE)
+        rows = [row]
+        before = FleetMemoryScreen._summary_line_from_rows(rows)
+        assert "1 stale" in before
+
+        row["status"] = STATUS_FRESH
+        after = FleetMemoryScreen._summary_line_from_rows(rows)
+        assert "0 stale" in after
+        assert "1 fresh" in after
+
+
+# ---------------------------------------------------------------------------
+# _update_row_for_instance — no-op guard cases
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRowForInstanceNoOp:
+    def test_empty_instance_id_is_noop(self) -> None:
+        screen = _make_screen()
+        screen._rows = [_row("web-1")]
+        _set_app(screen, _make_app())
+        # Must not raise; returns immediately.
+        screen._update_row_for_instance("")
+
+    def test_empty_rows_is_noop(self) -> None:
+        screen = _make_screen()
+        screen._rows = []
+        _set_app(screen, _make_app())
+        screen._update_row_for_instance("web-1")
+
+    def test_unknown_id_is_noop(self) -> None:
+        """When no row has raw_id == instance_id, nothing is updated."""
+        screen = _make_screen()
+        screen._rows = [_row("web-1")]
+        mock_app = _make_app()
+        _set_app(screen, mock_app)
+        mock_table = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_table):
+            screen._update_row_for_instance("unknown-id")
+        mock_table.update_cell_at.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _update_row_for_instance — cell update on STALE → FRESH flip
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRowForInstanceCellUpdate:
+    def test_stale_becomes_fresh_updates_cells(self) -> None:
+        """When a probe makes an instance fresh the status/modules/age cells update."""
+        from textual.coordinate import Coordinate
+
+        fresh_mods = _fresh_modules(age_seconds=30)
+        ms = _make_memory_service(module_map={"i-abc123": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("i-abc123", raw_provider="aws", status=STATUS_STALE)]
+        _set_app(screen, mock_app)
+
+        mock_table = MagicMock()
+        mock_status_widget = MagicMock()
+
+        def _query_one(selector, *args):
+            if "table" in selector:
+                return mock_table
+            return mock_status_widget
+
+        with patch.object(screen, "query_one", side_effect=_query_one):
+            screen._update_row_for_instance("i-abc123")
+
+        # Column 4 = status
+        update_calls = mock_table.update_cell_at.call_args_list
+        coords = [c[0][0] for c in update_calls]
+        values = [c[0][1] for c in update_calls]
+
+        col_indices = [coord.column for coord in coords]
+        assert 4 in col_indices, "Status cell (col 4) must be updated"
+        # Find what was set for col 4
+        status_value = values[col_indices.index(4)]
+        assert status_value == _STATUS_CELL[STATUS_FRESH]
+
+    def test_row_dict_status_updated_in_place(self) -> None:
+        """After _update_row_for_instance the _rows entry must reflect new status."""
+        fresh_mods = _fresh_modules(age_seconds=30)
+        ms = _make_memory_service(module_map={"i-abc123": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("i-abc123", status=STATUS_STALE)]
+        _set_app(screen, mock_app)
+
+        mock_widget = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_widget):
+            screen._update_row_for_instance("i-abc123")
+
+        assert screen._rows[0]["status"] == STATUS_FRESH
+
+    def test_modules_count_updated(self) -> None:
+        """Module count cell reflects the number of modules returned by the service."""
+        from textual.coordinate import Coordinate
+
+        fresh_mods = _fresh_modules(age_seconds=30)
+        # Add a second module so count = 2.
+        fresh_ts = next(iter(fresh_mods.values()))["probed_at"]
+        fresh_mods_2 = {"os": {"probed_at": fresh_ts}, "disk": {"probed_at": fresh_ts}}
+        ms = _make_memory_service(module_map={"i-xyz": fresh_mods_2})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("i-xyz", status=STATUS_STALE, modules=0)]
+        _set_app(screen, mock_app)
+
+        mock_widget = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_widget):
+            screen._update_row_for_instance("i-xyz")
+
+        # Col 5 = modules
+        update_calls = mock_widget.update_cell_at.call_args_list
+        coords = [c[0][0] for c in update_calls]
+        values = [c[0][1] for c in update_calls]
+        col_indices = [coord.column for coord in coords]
+        assert 5 in col_indices
+        modules_value = values[col_indices.index(5)]
+        assert modules_value == "2"
+
+    def test_age_cell_updated(self) -> None:
+        """Age cell (col 7) must be updated after a successful probe."""
+        from textual.coordinate import Coordinate
+
+        fresh_mods = _fresh_modules(age_seconds=90)  # 1m 30s ago
+        ms = _make_memory_service(module_map={"i-xyz": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("i-xyz", status=STATUS_STALE, age="—")]
+        _set_app(screen, mock_app)
+
+        mock_widget = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_widget):
+            screen._update_row_for_instance("i-xyz")
+
+        update_calls = mock_widget.update_cell_at.call_args_list
+        coords = [c[0][0] for c in update_calls]
+        values = [c[0][1] for c in update_calls]
+        col_indices = [coord.column for coord in coords]
+        assert 7 in col_indices
+        age_value = values[col_indices.index(7)]
+        # Age text should not be the placeholder "—" any more.
+        assert age_value != "—"
+
+    def test_widget_missing_does_not_raise(self) -> None:
+        """If query_one raises (screen navigated away), _update_row_for_instance is silent."""
+        fresh_mods = _fresh_modules()
+        ms = _make_memory_service(module_map={"i-abc": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("i-abc", status=STATUS_STALE)]
+        _set_app(screen, mock_app)
+
+        with patch.object(screen, "query_one", side_effect=Exception("no widget")):
+            # Must not raise.
+            screen._update_row_for_instance("i-abc")
+
+
+# ---------------------------------------------------------------------------
+# _update_row_for_instance — summary line recomputed live
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRowSummaryRecomputed:
+    def test_summary_updates_after_flip(self) -> None:
+        """The #fleet-memory-status widget must be updated after a row flips."""
+        fresh_mods = _fresh_modules(age_seconds=30)
+        ms = _make_memory_service(module_map={"web-1": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [
+            _row("web-1", status=STATUS_STALE),
+            _row("web-2", status=STATUS_STALE),
+        ]
+        _set_app(screen, mock_app)
+
+        mock_table = MagicMock()
+        mock_status = MagicMock()
+
+        def _query_one(selector, *args):
+            if "table" in selector:
+                return mock_table
+            return mock_status
+
+        with patch.object(screen, "query_one", side_effect=_query_one):
+            screen._update_row_for_instance("web-1")
+
+        # The status Static must have been updated.
+        mock_status.update.assert_called()
+        summary_arg = mock_status.update.call_args[0][0]
+        # After web-1 flips to fresh: 1 fresh, 1 stale.
+        assert "1 fresh" in summary_arg
+        assert "1 stale" in summary_arg
+
+
+# ---------------------------------------------------------------------------
+# _update_row_for_instance — raw_id / raw_provider used for memory lookup
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRowRawIdLookup:
+    def test_memory_service_called_with_raw_id_not_display_id(self) -> None:
+        """When demo-mode redacts the display id, memory lookup still uses raw_id."""
+        fresh_mods = _fresh_modules(age_seconds=30)
+        # Memory is keyed by raw_id "i-realid"
+        ms = _make_memory_service(module_map={"i-realid": fresh_mods})
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        # Simulate a demo-redacted row: display id differs from raw_id.
+        row = _row("i-realid", raw_provider="aws", status=STATUS_STALE)
+        row["id"] = "i-REDACTED"  # what the display shows
+        screen._rows = [row]
+        _set_app(screen, mock_app)
+
+        mock_widget = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_widget):
+            # Progress event always carries the real instance_id.
+            screen._update_row_for_instance("i-realid")
+
+        # Memory service must have been called with the raw (un-redacted) id.
+        ms.get_all_modules.assert_called_with("i-realid", "aws")
+        # Row should have been updated to fresh.
+        assert screen._rows[0]["status"] == STATUS_FRESH
+
+
+# ---------------------------------------------------------------------------
+# _update_row_for_instance — opted-out instance stays opted-out
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRowOptedOut:
+    def test_opted_out_status_not_overridden(self) -> None:
+        """An opted-out instance must not flip to fresh even if modules appear."""
+        fresh_mods = _fresh_modules(age_seconds=30)
+        ms = _make_memory_service(
+            module_map={"web-1": fresh_mods},
+            disabled_ids=["web-1"],
+        )
+        mock_app = _make_app(memory_service=ms)
+
+        screen = _make_screen()
+        screen._rows = [_row("web-1", status=STATUS_OPT_OUT)]
+        _set_app(screen, mock_app)
+
+        mock_widget = MagicMock()
+        with patch.object(screen, "query_one", return_value=mock_widget):
+            screen._update_row_for_instance("web-1")
+
+        assert screen._rows[0]["status"] == STATUS_OPT_OUT

--- a/tests/test_fleet_scan_service.py
+++ b/tests/test_fleet_scan_service.py
@@ -1,0 +1,637 @@
+"""Tests for FleetScanService — eligible_instances, scan, parallelism, progress."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from servonaut.services.memory.fleet_scan_service import (
+    FleetScanProgress,
+    FleetScanResult,
+    FleetScanService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _inst(
+    name: str,
+    iid: Optional[str] = None,
+    provider: str = "aws",
+) -> Dict[str, Any]:
+    return {
+        "id": iid or name,
+        "name": name,
+        "provider": provider,
+    }
+
+
+def _make_memory_service(
+    *,
+    disabled_ids: Optional[List[str]] = None,
+    stale_ids: Optional[List[str]] = None,
+    fresh_ids: Optional[List[str]] = None,
+    stale_seconds: float = 7 * 86400,
+) -> MagicMock:
+    """Return a memory service mock with configurable stale/opt-out state.
+
+    ``disabled_ids``: instance IDs/names for which is_memory_disabled returns True.
+    ``stale_ids``: instance IDs whose snapshots appear older than stale_seconds.
+    ``fresh_ids``: instance IDs whose snapshots appear younger than stale_seconds.
+    Instances absent from both stale/fresh have no modules (treated as stale/none).
+    """
+    from datetime import datetime, timezone, timedelta
+
+    disabled_ids = set(disabled_ids or [])
+    stale_ids = set(stale_ids or [])
+    fresh_ids = set(fresh_ids or [])
+
+    ms = MagicMock()
+    ms.snapshot_stale_seconds = stale_seconds
+
+    def _is_disabled(iid, name):
+        return (iid in disabled_ids) or (name in disabled_ids)
+
+    def _get_all_modules(iid, provider):
+        # Stale = probed_at is older than the threshold.
+        if iid in stale_ids:
+            old_ts = (
+                datetime.now(timezone.utc) - timedelta(seconds=stale_seconds + 3600)
+            ).isoformat()
+            return {"os": {"probed_at": old_ts}}
+        # Fresh = probed_at is recent.
+        if iid in fresh_ids:
+            fresh_ts = (
+                datetime.now(timezone.utc) - timedelta(seconds=60)
+            ).isoformat()
+            return {"os": {"probed_at": fresh_ts}}
+        # No modules → treated as "none" (stale) by eligible_instances.
+        return {}
+
+    ms.is_memory_disabled = MagicMock(side_effect=_is_disabled)
+    ms.get_all_modules = MagicMock(side_effect=_get_all_modules)
+    return ms
+
+
+def _make_memory_service_with_build_report(
+    succeed_ids: Optional[List[str]] = None,
+    fail_ids: Optional[List[str]] = None,
+) -> MagicMock:
+    """Memory service mock that exposes build_report (the primary scan path)."""
+    succeed_ids = set(succeed_ids or [])
+    fail_ids = set(fail_ids or [])
+
+    ms = MagicMock()
+    ms.is_memory_disabled = MagicMock(return_value=False)
+    ms.get_all_modules = MagicMock(return_value={})
+    ms.snapshot_stale_seconds = 7 * 86400
+
+    async def _build_report(inst):
+        iid = inst.get("id") or inst.get("name")
+        report = MagicMock()
+        if iid in succeed_ids:
+            report.has_any_success = True
+            report.overall_reason = None
+            report.failures = []
+        else:
+            report.has_any_success = False
+            report.overall_reason = "probe_error"
+            failure = MagicMock()
+            failure.module = "os"
+            failure.reason = "ssh_timeout"
+            failure.message = "Connection timed out"
+            report.failures = [failure]
+        return report
+
+    ms.build_report = AsyncMock(side_effect=_build_report)
+    return ms
+
+
+class _RefreshOnlyService:
+    """Minimal memory service stub that exposes only ``refresh`` (no ``build_report``)."""
+
+    def __init__(self, succeed_ids):
+        self.snapshot_stale_seconds = 7 * 86400
+        self._succeed_ids = set(succeed_ids or [])
+
+    def is_memory_disabled(self, iid, name):
+        return False
+
+    def get_all_modules(self, iid, provider):
+        return {}
+
+    async def refresh(self, inst):
+        iid = inst.get("id") or inst.get("name")
+        if iid in self._succeed_ids:
+            return {"os": {"probed_at": "2026-01-01T00:00:00+00:00"}}
+        return {}
+
+
+def _make_memory_service_with_refresh(
+    succeed_ids: Optional[List[str]] = None,
+) -> "_RefreshOnlyService":
+    """Memory service stub with only the refresh fallback path — no build_report."""
+    return _RefreshOnlyService(succeed_ids)
+
+
+# ---------------------------------------------------------------------------
+# eligible_instances — opt-out filtering
+# ---------------------------------------------------------------------------
+
+class TestEligibleInstancesOptOut:
+    def test_opted_out_instance_excluded(self) -> None:
+        ms = _make_memory_service(disabled_ids=["web-1"])
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1"), _inst("db-1")]
+        result = svc.eligible_instances(instances, stale_only=False)
+        names = [i["name"] for i in result]
+        assert "web-1" not in names
+        assert "db-1" in names
+
+    def test_is_memory_disabled_called_with_id_and_name(self) -> None:
+        ms = _make_memory_service()
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1", iid="i-abc123")]
+        svc.eligible_instances(instances, stale_only=False)
+        # Must be called with both id and name so either key fires opt-out.
+        ms.is_memory_disabled.assert_called_with("i-abc123", "web-1")
+
+    def test_all_opted_out_returns_empty(self) -> None:
+        ms = _make_memory_service(disabled_ids=["web-1", "db-1"])
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1"), _inst("db-1")]
+        result = svc.eligible_instances(instances, stale_only=False)
+        assert result == []
+
+    def test_empty_instances_returns_empty(self) -> None:
+        ms = _make_memory_service()
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([], stale_only=False)
+        assert result == []
+
+    def test_opted_out_excluded_even_when_stale_only_false(self) -> None:
+        ms = _make_memory_service(disabled_ids=["web-1"])
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([_inst("web-1")], stale_only=False)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# eligible_instances — stale_only filtering
+# ---------------------------------------------------------------------------
+
+class TestEligibleInstancesStaleOnly:
+    def test_stale_only_true_keeps_stale_instances(self) -> None:
+        ms = _make_memory_service(stale_ids=["web-1"])
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([_inst("web-1")], stale_only=True)
+        assert len(result) == 1
+
+    def test_stale_only_true_excludes_fresh_instances(self) -> None:
+        ms = _make_memory_service(fresh_ids=["web-1"])
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([_inst("web-1")], stale_only=True)
+        assert result == []
+
+    def test_stale_only_false_includes_fresh_instances(self) -> None:
+        ms = _make_memory_service(fresh_ids=["web-1"])
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([_inst("web-1")], stale_only=False)
+        assert len(result) == 1
+
+    def test_stale_only_true_includes_never_probed_no_modules(self) -> None:
+        """Instance with no modules is treated as stale/none → included."""
+        ms = _make_memory_service()  # no stale/fresh entries → empty modules
+        svc = FleetScanService(ms)
+        # get_all_modules returns {} → _compute_status → STATUS_NONE, not STALE.
+        # per spec, stale_only excludes STATUS_NONE — wait, spec says "stale or
+        # missing" in docstring, but code: stale_only keeps STATUS_STALE only.
+        # Let's verify by checking what the code actually does.
+        result = svc.eligible_instances([_inst("web-1")], stale_only=True)
+        # STATUS_NONE (no modules) is NOT STATUS_STALE → excluded when stale_only=True.
+        # This is the documented behaviour — only STATUS_STALE passes the gate.
+        assert result == []
+
+    def test_stale_only_false_includes_no_modules_instance(self) -> None:
+        """stale_only=False includes instances with no prior probes."""
+        ms = _make_memory_service()
+        svc = FleetScanService(ms)
+        result = svc.eligible_instances([_inst("web-1")], stale_only=False)
+        assert len(result) == 1
+
+    def test_mixed_stale_and_fresh_stale_only(self) -> None:
+        ms = _make_memory_service(stale_ids=["web-1", "web-2"], fresh_ids=["db-1"])
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1"), _inst("web-2"), _inst("db-1")]
+        result = svc.eligible_instances(instances, stale_only=True)
+        names = {i["name"] for i in result}
+        assert names == {"web-1", "web-2"}
+
+
+# ---------------------------------------------------------------------------
+# scan — success / failure paths via build_report
+# ---------------------------------------------------------------------------
+
+class TestScanBuildReportPath:
+    @pytest.mark.asyncio
+    async def test_successful_probes_appear_in_succeeded(self) -> None:
+        ms = _make_memory_service_with_build_report(succeed_ids=["web-1", "web-2"])
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1"), _inst("web-2")]
+        result = await svc.scan(instances, stale_only=False)
+        assert isinstance(result, FleetScanResult)
+        assert set(result.succeeded) == {"web-1", "web-2"}
+        assert result.failed == []
+
+    @pytest.mark.asyncio
+    async def test_failed_probe_appears_in_failed(self) -> None:
+        ms = _make_memory_service_with_build_report(fail_ids=["web-1"])
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1")]
+        result = await svc.scan(instances, stale_only=False)
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        entry = result.failed[0]
+        assert entry["instance"] == "web-1"
+        assert "reason" in entry
+        assert "failures" in entry
+
+    @pytest.mark.asyncio
+    async def test_mixed_succeed_and_fail(self) -> None:
+        ms = _make_memory_service_with_build_report(
+            succeed_ids=["web-1"], fail_ids=["db-1"]
+        )
+        svc = FleetScanService(ms)
+        instances = [_inst("web-1"), _inst("db-1")]
+        result = await svc.scan(instances, stale_only=False)
+        assert "web-1" in result.succeeded
+        assert any(e["instance"] == "db-1" for e in result.failed)
+
+    @pytest.mark.asyncio
+    async def test_no_eligible_instances_returns_empty_result(self) -> None:
+        ms = _make_memory_service(fresh_ids=["web-1"])
+        # fresh_ids with stale_only=True → no eligible instances
+        svc = FleetScanService(ms)
+        # build_report not needed since no instances pass eligibility
+        ms.build_report = AsyncMock()
+        result = await svc.scan([_inst("web-1")], stale_only=True)
+        assert result.succeeded == []
+        assert result.failed == []
+        ms.build_report.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# scan — refresh fallback path (no build_report attribute)
+# ---------------------------------------------------------------------------
+
+class TestScanRefreshFallbackPath:
+    @pytest.mark.asyncio
+    async def test_refresh_path_success(self) -> None:
+        ms = _make_memory_service_with_refresh(succeed_ids=["web-1"])
+        # _RefreshOnlyService has no build_report attribute by design.
+        assert not hasattr(ms, "build_report")
+        svc = FleetScanService(ms)
+        result = await svc.scan([_inst("web-1")], stale_only=False)
+        assert "web-1" in result.succeeded
+        assert result.failed == []
+
+    @pytest.mark.asyncio
+    async def test_refresh_path_empty_modules_goes_to_failed(self) -> None:
+        ms = _make_memory_service_with_refresh(succeed_ids=[])
+        assert not hasattr(ms, "build_report")
+        svc = FleetScanService(ms)
+        result = await svc.scan([_inst("web-1")], stale_only=False)
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        assert result.failed[0]["reason"] == "no_modules_returned"
+
+    @pytest.mark.asyncio
+    async def test_refresh_path_exception_captured(self) -> None:
+        class _RaiseOnRefresh(_RefreshOnlyService):
+            async def refresh(self, inst):
+                raise RuntimeError("ssh down")
+
+        ms = _RaiseOnRefresh(succeed_ids=[])
+        svc = FleetScanService(ms)
+        result = await svc.scan([_inst("web-1")], stale_only=False)
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        entry = result.failed[0]
+        assert entry["reason"] == "exception"
+        assert "ssh down" in entry["failures"][0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# scan — exception handling inside probe
+# ---------------------------------------------------------------------------
+
+class TestScanExceptionHandling:
+    @pytest.mark.asyncio
+    async def test_exception_in_build_report_captured(self) -> None:
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+        ms.build_report = AsyncMock(side_effect=ConnectionError("refused"))
+        svc = FleetScanService(ms)
+        result = await svc.scan([_inst("web-1")], stale_only=False)
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        assert result.failed[0]["reason"] == "exception"
+
+    @pytest.mark.asyncio
+    async def test_one_exception_does_not_abort_other_probes(self) -> None:
+        """A single failing probe must not prevent the rest from completing."""
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+
+        call_count = 0
+
+        async def _build_report(inst):
+            nonlocal call_count
+            call_count += 1
+            if inst["name"] == "bad-1":
+                raise RuntimeError("ssh error")
+            report = MagicMock()
+            report.has_any_success = True
+            report.overall_reason = None
+            report.failures = []
+            return report
+
+        ms.build_report = AsyncMock(side_effect=_build_report)
+        svc = FleetScanService(ms)
+        result = await svc.scan(
+            [_inst("bad-1"), _inst("good-1"), _inst("good-2")],
+            stale_only=False,
+        )
+        assert call_count == 3
+        assert "good-1" in result.succeeded
+        assert "good-2" in result.succeeded
+        assert any(e["instance"] == "bad-1" for e in result.failed)
+
+
+# ---------------------------------------------------------------------------
+# scan — parallelism bounded by max_parallel
+# ---------------------------------------------------------------------------
+
+class TestScanParallelismCap:
+    @pytest.mark.asyncio
+    async def test_max_parallel_respected(self) -> None:
+        """At most max_parallel probes should run concurrently."""
+        max_parallel = 2
+        concurrency_gate = asyncio.Event()
+        inflight: List[int] = []
+        peak: List[int] = []
+
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+
+        async def _build_report(inst):
+            inflight.append(1)
+            peak.append(len(inflight))
+            # Yield to let other coroutines enter if they're allowed.
+            await asyncio.sleep(0)
+            inflight.pop()
+            report = MagicMock()
+            report.has_any_success = True
+            report.overall_reason = None
+            report.failures = []
+            return report
+
+        ms.build_report = AsyncMock(side_effect=_build_report)
+
+        svc = FleetScanService(ms, max_parallel=max_parallel)
+        n_instances = 6
+        instances = [_inst(f"web-{i}") for i in range(n_instances)]
+        result = await svc.scan(instances, stale_only=False)
+
+        assert len(result.succeeded) == n_instances
+        # Peak concurrent inflight should never exceed max_parallel.
+        assert max(peak) <= max_parallel, (
+            f"Peak concurrency {max(peak)} exceeded max_parallel={max_parallel}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_parallel_one_serialises_probes(self) -> None:
+        """max_parallel=1 forces strictly serial execution."""
+        order: List[str] = []
+        start_order: List[str] = []
+
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+
+        async def _build_report(inst):
+            name = inst["name"]
+            start_order.append(name)
+            await asyncio.sleep(0)
+            order.append(name)
+            report = MagicMock()
+            report.has_any_success = True
+            report.overall_reason = None
+            report.failures = []
+            return report
+
+        ms.build_report = AsyncMock(side_effect=_build_report)
+        svc = FleetScanService(ms, max_parallel=1)
+        instances = [_inst(f"web-{i}") for i in range(4)]
+        await svc.scan(instances, stale_only=False)
+        # Each probe must start only after the prior one has yielded
+        # the semaphore — so start_order and order must be identical
+        # (no interleaving).
+        assert start_order == order
+
+
+# ---------------------------------------------------------------------------
+# scan — on_progress callback
+# ---------------------------------------------------------------------------
+
+class TestScanOnProgress:
+    @pytest.mark.asyncio
+    async def test_on_progress_called_once_per_instance(self) -> None:
+        ms = _make_memory_service_with_build_report(succeed_ids=["web-1", "db-1"])
+        svc = FleetScanService(ms)
+        progress_events: List[FleetScanProgress] = []
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            progress_events.append(ev)
+
+        await svc.scan(
+            [_inst("web-1"), _inst("db-1")],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert len(progress_events) == 2
+
+    @pytest.mark.asyncio
+    async def test_on_progress_carries_instance_id(self) -> None:
+        """Each FleetScanProgress must carry the raw instance id from the dict."""
+        ms = _make_memory_service_with_build_report(succeed_ids=["i-abc123"])
+        svc = FleetScanService(ms, max_parallel=1)
+        progress_events: List[FleetScanProgress] = []
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            progress_events.append(ev)
+
+        await svc.scan(
+            [_inst("web-1", iid="i-abc123")],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert len(progress_events) == 1
+        ev = progress_events[0]
+        # instance_name carries the display name (used by the progress line)
+        assert ev.instance_name == "web-1"
+        # instance_id carries the raw id (used by the live row updater)
+        assert ev.instance_id == "i-abc123"
+
+    @pytest.mark.asyncio
+    async def test_on_progress_instance_id_falls_back_to_name(self) -> None:
+        """When the instance dict has no 'id' key, instance_id == name."""
+        ms = _make_memory_service_with_build_report(succeed_ids=["no-id-server"])
+        svc = FleetScanService(ms, max_parallel=1)
+        progress_events: List[FleetScanProgress] = []
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            progress_events.append(ev)
+
+        # Pass an instance dict that has no "id" key.
+        await svc.scan(
+            [{"name": "no-id-server"}],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert len(progress_events) == 1
+        assert progress_events[0].instance_id == "no-id-server"
+
+    @pytest.mark.asyncio
+    async def test_on_progress_completed_is_monotonically_increasing(self) -> None:
+        ms = _make_memory_service_with_build_report(
+            succeed_ids=["web-1", "web-2", "web-3"]
+        )
+        svc = FleetScanService(ms, max_parallel=1)
+        completed_values: List[int] = []
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            completed_values.append(ev.completed)
+
+        await svc.scan(
+            [_inst("web-1"), _inst("web-2"), _inst("web-3")],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert completed_values == sorted(completed_values)
+        assert completed_values[-1] == 3
+
+    @pytest.mark.asyncio
+    async def test_on_progress_total_is_constant_across_events(self) -> None:
+        ms = _make_memory_service_with_build_report(succeed_ids=["a", "b", "c"])
+        svc = FleetScanService(ms)
+        totals: List[int] = []
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            totals.append(ev.total)
+
+        await svc.scan(
+            [_inst("a"), _inst("b"), _inst("c")],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert all(t == 3 for t in totals)
+
+    @pytest.mark.asyncio
+    async def test_on_progress_succeeded_reflects_outcome(self) -> None:
+        ms = _make_memory_service_with_build_report(
+            succeed_ids=["web-1"], fail_ids=["db-1"]
+        )
+        svc = FleetScanService(ms, max_parallel=1)
+        events_by_name: Dict[str, FleetScanProgress] = {}
+
+        def _on_progress(ev: FleetScanProgress) -> None:
+            events_by_name[ev.instance_name] = ev
+
+        await svc.scan(
+            [_inst("web-1"), _inst("db-1")],
+            stale_only=False,
+            on_progress=_on_progress,
+        )
+
+        assert events_by_name["web-1"].succeeded is True
+        assert events_by_name["db-1"].succeeded is False
+
+    @pytest.mark.asyncio
+    async def test_on_progress_exception_does_not_crash_scan(self) -> None:
+        """A misbehaving progress callback must not abort the scan."""
+        ms = _make_memory_service_with_build_report(succeed_ids=["web-1"])
+        svc = FleetScanService(ms)
+
+        def _bad_progress(ev: FleetScanProgress) -> None:
+            raise RuntimeError("callback error")
+
+        result = await svc.scan(
+            [_inst("web-1")],
+            stale_only=False,
+            on_progress=_bad_progress,
+        )
+        assert "web-1" in result.succeeded
+
+
+# ---------------------------------------------------------------------------
+# scan — CancelledError propagation
+# ---------------------------------------------------------------------------
+
+class TestScanCancelledError:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates_out_of_scan(self) -> None:
+        """asyncio.CancelledError must escape scan() so workers can unwind."""
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+
+        async def _cancel(inst):
+            raise asyncio.CancelledError()
+
+        ms.build_report = AsyncMock(side_effect=_cancel)
+        svc = FleetScanService(ms)
+
+        with pytest.raises(asyncio.CancelledError):
+            await svc.scan([_inst("web-1")], stale_only=False)
+
+    @pytest.mark.asyncio
+    async def test_scan_task_can_be_cancelled_externally(self) -> None:
+        """External task cancellation propagates through scan()."""
+        ms = MagicMock()
+        ms.is_memory_disabled = MagicMock(return_value=False)
+        ms.get_all_modules = MagicMock(return_value={})
+        ms.snapshot_stale_seconds = 7 * 86400
+
+        async def _slow_probe(inst):
+            await asyncio.sleep(60)  # Would block forever without cancellation.
+
+        ms.build_report = AsyncMock(side_effect=_slow_probe)
+        svc = FleetScanService(ms)
+
+        task = asyncio.create_task(
+            svc.scan([_inst("web-1")], stale_only=False)
+        )
+        # Let the coroutine enter the sleep.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from servonaut.config.schema import AppConfig, MemoryConfig
+from servonaut.config.schema import (
+    AppConfig,
+    MemoryConfig,
+    DEFAULT_AUTO_SCAN_INTERVAL_SECONDS,
+    DEFAULT_SNAPSHOT_STALE_SECONDS,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +56,54 @@ class TestMemoryConfigDefaults:
     ) -> None:
         assert default_app_config.memory.per_server_overrides == {}
 
+    # -- new auto-scan fields -----------------------------------
+
+    def test_auto_scan_enabled_defaults_false(
+        self, default_app_config: AppConfig
+    ) -> None:
+        assert default_app_config.memory.auto_scan_enabled is False
+
+    def test_auto_scan_interval_seconds_defaults_to_constant(
+        self, default_app_config: AppConfig
+    ) -> None:
+        assert (
+            default_app_config.memory.auto_scan_interval_seconds
+            == DEFAULT_AUTO_SCAN_INTERVAL_SECONDS
+        )
+
+    def test_auto_scan_interval_seconds_value(
+        self, default_app_config: AppConfig
+    ) -> None:
+        # The module-level constant must match the documented 24-hour default.
+        assert DEFAULT_AUTO_SCAN_INTERVAL_SECONDS == 86400
+        assert default_app_config.memory.auto_scan_interval_seconds == 86400
+
+    def test_auto_scan_stale_only_defaults_true(
+        self, default_app_config: AppConfig
+    ) -> None:
+        assert default_app_config.memory.auto_scan_stale_only is True
+
+    def test_memory_config_bare_construction_has_auto_scan_fields(self) -> None:
+        """MemoryConfig(**{}) absorbs the auto-scan fields from defaults."""
+        mc = MemoryConfig()
+        assert mc.auto_scan_enabled is False
+        assert mc.auto_scan_interval_seconds == DEFAULT_AUTO_SCAN_INTERVAL_SECONDS
+        assert mc.auto_scan_stale_only is True
+
+    def test_auto_sync_enabled_not_on_memory_config(self) -> None:
+        """auto_sync_enabled has been moved server-side; it must NOT be a MemoryConfig field."""
+        mc = MemoryConfig()
+        assert not hasattr(mc, "auto_sync_enabled"), (
+            "auto_sync_enabled must no longer live in MemoryConfig — "
+            "it is now server-side in MemorySettings"
+        )
+
+    def test_app_config_dict_construction_absorbs_auto_scan_fields(self) -> None:
+        """AppConfig(**dict) with a bare 'memory' key sets auto-scan fields at defaults."""
+        cfg = AppConfig(**{"default_username": "ubuntu"})
+        assert cfg.memory.auto_scan_enabled is False
+        assert cfg.memory.auto_scan_stale_only is True
+
 
 # ---------------------------------------------------------------------------
 # Round-trip through ConfigManager save/load
@@ -87,6 +140,59 @@ class TestMemoryConfigRoundTrip:
         assert "git" in mc.disabled_modules
         assert mc.default_ttl_overrides == {"services": 1800}
         assert mc.per_server_overrides["i-critical"]["memory_disabled"] is True
+
+    def test_auto_scan_fields_round_trip(self, tmp_path: Path) -> None:
+        """auto_scan_enabled, auto_scan_interval_seconds, and auto_scan_stale_only
+        all survive the JSON save/load cycle."""
+        from servonaut.config.manager import ConfigManager
+
+        config_path = tmp_path / "config.json"
+
+        import dataclasses
+        config = AppConfig()
+        config.memory = dataclasses.replace(
+            config.memory,
+            auto_scan_enabled=True,
+            auto_scan_interval_seconds=3600,
+            auto_scan_stale_only=False,
+        )
+
+        manager = ConfigManager()
+        manager._config_path = config_path
+        manager.save(config)
+
+        manager2 = ConfigManager()
+        manager2._config_path = config_path
+        mc = manager2.load().memory
+
+        assert mc.auto_scan_enabled is True
+        assert mc.auto_scan_interval_seconds == 3600
+        assert mc.auto_scan_stale_only is False
+
+    def test_existing_disk_config_without_new_fields_loads_cleanly(
+        self, tmp_path: Path
+    ) -> None:
+        """A config.json that pre-dates the new fields loads with safe defaults."""
+        from servonaut.config.manager import ConfigManager
+
+        config_path = tmp_path / "config.json"
+        # Write a minimal v5 config with no 'auto_*' keys inside memory.
+        old_config = {
+            "version": 5,
+            "memory": {
+                "enabled": True,
+                "redaction_enabled": True,
+            },
+        }
+        config_path.write_text(json.dumps(old_config))
+
+        manager = ConfigManager()
+        manager._config_path = config_path
+        mc = manager.load().memory
+
+        assert mc.auto_scan_enabled is False
+        assert mc.auto_scan_interval_seconds == DEFAULT_AUTO_SCAN_INTERVAL_SECONDS
+        assert mc.auto_scan_stale_only is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_probers.py
+++ b/tests/test_memory_probers.py
@@ -501,6 +501,114 @@ class TestLogsProber:
         prober = LogsProber(MagicMock(), MagicMock(), MagicMock())
         assert prober.name == "logs"
 
+    def test_instance_read_from_runner_attribute(self):
+        """probe() prefers the instance attached to the runner over self._instance.
+
+        This is the Fix-B regression: concurrent build_report calls each supply
+        a distinct ssh_runner whose .instance attribute points to the correct
+        server, so the shared _instance field is never the source of truth.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        instance_a = {"id": "i-abc123", "name": "web-1", "public_ip": "9.9.9.9"}
+        instance_b = {"id": "i-def456", "name": "db-1", "public_ip": "10.0.0.2"}
+
+        # Both probers return different path lists for different instances.
+        def _make_log_viewer(expected_instance_id, paths):
+            mock_log_viewer = MagicMock()
+            async def _probe(inst, ssh_svc, conn_svc):
+                assert inst["id"] == expected_instance_id, (
+                    f"LogsProber called probe_log_paths with wrong instance: "
+                    f"expected {expected_instance_id!r}, got {inst['id']!r}"
+                )
+                return paths
+            mock_log_viewer.probe_log_paths = AsyncMock(side_effect=_probe)
+            return mock_log_viewer
+
+        prober_a = LogsProber(
+            _make_log_viewer("i-abc123", ["/var/log/nginx/access.log"]),
+            MagicMock(), MagicMock(),
+        )
+        prober_b = LogsProber(
+            _make_log_viewer("i-def456", ["/var/log/mysql/error.log"]),
+            MagicMock(), MagicMock(),
+        )
+
+        # Seed the wrong instance on both probers (simulating a race where
+        # set_instance was called with A's data on prober_b, or vice versa).
+        prober_a.set_instance(instance_b)  # deliberately wrong
+        prober_b.set_instance(instance_a)  # deliberately wrong
+
+        # Build distinct runner objects — each carries its own .instance attribute.
+        # Using a single function and assigning twice would overwrite the attribute.
+        async def _noop_runner_a(cmd): return "", "", 0
+        _noop_runner_a.instance = instance_a  # type: ignore[attr-defined]
+        runner_a = _noop_runner_a
+
+        async def _noop_runner_b(cmd): return "", "", 0
+        _noop_runner_b.instance = instance_b  # type: ignore[attr-defined]
+        runner_b = _noop_runner_b
+
+        result_a = _run(prober_a.probe(runner_a))
+        result_b = _run(prober_b.probe(runner_b))
+
+        # Each prober must have used the instance from its runner, not _instance.
+        assert "/var/log/nginx/access.log" in result_a.observed["probed_paths"]
+        assert "/var/log/mysql/error.log" in result_b.observed["probed_paths"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_probes_no_cross_contamination(self):
+        """Two concurrent LogsProber.probe() calls via own ssh_runners return correct data.
+
+        Fix-B regression: with shared _instance the second prober would probe
+        the first instance's log paths if the runners carry the right instance.
+        """
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        instance_a = {"id": "i-abc123", "name": "web-1", "public_ip": "9.9.9.9"}
+        instance_b = {"id": "i-def456", "name": "db-1", "public_ip": "10.0.0.2"}
+
+        # Each log viewer only succeeds for the correct instance.
+        async def _probe_log_paths_a(inst, ssh_svc, conn_svc):
+            await asyncio.sleep(0)  # yield to allow interleaving
+            if inst["id"] != "i-abc123":
+                raise AssertionError(f"prober_a called with wrong instance {inst['id']!r}")
+            return ["/var/log/nginx/access.log"]
+
+        async def _probe_log_paths_b(inst, ssh_svc, conn_svc):
+            await asyncio.sleep(0)
+            if inst["id"] != "i-def456":
+                raise AssertionError(f"prober_b called with wrong instance {inst['id']!r}")
+            return ["/var/log/mysql/error.log"]
+
+        log_viewer_a = MagicMock()
+        log_viewer_a.probe_log_paths = AsyncMock(side_effect=_probe_log_paths_a)
+        log_viewer_b = MagicMock()
+        log_viewer_b.probe_log_paths = AsyncMock(side_effect=_probe_log_paths_b)
+
+        prober_a = LogsProber(log_viewer_a, MagicMock(), MagicMock())
+        prober_b = LogsProber(log_viewer_b, MagicMock(), MagicMock())
+
+        # Bind correct instances via runner attributes (the fixed path).
+        async def _noop_a(cmd): return "", "", 0
+        async def _noop_b(cmd): return "", "", 0
+        _noop_a.instance = instance_a  # type: ignore[attr-defined]
+        _noop_b.instance = instance_b  # type: ignore[attr-defined]
+
+        # Run both concurrently — simulates the concurrent build_report scenario.
+        result_a, result_b = await asyncio.gather(
+            prober_a.probe(_noop_a),
+            prober_b.probe(_noop_b),
+        )
+
+        assert "/var/log/nginx/access.log" in result_a.observed["probed_paths"], (
+            f"prober_a returned wrong paths: {result_a.observed}"
+        )
+        assert "/var/log/mysql/error.log" in result_b.observed["probed_paths"], (
+            f"prober_b returned wrong paths: {result_b.observed}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Write-guard (belt-and-suspenders)

--- a/tests/test_memory_screens.py
+++ b/tests/test_memory_screens.py
@@ -33,7 +33,12 @@ def _auth_with_feature(features: dict[str, bool]) -> MagicMock:
     return auth
 
 
-def _make_settings_service(*, digest: str = "weekly", mercure: bool = True) -> MagicMock:
+def _make_settings_service(
+    *,
+    digest: str = "weekly",
+    mercure: bool = True,
+    auto_sync: bool = False,
+) -> MagicMock:
     """Build a settings service mock that returns a real MemorySettings dataclass.
 
     Using the real dataclass instead of MagicMock catches field-name typos
@@ -47,6 +52,7 @@ def _make_settings_service(*, digest: str = "weekly", mercure: bool = True) -> M
         anomaly_rules={},
         raw={},
         ai_consent_mode="off",
+        auto_sync_enabled=auto_sync,
     )
     svc.get_settings = AsyncMock(return_value=settings)
     svc.patch_settings = AsyncMock(return_value=settings)
@@ -433,6 +439,80 @@ class TestSettingsScreenMemorySync:
             mercure = app.screen.query_one("#settings_msync_mercure", Switch)
             assert mercure.value is True
             assert app.memory_settings_service.get_settings.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_sync_switch_loads_from_settings(self):
+        """The auto-sync switch value is populated from MemorySettings.auto_sync_enabled."""
+        app = _SettingsApp(has_memory_sync_feature=True, sync_configured=True)
+        # Override the settings service to return auto_sync_enabled=True.
+        app.memory_settings_service = _make_settings_service(auto_sync=True)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await _open_memory_sync_panel(app, pilot)
+            await pilot.pause()
+            await pilot.pause()
+            auto_sync_sw = app.screen.query_one("#settings_msync_auto_sync", Switch)
+            assert auto_sync_sw.value is True
+
+    @pytest.mark.asyncio
+    async def test_auto_sync_switch_defaults_false_from_settings(self):
+        """The auto-sync switch is False when settings returns auto_sync_enabled=False."""
+        app = _SettingsApp(has_memory_sync_feature=True, sync_configured=True)
+        app.memory_settings_service = _make_settings_service(auto_sync=False)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await _open_memory_sync_panel(app, pilot)
+            await pilot.pause()
+            await pilot.pause()
+            auto_sync_sw = app.screen.query_one("#settings_msync_auto_sync", Switch)
+            assert auto_sync_sw.value is False
+
+    @pytest.mark.asyncio
+    async def test_auto_sync_delta_sent_on_save(self):
+        """Toggling auto-sync and saving sends auto_sync_enabled in the PATCH delta."""
+        from unittest.mock import call
+        from servonaut.services.memory.interfaces import MemorySettings
+
+        # Start with auto_sync=False so toggling to True produces a delta.
+        app = _SettingsApp(has_memory_sync_feature=True, sync_configured=True)
+        updated_settings = MemorySettings(
+            digest_frequency="weekly",
+            mercure_push_enabled=True,
+            anomaly_rules={},
+            raw={},
+            ai_consent_mode="off",
+            auto_sync_enabled=True,
+        )
+        svc = _make_settings_service(auto_sync=False)
+        svc.patch_settings = AsyncMock(return_value=updated_settings)
+        app.memory_settings_service = svc
+        # Provide a no-op _refresh_memory_sync_loop so the panel's await doesn't crash.
+        async def _noop_refresh():
+            pass
+        app._refresh_memory_sync_loop = _noop_refresh
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await _open_memory_sync_panel(app, pilot)
+            await pilot.pause()
+            await pilot.pause()
+            # Toggle the switch on.
+            auto_sync_sw = app.screen.query_one("#settings_msync_auto_sync", Switch)
+            auto_sync_sw.value = True
+            # Click Save.
+            await pilot.click("#btn_msync_save")
+            await pilot.pause()
+            await pilot.pause()
+
+        # patch_settings must have been called with the delta including auto_sync_enabled.
+        patch_calls = svc.patch_settings.call_args_list
+        assert len(patch_calls) >= 1
+        last_call_kwargs = patch_calls[-1].kwargs if patch_calls[-1].kwargs else {}
+        last_call_args = patch_calls[-1].args
+        # patch_settings is called as svc.patch_settings(delta_dict)
+        sent_delta = last_call_args[0] if last_call_args else last_call_kwargs.get("delta", {})
+        assert "auto_sync_enabled" in sent_delta
+        assert sent_delta["auto_sync_enabled"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_settings_service.py
+++ b/tests/test_memory_settings_service.py
@@ -18,6 +18,7 @@ from servonaut.services.memory.interfaces import (
     UpsellRequired,
     ValidationFailed,
 )
+from servonaut.services.api_client import APIClient
 from servonaut.services.memory.settings_service import MemorySettingsService
 
 
@@ -27,7 +28,7 @@ from servonaut.services.memory.settings_service import MemorySettingsService
 
 def _make_api_client(get_return=None, get_side_effect=None,
                      patch_return=None, patch_side_effect=None):
-    client = MagicMock()
+    client = MagicMock(spec=APIClient)
     client.get = AsyncMock(return_value=get_return or {})
     client.patch = AsyncMock(return_value=patch_return or {})
     if get_side_effect:
@@ -41,6 +42,7 @@ def _settings_payload(
     digest_frequency="weekly",
     mercure_push_enabled=True,
     anomaly_rules=None,
+    auto_sync_enabled=False,
 ) -> Dict[str, Any]:
     if anomaly_rules is None:
         anomaly_rules = {
@@ -55,6 +57,7 @@ def _settings_payload(
         "digest_frequency": digest_frequency,
         "mercure_push_enabled": mercure_push_enabled,
         "anomaly_rules": anomaly_rules,
+        "auto_sync_enabled": auto_sync_enabled,
     }
 
 
@@ -229,3 +232,72 @@ class TestConvenienceMethods:
             "/api/v1/memory/settings",
             json={"anomaly_rule:drift.os_kernel": False},
         )
+
+    @pytest.mark.asyncio
+    async def test_set_auto_sync_true_sends_correct_patch(self):
+        """set_auto_sync(True) sends {"auto_sync_enabled": True} via PATCH."""
+        api = _make_api_client(patch_return=_settings_payload(auto_sync_enabled=True))
+        svc = _make_service(api)
+        settings = await svc.set_auto_sync(True)
+        assert settings.auto_sync_enabled is True
+        api.patch.assert_called_once_with(
+            "/api/v1/memory/settings",
+            json={"auto_sync_enabled": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_auto_sync_false_sends_correct_patch(self):
+        """set_auto_sync(False) sends {"auto_sync_enabled": False} via PATCH."""
+        api = _make_api_client(patch_return=_settings_payload(auto_sync_enabled=False))
+        svc = _make_service(api)
+        settings = await svc.set_auto_sync(False)
+        assert settings.auto_sync_enabled is False
+        api.patch.assert_called_once_with(
+            "/api/v1/memory/settings",
+            json={"auto_sync_enabled": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_auto_sync_non_bool_raises_validation_failed(self):
+        """set_auto_sync: non-bool → ValidationFailed (local pre-check)."""
+        svc = _make_service()
+        with pytest.raises(ValidationFailed) as exc_info:
+            await svc.set_auto_sync("yes")  # type: ignore[arg-type]
+        assert "auto_sync_enabled" in exc_info.value.errors[0]["key"]
+
+
+# ---------------------------------------------------------------------------
+# auto_sync_enabled parse
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSyncParsing:
+
+    @pytest.mark.asyncio
+    async def test_get_settings_parses_auto_sync_enabled_true(self):
+        """get_settings parses auto_sync_enabled=True from the server payload."""
+        api = _make_api_client(get_return=_settings_payload(auto_sync_enabled=True))
+        svc = _make_service(api)
+        settings = await svc.get_settings()
+        assert settings.auto_sync_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_get_settings_parses_auto_sync_enabled_false(self):
+        """get_settings parses auto_sync_enabled=False (the default)."""
+        api = _make_api_client(get_return=_settings_payload(auto_sync_enabled=False))
+        svc = _make_service(api)
+        settings = await svc.get_settings()
+        assert settings.auto_sync_enabled is False
+
+    @pytest.mark.asyncio
+    async def test_get_settings_auto_sync_defaults_false_when_absent(self):
+        """get_settings returns auto_sync_enabled=False when key is absent from response."""
+        payload = {
+            "digest_frequency": "weekly",
+            "mercure_push_enabled": True,
+            "anomaly_rules": {},
+        }
+        api = _make_api_client(get_return=payload)
+        svc = _make_service(api)
+        settings = await svc.get_settings()
+        assert settings.auto_sync_enabled is False

--- a/tests/test_memory_sync_reactivate.py
+++ b/tests/test_memory_sync_reactivate.py
@@ -22,6 +22,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import types
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch, call
@@ -97,12 +98,30 @@ def _make_stub(
     else:
         stub.bootstrap_memory_cloud = AsyncMock(return_value=None)
 
+    # Bind the real helper methods that the orchestration coroutines call on
+    # ``self`` (the silent-unlock path was extracted out of the single
+    # reactivation method into these helpers).
+    stub._try_silent_memory_unlock = types.MethodType(
+        ServonautApp._try_silent_memory_unlock, stub
+    )
+    stub._clear_remember_device = types.MethodType(
+        ServonautApp._clear_remember_device, stub
+    )
+    stub._remember_passphrase_expired = types.MethodType(
+        ServonautApp._remember_passphrase_expired, stub
+    )
+
     return stub
 
 
 async def _run_reactivate(stub: SimpleNamespace) -> None:
-    """Drive _reactivate_memory_sync on the stub."""
+    """Drive the SILENT-only startup reactivation (no modal)."""
     await ServonautApp._reactivate_memory_sync(stub)  # type: ignore[arg-type]
+
+
+async def _run_prompt(stub: SimpleNamespace) -> None:
+    """Drive the contextual unlock (silent then modal prompt)."""
+    await ServonautApp.prompt_memory_sync_unlock(stub)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +212,12 @@ class TestSilentPath:
 
     @pytest.mark.asyncio
     async def test_silent_path_skipped_when_keychain_unavailable(self) -> None:
-        """When keychain is unavailable, silent path is skipped and prompt runs."""
+        """When keychain is unavailable, the silent path is skipped.
+
+        Driven through the contextual unlock (``prompt_memory_sync_unlock``):
+        the silent attempt finds no keychain, so the modal prompt runs with
+        NO keychain provider.
+        """
         import servonaut.services.memory.passphrase_store as ps
 
         sync = _make_sync_service(enrolled_locally=True)
@@ -208,7 +232,7 @@ class TestSilentPath:
         )
 
         with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
-            await _run_reactivate(stub)
+            await _run_prompt(stub)
 
         # bootstrap_memory_cloud WAS called (the prompt path), not with a
         # keychain provider but with no args (falls back to modal prompt).
@@ -224,8 +248,9 @@ class TestSilentPath:
         """MAJOR-1: when can_unwrap_local returns False (wrong/stale passphrase),
         the keychain is cleared and the prompt path runs.
 
-        The old behaviour (clear on bootstrap failure) no longer applies — the
-        new logic validates locally BEFORE calling bootstrap.
+        Driven through ``prompt_memory_sync_unlock``: the silent attempt detects
+        the stale passphrase locally (BEFORE any bootstrap), clears it, then the
+        modal prompt runs.
         """
         import servonaut.services.memory.passphrase_store as ps
 
@@ -260,7 +285,7 @@ class TestSilentPath:
             patch.object(ps, "_HAS_KEYRING", True),
             patch.object(ps, "_keyring", kr),
         ):
-            await _run_reactivate(stub)
+            await _run_prompt(stub)
 
         # Keychain was cleared (wrong passphrase detected locally)
         kr.delete_password.assert_called_once()
@@ -315,7 +340,7 @@ class TestPromptPath:
             bootstrap_side_effect=RuntimeError("Memory keypair unlock cancelled by user"),
         )
         # Must not raise
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
         stub.bootstrap_memory_cloud.assert_called_once()
 
     @pytest.mark.asyncio
@@ -328,7 +353,7 @@ class TestPromptPath:
             auth_service=auth,
             bootstrap_side_effect=RuntimeError("cancelled"),
         )
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
         stub.notify.assert_called()
         # severity must not be "error"
         for call_args in stub.notify.call_args_list:
@@ -347,7 +372,7 @@ class TestPromptPath:
             auth_service=auth,
             bootstrap_side_effect=IOError("connection failed"),
         )
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
         # Must not raise
 
     @pytest.mark.asyncio
@@ -356,7 +381,7 @@ class TestPromptPath:
         sync = _make_sync_service(enrolled_locally=True)
         auth = _make_auth_service()
         stub = _make_stub(sync_service=sync, auth_service=auth)
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
         for call_args in stub.notify.call_args_list:
             kw = call_args.kwargs
             assert kw.get("severity", "information") != "error"
@@ -494,6 +519,140 @@ class TestSilentPathMajor1:
 
 
 # ---------------------------------------------------------------------------
+# Remember TTL — silent unlock refuses an expired passphrase
+# ---------------------------------------------------------------------------
+
+
+class TestRememberExpiry:
+    @staticmethod
+    def _iso(delta_days: int) -> str:
+        from datetime import datetime, timedelta, timezone
+        return (datetime.now(timezone.utc) + timedelta(days=delta_days)).isoformat()
+
+    def _stub(self, expires_at: str) -> SimpleNamespace:
+        mem = MemoryConfig(
+            sync_remember_device=True, sync_remember_expires_at=expires_at
+        )
+        return _make_stub(
+            sync_service=_make_sync_service(enrolled_locally=True),
+            auth_service=_make_auth_service(),
+            memory_config=mem,
+        )
+
+    def test_expired_timestamp_is_expired(self) -> None:
+        stub = self._stub(self._iso(-1))
+        cfg = stub.config_manager.get()
+        assert ServonautApp._remember_passphrase_expired(stub, cfg) is True
+
+    def test_future_timestamp_is_not_expired(self) -> None:
+        stub = self._stub(self._iso(10))
+        cfg = stub.config_manager.get()
+        assert ServonautApp._remember_passphrase_expired(stub, cfg) is False
+
+    def test_empty_timestamp_is_not_expired_legacy(self) -> None:
+        """Legacy enrolment (no expiry recorded) is treated as not-expired."""
+        stub = self._stub("")
+        cfg = stub.config_manager.get()
+        assert ServonautApp._remember_passphrase_expired(stub, cfg) is False
+
+    def test_malformed_timestamp_fails_open(self) -> None:
+        stub = self._stub("not-a-timestamp")
+        cfg = stub.config_manager.get()
+        assert ServonautApp._remember_passphrase_expired(stub, cfg) is False
+
+    @pytest.mark.asyncio
+    async def test_silent_unlock_clears_keychain_when_expired(self) -> None:
+        """An expired remembered passphrase is cleared and NOT used to bootstrap.
+
+        Even though ``can_unwrap_local`` would succeed, the expiry check runs
+        first so no silent bootstrap happens and the keychain entry is purged.
+        """
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        sync.can_unwrap_local = MagicMock(return_value=True)
+        stub = self._stub(self._iso(-1))
+        stub.memory_sync_service = sync
+        # rebind helpers to the new sync service-bearing stub fields
+        kr = _make_fake_keyring(
+            backend_module="keyring.backends.SecretService", pw="old-pw"
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        kr.delete_password.assert_called_once()
+        stub.bootstrap_memory_cloud.assert_not_called()
+        sync.can_unwrap_local.assert_not_called()
+        stub.config_manager.update.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Remember TTL — _prompt_memory_passphrase stamps an expiry when remembering
+# ---------------------------------------------------------------------------
+
+
+class TestPromptStampsExpiry:
+    @pytest.mark.asyncio
+    async def test_remember_stores_passphrase_and_stamps_expiry(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        from servonaut.screens.memory_keys import PassphraseResult
+
+        cfg = AppConfig(memory=MemoryConfig())
+        cm = MagicMock()
+        cm.get = MagicMock(return_value=cfg)
+        cm.update = MagicMock()
+        stub = SimpleNamespace(
+            config_manager=cm,
+            notify=MagicMock(),
+            push_screen_wait=AsyncMock(
+                return_value=PassphraseResult(passphrase="pw", remember=True)
+            ),
+        )
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            pw = await ServonautApp._prompt_memory_passphrase(stub)  # type: ignore[arg-type]
+
+        assert pw == "pw"
+        kr.set_password.assert_called_once()
+        stamped = any(
+            getattr(c.kwargs.get("memory"), "sync_remember_expires_at", "")
+            for c in cm.update.call_args_list
+            if c.kwargs.get("memory") is not None
+        )
+        assert stamped, "expected sync_remember_expires_at to be stamped on remember"
+
+    @pytest.mark.asyncio
+    async def test_remember_without_keychain_warns_and_does_not_persist(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        from servonaut.screens.memory_keys import PassphraseResult
+
+        cfg = AppConfig(memory=MemoryConfig())
+        cm = MagicMock()
+        cm.get = MagicMock(return_value=cfg)
+        cm.update = MagicMock()
+        stub = SimpleNamespace(
+            config_manager=cm,
+            notify=MagicMock(),
+            push_screen_wait=AsyncMock(
+                return_value=PassphraseResult(passphrase="pw", remember=True)
+            ),
+        )
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            pw = await ServonautApp._prompt_memory_passphrase(stub)  # type: ignore[arg-type]
+
+        assert pw == "pw"
+        # No keychain → warn the user, do not flip the remember flag.
+        stub.notify.assert_called()
+        cm.update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # M4: stale sync_remember_device flag self-correction
 # ---------------------------------------------------------------------------
 
@@ -610,7 +769,7 @@ class TestSessionSkipAfterCancel:
         # Simulate that the user already cancelled in this session
         stub._memory_sync_prompt_skipped = True
 
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
 
         # bootstrap must NOT have been called
         stub.bootstrap_memory_cloud.assert_not_called()
@@ -628,7 +787,7 @@ class TestSessionSkipAfterCancel:
         )
         assert not getattr(stub, "_memory_sync_prompt_skipped", False)
 
-        await _run_reactivate(stub)
+        await _run_prompt(stub)
 
         assert getattr(stub, "_memory_sync_prompt_skipped", False) is True
 

--- a/tests/test_memory_sync_reactivate.py
+++ b/tests/test_memory_sync_reactivate.py
@@ -1,0 +1,809 @@
+"""Tests for the Memory Sync startup reactivation path in ServonautApp.
+
+Strategy: same duck-typed stub pattern as test_app_fleet_auto_scan.py —
+we bind the unbound async method onto a minimal SimpleNamespace that
+provides exactly the attributes the method reads, then drive it directly
+with pytest-asyncio.
+
+Covers:
+- _reactivate_memory_sync no-ops when sync service is None.
+- _reactivate_memory_sync no-ops when already configured.
+- _reactivate_memory_sync no-ops when not enrolled locally.
+- _reactivate_memory_sync no-ops when not authenticated.
+- _reactivate_memory_sync no-ops when memory_sync feature absent.
+- Silent path calls bootstrap with a keychain provider when
+  sync_remember_device=True + keychain available + passphrase present.
+- Silent path clears keychain on failure then falls through to prompt.
+- Prompt-cancel (RuntimeError from bootstrap) is swallowed (no crash).
+- Successful bootstrap calls _propagate_memory_key_material + _start_memory_sync_loop
+  (indirectly — we just verify bootstrap_memory_cloud is called).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from servonaut.app import ServonautApp
+from servonaut.config.schema import AppConfig, MemoryConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_config(*, sync_remember_device: bool = False) -> MemoryConfig:
+    return MemoryConfig(sync_remember_device=sync_remember_device)
+
+
+def _make_config(memory: MemoryConfig) -> AppConfig:
+    return AppConfig(memory=memory)
+
+
+def _make_sync_service(
+    *,
+    is_configured: bool = False,
+    enrolled_locally: bool = True,
+) -> MagicMock:
+    svc = MagicMock()
+    svc.is_configured = is_configured
+    svc.is_enrolled_locally = MagicMock(return_value=enrolled_locally)
+    return svc
+
+
+def _make_auth_service(
+    *,
+    is_authenticated: bool = True,
+    has_memory_sync: bool = True,
+) -> MagicMock:
+    auth = MagicMock()
+    auth.is_authenticated = is_authenticated
+    auth.has_feature = MagicMock(
+        side_effect=lambda slug: has_memory_sync if slug == "memory_sync" else False
+    )
+    return auth
+
+
+def _make_stub(
+    *,
+    sync_service=None,
+    auth_service=None,
+    memory_config: MemoryConfig | None = None,
+    bootstrap_side_effect=None,
+) -> SimpleNamespace:
+    if memory_config is None:
+        memory_config = _make_memory_config()
+    config = _make_config(memory_config)
+
+    config_manager = MagicMock()
+    config_manager.get = MagicMock(return_value=config)
+    config_manager.update = MagicMock()
+
+    stub = SimpleNamespace(
+        memory_sync_service=sync_service,
+        auth_service=auth_service,
+        config_manager=config_manager,
+        notify=MagicMock(),
+    )
+
+    # bootstrap_memory_cloud is always async
+    if bootstrap_side_effect is not None:
+        stub.bootstrap_memory_cloud = AsyncMock(side_effect=bootstrap_side_effect)
+    else:
+        stub.bootstrap_memory_cloud = AsyncMock(return_value=None)
+
+    return stub
+
+
+async def _run_reactivate(stub: SimpleNamespace) -> None:
+    """Drive _reactivate_memory_sync on the stub."""
+    await ServonautApp._reactivate_memory_sync(stub)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Guard conditions — must be no-ops
+# ---------------------------------------------------------------------------
+
+
+class TestReactivateGuards:
+    @pytest.mark.asyncio
+    async def test_noop_when_sync_service_is_none(self) -> None:
+        stub = _make_stub(sync_service=None)
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_already_configured(self) -> None:
+        sync = _make_sync_service(is_configured=True)
+        stub = _make_stub(sync_service=sync, auth_service=_make_auth_service())
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_enrolled_locally(self) -> None:
+        sync = _make_sync_service(is_configured=False, enrolled_locally=False)
+        stub = _make_stub(sync_service=sync, auth_service=_make_auth_service())
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_authenticated(self) -> None:
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service(is_authenticated=False)
+        stub = _make_stub(sync_service=sync, auth_service=auth)
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_memory_sync_feature(self) -> None:
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service(has_memory_sync=False)
+        stub = _make_stub(sync_service=sync, auth_service=auth)
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_auth_service_is_none(self) -> None:
+        sync = _make_sync_service(enrolled_locally=True)
+        stub = _make_stub(sync_service=sync, auth_service=None)
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Silent path (keychain)
+# ---------------------------------------------------------------------------
+
+
+class TestSilentPath:
+    @pytest.mark.asyncio
+    async def test_silent_path_calls_bootstrap_with_keychain_provider(self) -> None:
+        """When remember=True and keychain has passphrase, bootstrap is called
+        with a provider that returns the stored passphrase (no modal)."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(sync_service=sync, auth_service=auth, memory_config=mem_cfg)
+
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(
+                ps,
+                "_keyring",
+                _make_fake_keyring(backend_module="keyring.backends.SecretService", pw="my-pw"),
+            ),
+        ):
+            await _run_reactivate(stub)
+
+        stub.bootstrap_memory_cloud.assert_called_once()
+        # The provider was passed as a keyword arg — verify it's not None
+        _, kwargs = stub.bootstrap_memory_cloud.call_args
+        assert kwargs.get("passphrase_provider") is not None
+        # The provider is an async callable that returns the stored passphrase
+        provider = kwargs["passphrase_provider"]
+        pw_returned = await provider("unlock")
+        assert pw_returned == "my-pw"
+
+    @pytest.mark.asyncio
+    async def test_silent_path_skipped_when_keychain_unavailable(self) -> None:
+        """When keychain is unavailable, silent path is skipped and prompt runs."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            # bootstrap raises RuntimeError to simulate user cancel on the prompt
+            bootstrap_side_effect=RuntimeError("cancelled"),
+        )
+
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            await _run_reactivate(stub)
+
+        # bootstrap_memory_cloud WAS called (the prompt path), not with a
+        # keychain provider but with no args (falls back to modal prompt).
+        stub.bootstrap_memory_cloud.assert_called_once()
+        _, kwargs = stub.bootstrap_memory_cloud.call_args
+        # No passphrase_provider means the prompt path ran
+        assert kwargs.get("passphrase_provider") is None
+
+    @pytest.mark.asyncio
+    async def test_silent_path_clears_keychain_on_wrong_passphrase_then_prompts(
+        self,
+    ) -> None:
+        """MAJOR-1: when can_unwrap_local returns False (wrong/stale passphrase),
+        the keychain is cleared and the prompt path runs.
+
+        The old behaviour (clear on bootstrap failure) no longer applies — the
+        new logic validates locally BEFORE calling bootstrap.
+        """
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        # Simulate wrong/stale passphrase detected locally
+        sync.can_unwrap_local = MagicMock(return_value=False)
+        sync.clear_local_keypair_cache = MagicMock()
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+
+        call_count = 0
+
+        async def _bootstrap_side_effect(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            # can_unwrap_local=False means we skip silent bootstrap entirely.
+            # The only call is from the prompt path, which the user cancels.
+            raise RuntimeError("cancelled")
+
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            bootstrap_side_effect=_bootstrap_side_effect,
+        )
+
+        kr = _make_fake_keyring(
+            backend_module="keyring.backends.SecretService", pw="stale-pw"
+        )
+
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        # Keychain was cleared (wrong passphrase detected locally)
+        kr.delete_password.assert_called_once()
+        # Cache was cleared
+        sync.clear_local_keypair_cache.assert_called_once()
+        # Only the prompt call reached bootstrap (silent path skipped)
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_silent_path_success_does_not_call_prompt(self) -> None:
+        """If silent reactivation succeeds, the modal prompt is NOT shown."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            # Silent bootstrap succeeds (returns None)
+        )
+
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(
+                ps,
+                "_keyring",
+                _make_fake_keyring(backend_module="keyring.backends.SecretService", pw="pw"),
+            ),
+        ):
+            await _run_reactivate(stub)
+
+        # Only ONE bootstrap call (the silent one), not two
+        stub.bootstrap_memory_cloud.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Prompt path
+# ---------------------------------------------------------------------------
+
+
+class TestPromptPath:
+    @pytest.mark.asyncio
+    async def test_prompt_cancel_is_swallowed_no_crash(self) -> None:
+        """RuntimeError from bootstrap (user cancel) must not propagate."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            bootstrap_side_effect=RuntimeError("Memory keypair unlock cancelled by user"),
+        )
+        # Must not raise
+        await _run_reactivate(stub)
+        stub.bootstrap_memory_cloud.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_prompt_cancel_shows_info_notify(self) -> None:
+        """A cancel leaves a brief info notification (not an error)."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            bootstrap_side_effect=RuntimeError("cancelled"),
+        )
+        await _run_reactivate(stub)
+        stub.notify.assert_called()
+        # severity must not be "error"
+        for call_args in stub.notify.call_args_list:
+            kw = call_args.kwargs
+            assert kw.get("severity", "information") != "error", (
+                f"Expected non-error notify on cancel, got severity={kw.get('severity')}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_runtime_error_is_swallowed(self) -> None:
+        """Other exceptions (network errors etc.) are also swallowed."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            bootstrap_side_effect=IOError("connection failed"),
+        )
+        await _run_reactivate(stub)
+        # Must not raise
+
+    @pytest.mark.asyncio
+    async def test_prompt_path_success_sends_no_error_notify(self) -> None:
+        """Successful prompt-path reactivation does not produce an error notify."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(sync_service=sync, auth_service=auth)
+        await _run_reactivate(stub)
+        for call_args in stub.notify.call_args_list:
+            kw = call_args.kwargs
+            assert kw.get("severity", "information") != "error"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_keyring(*, backend_module: str, pw: str | None = "pw"):
+    """Return a minimal keyring module stub with a known backend module.
+
+    Uses a dynamically-created class so that ``type(backend).__module__``
+    returns *backend_module* — SimpleNamespace is an immutable type and
+    does not allow setting ``__module__`` on its type object.
+    """
+    BackendClass = type("Keyring", (), {"__module__": backend_module})
+    backend = BackendClass()
+
+    kr = MagicMock()
+    kr.get_keyring.return_value = backend
+    kr.get_password = MagicMock(return_value=pw)
+    kr.set_password = MagicMock()
+    kr.delete_password = MagicMock()
+    return kr
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-1: silent-path — wrong passphrase clears, network error does NOT clear
+# ---------------------------------------------------------------------------
+
+
+class TestSilentPathMajor1:
+    @pytest.mark.asyncio
+    async def test_wrong_passphrase_clears_keychain_and_flag(self) -> None:
+        """When can_unwrap_local returns False (wrong passphrase), the keychain
+        entry and the sync_remember_device flag must be cleared."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        sync.can_unwrap_local = MagicMock(return_value=False)
+        sync.clear_local_keypair_cache = MagicMock()
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(sync_service=sync, auth_service=auth, memory_config=mem_cfg)
+        # bootstrap is a RuntimeError (user cancel) if the prompt path runs
+        stub.bootstrap_memory_cloud = AsyncMock(side_effect=RuntimeError("cancelled"))
+
+        kr = _make_fake_keyring(
+            backend_module="keyring.backends.SecretService", pw="stale-pw"
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        # Keychain must be cleared (wrong passphrase)
+        kr.delete_password.assert_called_once()
+        # Local cache must be cleared
+        sync.clear_local_keypair_cache.assert_called_once()
+        # Config flag must be reset
+        stub.config_manager.update.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_network_error_after_valid_passphrase_does_not_clear(self) -> None:
+        """When can_unwrap_local returns True (valid passphrase) but bootstrap
+        fails with a network error, the keychain and flag must NOT be cleared."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True, is_configured=False)
+        sync.can_unwrap_local = MagicMock(return_value=True)
+        sync.clear_local_keypair_cache = MagicMock()
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            # Simulate a network error AFTER can_unwrap_local returned True
+            bootstrap_side_effect=IOError("connection refused"),
+        )
+
+        kr = _make_fake_keyring(
+            backend_module="keyring.backends.SecretService", pw="valid-pw"
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        # Bootstrap was called once (silent path)
+        stub.bootstrap_memory_cloud.assert_called_once()
+        # Keychain must NOT be cleared (passphrase was valid)
+        kr.delete_password.assert_not_called()
+        # Local cache must NOT be cleared
+        sync.clear_local_keypair_cache.assert_not_called()
+        # Config update must NOT have cleared the flag
+        for call_args in stub.config_manager.update.call_args_list:
+            kw = call_args.kwargs
+            mem = kw.get("memory") or (call_args.args[0] if call_args.args else None)
+            if mem is not None:
+                # If config was updated, the flag must NOT be False
+                flag = getattr(mem, "sync_remember_device", True)
+                assert flag is not False, (
+                    "sync_remember_device must not be reset on a network error "
+                    f"after valid passphrase; got memory={mem!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_valid_passphrase_does_not_fall_to_prompt(self) -> None:
+        """When can_unwrap_local returns True and bootstrap succeeds, the modal
+        prompt must NOT run (return early after success)."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        sync.can_unwrap_local = MagicMock(return_value=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(sync_service=sync, auth_service=auth, memory_config=mem_cfg)
+
+        kr = _make_fake_keyring(
+            backend_module="keyring.backends.SecretService", pw="valid-pw"
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        # Exactly one call — the silent bootstrap; no second call for the prompt
+        stub.bootstrap_memory_cloud.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# M4: stale sync_remember_device flag self-correction
+# ---------------------------------------------------------------------------
+
+
+class TestM4StaleFlagSelfCorrection:
+    @pytest.mark.asyncio
+    async def test_flag_cleared_when_keychain_unavailable(self) -> None:
+        """When sync_remember_device=True but keychain is unavailable,
+        the flag must be reset to False."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            bootstrap_side_effect=RuntimeError("cancelled"),
+        )
+
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            await _run_reactivate(stub)
+
+        # Config must have been updated to clear the flag
+        stub.config_manager.update.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_cleared_when_no_passphrase_stored(self) -> None:
+        """When sync_remember_device=True and keychain is available but
+        no passphrase is stored, the flag must be reset to False."""
+        import servonaut.services.memory.passphrase_store as ps
+
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        mem_cfg = _make_memory_config(sync_remember_device=True)
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            memory_config=mem_cfg,
+            bootstrap_side_effect=RuntimeError("cancelled"),
+        )
+
+        # Keychain available but empty (get_passphrase returns None)
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService", pw=None)
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await _run_reactivate(stub)
+
+        stub.config_manager.update.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# M10: keyring_available allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestKeychainAllowlist:
+    def _check_available(self, backend_module: str) -> bool:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_fake_keyring(backend_module=backend_module)
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            return ps.keyring_available()
+
+    def test_secretservice_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.SecretService") is True
+
+    def test_secretservice_lowercase_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.secretservice") is True
+
+    def test_kwallet_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.kwallet") is True
+
+    def test_macos_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.macOS") is True
+
+    def test_windows_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.Windows") is True
+
+    def test_chainer_is_accepted(self) -> None:
+        assert self._check_available("keyring.backends.chainer") is True
+
+    def test_fail_backend_is_rejected(self) -> None:
+        assert self._check_available("keyring.backends.fail") is False
+
+    def test_null_backend_is_rejected(self) -> None:
+        assert self._check_available("keyring.backends.null") is False
+
+    def test_unknown_backend_is_rejected(self) -> None:
+        assert self._check_available("some.unknown.backend") is False
+
+    def test_empty_module_is_rejected(self) -> None:
+        assert self._check_available("") is False
+
+
+# ---------------------------------------------------------------------------
+# M11: session skip — don't re-prompt after user cancels
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSkipAfterCancel:
+    @pytest.mark.asyncio
+    async def test_no_reprompt_after_cancel_within_session(self) -> None:
+        """If the user cancelled the modal in this session
+        (_memory_sync_prompt_skipped=True), the prompt must not run again."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(sync_service=sync, auth_service=auth)
+        # Simulate that the user already cancelled in this session
+        stub._memory_sync_prompt_skipped = True
+
+        await _run_reactivate(stub)
+
+        # bootstrap must NOT have been called
+        stub.bootstrap_memory_cloud.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_sets_skip_flag(self) -> None:
+        """A RuntimeError from bootstrap (user cancel) must set
+        _memory_sync_prompt_skipped=True on the stub."""
+        sync = _make_sync_service(enrolled_locally=True)
+        auth = _make_auth_service()
+        stub = _make_stub(
+            sync_service=sync,
+            auth_service=auth,
+            bootstrap_side_effect=RuntimeError("cancelled"),
+        )
+        assert not getattr(stub, "_memory_sync_prompt_skipped", False)
+
+        await _run_reactivate(stub)
+
+        assert getattr(stub, "_memory_sync_prompt_skipped", False) is True
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-2: logout clears cache + keychain + flag
+# ---------------------------------------------------------------------------
+
+
+class TestLogoutClearsMemorySyncState:
+    def _make_app_stub(self, *, has_sync: bool = True) -> Any:
+        """Build a minimal stub for on_user_logout."""
+        from servonaut.config.schema import AppConfig, MemoryConfig
+        import dataclasses as _dc
+
+        memory_cfg = MemoryConfig(sync_remember_device=True)
+        cfg = AppConfig(memory=memory_cfg)
+        cm = MagicMock()
+        cm.get = MagicMock(return_value=cfg)
+        cm.update = MagicMock()
+
+        sync = MagicMock()
+        sync.lock = MagicMock()
+        sync.clear_local_keypair_cache = MagicMock()
+
+        stub = SimpleNamespace(
+            config_sync_service=MagicMock(),
+            config_manager=cm,
+            memory_sync_service=sync if has_sync else None,
+        )
+        return stub
+
+    def test_logout_clears_local_keypair_cache(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        stub = self._make_app_stub()
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            ServonautApp.on_user_logout(stub)  # type: ignore[arg-type]
+        stub.memory_sync_service.clear_local_keypair_cache.assert_called_once()
+
+    def test_logout_locks_in_memory_key(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        stub = self._make_app_stub()
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            ServonautApp.on_user_logout(stub)  # type: ignore[arg-type]
+        stub.memory_sync_service.lock.assert_called_once()
+
+    def test_logout_clears_keychain_passphrase(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        stub = self._make_app_stub()
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            ServonautApp.on_user_logout(stub)  # type: ignore[arg-type]
+        kr.delete_password.assert_called_once()
+
+    def test_logout_resets_remember_flag(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        stub = self._make_app_stub()
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            ServonautApp.on_user_logout(stub)  # type: ignore[arg-type]
+        stub.config_manager.update.assert_called()
+
+    def test_logout_noop_when_no_sync_service(self) -> None:
+        """Logout must not crash when memory_sync_service is None."""
+        import servonaut.services.memory.passphrase_store as ps
+        stub = self._make_app_stub(has_sync=False)
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            ServonautApp.on_user_logout(stub)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-3: _do_rotate with remember=True sets sync_remember_device=True
+# ---------------------------------------------------------------------------
+
+
+class TestRotateWithRemember:
+    """Duck-type _do_rotate to verify MAJOR-3: when the user rotates their
+    keypair and ticks "remember this device", config.memory.sync_remember_device
+    is set to True in addition to storing the passphrase in the keychain.
+    """
+
+    def _make_screen_stub(self, *, remember: bool) -> SimpleNamespace:
+        """Build a minimal duck-typed screen stub for ``_do_rotate``.
+
+        ``_do_rotate`` reads: self.app.memory_sync_service, self.app.push_screen_wait,
+        self.app.config_manager, self.app.notify, self._set_busy, self._clear_busy,
+        self._show_setup_error, and self._render_state.
+        """
+        from servonaut.config.schema import AppConfig, MemoryConfig
+        from servonaut.screens.memory_keys import PassphraseResult
+
+        memory_cfg = MemoryConfig(sync_remember_device=False)
+        cfg = AppConfig(memory=memory_cfg)
+        cm = MagicMock()
+        cm.get = MagicMock(return_value=cfg)
+        cm.update = MagicMock()
+
+        sync = MagicMock()
+        sync.is_configured = True
+        sync.rotate_keypair = AsyncMock()
+
+        old_result = PassphraseResult(passphrase="old-pw", remember=False)
+        new_result = PassphraseResult(passphrase="new-pw", remember=remember)
+
+        app_stub = SimpleNamespace(
+            memory_sync_service=sync,
+            config_manager=cm,
+            notify=MagicMock(),
+            # push_screen_wait is called twice: first for old_result, then new_result
+            push_screen_wait=AsyncMock(side_effect=[old_result, new_result]),
+        )
+
+        stub = SimpleNamespace(
+            app=app_stub,
+            _set_busy=MagicMock(),
+            _clear_busy=MagicMock(),
+            _show_setup_error=MagicMock(),
+            _render_state=MagicMock(),
+        )
+        return stub
+
+    @pytest.mark.asyncio
+    async def test_rotate_with_remember_sets_config_flag(self) -> None:
+        """MAJOR-3: rotate + remember=True must set sync_remember_device=True."""
+        import servonaut.services.memory.passphrase_store as ps
+        from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+        stub = self._make_screen_stub(remember=True)
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await MemorySyncSetupScreen._do_rotate(stub)  # type: ignore[arg-type]
+
+        stub.app.config_manager.update.assert_called()
+        # Find the call where sync_remember_device was set to True
+        updated_to_true = any(
+            getattr(
+                c.kwargs.get("memory") or (c.args[0] if c.args else None),
+                "sync_remember_device",
+                None,
+            ) is True
+            for c in stub.app.config_manager.update.call_args_list
+        )
+        assert updated_to_true, (
+            "Expected config_manager.update to set sync_remember_device=True on "
+            f"rotate+remember. Calls: {stub.app.config_manager.update.call_args_list}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rotate_without_remember_does_not_set_flag(self) -> None:
+        """rotate + remember=False must NOT set sync_remember_device=True."""
+        import servonaut.services.memory.passphrase_store as ps
+        from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+        stub = self._make_screen_stub(remember=False)
+        kr = _make_fake_keyring(backend_module="keyring.backends.SecretService")
+
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            await MemorySyncSetupScreen._do_rotate(stub)  # type: ignore[arg-type]
+
+        # Either update was not called or it set flag to False (never True)
+        for c in stub.app.config_manager.update.call_args_list:
+            mem = c.kwargs.get("memory") or (c.args[0] if c.args else None)
+            if mem is not None:
+                flag = getattr(mem, "sync_remember_device", False)
+                assert flag is not True, (
+                    f"sync_remember_device must not be True when remember=False; "
+                    f"got {flag!r}"
+                )

--- a/tests/test_memory_sync_service.py
+++ b/tests/test_memory_sync_service.py
@@ -36,6 +36,7 @@ from servonaut.services.memory.interfaces import (
     UpsellRequired,
     ValidationFailed,
 )
+from servonaut.services.api_client import APIClient
 from servonaut.services.memory.sync_service import MemorySyncService
 from servonaut.services.memory.rate_limiter import RateLimiter
 
@@ -52,8 +53,13 @@ def _make_api_client(
     patch_return=None,
     delete_return=None,
 ):
-    """Build a minimal mock APIClient."""
-    client = MagicMock()
+    """Build a minimal mock APIClient.
+
+    M6: use ``MagicMock(spec=APIClient)`` so positional-payload calls
+    (e.g. ``api.post("/foo", payload)`` instead of ``api.post("/foo", json=payload)``)
+    raise ``TypeError`` at test time rather than silently passing.
+    """
+    client = MagicMock(spec=APIClient)
     client.get = AsyncMock(return_value=get_return or {})
     client.post = AsyncMock(return_value=post_return or {})
     client.patch = AsyncMock(return_value=patch_return or {})
@@ -125,6 +131,10 @@ def _make_service(
     )
     if tmp_path:
         svc._queue_path = tmp_path / "memory" / "sync_queue.jsonl"
+        # Redirect the keypair cache path so tests don't accidentally read
+        # the developer's real ~/.servonaut/memory/keys.json and fail with
+        # a wrong-passphrase DecryptionFailedError.
+        svc._key_cache_path = tmp_path / "memory" / "keys.json"
     if configured:
         svc._self_pubkey = b"\x00" * 32
         svc._self_privkey = b"\x01" * 32
@@ -163,7 +173,8 @@ class TestBootstrap:
         api = _make_api_client(get_side_effect=FeatureDisabledError(
             code="feature_disabled", message="maintenance", status=503
         ))
-        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        # M7: must be unconfigured so the bootstrap guard doesn't no-op
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
         with pytest.raises(BackendMaintenance):
             await svc.bootstrap(passphrase_provider=AsyncMock(return_value="password1234ABCD!!"))
 
@@ -173,7 +184,8 @@ class TestBootstrap:
         api = _make_api_client(get_side_effect=FeatureNotAvailableError(
             code="feature_not_available", message="beta", status=403
         ))
-        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        # M7: must be unconfigured so the bootstrap guard doesn't no-op
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
         with pytest.raises(BetaWaitlist):
             await svc.bootstrap(passphrase_provider=AsyncMock(return_value="password1234ABCD!!"))
 
@@ -183,7 +195,8 @@ class TestBootstrap:
         api = _make_api_client(get_side_effect=ForbiddenEntitlementError(
             code="forbidden_entitlement", message="upgrade", status=403
         ))
-        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        # M7: must be unconfigured so the bootstrap guard doesn't no-op
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
         with pytest.raises(UpsellRequired):
             await svc.bootstrap(passphrase_provider=AsyncMock(return_value="password1234ABCD!!"))
 
@@ -217,7 +230,8 @@ class TestBootstrap:
         api.get.side_effect = get_side
         api.post.side_effect = post_side
 
-        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        # M7: must be unconfigured so the bootstrap guard doesn't no-op
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
         passphrase_provider = AsyncMock(return_value=passphrase)
 
         with patch("servonaut.services.memory.sync_service.generate_keypair") as gk, \
@@ -1053,3 +1067,587 @@ class TestEntitlementCheck:
         assert call_count[0] == 0, (
             "Entitlement predicate should not be evaluated when is_configured is False"
         )
+
+
+# ---------------------------------------------------------------------------
+# Local keypair cache — is_enrolled_locally / clear / persist / _ensure_keypair
+# ---------------------------------------------------------------------------
+
+import base64
+import json as _json
+
+def _fake_wrapped_json() -> str:
+    return '{"kdf":"argon2id","pw_score":4,"salt":"AAAA","nonce":"AAAA","ct":"AAAA","ops_limit":1,"mem_limit":1}'
+
+
+def _write_cache(
+    path: Path,
+    *,
+    pub_b64: str,
+    wrapped_json: str,
+    fingerprint: str = "a" * 64,
+    user_id: Optional[int] = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {
+        "public_key": pub_b64,
+        "wrapped_private_key": wrapped_json,
+        "fingerprint": fingerprint,
+    }
+    if user_id is not None:
+        data["user_id"] = user_id
+    path.write_text(_json.dumps(data))
+
+
+class TestLocalKeypairCache:
+    """is_enrolled_locally, clear_local_keypair_cache, _persist_key_cache."""
+
+    def test_is_enrolled_locally_false_when_no_cache(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        svc._key_cache_path = tmp_path / "memory" / "keys.json"
+        assert svc.is_enrolled_locally() is False
+
+    def test_is_enrolled_locally_true_when_cache_exists(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        _write_cache(
+            cache_path,
+            pub_b64=base64.b64encode(b"\x01" * 32).decode(),
+            wrapped_json=_fake_wrapped_json(),
+        )
+        assert svc.is_enrolled_locally() is True
+
+    def test_clear_local_keypair_cache_removes_file(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        _write_cache(
+            cache_path,
+            pub_b64=base64.b64encode(b"\x01" * 32).decode(),
+            wrapped_json=_fake_wrapped_json(),
+        )
+        assert cache_path.exists()
+        svc.clear_local_keypair_cache()
+        assert not cache_path.exists()
+
+    def test_clear_local_keypair_cache_noop_when_absent(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        svc._key_cache_path = tmp_path / "memory" / "keys.json"
+        # Must not raise even when file doesn't exist
+        svc.clear_local_keypair_cache()
+
+    def test_persist_key_cache_writes_atomic_file(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._persist_key_cache(
+            "AAEC",
+            _fake_wrapped_json(),
+            "fingerprint-abc",
+        )
+        assert cache_path.exists()
+        data = _json.loads(cache_path.read_text())
+        assert data["public_key"] == "AAEC"
+        assert data["fingerprint"] == "fingerprint-abc"
+        # CRITICAL: no unwrapped key, no passphrase
+        assert "private_key" not in data
+        assert "passphrase" not in data
+
+    def test_persist_key_cache_mode_0600(self, tmp_path: Path) -> None:
+        import stat
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._persist_key_cache(
+            base64.b64encode(b"\x01" * 32).decode(),
+            _fake_wrapped_json(),
+            "fp",
+        )
+        mode = stat.S_IMODE(cache_path.stat().st_mode)
+        assert mode == 0o600, f"Expected 0600, got {oct(mode)}"
+
+
+class TestEnsureKeypairCachePath:
+    """_ensure_keypair uses local cache when present; falls back to network."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_network_call(self, tmp_path: Path) -> None:
+        """When the local cache exists, GET /keys/me must NOT be called."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        wrapped_json = _fake_wrapped_json()
+
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42  # still needed by bootstrap internals
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=wrapped_json)
+
+        passphrase_provider = AsyncMock(return_value="correct-passphrase")
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            # M5: _derive_public_key is called after unwrap; mock it to return
+            # the cached pubkey so the integrity check passes with this test's
+            # arbitrary private-key fixture value.
+            svc._derive_public_key = MagicMock(return_value=base64.b64decode(pub_b64))
+            await svc._ensure_keypair(passphrase_provider)
+
+        # Network call must NOT have been made
+        api.get.assert_not_called()
+        # Private key was set
+        assert svc._self_privkey == b"\x02" * 32
+        assert svc._self_pubkey == base64.b64decode(pub_b64)
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_bad_passphrase_reraises_no_network(
+        self, tmp_path: Path
+    ) -> None:
+        """Bad passphrase on the cache path re-raises immediately.
+        The service must NOT silently fall back to the network path.
+        """
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        passphrase_provider = AsyncMock(return_value="wrong-passphrase")
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.side_effect = ValueError("decryption failed: bad mac")
+            with pytest.raises(ValueError, match="decryption failed"):
+                await svc._ensure_keypair(passphrase_provider)
+
+        # Network path must not have been attempted
+        api.get.assert_not_called()
+        # Partial state must not leak: pubkey should remain unset
+        assert svc._self_pubkey is None
+        assert svc._self_privkey is None
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_network_and_persists_cache(
+        self, tmp_path: Path
+    ) -> None:
+        """When no local cache exists, GET /keys/me is called and the result
+        is persisted to the cache file."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        wrapped_json = _fake_wrapped_json()
+
+        async def get_side(path, **kwargs):
+            if "/keys/me" in path:
+                return {
+                    "public_key": pub_b64,
+                    "wrapped_private_key": wrapped_json,
+                    "fingerprint": "fp-net",
+                }
+            return {}
+
+        api = _make_api_client()
+        api.get.side_effect = get_side
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+
+        passphrase_provider = AsyncMock(return_value="correct-passphrase")
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            await svc._ensure_keypair(passphrase_provider)
+
+        # Network call was made
+        api.get.assert_called()
+        # Cache was persisted
+        assert cache_path.exists()
+        cached = _json.loads(cache_path.read_text())
+        assert cached["public_key"] == pub_b64
+        assert cached["fingerprint"] == "fp-net"
+        assert "private_key" not in cached
+
+    @pytest.mark.asyncio
+    async def test_enrol_path_persists_cache(self, tmp_path: Path) -> None:
+        """After a 404 on /keys/me (new user), the enrolled keypair is cached."""
+        from servonaut.services.memory.crypto import KeyPair
+
+        async def get_side(path, **kwargs):
+            if "/keys/me" in path:
+                raise NotFoundError(code="not_found", message="no key", status=404)
+            return {}
+
+        api = _make_api_client()
+        api.get.side_effect = get_side
+        api.post = AsyncMock(return_value={})
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+
+        passphrase_provider = AsyncMock(return_value="new-passphrase")
+
+        fake_kp = KeyPair(
+            public_key=b"\x03" * 32,
+            private_key=b"\x04" * 32,
+            fingerprint="enrolled-fp",
+        )
+        fake_wrapped = MagicMock()
+        fake_wrapped.to_json.return_value = _fake_wrapped_json()
+
+        with (
+            patch("servonaut.services.memory.sync_service.generate_keypair", return_value=fake_kp),
+            patch("servonaut.services.memory.sync_service.wrap_private_key", return_value=fake_wrapped),
+        ):
+            await svc._ensure_keypair(passphrase_provider)
+
+        assert cache_path.exists()
+        cached = _json.loads(cache_path.read_text())
+        assert cached["fingerprint"] == "enrolled-fp"
+        assert "private_key" not in cached
+
+
+class TestRotateKeypairUpdatesCache:
+    """rotate_keypair must overwrite the local cache with the new wrapped key."""
+
+    @pytest.mark.asyncio
+    async def test_rotate_overwrites_cache(self, tmp_path: Path) -> None:
+        from servonaut.services.memory.crypto import KeyPair
+
+        # Seed the service with an existing cache (old key)
+        api = _make_api_client()
+        async def get_side(path, **kwargs):
+            return {
+                "public_key": base64.b64encode(b"\x01" * 32).decode(),
+                "wrapped_private_key": _fake_wrapped_json(),
+                "fingerprint": "old-fp",
+            }
+        api.get.side_effect = get_side
+        api.post = AsyncMock(return_value={})
+
+        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        # Pre-seed a "stale" cache entry
+        _write_cache(
+            cache_path,
+            pub_b64=base64.b64encode(b"\x01" * 32).decode(),
+            wrapped_json=_fake_wrapped_json(),
+            fingerprint="old-fp",
+        )
+
+        new_kp = KeyPair(
+            public_key=b"\x05" * 32,
+            private_key=b"\x06" * 32,
+            fingerprint="new-fp",
+        )
+        new_wrapped = MagicMock()
+        new_wrapped.to_json.return_value = _fake_wrapped_json()
+
+        with (
+            patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk,
+            patch("servonaut.services.memory.sync_service.generate_keypair", return_value=new_kp),
+            patch("servonaut.services.memory.sync_service.wrap_private_key", return_value=new_wrapped),
+        ):
+            uwk.return_value = b"\x02" * 32
+            await svc.rotate_keypair("old-pass", "new-pass")
+
+        assert cache_path.exists()
+        cached = _json.loads(cache_path.read_text())
+        assert cached["fingerprint"] == "new-fp", (
+            f"Cache should hold new fingerprint, got {cached.get('fingerprint')}"
+        )
+        assert "private_key" not in cached
+
+
+# ---------------------------------------------------------------------------
+# M7: double-bootstrap no-op when already configured
+# ---------------------------------------------------------------------------
+
+
+class TestDoubleBootstrapNoOp:
+    @pytest.mark.asyncio
+    async def test_second_bootstrap_is_noop(self, tmp_path: Path) -> None:
+        """If is_configured is True when bootstrap is called, it must return
+        immediately without touching the network or the passphrase_provider."""
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path)
+        # svc is already configured (keys set by _make_service)
+        assert svc.is_configured is True
+
+        passphrase_provider = AsyncMock(return_value="pw")
+        await svc.bootstrap(passphrase_provider=passphrase_provider)
+
+        # No network calls
+        api.get.assert_not_called()
+        api.post.assert_not_called()
+        # Passphrase was never requested
+        passphrase_provider.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-2: user_id binding — cache ignored on user_id mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdBinding:
+    @pytest.mark.asyncio
+    async def test_cache_ignored_when_user_id_mismatch(self, tmp_path: Path) -> None:
+        """When the cached user_id differs from the current user, the local
+        cache must be cleared and the service must fall back to the network path."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        wrapped_json = _fake_wrapped_json()
+
+        async def get_side(path, **kwargs):
+            if "/keys/me" in path:
+                return {
+                    "public_key": pub_b64,
+                    "wrapped_private_key": wrapped_json,
+                    "fingerprint": "net-fp",
+                }
+            return {}
+
+        api = _make_api_client()
+        api.get.side_effect = get_side
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        # Cache was written by user 99, but current user is 42.
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=wrapped_json, user_id=99)
+        svc._self_user_id = 42
+
+        passphrase_provider = AsyncMock(return_value="pw")
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            await svc._ensure_keypair(passphrase_provider)
+
+        # Stale cache was cleared then the network path wrote a fresh one —
+        # assert that the network GET was called (stale cache was NOT used).
+        api.get.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_accepted_when_user_id_matches(self, tmp_path: Path) -> None:
+        """Cache with the correct user_id must be used (no network call)."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json(), user_id=42)
+
+        passphrase_provider = AsyncMock(return_value="pw")
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            svc._derive_public_key = MagicMock(return_value=base64.b64decode(pub_b64))
+            await svc._ensure_keypair(passphrase_provider)
+
+        api.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_accepted_when_no_user_id_in_cache(self, tmp_path: Path) -> None:
+        """Old-format cache without user_id field must still be usable
+        (backward compat — user_id gate only triggers when BOTH sides have a value)."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        # Old-format: no user_id key in the JSON
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        passphrase_provider = AsyncMock(return_value="pw")
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            svc._derive_public_key = MagicMock(return_value=base64.b64decode(pub_b64))
+            await svc._ensure_keypair(passphrase_provider)
+
+        api.get.assert_not_called()
+
+    def test_persist_key_cache_stores_user_id(self, tmp_path: Path) -> None:
+        """_persist_key_cache must write user_id to the cache file when provided."""
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._persist_key_cache("AAEC", _fake_wrapped_json(), "fp", user_id=42)
+        data = _json.loads(cache_path.read_text())
+        assert data.get("user_id") == 42, f"Expected user_id=42, got {data.get('user_id')}"
+        # No secrets
+        assert "private_key" not in data
+        assert "passphrase" not in data
+
+    def test_persist_key_cache_omits_user_id_when_none(self, tmp_path: Path) -> None:
+        """_persist_key_cache must NOT write user_id when it is None."""
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._persist_key_cache("AAEC", _fake_wrapped_json(), "fp")
+        data = _json.loads(cache_path.read_text())
+        assert "user_id" not in data
+
+
+# ---------------------------------------------------------------------------
+# M5: pubkey integrity check — mismatch rejects cache and falls to network
+# ---------------------------------------------------------------------------
+
+
+class TestPubkeyIntegrityCheck:
+    @pytest.mark.asyncio
+    async def test_pubkey_mismatch_clears_cache_and_falls_to_network(
+        self, tmp_path: Path
+    ) -> None:
+        """When the derived public key doesn't match the cached public_key, the
+        cache is treated as corrupt: it is cleared and the network path is used."""
+        # Cache has pub_b64 = all-0x01 bytes, but unwrapping gives a privkey
+        # whose actual public key is all-0xFF bytes (mismatch).
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        mismatched_pub = b"\xff" * 32  # what derivation returns
+        wrapped_json = _fake_wrapped_json()
+
+        async def get_side(path, **kwargs):
+            if "/keys/me" in path:
+                return {
+                    "public_key": pub_b64,
+                    "wrapped_private_key": wrapped_json,
+                    "fingerprint": "net-fp",
+                }
+            return {}
+
+        api = _make_api_client()
+        api.get.side_effect = get_side
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=wrapped_json)
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            # _derive_public_key returns a key that does NOT match the cache
+            svc._derive_public_key = MagicMock(return_value=mismatched_pub)
+            await svc._ensure_keypair(AsyncMock(return_value="pw"))
+
+        # Corrupt cache was cleared then network path wrote a fresh one —
+        # assert that the network GET was called (corrupt cache was NOT used).
+        api.get.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_pubkey_match_accepts_cache(self, tmp_path: Path) -> None:
+        """When derived pubkey matches cached pubkey, the cache is accepted."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            # Derivation returns the cached pubkey → match
+            svc._derive_public_key = MagicMock(return_value=base64.b64decode(pub_b64))
+            await svc._ensure_keypair(AsyncMock(return_value="pw"))
+
+        # Cache was used — no network call
+        api.get.assert_not_called()
+        assert svc._self_pubkey == base64.b64decode(pub_b64)
+
+    @pytest.mark.asyncio
+    async def test_pubkey_check_skipped_when_derive_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """When _derive_public_key returns None (PyNaCl unavailable), the M5
+        check is skipped and the cache is still accepted."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        api = _make_api_client()
+        svc = _make_service(api_client=api, tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        svc._self_user_id = 42
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            svc._derive_public_key = MagicMock(return_value=None)
+            await svc._ensure_keypair(AsyncMock(return_value="pw"))
+
+        api.get.assert_not_called()
+        assert svc._self_pubkey == base64.b64decode(pub_b64)
+
+
+# ---------------------------------------------------------------------------
+# M12: lock() method
+# ---------------------------------------------------------------------------
+
+
+class TestLockMethod:
+    def test_lock_clears_key_material(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        assert svc.is_configured is True
+        svc.lock()
+        assert svc._self_pubkey is None
+        assert svc._self_privkey is None
+        assert svc.is_configured is False
+
+    def test_lock_fires_listeners(self, tmp_path: Path) -> None:
+        from servonaut.services.memory.interfaces import MemorySyncStatus
+        svc = _make_service(tmp_path=tmp_path)
+        received: List[MemorySyncStatus] = []
+        svc.subscribe(received.append)
+        svc.lock()
+        assert len(received) >= 1
+
+
+# ---------------------------------------------------------------------------
+# can_unwrap_local
+# ---------------------------------------------------------------------------
+
+
+class TestCanUnwrapLocal:
+    def test_returns_false_when_no_cache(self, tmp_path: Path) -> None:
+        svc = _make_service(tmp_path=tmp_path)
+        svc._key_cache_path = tmp_path / "memory" / "keys.json"
+        assert svc.can_unwrap_local("any-passphrase") is False
+
+    def test_returns_false_when_unwrap_fails(self, tmp_path: Path) -> None:
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.side_effect = ValueError("bad mac")
+            result = svc.can_unwrap_local("wrong-passphrase")
+
+        assert result is False
+
+    def test_returns_true_when_unwrap_succeeds(self, tmp_path: Path) -> None:
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        svc = _make_service(tmp_path=tmp_path)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x02" * 32
+            result = svc.can_unwrap_local("correct-passphrase")
+
+        assert result is True
+
+    def test_does_not_mutate_self_keys(self, tmp_path: Path) -> None:
+        """can_unwrap_local must NEVER modify _self_pubkey or _self_privkey."""
+        pub_b64 = base64.b64encode(b"\x01" * 32).decode()
+        svc = _make_service(tmp_path=tmp_path, configured=False)
+        cache_path = tmp_path / "memory" / "keys.json"
+        svc._key_cache_path = cache_path
+        _write_cache(cache_path, pub_b64=pub_b64, wrapped_json=_fake_wrapped_json())
+
+        with patch("servonaut.services.memory.sync_service.unwrap_private_key") as uwk:
+            uwk.return_value = b"\x99" * 32
+            svc.can_unwrap_local("pw")
+
+        assert svc._self_pubkey is None, "can_unwrap_local must not set _self_pubkey"
+        assert svc._self_privkey is None, "can_unwrap_local must not set _self_privkey"

--- a/tests/test_memory_sync_service.py
+++ b/tests/test_memory_sync_service.py
@@ -986,3 +986,70 @@ class TestSubscribe:
 
         assert len(received) >= 1
         assert isinstance(received[-1], MemorySyncStatus)
+
+
+# ---------------------------------------------------------------------------
+# SEC-3: entitlement predicate gate on enqueue_module
+# ---------------------------------------------------------------------------
+
+
+class TestEntitlementCheck:
+    """enqueue_module honours set_entitlement_check(fn).
+
+    An enrolled user (is_configured=True) whose plan entitlement has lapsed
+    must NOT accumulate plaintext JSONL envelopes — those can never be drained
+    to the server (no entitlement = server rejects) and sit on disk indefinitely.
+    """
+
+    def test_enqueue_noop_when_predicate_returns_false(self, tmp_path):
+        """Queue must NOT grow when the entitlement predicate returns False."""
+        svc = _make_service(tmp_path=tmp_path)  # configured=True by default
+        svc.set_entitlement_check(lambda: False)
+
+        result = _make_module_result()
+        svc.enqueue_module({"id": "web-01", "name": "web-01"}, "os", result)
+
+        assert len(svc._pending) == 0, (
+            "Expected queue length 0 (entitlement predicate returned False), "
+            f"got {len(svc._pending)}"
+        )
+
+    def test_enqueue_normal_when_predicate_returns_true(self, tmp_path):
+        """Queue grows normally when the entitlement predicate returns True."""
+        svc = _make_service(tmp_path=tmp_path)
+        svc.set_entitlement_check(lambda: True)
+
+        result = _make_module_result()
+        svc.enqueue_module({"id": "web-01", "name": "web-01"}, "os", result)
+
+        assert len(svc._pending) == 1
+
+    def test_enqueue_normal_when_predicate_unset(self, tmp_path):
+        """No predicate wired → current behaviour preserved (always enqueue when configured)."""
+        svc = _make_service(tmp_path=tmp_path)
+        # Explicitly do NOT call set_entitlement_check
+
+        result = _make_module_result()
+        svc.enqueue_module({"id": "web-01", "name": "web-01"}, "os", result)
+
+        assert len(svc._pending) == 1
+
+    def test_predicate_not_called_when_unconfigured(self, tmp_path):
+        """The is_configured gate fires before the entitlement check — predicate
+        must NOT be called when the keypair is not yet enrolled."""
+        call_count: List[int] = [0]
+
+        def counting_predicate() -> bool:
+            call_count[0] += 1
+            return True
+
+        svc = _make_service(tmp_path=tmp_path, configured=False)
+        svc.set_entitlement_check(counting_predicate)
+
+        result = _make_module_result()
+        svc.enqueue_module({"id": "web-01", "name": "web-01"}, "os", result)
+
+        assert len(svc._pending) == 0
+        assert call_count[0] == 0, (
+            "Entitlement predicate should not be evaluated when is_configured is False"
+        )

--- a/tests/test_passphrase_store.py
+++ b/tests/test_passphrase_store.py
@@ -1,0 +1,282 @@
+"""Tests for services/memory/passphrase_store.py.
+
+Covers:
+- keyring_available returns False when keyring package is absent.
+- keyring_available returns False when the backend is the fail/null backend.
+- keyring_available returns True for a real backend.
+- store/get/clear round-trip with a mocked keyring backend.
+- All public functions swallow exceptions and never raise.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_keyring_module(
+    *,
+    backend_module: str = "keyring.backends.kwallet",
+    set_password_exc: Optional[Exception] = None,
+    get_password_return: Optional[str] = "secret123",
+    get_password_exc: Optional[Exception] = None,
+    delete_password_exc: Optional[Exception] = None,
+):
+    """Return a minimal keyring module stub."""
+    # Create a dynamic class whose __module__ is the desired backend path so
+    # that passphrase_store.keyring_available()'s `type(backend).__module__`
+    # check works correctly.
+    BackendClass = type("Keyring", (), {"__module__": backend_module})
+    backend = BackendClass()
+
+    kr = MagicMock()
+    kr.get_keyring.return_value = backend
+
+    if set_password_exc is not None:
+        kr.set_password = MagicMock(side_effect=set_password_exc)
+    else:
+        kr.set_password = MagicMock()
+
+    if get_password_exc is not None:
+        kr.get_password = MagicMock(side_effect=get_password_exc)
+    else:
+        kr.get_password = MagicMock(return_value=get_password_return)
+
+    if delete_password_exc is not None:
+        kr.delete_password = MagicMock(side_effect=delete_password_exc)
+    else:
+        kr.delete_password = MagicMock()
+
+    return kr
+
+
+def _import_store_fresh():
+    """Import passphrase_store with a fresh module state (bypasses module cache)."""
+    import importlib
+    import servonaut.services.memory.passphrase_store as ps
+    importlib.reload(ps)
+    return ps
+
+
+# ---------------------------------------------------------------------------
+# keyring_available
+# ---------------------------------------------------------------------------
+
+
+class TestKeychainAvailable:
+    def test_unavailable_when_keyring_absent(self) -> None:
+        """When keyring is not installed, keyring_available must return False."""
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            assert ps.keyring_available() is False
+
+    def test_unavailable_when_fail_backend(self) -> None:
+        """keyring.backends.fail.Keyring backend → unavailable."""
+        kr = _make_keyring_module(backend_module="keyring.backends.fail")
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            assert ps.keyring_available() is False
+
+    def test_unavailable_when_null_backend(self) -> None:
+        """keyring.backends.null.Keyring backend → unavailable."""
+        kr = _make_keyring_module(backend_module="keyring.backends.null")
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            assert ps.keyring_available() is False
+
+    def test_available_when_real_backend(self) -> None:
+        """A real (non-fail, non-null) backend → available."""
+        kr = _make_keyring_module(backend_module="keyring.backends.SecretService")
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            assert ps.keyring_available() is True
+
+    def test_unavailable_when_get_keyring_raises(self) -> None:
+        """If get_keyring() raises, available returns False without propagating."""
+        kr = MagicMock()
+        kr.get_keyring.side_effect = RuntimeError("keyring daemon not running")
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr):
+            assert ps.keyring_available() is False
+
+
+# ---------------------------------------------------------------------------
+# store / get / clear round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestStoreGetClear:
+    def _with_real_backend(self):
+        """Context manager that patches in a real-ish keyring backend."""
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(backend_module="keyring.backends.SecretService")
+        return patch.object(ps, "_HAS_KEYRING", True), patch.object(ps, "_keyring", kr), kr
+
+    def test_store_returns_true_on_success(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(backend_module="keyring.backends.SecretService")
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            result = ps.store_passphrase("my-passphrase")
+        assert result is True
+        kr.set_password.assert_called_once_with(
+            "servonaut-memory-sync", "default", "my-passphrase"
+        )
+
+    def test_get_returns_stored_value(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(
+            backend_module="keyring.backends.SecretService",
+            get_password_return="my-passphrase",
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            result = ps.get_passphrase()
+        assert result == "my-passphrase"
+        kr.get_password.assert_called_once_with(
+            "servonaut-memory-sync", "default"
+        )
+
+    def test_clear_calls_delete(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(backend_module="keyring.backends.SecretService")
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            ps.clear_passphrase()
+        kr.delete_password.assert_called_once_with(
+            "servonaut-memory-sync", "default"
+        )
+
+    def test_store_returns_false_when_unavailable(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            assert ps.store_passphrase("pw") is False
+
+    def test_get_returns_none_when_unavailable(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            assert ps.get_passphrase() is None
+
+    def test_clear_noop_when_unavailable(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        with patch.object(ps, "_HAS_KEYRING", False), patch.object(ps, "_keyring", None):
+            ps.clear_passphrase()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# Exception swallowing
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionSwallowing:
+    def test_store_swallows_set_password_error(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(
+            backend_module="keyring.backends.SecretService",
+            set_password_exc=OSError("keychain locked"),
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            result = ps.store_passphrase("pw")
+        assert result is False  # Never raises, returns False
+
+    def test_get_swallows_get_password_error(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(
+            backend_module="keyring.backends.SecretService",
+            get_password_exc=PermissionError("denied"),
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            result = ps.get_passphrase()
+        assert result is None  # Never raises, returns None
+
+    def test_clear_swallows_delete_error(self) -> None:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(
+            backend_module="keyring.backends.SecretService",
+            delete_password_exc=OSError("not found"),
+        )
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            ps.clear_passphrase()  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# M10: keyring_available ALLOWLIST — known-good backends are accepted,
+# unknown/dummy backends are rejected
+# ---------------------------------------------------------------------------
+
+
+class TestKeyringAllowlist:
+    """Verify the allowlist-based keyring_available() logic.
+
+    An unknown backend (fail, null, or an arbitrary third-party module)
+    must be rejected so we never silently lose a stored passphrase.
+    """
+
+    def _available_for(self, backend_module: str) -> bool:
+        import servonaut.services.memory.passphrase_store as ps
+        kr = _make_keyring_module(backend_module=backend_module)
+        with (
+            patch.object(ps, "_HAS_KEYRING", True),
+            patch.object(ps, "_keyring", kr),
+        ):
+            return ps.keyring_available()
+
+    # --- Accepted backends ---
+
+    def test_secretservice_accepted(self) -> None:
+        assert self._available_for("keyring.backends.SecretService") is True
+
+    def test_secretservice_lowercase_accepted(self) -> None:
+        assert self._available_for("keyring.backends.secretservice") is True
+
+    def test_kwallet_accepted(self) -> None:
+        assert self._available_for("keyring.backends.kwallet") is True
+
+    def test_macos_accepted(self) -> None:
+        assert self._available_for("keyring.backends.macOS") is True
+
+    def test_windows_accepted(self) -> None:
+        assert self._available_for("keyring.backends.Windows") is True
+
+    def test_credential_locker_accepted(self) -> None:
+        assert self._available_for("keyring.backends.CredentialLocker") is True
+
+    def test_chainer_accepted(self) -> None:
+        assert self._available_for("keyring.backends.chainer") is True
+
+    # --- Rejected backends ---
+
+    def test_fail_backend_rejected(self) -> None:
+        assert self._available_for("keyring.backends.fail") is False
+
+    def test_null_backend_rejected(self) -> None:
+        assert self._available_for("keyring.backends.null") is False
+
+    def test_unknown_third_party_rejected(self) -> None:
+        assert self._available_for("some.third_party.KeyringBackend") is False
+
+    def test_empty_module_rejected(self) -> None:
+        assert self._available_for("") is False

--- a/tests/test_settings_memory_panel.py
+++ b/tests/test_settings_memory_panel.py
@@ -1,0 +1,240 @@
+"""Tests for the Memory & Sync settings panel (screens/settings/panels/memory.py).
+
+Exercises the auto-scan toggle and interval validation:
+- ``collect()`` validation for auto_scan_interval_seconds (<60, >max, valid)
+- ``persist()`` round-trips auto_scan_enabled and auto_scan_interval_seconds
+  via dataclasses.replace to disk and verifies they are read back correctly.
+- ``persist()`` preserves un-exposed fields (per_server_overrides, etc.) so
+  unrelated memory config is not clobbered.
+
+Uses the same ``_PanelHost`` / ``_temp_config_manager`` harness established in
+``test_settings_panels_roundtrip.py`` so the panel exercises real Textual
+widget mounting, real ConfigManager writes, and real disk round-trips.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional, Type
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import Input, Switch
+
+from servonaut.config.manager import ConfigManager
+from servonaut.config.schema import AppConfig, MemoryConfig
+from servonaut.screens.settings.base import SettingsPanel, ValidationError
+from servonaut.styles import CSS_FILES
+from servonaut.screens.settings.panels.memory import MemoryPanel
+
+
+# ---------------------------------------------------------------------------
+# Harness (mirrors test_settings_panels_roundtrip.py)
+# ---------------------------------------------------------------------------
+
+
+def _temp_config_manager(tmp_path, config: AppConfig) -> ConfigManager:
+    manager = ConfigManager()
+    manager._config_path = tmp_path / "config.json"
+    manager._config = config
+    manager.save(config)
+    return manager
+
+
+def _reload(tmp_path) -> AppConfig:
+    manager = ConfigManager()
+    manager._config_path = tmp_path / "config.json"
+    return manager.load()
+
+
+class _PanelHost(App):
+    CSS_PATH = CSS_FILES
+
+    def __init__(
+        self,
+        panel_cls: Type[SettingsPanel],
+        manager: ConfigManager,
+        has_memory_sync: bool = False,
+    ) -> None:
+        super().__init__()
+        self._panel_cls = panel_cls
+        self.config_manager = manager
+        self.auth_service = MagicMock()
+        self.auth_service.is_authenticated = has_memory_sync
+        self.auth_service.has_feature = MagicMock(
+            side_effect=lambda feat: feat == "memory_sync" and has_memory_sync
+        )
+        self.aws_object_storage_service = None
+        self.hetzner_object_storage_service = None
+        self.ovh_object_storage_service = None
+        self.panel: Optional[SettingsPanel] = None
+
+    def on_mount(self) -> None:
+        self.panel = self._panel_cls()
+        self.mount(self.panel)
+
+
+# ---------------------------------------------------------------------------
+# collect() — interval validation
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryPanelCollectValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_auto_scan_interval_below_60(self, tmp_path) -> None:
+        """collect() raises ValidationError when interval < 60."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = "59"
+            with pytest.raises(ValidationError) as exc:
+                panel.collect()
+            assert exc.value.field_id == "memory_auto_scan_interval"
+
+    @pytest.mark.asyncio
+    async def test_rejects_auto_scan_interval_zero(self, tmp_path) -> None:
+        """collect() raises ValidationError for interval = 0."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = "0"
+            with pytest.raises(ValidationError) as exc:
+                panel.collect()
+            assert exc.value.field_id == "memory_auto_scan_interval"
+
+    @pytest.mark.asyncio
+    async def test_rejects_auto_scan_interval_above_max(self, tmp_path) -> None:
+        """collect() raises ValidationError when interval > _MAX_SECONDS."""
+        from servonaut.screens.settings.panels.memory import _MAX_SECONDS
+
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = str(
+                _MAX_SECONDS + 1
+            )
+            with pytest.raises(ValidationError) as exc:
+                panel.collect()
+            assert exc.value.field_id == "memory_auto_scan_interval"
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_integer_auto_scan_interval(self, tmp_path) -> None:
+        """collect() raises ValidationError for a non-integer interval."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = "daily"
+            with pytest.raises(ValidationError) as exc:
+                panel.collect()
+            assert exc.value.field_id == "memory_auto_scan_interval"
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_auto_scan_interval(self, tmp_path) -> None:
+        """collect() succeeds for a valid interval (60 ≤ value ≤ _MAX_SECONDS)."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = "3600"
+            fields = panel.collect()
+        assert fields["auto_scan_interval_seconds"] == 3600
+
+    @pytest.mark.asyncio
+    async def test_accepts_minimum_interval_60(self, tmp_path) -> None:
+        """collect() accepts the minimum valid value of exactly 60."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_interval", Input).value = "60"
+            fields = panel.collect()
+        assert fields["auto_scan_interval_seconds"] == 60
+
+
+# ---------------------------------------------------------------------------
+# persist() — round-trip via disk + preserve unexposed fields
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryPanelPersistRoundTrip:
+    @pytest.mark.asyncio
+    async def test_auto_scan_enabled_persists(self, tmp_path) -> None:
+        """Toggling auto-scan enabled writes the value through to disk."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_enabled", Switch).value = True
+            panel.query_one("#memory_auto_scan_interval", Input).value = "7200"
+            panel.persist()
+            await pilot.pause()
+
+        mc = _reload(tmp_path).memory
+        assert mc.auto_scan_enabled is True
+        assert mc.auto_scan_interval_seconds == 7200
+
+    @pytest.mark.asyncio
+    async def test_persist_preserves_per_server_overrides(self, tmp_path) -> None:
+        """persist() must NOT clobber per_server_overrides (unexposed field)."""
+        seeded_mem = MemoryConfig(
+            per_server_overrides={
+                "i-abc123": {"memory_disabled": True},
+            }
+        )
+        seeded = AppConfig(memory=seeded_mem)
+        manager = _temp_config_manager(tmp_path, seeded)
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            # Enable auto-scan (a new field) and save.
+            panel.query_one("#memory_auto_scan_enabled", Switch).value = True
+            panel.query_one("#memory_auto_scan_interval", Input).value = "3600"
+            panel.persist()
+            await pilot.pause()
+
+        fresh = _reload(tmp_path).memory
+        # New field written correctly.
+        assert fresh.auto_scan_enabled is True
+        assert fresh.auto_scan_interval_seconds == 3600
+        # Unexposed field preserved verbatim — the central correctness invariant.
+        assert fresh.per_server_overrides == {
+            "i-abc123": {"memory_disabled": True}
+        }
+
+    @pytest.mark.asyncio
+    async def test_persist_preserves_disabled_modules_alongside_new_fields(
+        self, tmp_path
+    ) -> None:
+        """disabled_modules (exposed) and per_server_overrides (not) both survive."""
+        seeded_mem = MemoryConfig(
+            disabled_modules=["containers"],
+            per_server_overrides={"db-1": {"memory_disabled": False}},
+        )
+        seeded = AppConfig(memory=seeded_mem)
+        manager = _temp_config_manager(tmp_path, seeded)
+        app = _PanelHost(MemoryPanel, manager)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            panel = app.panel
+            panel.query_one("#memory_auto_scan_enabled", Switch).value = True
+            panel.query_one("#memory_auto_scan_interval", Input).value = "86400"
+            panel.persist()
+            await pilot.pause()
+
+        fresh = _reload(tmp_path).memory
+        assert fresh.auto_scan_enabled is True
+        assert "containers" in fresh.disabled_modules
+        assert fresh.per_server_overrides == {"db-1": {"memory_disabled": False}}


### PR DESCRIPTION
## Summary

Makes fleet memory **stay fresh on its own** and gives clearer feedback while it does.

- **Background auto-scan (opt-in).** An app-owned background worker periodically rebuilds *stale* server memory across the fleet (default: daily, stale-only). It is owned by the app, not a screen, so it **keeps running when you navigate away**. Controls live in **Settings → Memory & Sync** (enable + interval), with a quick toggle and a live status indicator (`● Auto-scan on · next in ~Xh`) on the Fleet Memory page.
- **Manual "Scan All" now finishes in the background.** Previously, leaving the panel cancelled an in-progress scan. The manual scan is now app-owned (its own worker group), so it completes regardless of navigation; returning mid-scan shows it is still in progress.
- **Auto-sync for paid plans.** A server-backed `auto_sync_enabled` preference gates the memory sync drain loop (behind the `memory_sync` entitlement), so snapshots push to the server and the weekly fleet reports have fresh data. Toggle in the Memory Sync settings panel — disabled on free plans, and the server enforces the gate independently.
- **Live scan feedback.** Per-row Memory / Modules / Last-probed cells update as each instance finishes (no more "everything looks stale until I leave and come back"), the fresh/stale summary recomputes live, and there's an explicit **Refresh** button.

## Notable fix

Concurrent fleet probes shared a single stateful log prober, so one instance's scan could record **another instance's** log paths. The probed instance is now resolved from the per-call SSH runner instead of shared mutable state, removing the race while preserving probe parallelism. (Reproduced and covered by a regression test.)

## Implementation notes

- New `FleetScanService` extracts the reusable bulk-scan orchestration (eligibility + bounded-parallel probe fan-out + progress callback) shared by the screen and the background loop.
- `MemoryConfig` gains `auto_scan_enabled`, `auto_scan_interval_seconds`, `auto_scan_stale_only` — additive with defaults, no schema migration. The interval is floored at 60s (loop) and validated in the settings panel.
- The auto-sync preference is server-owned (consistent across devices and lets the server reason about explicit opt-outs); the client reads it on cloud bootstrap and on panel save.

## Testing

- Full suite green (**5488 passed / 0 failed**).
- New coverage: `FleetScanService` (eligibility, opt-out, parallelism bound, cancellation), the auto-scan loop + auto-sync gating, the settings-service round-trip, the live row-update path, the app-owned manual scan (survives navigation), and the prober concurrency regression.

## Follow-ups (not in this PR)

- An enrolled user whose entitlement later lapses can accumulate (redacted but plaintext) sync envelopes on disk during auto-scan, since the enqueue path gates on enrolment rather than entitlement. Pre-existing; the always-on auto-scan increases the rate. Worth gating the enqueue path on entitlement separately.
- The server-side preference round-trip is covered by unit tests with the API mocked; a live end-to-end check against a paid account is recommended before relying on it in production.
- Minor: extract the shared status-classification vocabulary into one dependency-free module (currently a documented, kept-in-sync duplicate between the screen and the scan service).
