### PR TITLE
fix(ssh): keepalives + configurable timeouts to stop long-op disconnects

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -294,7 +294,10 @@ class ServonautApp(App):
         self.scan_service = ScanService(self.config_manager)
         self.keyword_store = KeywordStore(config.keyword_store_path)
         self.terminal_service = TerminalService(preferred=config.terminal_emulator)
-        self.scp_service = SCPService()
+        self.scp_service = SCPService(
+            ssh_config=config.ssh,
+            transfer_timeout_seconds=config.mcp.transfer_timeout_seconds,
+        )
         self.command_history = CommandHistoryService(config.command_history_path)
         self.custom_server_service = CustomServerService(self.config_manager)
         self.log_viewer_service = LogViewerService(self.config_manager)

--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -29,6 +29,7 @@ from .schema import (
     ScanRule,
     ConnectionProfile,
     ConnectionRule,
+    SSHConfig,
     CONFIG_VERSION,
 )
 from .migration import migrate_to_latest, create_backup
@@ -629,6 +630,7 @@ class ConfigManager:
         gcp = _coerce(GCPConfig, raw_data.get('gcp', {}), 'gcp')
         azure = _coerce(AzureConfig, raw_data.get('azure', {}), 'azure')
         memory = _coerce(MemoryConfig, raw_data.get('memory', {}), 'memory')
+        ssh_config = _coerce(SSHConfig, raw_data.get('ssh', {}), 'ssh')
 
         # Build AppConfig with converted objects, filtering out unknown keys
         valid_fields = {f.name for f in fields(AppConfig)}
@@ -648,6 +650,7 @@ class ConfigManager:
         config_dict['gcp'] = gcp
         config_dict['azure'] = azure
         config_dict['memory'] = memory
+        config_dict['ssh'] = ssh_config
 
         # Warn about dropped keys for debugging
         unknown_keys = set(raw_data.keys()) - valid_fields

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -390,6 +390,37 @@ class RelayConfig:
 
 
 @dataclass
+class SSHConfig:
+    """SSH keepalive and connection timeout settings.
+
+    Applied to every SSH/SCP command Servonaut builds, guarding against
+    idle connections being reaped by NAT gateways, cloud firewalls, or
+    sshd's own ``ClientAliveInterval``. Values are emitted as ``-o``
+    options on every command; ``extra_ssh_options`` on a profile or
+    custom server can refine them further.
+
+    Attributes:
+        server_alive_interval: Seconds between SSH keepalive packets sent
+            to the server (``ServerAliveInterval``). 0 disables keepalives.
+        server_alive_count_max: Number of keepalive packets that may go
+            unacknowledged before the client treats the connection as dead
+            (``ServerAliveCountMax``). With defaults the client waits
+            30 × 5 = 150 s before giving up.
+        tcp_keepalive: Enable TCP-level keepalive (``TCPKeepAlive``). Most
+            NAT devices still drop idle connections despite TCP KA; the SSH
+            application-layer keepalive above is therefore the primary
+            protection.
+        connect_timeout: Seconds before giving up on the initial TCP
+            connection (``ConnectTimeout``). 0 means OS default, which can
+            block for minutes on an unreachable host.
+    """
+    server_alive_interval: int = 30
+    server_alive_count_max: int = 5
+    tcp_keepalive: bool = True
+    connect_timeout: int = 15
+
+
+@dataclass
 class MCPConfig:
     """MCP server configuration."""
     guard_level: str = "standard"  # readonly, standard, dangerous
@@ -412,6 +443,14 @@ class MCPConfig:
     # mutate=true, AND a mandatory two-phase confirmation token, and the most
     # unrecoverable ops stay refused regardless (see _AWS_NEVER_DESTRUCTIVE).
     allow_destructive_aws_call: bool = False
+    # Configurable SSH command timeout for MCP run_command. Raise this for
+    # long-running but healthy commands (e.g. builds, bulk migrations) that
+    # the default 60 s cap would abort prematurely. A timeout is surfaced as
+    # a distinct "timed out" message; it does NOT trigger the SSM fallback.
+    command_timeout_seconds: int = 60
+    # Configurable SCP transfer timeout. Large files or slow links may need
+    # more than the default 300 s; set higher rather than retrying blind.
+    transfer_timeout_seconds: int = 300
 
 
 @dataclass
@@ -932,6 +971,10 @@ class AppConfig:
     chat_inject_server_memory_decision: str = "unset"
     sync_encryption_enabled: bool = True
     memory: MemoryConfig = field(default_factory=MemoryConfig)
+    # SSH keepalive and timeout settings applied to every SSH/SCP command.
+    # Additive default — old configs without this key load cleanly (uses
+    # SSHConfig() defaults) and no config migration is required.
+    ssh: SSHConfig = field(default_factory=SSHConfig)
     # T11: first-connect memory-build prompt gating.
     # Counts how many times the user has dismissed the post-connect banner
     # asking "Build memory for <server>? [y]".  After three dismissals the

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -293,7 +293,10 @@ def _relay_run_foreground() -> None:
     custom_server_service = CustomServerService(config_manager)
     ssh_service = SSHService(config_manager)
     connection_service = ConnectionService(config_manager)
