### PR TITLE
fix(team): resolve local config via config_manager in share/pull forms

### DIFF
--- a/src/servonaut/screens/team_management.py
+++ b/src/servonaut/screens/team_management.py
@@ -830,7 +830,8 @@ class TeamManagementScreen(Screen):
 
     def _show_push_config_form(self) -> None:
         from servonaut.services.team_config_subset import build_shareable_subset
-        config = getattr(self.app, "config", None)
+        config_manager = getattr(self.app, "config_manager", None)
+        config = config_manager.get() if config_manager is not None else None
         if config is None:
             self.notify("Local config not available.", severity="error")
             return
@@ -854,7 +855,8 @@ class TeamManagementScreen(Screen):
 
     def _show_pull_config_form(self, remote_payload: dict) -> None:
         from servonaut.services.team_config_subset import diff_against_local
-        config = getattr(self.app, "config", None)
+        config_manager = getattr(self.app, "config_manager", None)
+        config = config_manager.get() if config_manager is not None else None
         if config is None:
             self.notify("Local config not available.", severity="error")
             return
@@ -1213,7 +1215,8 @@ class TeamManagementScreen(Screen):
         if not self._can_manage_members():
             self.notify("Only owners and admins can push team configs.", severity="warning")
             return
-        config = getattr(self.app, "config", None)
+        config_manager = getattr(self.app, "config_manager", None)
+        config = config_manager.get() if config_manager is not None else None
         if config is None:
             self.notify("Local config not available.", severity="error")
             return
@@ -1289,8 +1292,8 @@ class TeamManagementScreen(Screen):
         if self._pending_pull_payload is None:
             self.notify("Click 'Pull Latest' first to fetch the team config.", severity="warning")
             return
-        config = getattr(self.app, "config", None)
         config_manager = getattr(self.app, "config_manager", None)
+        config = config_manager.get() if config_manager is not None else None
         if config is None or config_manager is None:
             self.notify("Local config manager not available — cannot apply.", severity="error")
             return

--- a/tests/test_team_config_dead_config_regression.py
+++ b/tests/test_team_config_dead_config_regression.py
@@ -1,0 +1,45 @@
+"""Regression: team config push/pull must read config via config_manager.
+
+These forms previously read ``getattr(self.app, "config", None)`` — but the app
+exposes ``config_manager``, not ``config``, so the lookup was always ``None`` and
+the forms always errored with "Local config not available." This guards that the
+config is now resolved through ``config_manager.get()``.
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from servonaut.screens.team_management import TeamManagementScreen
+
+
+def _summary():
+    return {
+        "connection_profiles": 0,
+        "connection_rules": 0,
+        "scan_rules": 0,
+        "custom_servers": 0,
+        "stripped_paths": 0,
+    }
+
+
+def test_push_config_form_resolves_config_via_config_manager():
+    screen = TeamManagementScreen.__new__(TeamManagementScreen)
+    screen.query_one = MagicMock()
+    screen.notify = MagicMock()
+
+    sentinel_config = object()
+    mock_app = MagicMock()
+    mock_app.config_manager.get.return_value = sentinel_config
+
+    with patch.object(TeamManagementScreen, "app", new_callable=PropertyMock, return_value=mock_app), \
+         patch("servonaut.services.team_config_subset.build_shareable_subset",
+               return_value=({}, _summary())) as bss:
+        screen._show_push_config_form()
+
+    # The form got PAST the None-guard (no error notify) and used the config
+    # returned by config_manager.get() — proving the dead self.app.config read
+    # is gone.
+    mock_app.config_manager.get.assert_called_once()
+    bss.assert_called_once_with(sentinel_config)
+    # No "Local config not available." error was raised.
+    for call in screen.notify.call_args_list:
+        assert "not available" not in str(call)


### PR DESCRIPTION
## Problem

The team config **share** and **pull** forms (`_show_push_config_form`, `_show_pull_config_form`, and the apply path) read the local config via `getattr(self.app, "config", None)`. The app exposes `config_manager`, **not** a `config` attribute, so this lookup was always `None` — the forms always short-circuited with *"Local config not available."* and never worked.

## Fix

Resolve the config through `config_manager.get()` (the established pattern used across the other screens) at all four call sites. Added a regression test that fails against the old dead read.

## Testing

- New regression test asserts the share form resolves config via `config_manager.get()` and proceeds past the None-guard.
- Existing team suite green (209 passed).