### PR TITLE
feat(findings): block_ip remediation verb — local IPBanService dispatch

### DIFF
--- a/src/servonaut/screens/findings.py
+++ b/src/servonaut/screens/findings.py
@@ -945,10 +945,25 @@ class FindingDetailScreen(Screen[bool]):
                         classes="finding_remediation_action",
                     ))
                 # "investigate" is advisory prose — there is nothing to
-                # execute. Every other playbook action gets a Run button
-                # that starts the server-signed preview → confirm flow;
-                # the server enforces the risk-tier allowlist on its end.
-                if can_remediate and action and action != "investigate":
+                # execute. The server marks each option automatable (an
+                # authored command exists); absent means true so older
+                # payloads keep their Run buttons. Non-automatable
+                # options render as manual guidance instead of a Run
+                # button that would dead-end in a 422 at preview.
+                automatable = rem.get("automatable")
+                is_automatable = True if automatable is None else bool(automatable)
+                if (can_remediate and action and action != "investigate"
+                        and not is_automatable):
+                    children.append(Static(
+                        "  [dim]Manual action — no automated command is "
+                        "available for this option yet.[/dim]",
+                        classes="finding_remediation_manual",
+                    ))
+                # Every other playbook action gets a Run button that
+                # starts the server-signed preview → confirm flow; the
+                # server enforces the risk-tier allowlist on its end.
+                if (can_remediate and action and action != "investigate"
+                        and is_automatable):
                     button_id = f"btn_finding_remediate_{index}"
                     self._remediation_buttons[button_id] = dict(rem)
                     # Button labels are Rich-markup parsed — escape the

--- a/src/servonaut/services/ip_ban_service.py
+++ b/src/servonaut/services/ip_ban_service.py
@@ -50,7 +50,13 @@ class WAFStrategy(IPBanStrategyInterface):
                 Addresses=addresses,
                 LockToken=response['LockToken'],
             )
-            return {'success': True, 'message': f'Banned {ip_address} via WAF IP set'}
+            # The unban handle for a WAF ban is the CIDR entry within
+            # this ip_set — persisted as rule_id in remediation evidence.
+            return {
+                'success': True,
+                'message': f'Banned {ip_address} via WAF IP set',
+                'rule_id': cidr,
+            }
 
         return await loop.run_in_executor(None, _ban)
 
@@ -118,7 +124,7 @@ class SecurityGroupStrategy(IPBanStrategyInterface):
                     if (ip_range.get('CidrIp') == _to_cidr(ip_address)
                             and ip_range.get('Description') == SecurityGroupStrategy._BAN_DESCRIPTION):
                         return {'success': False, 'message': f'{ip_address} already banned in security group'}
-            ec2.authorize_security_group_ingress(
+            auth_response = ec2.authorize_security_group_ingress(
                 GroupId=config.security_group_id,
                 IpPermissions=[{
                     'IpProtocol': '-1',
@@ -128,7 +134,14 @@ class SecurityGroupStrategy(IPBanStrategyInterface):
                     }],
                 }],
             )
-            return {'success': True, 'message': f'Banned {ip_address} via security group'}
+            rules = auth_response.get('SecurityGroupRules') if isinstance(auth_response, dict) else None
+            rule = rules[0] if isinstance(rules, list) and rules and isinstance(rules[0], dict) else {}
+            rule_id = rule.get('SecurityGroupRuleId') or _to_cidr(ip_address)
+            return {
+                'success': True,
+                'message': f'Banned {ip_address} via security group',
+                'rule_id': rule_id,
+            }
 
         return await loop.run_in_executor(None, _ban)
 
@@ -208,7 +221,11 @@ class NACLStrategy(IPBanStrategyInterface):
                 Egress=False,
                 CidrBlock=cidr,
             )
-            return {'success': True, 'message': f'Banned {ip_address} via NACL rule {rule_number}'}
+            return {
+                'success': True,
+                'message': f'Banned {ip_address} via NACL rule {rule_number}',
+                'rule_id': str(rule_number),
+            }
 
         return await loop.run_in_executor(None, _ban)
 

--- a/src/servonaut/services/relay_executors.py
+++ b/src/servonaut/services/relay_executors.py
@@ -194,6 +194,23 @@ class RelayExecutors:
             bytes=_utf8_len(message),
         )
 