-    scp_service = SCPService()
+    scp_service = SCPService(
+        ssh_config=config.ssh,
+        transfer_timeout_seconds=config.mcp.transfer_timeout_seconds,
+    )
 
     executors = RelayExecutors(
         config_manager, aws_service, custom_server_service,

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -44,7 +44,10 @@ def build_headless_tools(config_manager=None):
     ssh_service = SSHService(config_manager)
     connection_service = ConnectionService(config_manager)
     log_viewer_service = LogViewerService(config_manager)
-    scp_service = SCPService()
+    scp_service = SCPService(
+        ssh_config=config.ssh,
+        transfer_timeout_seconds=config.mcp.transfer_timeout_seconds,
+    )
 
     # MemoryService — headless init, same construction as app.py::_init_services
     memory_service = None

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -266,13 +266,22 @@ class ServonautTools:
             return await self._run_command_via_ssm(instance, command, args)
 
         # --- SSH (ssh / auto) ------------------------------------------
-        output, conn_failed = await self._run_command_via_ssh(instance, command)
+        output, conn_failed, timed_out = await self._run_command_via_ssh(
+            instance, command,
+        )
+
+        # A command timeout means the host WAS reachable — the command simply
+        # ran past the budget. Surface the message and stop; no SSM fallback.
+        if timed_out:
+            self._audit.log('run_command', args, '', False, 'command_timeout')
+            return output  # already contains the human-readable timeout message
+
         if not conn_failed:
             result = f"{output}\n[transport_used: ssh]"
             self._audit.log('run_command', args, result, True)
             return result
 
-        # SSH connection failed.
+        # SSH connection failed (host not reachable / sshd refused).
         if transport == "ssh":
             msg = (
                 "Error: SSH connection failed (host not reachable / sshd "
@@ -310,7 +319,15 @@ class ServonautTools:
         return any(sig in low for sig in signatures)
 
     async def _run_command_via_ssh(self, instance: Dict, command: str):
-        """Run via SSH. Returns (formatted_output_or_error, connection_failed)."""
+        """Run via SSH. Returns (output_or_msg, connection_failed, timed_out).
+
+        Three distinct outcomes:
+          - Success:          (output_str, False, False)
+          - Command timeout:  (timeout_msg, False, True)  — host IS reachable;
+                              the caller must NOT trigger SSM fallback.
+          - Connection error: (None, True, False)          — sshd unreachable;
+                              caller may fall back to SSM when available.
+        """
         conn = self._resolve_connection(instance)
         ssh_cmd = self._ssh_service.build_ssh_command(
             host=conn['host'], username=conn['username'], key_path=conn['key_path'],
@@ -318,17 +335,26 @@ class ServonautTools:
             port=conn.get('port'),
             extra_options=conn.get('extra_options') or [],
         )
+        timeout = self._config_manager.get().mcp.command_timeout_seconds
         try:
-            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=60)
+            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
         except asyncio.TimeoutError:
-            return (None, True)  # timeout == connection-level failure
+            # The SSH connection itself was alive (keepalives kept it open);
+            # the *command* simply ran longer than the allowed budget.
+            # Surface a clear message and do NOT signal a connection failure —
+            # the caller must not trigger SSM fallback for a timeout.
+            msg = (
+                f"command timed out after {timeout}s "
+                f"(host reachable; raise mcp.command_timeout_seconds for long ops)"
+            )
+            return (msg, False, True)
         except Exception as e:  # noqa: BLE001
-            return (f"Error: {e}", False)
+            return (f"Error: {e}", False, False)
 
         stderr_text = stderr.decode('utf-8', errors='replace') if stderr else ""
         # Empty stdout + a connection signature in stderr → sshd unreachable.
         if not stdout and self._is_ssh_connection_failure(stderr_text):
-            return (None, True)
+            return (None, True, False)
 
         output = stdout.decode('utf-8', errors='replace')
         lines = output.split('\n')
@@ -336,7 +362,7 @@ class ServonautTools:
             output = '\n'.join(lines[:self._max_lines]) + f'\n... (truncated, {len(lines)} total lines)'
         if stderr_text:
             output += f"\nSTDERR:\n{stderr_text}"
-        return (output, False)
+        return (output, False, False)
 
     async def _run_command_via_ssm(
         self, instance: Dict, command: str, args: Dict, ssh_fell_back: bool = False,
@@ -426,10 +452,14 @@ class ServonautTools:
             extra_options=conn.get('extra_options') or [],
         )
 
+        timeout = self._config_manager.get().mcp.command_timeout_seconds
         try:
-            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=60)
+            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
         except asyncio.TimeoutError:
-            return "Error: Command timed out after 60 seconds"
+            return (
+                f"command timed out after {timeout}s "
+                f"(host reachable; raise mcp.command_timeout_seconds for long ops)"
+            )
         except Exception as e:
             return f"Error: {e}"
 

--- a/src/servonaut/services/connection_service.py
+++ b/src/servonaut/services/connection_service.py
@@ -129,6 +129,21 @@ class ConnectionService(ConnectionServiceInterface):
                 '-o', 'StrictHostKeyChecking=no',
                 '-o', 'IdentitiesOnly=yes',
             ]
+            # Add keepalive options on the bastion hop so long operations
+            # don't get reaped by the gateway firewall before the inner
+            # connection completes.
+            try:
+                ssh_cfg = self._config_manager.get().ssh
+            except Exception:
+                from servonaut.config.schema import SSHConfig
+                ssh_cfg = SSHConfig()
+            _tcp_ka = 'yes' if ssh_cfg.tcp_keepalive else 'no'
+            parts.extend([
+                '-o', f'ServerAliveInterval={ssh_cfg.server_alive_interval}',
+                '-o', f'ServerAliveCountMax={ssh_cfg.server_alive_count_max}',
+                '-o', f'TCPKeepAlive={_tcp_ka}',
+                '-o', f'ConnectTimeout={ssh_cfg.connect_timeout}',
+            ])
             if profile.ssh_port != 22:
                 parts.extend(['-p', str(profile.ssh_port)])
             parts.extend(['-W', '%h:%p', f'{bastion_user}@{profile.bastion_host}'])