+    async def find_instance(self, identifier: str) -> Optional[Dict]:
+        """Public instance lookup for callers outside the executor
+        dispatch (the remediation path uses it to learn the target's own
+        addresses for the block_ip self-ban refusal)."""
+        return await self._find_instance(identifier)
+
+    @property
+    def ip_ban_service(self):
+        """Lazily-built :class:`IPBanService` for local-dispatch
+        remediation verbs. Built from this executor's own config manager
+        so every construction site (TUI relay manager, headless connect)
+        gets it without wiring churn."""
+        if getattr(self, "_ip_ban_service", None) is None:
+            from servonaut.services.ip_ban_service import IPBanService
+            self._ip_ban_service = IPBanService(self._config_manager)
+        return self._ip_ban_service
+
     async def _find_instance(self, identifier: str) -> Optional[Dict]:
         """Find instance by ID or name across all providers (AWS + custom)."""
         aws_instances = await self._aws_service.fetch_instances_cached()

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -907,10 +907,21 @@ class RelayListener:
         output = ""
         error_message = ""
 
+        from servonaut.services.remediation_executor import (
+            LOCAL_DISPATCH_VERBS,
+        )
+
         if self._executors is None:
             error_message = (
                 "remediation_executor_unavailable: this CLI session "
                 "cannot execute remediations"
+            )
+        elif verb in LOCAL_DISPATCH_VERBS:
+            # block_ip never becomes a command line — it dispatches to
+            # the local curated IP-ban service (WAF/SG/NACL), which is
+            # already audited via the ip_ban audit trail.
+            status, output, error_message = await self._execute_block_ip(
+                raw, payload,
             )
         else:
             try:
@@ -1002,6 +1013,118 @@ class RelayListener:
         logger.info("Proactive remediation: %s", msg)
         print(f"  {msg}")
         await self._post_result(response)
+
+    async def _execute_block_ip(
+        self, raw: dict, payload: dict,
+    ) -> tuple:
+        """Execute a confirmed ``block_ip`` remediation locally.
+
+        Returns ``(status, output, error_message)`` for the shared
+        CommandResponse post. Per contract §F.3, ``status`` reflects
+        whether this CLI could PROCESS the dispatch — a ban that ran and
+        failed is ``status="success"`` with ``ok:false`` + slug in the
+        JSON payload; validation refusals and a missing IP-ban config are
+        can't-process (``status="error"``, slug-first message).
+
+        The ip in the payload was derived SERVER-SIDE from the finding's
+        stored evidence; the rails here (public-only, no CIDR, never the
+        instance's own addresses) are the client-side mirror.
+        """
+        from servonaut.services.remediation_executor import (
+            RemediationValidationError,
+            build_remediation_result,
+            coerce_dry_run,
+            validate_block_ip_payload,
+        )
+
+        # The target's own addresses are refused ban targets. A failed
+        # lookup only loses the refusal mirror — the server enforces the
+        # same rail authoritatively, so proceed rather than dead-ending.
+        target = str(raw.get("target_server_id") or "")
+        refused = set()
+        region_hint = ""
+        instance = None
+        if target:
+            try:
+                instance = await self._executors.find_instance(target)
+            except Exception:  # noqa: BLE001 — refusal mirror only
+                logger.warning(
+                    "block_ip: instance lookup failed for %r; continuing "
+                    "without the local self-ban mirror", target,
+                )
+        if instance:
+            for key in ("public_ip", "private_ip"):
+                value = instance.get(key)
+                if isinstance(value, str) and value.strip():
+                    refused.add(value.strip())
+            region_hint = str(instance.get("region") or "")
+
+        try:
+            ip, method = validate_block_ip_payload(
+                payload, frozenset(refused),
+            )
+        except RemediationValidationError as exc:
+            return "error", "", str(exc)
+
+        # Resolve the IPBanConfig for the requested method, preferring a
+        # region match (envelope region, else the instance's region).
+        svc = self._executors.ip_ban_service
+        candidates = [c for c in svc.get_configs() if c.method == method]
+        region = str(payload.get("region") or "") or region_hint
+        config = None
+        if region:
+            config = next(
+                (c for c in candidates if c.region == region), None,
+            )
+        if config is None and candidates:
+            config = candidates[0]
+        if config is None:
+            return "error", "", (
+                f"block_ip_config_missing: no IP-ban configuration with "
+                f"method '{method}' exists on this CLI — add one under "
+                f"IP Ban settings first"
+            )
+
+        extra = {"strategy": method, "ip": ip, "ip_ban_config": config.name}
+        if coerce_dry_run(payload):
+            output = build_remediation_result(
+                verb="block_ip", ok=True, exit_code=0,
+                output=(
+                    f"DRY RUN - would ban {ip} via {method} config "
+                    f"'{config.name}' (no change made)"
+                ),
+                payload=payload,
+                extra={**extra, "rule_id": None, "would_ban": True},
+            )
+            return "success", output, ""
+
+        try:
+            result = await svc.ban_ip(ip, config.name)
+        except Exception as exc:  # noqa: BLE001 — must still answer
+            logger.exception("block_ip dispatch failed: %s", exc)
+            result = {"success": False, "message": str(exc)}
+
+        message = str(result.get("message") or "")
+        if result.get("success"):
+            output = build_remediation_result(
+                verb="block_ip", ok=True, exit_code=0, output=message,
+                payload=payload,
+                extra={**extra, "rule_id": result.get("rule_id")},
+            )
+            return "success", output, ""
+        if "already banned" in message.lower():
+            # Idempotent: the goal state (ip banned) already holds.
+            output = build_remediation_result(
+                verb="block_ip", ok=True, exit_code=0, output=message,
+                payload=payload,
+                extra={**extra, "rule_id": None, "already_banned": True},
+            )
+            return "success", output, ""
+        output = build_remediation_result(
+            verb="block_ip", ok=False, exit_code=1, output=message,
+            payload=payload, slug="block_ip_failed", extra=extra,
+        )
+        return "success", output, ""
 
     @staticmethod
     def _carries_tool_call_id(raw: dict) -> bool:

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -21,6 +21,7 @@ the listener owns transport, dedup, and the always-answer contract.
 """
 from __future__ import annotations
 
+import ipaddress
 import json
 import re
 import shlex
@@ -29,9 +30,28 @@ from typing import Any, Dict, Optional, Tuple
 #: Relay envelopes with this ``source`` route to the remediation path.
 REMEDIATION_SOURCE = "proactive_remediation"
 
+#: Verbs executed as an SSH command on the target box (built locally
+#: from validated payload fields, judged via the exit marker).
+SSH_COMMAND_VERBS = frozenset({"certbot_renew"})
+
+#: Verbs executed by a LOCAL curated service call (no SSH, no shell) —
+#: ``block_ip`` dispatches to :class:`IPBanService` (WAF / security
+#: group / NACL strategies), which is already audited via the IP-ban
+#: audit trail.
+LOCAL_DISPATCH_VERBS = frozenset({"block_ip"})
+
 #: The verbs this CLI knows how to execute. Grows one playbook at a time,
 #: in lockstep with the server-side allowlist — never a generic shell.
-REMEDIATION_VERBS = frozenset({"certbot_renew"})
+REMEDIATION_VERBS = SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS
+
+assert not (SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS), (
+    "a remediation verb cannot be both SSH-command and local-dispatch"
+)
+
+#: Ban mechanisms the ``block_ip`` envelope may request. Must name an
+#: :class:`IPBanConfig` method this CLI actually has configured — the
+#: listener resolves the config and refuses when none matches.
+BLOCK_IP_METHODS = frozenset({"waf", "security_group", "nacl"})
 
 #: Marker echoed after the remote command so the caller can recover the
 #: exit code from stdout (the SSH seam doesn't expose it directly).
@@ -73,6 +93,11 @@ def _coerce_dry_run(payload: Dict[str, Any]) -> bool:
     return False
 
 
+#: Public name for callers outside this module (the relay listener's
+#: local-dispatch path); the leading-underscore original predates it.
+coerce_dry_run = _coerce_dry_run
+
+
 def _require_cert_name(payload: Dict[str, Any]) -> str:
     cert_name = payload.get("cert_name")
     if not isinstance(cert_name, str) or not cert_name:
@@ -103,20 +128,88 @@ _VERB_BUILDERS = {
     "certbot_renew": _build_certbot_renew,
 }
 
-# A builder registered here without a matching entry in REMEDIATION_VERBS
+# A builder registered here without a matching entry in SSH_COMMAND_VERBS
 # (or vice versa) would silently activate a verb the allowlist doesn't
 # document — fail the import instead of drifting quietly.
-assert set(_VERB_BUILDERS) == REMEDIATION_VERBS, (
-    "REMEDIATION_VERBS and _VERB_BUILDERS have drifted out of sync"
+assert set(_VERB_BUILDERS) == SSH_COMMAND_VERBS, (
+    "SSH_COMMAND_VERBS and _VERB_BUILDERS have drifted out of sync"
 )
 
 
+def validate_block_ip_payload(
+    payload: Dict[str, Any],
+    refused_ips: frozenset[str] = frozenset(),
+) -> Tuple[str, str]:
+    """Validate a ``block_ip`` payload; return ``(canonical_ip, method)``.
+
+    Client-side mirror of the server's rails (defense-in-depth — the
+    server derives the ip from the finding's stored evidence and applies
+    the same refusals authoritatively on its side):
+
+    - exactly ONE ip address, no CIDR (v1)
+    - globally routable only — private / loopback / link-local /
+      multicast / reserved / unspecified are all refused (a ban on any
+      of those is at best a no-op and at worst a self-lockout)
+    - never an address in ``refused_ips`` (the target instance's own
+      public/private addresses, where the caller knows them)
+    - ``method`` from :data:`BLOCK_IP_METHODS`
+    """
+    raw_ip = payload.get("ip")
+    if not isinstance(raw_ip, str) or not raw_ip.strip():
+        raise RemediationValidationError(
+            "invalid_block_ip_address: payload is missing an ip",
+        )
+    candidate = raw_ip.strip()
+    if "/" in candidate:
+        raise RemediationValidationError(
+            f"invalid_block_ip_address: {candidate!r} is a network — "
+            f"block_ip takes exactly one address (no CIDR in v1)",
+        )
+    try:
+        addr = ipaddress.ip_address(candidate)
+    except ValueError:
+        raise RemediationValidationError(
+            f"invalid_block_ip_address: {candidate!r} is not a valid "
+            f"IPv4/IPv6 address",
+        ) from None
+    # Explicit category checks alongside is_global: Python's is_global
+    # follows the IANA special registries, which mark some multicast
+    # ranges "globally reachable" — never a valid ban target here.
+    if (addr.is_multicast or addr.is_loopback or addr.is_link_local
+            or addr.is_private or addr.is_reserved or addr.is_unspecified
+            or not addr.is_global):
+        raise RemediationValidationError(
+            f"block_ip_address_not_public: {addr} is private, loopback, "
+            f"link-local, multicast, or reserved — refusing to ban it",
+        )
+    canonical = str(addr)
+    if canonical in refused_ips or candidate in refused_ips:
+        raise RemediationValidationError(
+            f"block_ip_self_ban_refused: {canonical} belongs to the "
+            f"target instance — banning it would cut the box off",
+        )
+    method = payload.get("method")
+    if not isinstance(method, str) or method not in BLOCK_IP_METHODS:
+        allowed = ", ".join(sorted(BLOCK_IP_METHODS))
+        raise RemediationValidationError(
+            f"invalid_block_ip_method: {method!r} is not one of "
+            f"{allowed}",
+        )
+    return canonical, method
+
+
 def build_remediation_command(verb: str, payload: Dict[str, Any]) -> str:
-    """Build the exact remote command for an allowlisted verb.
+    """Build the exact remote command for an allowlisted SSH verb.
 
     Raises :class:`RemediationValidationError` (slug-first message) for
-    unknown verbs or payloads that fail shape validation.
+    unknown verbs, local-dispatch verbs (which never become a command
+    line), or payloads that fail shape validation.
     """