--- a/src/servonaut/services/scp_service.py
+++ b/src/servonaut/services/scp_service.py
@@ -8,6 +8,7 @@ import subprocess
 from typing import List, Optional, Tuple
 
 from servonaut.services.interfaces import SCPServiceInterface
+from servonaut.config.schema import SSHConfig
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,25 @@ class SCPService(SCPServiceInterface):
 
     Uses same ProxyJump pattern as SSH for bastion support.
     Uses IdentitiesOnly=yes when a key is specified to prevent auth failures.
+
+    Args:
+        ssh_config: SSH keepalive / timeout settings. Defaults to
+            ``SSHConfig()`` (30 s keepalive interval, 5 retries, 15 s
+            connect timeout) so existing ``SCPService()`` callers keep
+            working without any change.
+        transfer_timeout_seconds: Subprocess timeout for a single SCP
+            transfer. Defaults to 300 s. Pass
+            ``config.mcp.transfer_timeout_seconds`` from construction
+            sites that are aware of the MCP config.
     """
+
+    def __init__(
+        self,
+        ssh_config: Optional[SSHConfig] = None,
+        transfer_timeout_seconds: int = 300,
+    ) -> None:
+        self._ssh_config = ssh_config if ssh_config is not None else SSHConfig()
+        self._transfer_timeout_seconds = transfer_timeout_seconds
 
     def build_upload_command(
         self,
@@ -103,6 +122,7 @@ class SCPService(SCPServiceInterface):
         logger.info("Executing SCP transfer: %s", ' '.join(command))
         loop = asyncio.get_event_loop()
 
+        timeout = self._transfer_timeout_seconds
         try:
             result = await loop.run_in_executor(
                 None,
@@ -110,7 +130,7 @@ class SCPService(SCPServiceInterface):
                     command,
                     capture_output=True,
                     text=True,
-                    timeout=300,
+                    timeout=timeout,
                     stdin=subprocess.DEVNULL
                 )
             )
@@ -123,8 +143,8 @@ class SCPService(SCPServiceInterface):
             return result.returncode, result.stdout, result.stderr
 
         except subprocess.TimeoutExpired:
-            logger.error("SCP transfer timed out after 300 seconds")
-            return 1, '', 'Transfer timed out after 300 seconds'
+            logger.error("SCP transfer timed out after %d seconds", timeout)
+            return 1, '', f'Transfer timed out after {timeout}s (raise mcp.transfer_timeout_seconds for large files)'
         except Exception as e:
             logger.error("SCP transfer error: %s", e)
             return 1, '', str(e)
@@ -153,6 +173,16 @@ class SCPService(SCPServiceInterface):
             '-o', 'StrictHostKeyChecking=no',
             '-o', 'UserKnownHostsFile=/dev/null',
         ]
+
+        # SSH keepalive options — same values as build_ssh_command, guarding
+        # against NAT/firewall drops during long transfers.
+        _tcp_ka = 'yes' if self._ssh_config.tcp_keepalive else 'no'
+        cmd.extend([
+            '-o', f'ServerAliveInterval={self._ssh_config.server_alive_interval}',
+            '-o', f'ServerAliveCountMax={self._ssh_config.server_alive_count_max}',
+            '-o', f'TCPKeepAlive={_tcp_ka}',
+            '-o', f'ConnectTimeout={self._ssh_config.connect_timeout}',
+        ])
 
         # Add non-default port (SCP uses -P uppercase, unlike SSH's -p)
         if port is not None and port != 22:

--- a/src/servonaut/services/ssh_service.py
+++ b/src/servonaut/services/ssh_service.py
@@ -558,6 +558,25 @@ class SSHService(SSHServiceInterface):
             '-o', 'UserKnownHostsFile=/dev/null',
         ]
 
+        # SSH keepalive options — guard against NAT/firewall idle drops.
+        # Emitted before extra_options so that per-profile overrides placed
+        # in extra_options appear later in argv; however, OpenSSH honours the
+        # FIRST matching -o value, so extra_options intentionally cannot
+        # override these globals. Operators needing a different value for a
+        # specific host should set ssh.server_alive_interval in config.json.
+        try:
+            ssh_cfg = self._config_manager.get().ssh
+        except Exception:
+            from servonaut.config.schema import SSHConfig
+            ssh_cfg = SSHConfig()
+        _tcp_ka = 'yes' if ssh_cfg.tcp_keepalive else 'no'
+        cmd.extend([
+            '-o', f'ServerAliveInterval={ssh_cfg.server_alive_interval}',
+            '-o', f'ServerAliveCountMax={ssh_cfg.server_alive_count_max}',
+            '-o', f'TCPKeepAlive={_tcp_ka}',
+            '-o', f'ConnectTimeout={ssh_cfg.connect_timeout}',
+        ])
+
         # Add non-default port
         if port is not None and port != 22:
             cmd.extend(['-p', str(port)])

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,7 +1,7 @@
 """Tests for configuration migration."""
 
 from servonaut.config.migration import migrate_v1_to_v2, migrate_to_latest, create_backup
-from servonaut.config.schema import CONFIG_VERSION
+from servonaut.config.schema import AppConfig, SSHConfig, CONFIG_VERSION
 
 
 class TestMigrateV1ToV2:
@@ -83,6 +83,31 @@ class TestMigrateToLatest:
         cfg = {'version': CONFIG_VERSION, 'ai_provider': {}}
         out = migrate_to_latest(cfg)
         assert out['version'] == CONFIG_VERSION
+
+    def test_old_config_without_ssh_key_loads_clean(self):
+        """A config that pre-dates the ssh field loads with SSHConfig defaults.
+
+        This verifies the additive convention — CONFIG_VERSION did NOT change
+        and no migration step was added; AppConfig(**config_dict) must supply
+        the SSHConfig default_factory when the key is absent.
+        """
+        old_config = {
+            'version': CONFIG_VERSION,
+            'default_key': '/home/user/.ssh/id_rsa',
+            'default_username': 'ec2-user',
+            # intentionally NO 'ssh' key
+        }
+        # Simulate what manager._deserialize does: filter to valid fields and
+        # call AppConfig(**config_dict).  The 'ssh' key is absent, so the
+        # default_factory must supply an SSHConfig() instance.
+        from dataclasses import fields
+        valid = {f.name for f in fields(AppConfig)}
+        config_dict = {k: v for k, v in old_config.items() if k in valid}
+        config = AppConfig(**config_dict)
+        assert isinstance(config.ssh, SSHConfig)
+        assert config.ssh.server_alive_interval == 30
+        assert config.mcp.command_timeout_seconds == 60
+        assert config.mcp.transfer_timeout_seconds == 300
 
 
 class TestCreateBackup:

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -2,9 +2,11 @@
 
 from servonaut.config.schema import (
     AppConfig,
+    MCPConfig,
     ScanRule,
     ConnectionProfile,
     ConnectionRule,
+    SSHConfig,
     CONFIG_VERSION,
 )
 
@@ -91,3 +93,70 @@ class TestConnectionRule:
         )
         assert rule.profile_name == 'bastion-prod'
         assert rule.match_conditions == {'region': 'us-east-1'}
+
+
+class TestSSHConfig:
+
+    def test_defaults(self):
+        cfg = SSHConfig()
+        assert cfg.server_alive_interval == 30
+        assert cfg.server_alive_count_max == 5
+        assert cfg.tcp_keepalive is True
+        assert cfg.connect_timeout == 15
+
+    def test_custom_values(self):
+        cfg = SSHConfig(
+            server_alive_interval=60,
+            server_alive_count_max=3,
+            tcp_keepalive=False,
+            connect_timeout=30,
+        )
+        assert cfg.server_alive_interval == 60
+        assert cfg.server_alive_count_max == 3
+        assert cfg.tcp_keepalive is False
+        assert cfg.connect_timeout == 30
+
+
+class TestMCPConfigTimeouts:
+
+    def test_default_timeouts(self):
+        cfg = MCPConfig()
+        assert cfg.command_timeout_seconds == 60
+        assert cfg.transfer_timeout_seconds == 300
+
+    def test_custom_timeouts(self):
+        cfg = MCPConfig(command_timeout_seconds=300, transfer_timeout_seconds=600)
+        assert cfg.command_timeout_seconds == 300
+        assert cfg.transfer_timeout_seconds == 600
+
+
+class TestAppConfigAdditiveSshField:
+
+    def test_app_config_has_ssh_field_with_defaults(self):
+        """AppConfig() must expose .ssh with SSHConfig defaults (additive)."""
+        config = AppConfig()
+        assert hasattr(config, 'ssh')
+        assert isinstance(config.ssh, SSHConfig)
+        assert config.ssh.server_alive_interval == 30
+        assert config.ssh.connect_timeout == 15
+
+    def test_app_config_ssh_independent_across_instances(self):
+        """Mutable default isolation — two AppConfig() share no state."""
+        c1 = AppConfig()
+        c2 = AppConfig()
+        c1.ssh.server_alive_interval = 999
+        assert c2.ssh.server_alive_interval == 30
+
+    def test_app_config_loaded_without_ssh_key_uses_defaults(self):
+        """Old configs that lack the 'ssh' key load cleanly via AppConfig()."""
+        # Simulate what the manager does: AppConfig(**config_dict) where
+        # config_dict has no 'ssh' key.
+        config_dict = {'default_key': '/some/key', 'default_username': 'ubuntu'}
+        config = AppConfig(**config_dict)
+        assert isinstance(config.ssh, SSHConfig)
+        assert config.ssh.server_alive_interval == 30
+
+    def test_app_config_mcp_timeout_defaults(self):
+        config = AppConfig()
+        assert config.mcp.command_timeout_seconds == 60
+        assert config.mcp.transfer_timeout_seconds == 300

--- a/tests/test_connection_service.py
+++ b/tests/test_connection_service.py
@@ -95,6 +95,11 @@ class TestGetProxyArgs(TestConnectionService):
         assert 'ProxyCommand=' in args[1]
         assert 'bastion.example.com' in args[1]
         assert 'IdentitiesOnly=yes' in args[1]
+        # Keepalive options must be present in the inner bastion ssh command
+        assert 'ServerAliveInterval=30' in args[1]
+        assert 'ServerAliveCountMax=5' in args[1]
+        assert 'TCPKeepAlive=yes' in args[1]
+        assert 'ConnectTimeout=15' in args[1]
 
     def test_without_bastion_key_uses_proxy_jump(self, service):
         profile = ConnectionProfile(
@@ -143,6 +148,8 @@ class TestGetProxyArgs(TestConnectionService):
         proxy_cmd = args[1]
         assert '-p' in proxy_cmd
         assert '2222' in proxy_cmd
+        # Keepalive options present even with custom port
+        assert 'ServerAliveInterval=30' in proxy_cmd
 
 
 class TestGetProxyJumpString(TestConnectionService):
@@ -176,22 +183,22 @@ class TestGetProxyJumpString(TestConnectionService):
 class TestGetTargetHost(TestConnectionService):
 
     def test_direct_prefers_public_ip(self, service):
-        instance = {'public_ip': '54.1.2.3', 'private_ip': '10.0.1.1'}
-        assert service.get_target_host(instance) == '54.1.2.3'
+        instance = {'public_ip': '9.9.9.9', 'private_ip': '10.0.1.1'}
+        assert service.get_target_host(instance) == '9.9.9.9'
 
     def test_direct_falls_back_to_private(self, service):
         instance = {'public_ip': None, 'private_ip': '10.0.1.1'}
         assert service.get_target_host(instance) == '10.0.1.1'
 
     def test_bastion_prefers_private_ip(self, service):
-        instance = {'public_ip': '54.1.2.3', 'private_ip': '10.0.1.1'}
+        instance = {'public_ip': '9.9.9.9', 'private_ip': '10.0.1.1'}
         profile = ConnectionProfile(name='test', bastion_host='bastion.example.com')
         assert service.get_target_host(instance, profile) == '10.0.1.1'
 
     def test_bastion_falls_back_to_public(self, service):
-        instance = {'public_ip': '54.1.2.3', 'private_ip': None}
+        instance = {'public_ip': '9.9.9.9', 'private_ip': None}
         profile = ConnectionProfile(name='test', bastion_host='bastion.example.com')
-        assert service.get_target_host(instance, profile) == '54.1.2.3'
+        assert service.get_target_host(instance, profile) == '9.9.9.9'
 
     def test_no_ip_returns_empty(self, service):
         instance = {'public_ip': None, 'private_ip': None}

--- a/tests/test_incident_response_tools.py
+++ b/tests/test_incident_response_tools.py
@@ -528,12 +528,19 @@ def test_run_command_auto_falls_back_to_ssm_on_conn_failure(monkeypatch):
     assert "from-ssm" in out and "[transport_used: ssm]" in out
 
 
-def test_run_command_auto_timeout_triggers_ssm(monkeypatch):
+def test_run_command_auto_timeout_reports_not_ssm(monkeypatch):
+    # Behavior change (intentional): a command-duration timeout means SSH is
+    # healthy but the command ran longer than mcp.command_timeout_seconds. With
+    # SSH keepalives now detecting genuine transport failures separately (which
+    # DO still fall back to SSM), a timeout must NOT silently switch to SSM —
+    # it reports clearly so the caller can raise the timeout for long ops.
     _patch_ssh(monkeypatch, timeout=True)
-    _patch_ssm(monkeypatch, {"ok": True, "status": "Success",
-                             "stdout": "ok", "stderr": "", "error": ""})
+    fake = _patch_ssm(monkeypatch, {"ok": True, "status": "Success",
+                                    "stdout": "ok", "stderr": "", "error": ""})
     out = asyncio.run(_run_tools().run_command("i-1", "ls"))
-    assert "[transport_used: ssm]" in out
+    assert "timed out" in out
+    assert "[transport_used: ssm]" not in out
+    fake.run_command.assert_not_called()  # timeout is not a transport failure
 
 
 def test_run_command_auto_ssh_success_no_ssm(monkeypatch):
@@ -606,7 +613,7 @@ def test_parse_wafv2_arn():
 
 
 def test_to_cidr_and_validate():
-    assert _to_cidr("1.2.3.4") == "1.2.3.4/32"
+    assert _to_cidr("9.9.9.9") == "9.9.9.9/32"
     assert _to_cidr("1.2.3.0/24") == "1.2.3.0/24"
     svc = IPBanService(MagicMock())
     assert svc.validate_ip("1.1.1.1")

--- a/tests/test_memory_mcp_tools.py
+++ b/tests/test_memory_mcp_tools.py
@@ -38,7 +38,7 @@ _CANNED_INSTANCE: Dict[str, Any] = {
     "name": "web-server-prod",
     "type": "t3.medium",
     "state": "running",
-    "public_ip": "54.1.2.3",
+    "public_ip": "9.9.9.9",
     "private_ip": "10.0.0.1",
     "region": "us-east-1",
     "key_name": "prod-key",
@@ -50,7 +50,7 @@ _CANNED_INSTANCE_CUSTOM: Dict[str, Any] = {
     "name": "my-custom-box",
     "type": "custom",
     "state": "unknown",
-    "public_ip": "1.2.3.4",
+    "public_ip": "9.9.9.9",
     "provider": "custom",
     "is_custom": True,
 }
@@ -872,3 +872,144 @@ class TestFullFormatRawOutputStripped:
         os_data = modules["os"]
         assert "observed" in os_data
         assert "probed_at" in os_data
+
+
+# ---------------------------------------------------------------------------
+# SSH command timeout vs connection failure distinction (run_command)
+# ---------------------------------------------------------------------------
+
+class TestRunCommandTimeoutVsConnectionFailure:
+    """A command timeout must NOT trigger SSM fallback or be labelled as a
+    connection failure.  Only a genuine sshd-unreachable event may fall back
+    to SSM when transport='auto'.
+
+    The tests use GuardLevel.DANGEROUS so the command allowlist doesn't block
+    the test command before SSH is reached.
+    """
+
+    def _make_tools_with_instance(self) -> ServonautTools:
+        # DANGEROUS guard so the command allowlist does not interfere.
+        tools = _make_tools(
+            guard_level=GuardLevel.DANGEROUS,
+            instance_to_find=_CANNED_INSTANCE,
+        )
+
+        # Wire a minimal _resolve_connection that returns a valid conn dict.
+        def _fake_resolve(instance):  # type: ignore[override]
+            return {
+                'host': '9.9.9.9',
+                'username': 'ec2-user',
+                'key_path': None,
+                'proxy_args': [],
+                'extra_options': [],
+            }
+
+        tools._resolve_connection = _fake_resolve  # type: ignore[method-assign]
+        return tools
+
+    def test_timeout_returns_timed_out_message_not_connection_failed(self):
+        """asyncio.TimeoutError → timed_out=True message, not connection error."""
+        tools = self._make_tools_with_instance()
+
+        # Patch run_ssh_subprocess to simulate a command timeout.
+        async def _timeout_ssh(cmd, timeout):
+            raise asyncio.TimeoutError()
+
+        import servonaut.mcp.tools as tools_module
+        original = tools_module.run_ssh_subprocess
+        try:
+            tools_module.run_ssh_subprocess = _timeout_ssh
+            # Use a command that IS in the dangerous allowlist.
+            result = run(tools.run_command(_CANNED_INSTANCE["id"], "uptime"))
+        finally:
+            tools_module.run_ssh_subprocess = original
+
+        # Must surface a timeout message, NOT "connection failed".
+        assert "timed out" in result
+        assert "command_timeout_seconds" in result
+        assert "connection failed" not in result.lower()
+        # Must NOT be annotated as SSM (no fallback triggered).
+        assert "ssm" not in result.lower()
+
+    def test_timeout_audit_logged_as_command_timeout(self):
+        """A timeout is logged with reason='command_timeout', success=False."""
+        tools = self._make_tools_with_instance()
+
+        async def _timeout_ssh(cmd, timeout):
+            raise asyncio.TimeoutError()
+
+        import servonaut.mcp.tools as tools_module
+        original = tools_module.run_ssh_subprocess
+        try:
+            tools_module.run_ssh_subprocess = _timeout_ssh
+            run(tools.run_command(_CANNED_INSTANCE["id"], "uptime"))
+        finally:
+            tools_module.run_ssh_subprocess = original
+
+        # audit.log must have been called with success=False and reason='command_timeout'
+        tools._audit.log.assert_called()
+        last_call = tools._audit.log.call_args
+        # Positional args: (tool_name, args_dict, result_str, success, reason)
+        assert last_call[0][3] is False  # success=False
+        assert last_call[0][4] == 'command_timeout'  # reason
+
+    def test_timeout_honours_config_value(self):
+        """The timeout value passed to run_ssh_subprocess matches the config."""
+        # Use DANGEROUS guard level so the allowlist doesn't block us.
+        mcp_cfg = MCPConfig(guard_level="dangerous", command_timeout_seconds=120)
+        app_cfg = AppConfig(mcp=mcp_cfg)
+        config_manager = MagicMock()
+        config_manager.get.return_value = app_cfg
+
+        aws_service = MagicMock()
+        aws_service.fetch_instances_cached = AsyncMock(return_value=[])
+        custom_server_service = MagicMock()
+        custom_server_service.list_as_instances.return_value = []
+        cache_service = MagicMock()
+        ssh_service = MagicMock()
+        ssh_service.build_ssh_command.return_value = ['ssh', 'dummy']
+        connection_service = MagicMock()
+        scp_service = MagicMock()
+        ovh_service = MagicMock()
+        ovh_service.fetch_instances_cached = AsyncMock(return_value=[])
+        guard = CommandGuard(app_cfg.mcp)
+        audit = MagicMock()
+        audit.log = MagicMock()
+
+        tools = ServonautTools(
+            config_manager, aws_service, custom_server_service, cache_service,
+            ssh_service, connection_service, scp_service,
+            guard, audit,
+            ovh_service=ovh_service,
+        )
+
+        async def _fake_find(iid):
+            return _CANNED_INSTANCE
+
+        tools._find_instance = _fake_find  # type: ignore[method-assign]
+
+        def _fake_resolve(inst):
+            return {
+                'host': '9.9.9.9', 'username': 'ec2-user',
+                'key_path': None, 'proxy_args': [], 'extra_options': [],
+            }
+
+        tools._resolve_connection = _fake_resolve  # type: ignore[method-assign]
+
+        captured_timeout = []
+
+        async def _capture_ssh(cmd, timeout):
+            captured_timeout.append(timeout)
+            raise asyncio.TimeoutError()
+
+        import servonaut.mcp.tools as tools_module
+        original = tools_module.run_ssh_subprocess
+        try:
+            tools_module.run_ssh_subprocess = _capture_ssh
+            run(tools.run_command(_CANNED_INSTANCE["id"], "uptime"))
+        finally:
+            tools_module.run_ssh_subprocess = original
+
+        assert captured_timeout == [120], (
+            f"Expected timeout=120 from config, got {captured_timeout}"
+        )

--- a/tests/test_scp_service.py
+++ b/tests/test_scp_service.py
@@ -22,13 +22,13 @@ class TestBuildUploadCommand(TestSCPService):
         assert cmd[0] == 'scp'
         assert 'StrictHostKeyChecking=no' in cmd
         assert '/tmp/file.txt' in cmd
-        assert 'ec2-user@9.9.9.9:/home/ec2-user/' in cmd
+        assert 'ec2-user@9.9.9.9:/home/ec2-user/' in cmd  # leak-guard:allow (AWS default account, not a personal path)
 
     def test_includes_keepalive_options(self):
         """SCP base args carry the same keepalive options as SSH."""
         cmd = self.scp_service.build_upload_command(
             local_path='/tmp/file.txt',
-            remote_path='/home/ec2-user/',
+            remote_path='/home/ec2-user/',  # leak-guard:allow (AWS default account, not a personal path)
             host='9.9.9.9',
             username='ec2-user',
         )

--- a/tests/test_scp_service.py
+++ b/tests/test_scp_service.py
@@ -1,6 +1,7 @@
 """Tests for SCP service."""
 
 from servonaut.services.scp_service import SCPService
+from servonaut.config.schema import SSHConfig
 
 
 class TestSCPService:
@@ -15,19 +16,50 @@ class TestBuildUploadCommand(TestSCPService):
         cmd = self.scp_service.build_upload_command(
             local_path='/tmp/file.txt',
             remote_path='/home/ec2-user/',
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
         )
         assert cmd[0] == 'scp'
         assert 'StrictHostKeyChecking=no' in cmd
         assert '/tmp/file.txt' in cmd
-        assert 'ec2-user@1.2.3.4:/home/ec2-user/' in cmd
+        assert 'ec2-user@9.9.9.9:/home/ec2-user/' in cmd
+
+    def test_includes_keepalive_options(self):
+        """SCP base args carry the same keepalive options as SSH."""
+        cmd = self.scp_service.build_upload_command(
+            local_path='/tmp/file.txt',
+            remote_path='/home/ec2-user/',
+            host='9.9.9.9',
+            username='ec2-user',
+        )
+        assert 'ServerAliveInterval=30' in cmd
+        assert 'ServerAliveCountMax=5' in cmd
+        assert 'TCPKeepAlive=yes' in cmd
+        assert 'ConnectTimeout=15' in cmd
+
+    def test_custom_ssh_config_values_flow_through(self):
+        """Custom SSHConfig values are reflected in SCP base args."""
+        custom_ssh = SSHConfig(
+            server_alive_interval=120,
+            server_alive_count_max=2,
+            tcp_keepalive=False,
+            connect_timeout=10,
+        )
+        svc = SCPService(ssh_config=custom_ssh)
+        cmd = svc.build_upload_command(
+            local_path='/tmp/f', remote_path='/remote',
+            host='9.9.9.9', username='user',
+        )
+        assert 'ServerAliveInterval=120' in cmd
+        assert 'ServerAliveCountMax=2' in cmd
+        assert 'TCPKeepAlive=no' in cmd
+        assert 'ConnectTimeout=10' in cmd
 
     def test_with_key(self):
         cmd = self.scp_service.build_upload_command(
             local_path='/tmp/file.txt',
             remote_path='/home/ec2-user/',
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
             key_path='/path/to/key.pem',
         )
@@ -65,29 +97,45 @@ class TestBuildDownloadCommand(TestSCPService):
         cmd = self.scp_service.build_download_command(
             remote_path='/var/log/app.log',
             local_path='/tmp/',
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
         )
         assert cmd[0] == 'scp'
-        assert 'ec2-user@1.2.3.4:/var/log/app.log' in cmd
+        assert 'ec2-user@9.9.9.9:/var/log/app.log' in cmd
         assert '/tmp/' in cmd
 
     def test_argument_order(self):
         upload = self.scp_service.build_upload_command(
             local_path='/local',
             remote_path='/remote',
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='user',
         )
         download = self.scp_service.build_download_command(
             remote_path='/remote',
             local_path='/local',
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='user',
         )
         # Upload: ... local user@host:remote
         assert upload[-2] == '/local'
-        assert upload[-1] == 'user@1.2.3.4:/remote'
+        assert upload[-1] == 'user@9.9.9.9:/remote'
         # Download: ... user@host:remote local
-        assert download[-2] == 'user@1.2.3.4:/remote'
+        assert download[-2] == 'user@9.9.9.9:/remote'
         assert download[-1] == '/local'
+
+
+class TestSCPServiceDefaults:
+
+    def test_default_constructor_uses_ssh_config_defaults(self):
+        """SCPService() with no args uses SSHConfig() defaults."""
+        svc = SCPService()
+        assert svc._ssh_config.server_alive_interval == 30
+        assert svc._ssh_config.server_alive_count_max == 5
+        assert svc._ssh_config.tcp_keepalive is True
+        assert svc._ssh_config.connect_timeout == 15
+        assert svc._transfer_timeout_seconds == 300
+
+    def test_custom_transfer_timeout_stored(self):
+        svc = SCPService(transfer_timeout_seconds=600)
+        assert svc._transfer_timeout_seconds == 600

--- a/tests/test_settings_registry_coverage.py
+++ b/tests/test_settings_registry_coverage.py
@@ -73,6 +73,7 @@ _FIELD_TO_PANEL = {
     "ai_chunk_size": "ai_chat",
     "ai_system_prompt": "ai_chat",
     "mcp": "mcp",
+    "ssh": "_no_ui",  # advanced SSH transport tuning (keepalive/connect timeout); editable via config.json, not surfaced in the Settings TUI
     "relay": "relay",
     "ovh": "ovh",
     "hetzner": "hetzner",

--- a/tests/test_ssh_service.py
+++ b/tests/test_ssh_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from servonaut.services.ssh_service import SSHService
-from servonaut.config.schema import AppConfig
+from servonaut.config.schema import AppConfig, SSHConfig
 
 
 class TestSSHService:
@@ -32,15 +32,40 @@ class TestSSHService:
 class TestBuildSshCommand(TestSSHService):
 
     def test_basic_command(self, ssh_service):
-        cmd = ssh_service.build_ssh_command(host='1.2.3.4', username='ec2-user')
+        cmd = ssh_service.build_ssh_command(host='9.9.9.9', username='ec2-user')
         assert cmd[0] == 'ssh'
         assert '-o' in cmd
         assert 'StrictHostKeyChecking=no' in cmd
-        assert 'ec2-user@1.2.3.4' in cmd
+        assert 'ec2-user@9.9.9.9' in cmd
+
+    def test_includes_keepalive_options(self, ssh_service):
+        """Keepalive options protect against NAT/firewall idle drops."""
+        cmd = ssh_service.build_ssh_command(host='9.9.9.9', username='ec2-user')
+        assert 'ServerAliveInterval=30' in cmd
+        assert 'ServerAliveCountMax=5' in cmd
+        assert 'TCPKeepAlive=yes' in cmd
+        assert 'ConnectTimeout=15' in cmd
+
+    def test_custom_ssh_config_values_flow_through(self):
+        """Custom SSHConfig values are emitted in the built command."""
+        custom_ssh_cfg = SSHConfig(
+            server_alive_interval=60,
+            server_alive_count_max=3,
+            tcp_keepalive=False,
+            connect_timeout=30,
+        )
+        manager = MagicMock()
+        manager.get.return_value = AppConfig(ssh=custom_ssh_cfg)
+        svc = SSHService(manager)
+        cmd = svc.build_ssh_command(host='9.9.9.9', username='user')
+        assert 'ServerAliveInterval=60' in cmd
+        assert 'ServerAliveCountMax=3' in cmd
+        assert 'TCPKeepAlive=no' in cmd
+        assert 'ConnectTimeout=30' in cmd
 
     def test_with_key_path(self, ssh_service):
         cmd = ssh_service.build_ssh_command(
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
             key_path='/path/to/key.pem',
         )
@@ -69,7 +94,7 @@ class TestBuildSshCommand(TestSSHService):
 
     def test_with_remote_command(self, ssh_service):
         cmd = ssh_service.build_ssh_command(
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
             remote_command='ls -la',
         )
@@ -77,7 +102,7 @@ class TestBuildSshCommand(TestSSHService):
 
     def test_key_path_tilde_expansion(self, ssh_service):
         cmd = ssh_service.build_ssh_command(
-            host='1.2.3.4',
+            host='9.9.9.9',
             username='ec2-user',
             key_path='~/my-key.pem',
         )
@@ -85,7 +110,7 @@ class TestBuildSshCommand(TestSSHService):
         assert '~' not in cmd[key_idx]
 
     def test_no_key_means_no_identities_only(self, ssh_service):
-        cmd = ssh_service.build_ssh_command(host='1.2.3.4', username='ec2-user')
+        cmd = ssh_service.build_ssh_command(host='9.9.9.9', username='ec2-user')
         assert 'IdentitiesOnly=yes' not in cmd
 
 


### PR DESCRIPTION
## Problem

Agent/MCP-driven SSH disconnected on longer operations, while manual `ssh` to the same host did not.

Root causes (client-side):
1. **No SSH keepalives.** Our programmatic command sent no keepalive options, so a long or quiet operation got reaped by NAT/firewall/sshd. Manual ssh survived only because the operator's `~/.ssh/config` keepalives are **alias-scoped** and never match our **raw-IP** connections.
2. **Hardcoded 60s command timeout** that killed long-but-healthy commands **and mislabeled them as connection failures** (wrongly triggering the SSM fallback in `transport=auto`).

## Fix (all client-side, no server change)

- **Keepalives on all three SSH paths** — the command builder, SCP, and the **bastion ProxyCommand inner ssh (both hops)** — driven by a new tunable `SSHConfig` (`server_alive_interval=30`, `server_alive_count_max=5`, `tcp_keepalive=true`, `connect_timeout=15`). Additive config, no migration. New command:
  ```
  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
      -o ServerAliveInterval=30 -o ServerAliveCountMax=5 -o TCPKeepAlive=yes -o ConnectTimeout=15 …
  ```
- **Configurable timeouts**: `MCPConfig.command_timeout_seconds` (60) and `transfer_timeout_seconds` (300) replace the hardcoded values.
- **Timeout ≠ connection failure**: a command-duration timeout now reports `command timed out after Ns (host reachable; raise mcp.command_timeout_seconds for long ops)` and does **not** fall back to SSM. Genuine transport failures — now reliably detected by the keepalives — still fall back to SSM. (Deliberate behavior change; the auto-timeout test was updated accordingly.)
- Memory probers keep their intentional 5s per-command cap and inherit the keepalives via the shared command builder.

## Testing

Full suite green (5387 passed). New coverage: keepalive options on the SSH/SCP/ProxyCommand paths (incl. custom `SSHConfig` values), additive config load without migration, and the timeout-vs-connection-failure distinction.

Note: a few placeholder test IPs in touched files were normalized to the neutral `9.9.9.9`.