+    if verb in LOCAL_DISPATCH_VERBS:
+        raise RemediationValidationError(
+            f"local_dispatch_verb: {verb!r} executes via a local curated "
+            f"service call, never an SSH command",
+        )
     builder = _VERB_BUILDERS.get(verb)
     if builder is None:
         raise RemediationValidationError(
@@ -234,6 +327,7 @@ def build_remediation_result(
     output: str,
     payload: Dict[str, Any],
     slug: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
 ) -> str:
     """JSON result payload posted back on the command-result route.
 
@@ -256,4 +350,9 @@ def build_remediation_result(
         result["slug"] = slug
     if verb == "certbot_renew" and isinstance(payload.get("cert_name"), str):
         result["cert_name"] = payload["cert_name"]
+    if extra:
+        # Verb-specific structured fields (block_ip: strategy / rule_id /
+        # ip). Additive only — the §F.3 core keys always win.
+        for key, value in extra.items():
+            result.setdefault(key, value)
     return json.dumps(result)

--- a/src/servonaut/styles/screens/findings.tcss
+++ b/src/servonaut/styles/screens/findings.tcss
@@ -197,6 +197,11 @@
     color: $text-muted;
 }
 
+.finding_remediation_manual {
+    height: auto;
+    color: $text-muted;
+}
+
 /* ---- Remediation run buttons + confirm modal (Phase 3) ---- */
 
 .finding_remediation_run {

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -330,6 +330,75 @@ class TestFindingDetailScreen:
             assert screen._remediation_buttons == {}
 
     @pytest.mark.asyncio
+    async def test_non_automatable_option_renders_manual_not_run(self):
+        # Server marks options automatable when an authored command
+        # exists; automatable:false must render as manual guidance —
+        # never a Run button that dead-ends in a preview 422.
+        finding = _finding(remediations=[{
+            "label": "Rotate the exposed credentials",
+            "description": "Rotate keys used from the flagged host.",
+            "action": "rotate_credentials",
+            "risk_tier": "medium",
+            "reversible": False,
+            "automatable": False,
+        }])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=_mock_findings_service(),
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            assert screen._remediation_buttons == {}
+            text = _rendered_text(app)
+            assert "Manual action" in text
+
+    @pytest.mark.asyncio
+    async def test_absent_automatable_keeps_run_button(self):
+        # Back-compat: payloads from servers that predate the flag keep
+        # their Run buttons (absent means true).
+        finding = _finding(remediations=[{
+            "label": "Ban the offending address",
+            "description": "Block at the edge.",
+            "action": "block_ip",
+            "risk_tier": "medium",
+            "reversible": True,
+        }])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=_mock_findings_service(),
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            assert len(screen._remediation_buttons) == 1
+
+    @pytest.mark.asyncio
+    async def test_automatable_true_keeps_run_button(self):
+        finding = _finding(remediations=[{
+            "label": "Ban the offending address",
+            "description": "Block at the edge.",
+            "action": "block_ip",
+            "risk_tier": "medium",
+            "reversible": True,
+            "automatable": True,
+        }])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=_mock_findings_service(),
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            assert len(screen._remediation_buttons) == 1
+
+    @pytest.mark.asyncio
     async def test_run_button_fetches_preview_and_opens_confirm_modal(self):
         svc = _mock_findings_service()
         svc.remediate_preview = AsyncMock(return_value={

--- a/tests/test_ip_ban_service.py
+++ b/tests/test_ip_ban_service.py
@@ -82,6 +82,8 @@ class TestWAFStrategy:
 
         assert result['success'] is True
         assert '1.2.3.4' in result['message']
+        # The unban handle persisted as remediation evidence.
+        assert result['rule_id'] == '1.2.3.4/32'
         fake_client.update_ip_set.assert_called_once()
         call_kwargs = fake_client.update_ip_set.call_args[1]
         assert '1.2.3.4/32' in call_kwargs['Addresses']
@@ -185,6 +187,11 @@ class TestSecurityGroupStrategy:
 
         fake_client = MagicMock()
         fake_client.describe_security_groups.return_value = self._make_sg_response()
+        fake_client.authorize_security_group_ingress.return_value = {
+            'SecurityGroupRules': [
+                {'SecurityGroupRuleId': 'sgr-0123456789abcdef0'},
+            ],
+        }
 
         with patch('boto3.client', return_value=fake_client):
             result = asyncio.run(
@@ -192,6 +199,7 @@ class TestSecurityGroupStrategy:
             )
 
         assert result['success'] is True
+        assert result['rule_id'] == 'sgr-0123456789abcdef0'
         fake_client.authorize_security_group_ingress.assert_called_once()
         call_kwargs = fake_client.authorize_security_group_ingress.call_args[1]
         ip_perms = call_kwargs['IpPermissions']
@@ -287,6 +295,8 @@ class TestNACLStrategy:
         assert call_kwargs['CidrBlock'] == '1.2.3.4/32'
         assert call_kwargs['RuleAction'] == 'deny'
         assert call_kwargs['Egress'] is False
+        # rule_id is the NACL rule number actually used — the unban handle.
+        assert result['rule_id'] == str(call_kwargs['RuleNumber'])
 
     def test_ban_ip_duplicate_returns_failure(self):
         strategy = NACLStrategy()

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -455,3 +455,312 @@ class TestRemediationRouting:
         assert response.error_message.startswith(
             "probe_executor_unavailable:",
         )
+
+
+# ---------------------------------------------------------------------------
+# block_ip — payload validation (client-side mirror of the server rails)
+# ---------------------------------------------------------------------------
+
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    BLOCK_IP_METHODS,
+    LOCAL_DISPATCH_VERBS,
+    SSH_COMMAND_VERBS,
+    validate_block_ip_payload,
+)
+
+
+class TestVerbSets:
+    def test_block_ip_is_an_allowlisted_local_dispatch_verb(self):
+        assert "block_ip" in REMEDIATION_VERBS
+        assert "block_ip" in LOCAL_DISPATCH_VERBS
+        assert "block_ip" not in SSH_COMMAND_VERBS
+
+    def test_ssh_and_local_sets_partition_the_allowlist(self):
+        assert SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS == REMEDIATION_VERBS
+        assert not SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS
+
+    def test_block_ip_never_becomes_a_command_line(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command("block_ip", {"ip": "9.9.9.9"})
+        assert str(exc.value).startswith("local_dispatch_verb:")
+
+
+class TestValidateBlockIpPayload:
+    def test_valid_public_ipv4(self):
+        ip, method = validate_block_ip_payload(
+            {"ip": "9.9.9.9", "method": "waf"},
+        )
+        assert ip == "9.9.9.9"
+        assert method == "waf"
+
+    def test_valid_public_ipv6(self):
+        ip, method = validate_block_ip_payload(
+            {"ip": "2606:4700:4700::1111", "method": "nacl"},
+        )
+        assert ip == "2606:4700:4700::1111"
+        assert method == "nacl"
+
+    @pytest.mark.parametrize("payload", [
+        {},
+        {"ip": None},
+        {"ip": 42},
+        {"ip": "   "},
+    ])
+    def test_missing_or_nonstring_ip_rejected(self, payload):
+        payload.setdefault("method", "waf")
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload(payload)
+        assert str(exc.value).startswith("invalid_block_ip_address:")
+
+    def test_cidr_rejected(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload({"ip": "9.9.9.0/24", "method": "waf"})
+        assert str(exc.value).startswith("invalid_block_ip_address:")
+
+    @pytest.mark.parametrize("garbage", ["not-an-ip", "999.999.1.1", "9.9.9.9 extra"])
+    def test_garbage_rejected(self, garbage):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload({"ip": garbage, "method": "waf"})
+        assert str(exc.value).startswith("invalid_block_ip_address:")
+
+    @pytest.mark.parametrize("bad_ip", [
+        "10.0.0.5",          # private
+        "192.168.1.1",       # private
+        "172.16.0.1",        # private
+        "127.0.0.1",         # loopback
+        "169.254.1.1",       # link-local
+        "224.0.0.1",         # multicast
+        "240.0.0.1",         # reserved
+        "0.0.0.0",           # unspecified
+        "100.64.0.1",        # shared address space (CGN)
+        "::1",               # v6 loopback
+        "fe80::1",           # v6 link-local
+        "fd00::1",           # v6 ULA
+    ])
+    def test_non_global_addresses_refused(self, bad_ip):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload({"ip": bad_ip, "method": "waf"})
+        assert str(exc.value).startswith("block_ip_address_not_public:")
+
+    def test_instance_own_ip_refused(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload(
+                {"ip": "9.9.9.9", "method": "waf"},
+                refused_ips=frozenset({"9.9.9.9"}),
+            )
+        assert str(exc.value).startswith("block_ip_self_ban_refused:")
+
+    @pytest.mark.parametrize("bad_method", [
+        None, "", "ufw", "iptables", "WAF", 42,
+    ])
+    def test_unknown_method_rejected(self, bad_method):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_block_ip_payload(
+                {"ip": "9.9.9.9", "method": bad_method},
+            )
+        assert str(exc.value).startswith("invalid_block_ip_method:")
+
+    def test_method_enum_matches_ip_ban_strategies(self):
+        from servonaut.services.ip_ban_service import IPBanService
+        assert BLOCK_IP_METHODS == frozenset(IPBanService.STRATEGIES)
+
+
+class TestBuildResultExtras:
+    def test_extras_are_additive(self):
+        raw = build_remediation_result(
+            verb="block_ip", ok=True, exit_code=0, output="banned",
+            payload={"dry_run": False},
+            extra={"strategy": "waf", "rule_id": "9.9.9.9/32",
+                   "ip": "9.9.9.9"},
+        )
+        result = json.loads(raw)
+        assert result["strategy"] == "waf"
+        assert result["rule_id"] == "9.9.9.9/32"
+        assert result["ip"] == "9.9.9.9"
+        assert result["ok"] is True
+
+    def test_extras_cannot_override_core_contract_keys(self):
+        raw = build_remediation_result(
+            verb="block_ip", ok=False, exit_code=1, output="",
+            payload={}, slug="block_ip_failed",
+            extra={"ok": True, "exit_code": 0, "slug": "spoofed"},
+        )
+        result = json.loads(raw)
+        assert result["ok"] is False
+        assert result["exit_code"] == 1
+        assert result["slug"] == "block_ip_failed"
+
+
+# ---------------------------------------------------------------------------
+# block_ip — listener routing (local dispatch, never SSH)
+# ---------------------------------------------------------------------------
+
+
+def _ip_ban_config(name="ban-waf", method="waf", region=""):
+    from servonaut.config.schema import IPBanConfig
+    return IPBanConfig(name=name, method=method, region=region)
+
+
+def make_block_ip_listener(
+    *,
+    configs=None,
+    ban_result=None,
+    instance=None,
+):
+    listener = make_listener()
+    executors = listener._executors
+    executors.find_instance = AsyncMock(return_value=instance)
+    ip_ban = MagicMock()
+    ip_ban.get_configs = MagicMock(
+        return_value=configs if configs is not None else [_ip_ban_config()],
+    )
+    ip_ban.ban_ip = AsyncMock(
+        return_value=ban_result if ban_result is not None else {
+            "success": True,
+            "message": "Banned 9.9.9.9 via WAF IP set",
+            "rule_id": "9.9.9.9/32",
+        },
+    )
+    # The lazy property on the real RelayExecutors is replaced wholesale
+    # here because the executors object is a MagicMock.
+    executors.ip_ban_service = ip_ban
+    return listener, ip_ban
+
+
+def block_ip_event(*, payload=None, target="web-1"):
+    return remediation_event(
+        req_id="rmd-ban-1", verb="block_ip", target=target,
+        payload=payload if payload is not None else {
+            "finding_id": "fnd-2", "action": "block_ip",
+            "ip": "9.9.9.9", "method": "waf", "dry_run": False,
+        },
+    )
+
+
+class TestBlockIpRouting:
+    def test_success_path_dispatches_locally_never_ssh(self):
+        listener, ip_ban = make_block_ip_listener()
+        run(listener._handle_event(block_ip_event()))
+
+        # Local dispatch only — the SSH command executor is never used.
+        listener._executors.execute.assert_not_awaited()
+        ip_ban.ban_ip.assert_awaited_once_with("9.9.9.9", "ban-waf")
+
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is True
+        assert result["exit_code"] == 0
+        assert result["strategy"] == "waf"
+        assert result["rule_id"] == "9.9.9.9/32"
+        assert result["ip"] == "9.9.9.9"
+
+    def test_dry_run_makes_no_mutation(self):
+        listener, ip_ban = make_block_ip_listener()
+        run(listener._handle_event(block_ip_event(payload={
+            "finding_id": "fnd-2", "action": "block_ip",
+            "ip": "9.9.9.9", "method": "waf", "dry_run": True,
+        })))
+        ip_ban.ban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        assert result["would_ban"] is True
+        assert result["rule_id"] is None
+
+    def test_instance_own_ip_is_refused(self):
+        listener, ip_ban = make_block_ip_listener(
+            instance={"id": "i-1", "name": "web-1",
+                      "public_ip": "9.9.9.9", "private_ip": "10.0.0.5",
+                      "region": "eu-west-1"},
+        )
+        run(listener._handle_event(block_ip_event()))
+        ip_ban.ban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith(
+            "block_ip_self_ban_refused:",
+        )
+
+    def test_private_ip_is_refused(self):
+        listener, ip_ban = make_block_ip_listener()
+        run(listener._handle_event(block_ip_event(payload={
+            "finding_id": "fnd-2", "action": "block_ip",
+            "ip": "192.168.1.50", "method": "waf",
+        })))
+        ip_ban.ban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith(
+            "block_ip_address_not_public:",
+        )
+
+    def test_missing_config_for_method_is_cant_process(self):
+        listener, ip_ban = make_block_ip_listener(configs=[])
+        run(listener._handle_event(block_ip_event()))
+        ip_ban.ban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("block_ip_config_missing:")
+
+    def test_region_match_preferred_over_first_config(self):
+        listener, ip_ban = make_block_ip_listener(configs=[
+            _ip_ban_config(name="ban-us", method="waf", region="us-east-1"),
+            _ip_ban_config(name="ban-eu", method="waf", region="eu-west-1"),
+        ])
+        run(listener._handle_event(block_ip_event(payload={
+            "finding_id": "fnd-2", "action": "block_ip",
+            "ip": "9.9.9.9", "method": "waf", "region": "eu-west-1",
+        })))
+        ip_ban.ban_ip.assert_awaited_once_with("9.9.9.9", "ban-eu")
+
+    def test_ran_but_failed_ban_reports_slug_in_payload(self):
+        listener, ip_ban = make_block_ip_listener(ban_result={
+            "success": False, "message": "AccessDenied: not authorized",
+        })
+        run(listener._handle_event(block_ip_event()))
+        response = posted_response(listener)
+        # Transport fine, outcome in the payload (contract F.3).
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is False
+        assert result["exit_code"] == 1
+        assert result["slug"] == "block_ip_failed"
+        assert "AccessDenied" in result["stdout_tail"]
+
+    def test_already_banned_is_idempotent_success(self):
+        listener, ip_ban = make_block_ip_listener(ban_result={
+            "success": False,
+            "message": "9.9.9.9 already banned in WAF",
+        })
+        run(listener._handle_event(block_ip_event()))
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is True
+        assert result["already_banned"] is True
+
+    def test_ban_exception_still_answers(self):
+        listener, ip_ban = make_block_ip_listener()
+        ip_ban.ban_ip = AsyncMock(side_effect=RuntimeError("boom"))
+        run(listener._handle_event(block_ip_event()))
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is False
+        assert result["slug"] == "block_ip_failed"
+
+    def test_failed_instance_lookup_does_not_block_execution(self):
+        # The self-ban mirror is best-effort; the server enforces the
+        # same rail authoritatively.
+        listener, ip_ban = make_block_ip_listener()
+        listener._executors.find_instance = AsyncMock(
+            side_effect=RuntimeError("cache unavailable"),
+        )
+        run(listener._handle_event(block_ip_event()))
+        ip_ban.ban_ip.assert_awaited_once()
+        response = posted_response(listener)
+        assert response.status == "success"


### PR DESCRIPTION
## Summary
Second remediation verb for proactive monitoring, executing through the existing audited IP-ban path — never SSH, never server-supplied command text.

- `block_ip` dispatches locally onto `IPBanService` (WAF ip-set / security-group ingress / NACL deny), resolved by requested method with region preference.
- Client-side rails (defense-in-depth mirror of the server's authoritative checks): strict single-IP parse (no CIDR), refuse private/loopback/link-local/multicast/reserved/unspecified addresses (explicit category checks — `is_global` alone passes some multicast), refuse the target instance's own addresses.
- `dry_run` reports the would-be ban with zero mutation; already-banned is idempotent success.
- Ban strategies now return a `rule_id` (WAF CIDR entry / SG rule id / NACL rule number) persisted in remediation evidence for a future unban verb.
- Findings detail honors the additive `automatable` flag: manual-only options render as guidance instead of a Run button that would 422 at preview (absent = true for back-compat).

## Test plan
- 34 new tests: payload rails, listener routing (local dispatch only — SSH executor never touched), dry-run zero-mutation, idempotency, config resolution, strategy rule-ids, screen rendering.
- Full suite green (6150 passed).