### PR TITLE
feat(mcp): disk_usage + pending_updates probes, journal_errors failed-units

### DIFF
--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -105,6 +105,7 @@ class CommandGuard:
             # aggregation, TLS cert expiry discovery, and SSH auth-log
             # summaries. Read-only over SSH with sudo -n fallback.
             'journal_errors', 'tls_cert_check', 'auth_log_summary',
+            'disk_usage', 'pending_updates',
         }
         standard_tools = readonly_tools | {
             'run_command', 'get_logs',

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -2130,11 +2130,12 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     "journal_errors": {
         "description": (
             "Aggregate journald problems on one instance: error-priority "
-            "entries per unit, kernel OOM kills, and service "
-            "restart/failure records. Read-only (journalctl over SSH; "
-            "sudo -n fallback). Returns JSON: {entries: [{unit, level, "
-            "count, sample}], oom_kills: [{unit, count, last_at}], "
-            "restarts: [{unit, count, last_at}]}. Errors: "
+            "entries per unit, kernel OOM kills, service restart/failure "
+            "records, and CURRENT failed units (systemctl --failed). "
+            "Read-only (journalctl over SSH; sudo -n fallback). Returns "
+            "JSON: {entries: [{unit, level, count, sample}], oom_kills: "
+            "[{unit, count, last_at}], restarts: [{unit, count, "
+            "last_at}], failed_units: [{unit, description}]}. Errors: "
             "journal_not_available, journal_permission_denied."
         ),
         "schema": {
@@ -2154,6 +2155,56 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "integer",
                     "description": "Max rows per section (1-100, default 20).",
                     "default": 20,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "disk_usage": {
+        "description": (
+            "Per-filesystem disk usage on one instance plus the top "
+            "directory consumers under the fullest mount. Read-only "
+            "(df bytes+inodes with pseudo-filesystems excluded; depth-2 "
+            "du, sudo -n when available). Returns JSON: {filesystems: "
+            "[{mount, size_bytes, used_pct, inodes_used_pct}], "
+            "fullest_mount, top_consumers: [{path, size_bytes}]}. "
+            "Errors: df_not_available."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID or name.",
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "Max top-consumer rows (1-100, "
+                                   "default 20).",
+                    "default": 20,
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
+    "pending_updates": {
+        "description": (
+            "Pending package updates on one instance: security vs total "
+            "counts, reboot-required state, and sample package names. "
+            "Read-only (apt-get simulation on Debian/Ubuntu, dnf "
+            "updateinfo/check-update on RHEL-family; never installs). "
+            "Returns JSON: {manager, security_count, total_count, "
+            "reboot_required, sample_packages: []}. Errors: "
+            "pkg_manager_not_supported."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID or name.",
                 },
             },
             "required": ["instance_id"],

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -5815,6 +5815,8 @@ class ServonautTools:
             'echo "===RESTARTS==="; '
             '$J _PID=1 --since "$S" --no-pager 2>/dev/null '
             '| grep -E "Scheduled restart|Failed with result" | tail -n 500; '
+            'echo "===FAILED==="; '
+            'systemctl --failed --no-legend --plain 2>/dev/null | head -n 100; '
             'true'
         )
         try:
@@ -5839,6 +5841,118 @@ class ServonautTools:
             stdout, top_n=max(1, min(int(top_n or 20), 100)),
         ))
         self._audit.log('journal_errors', args, f"{len(result)} chars", True)
+        return result
+
+    async def disk_usage(self, instance_id: str, top_n: int = 20) -> str:
+        """Per-filesystem usage plus top directory consumers.
+
+        Read-only: df (bytes + inodes, pseudo-filesystems excluded) and a
+        depth-2 du under the fullest mount (sudo -n when available so
+        root-owned trees are counted).
+        """
+        from servonaut.utils.system_probe import parse_disk_usage
+
+        args = {'instance_id': instance_id, 'top_n': top_n}
+        allowed, reason = self._guard.check_tool('disk_usage')
+        if not allowed:
+            self._audit.log('disk_usage', args, '', False, reason)
+            return f"Blocked: {reason}"
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('disk_usage', args, '', False, 'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        remote = (
+            'X="-x tmpfs -x devtmpfs -x squashfs -x overlay"; '
+            'echo "===FS==="; '
+            'df -P -B1 $X 2>/dev/null | tail -n +2; '
+            'echo "===INODES==="; '
+            'df -P -i $X 2>/dev/null | tail -n +2; '
+            'M=$(df -P $X 2>/dev/null | tail -n +2 '
+            '| sort -k5 -rn | head -n 1 | awk \'{print $6}\'); '
+            'echo "===TOP==="; '
+            'if sudo -n true 2>/dev/null; then DU="sudo -n du"; '
+            'else DU="du"; fi; '
+            'if [ -n "$M" ]; then '
+            '$DU -x -B1 -d 2 "$M" 2>/dev/null | sort -rn | head -n 60; fi; '
+            'true'
+        )
+        try:
+            stdout, _stderr = await self._exec_ssh(instance, remote, timeout=120)
+        except asyncio.TimeoutError:
+            self._audit.log('disk_usage', args, '', False, 'timeout')
+            return "Error: disk_usage timed out after 120 seconds"
+        except Exception as e:
+            self._audit.log('disk_usage', args, '', False, f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        parsed = parse_disk_usage(
+            stdout, top_n=max(1, min(int(top_n or 20), 100)),
+        )
+        if not parsed["filesystems"]:
+            self._audit.log('disk_usage', args, '', False, 'df_not_available')
+            return "Error: df_not_available"
+        result = json.dumps(parsed)
+        self._audit.log('disk_usage', args, f"{len(result)} chars", True)
+        return result
+
+    async def pending_updates(self, instance_id: str) -> str:
+        """Pending package updates + reboot-required state.
+
+        Read-only: apt-get -s (simulation, no lock) on Debian/Ubuntu,
+        dnf updateinfo/check-update on RHEL-family. Never installs.
+        """
+        from servonaut.utils.system_probe import parse_pending_updates
+
+        args = {'instance_id': instance_id}
+        allowed, reason = self._guard.check_tool('pending_updates')
+        if not allowed:
+            self._audit.log('pending_updates', args, '', False, reason)
+            return f"Blocked: {reason}"
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('pending_updates', args, '', False,
+                            'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        remote = (
+            'if command -v apt-get >/dev/null 2>&1; then '
+            'echo "===APT==="; '
+            'apt-get -s -o Debug::NoLocking=1 upgrade 2>/dev/null '
+            '| grep "^Inst" | head -n 500; '
+            'echo "===REBOOT==="; '
+            'if [ -f /var/run/reboot-required ]; then echo yes; '
+            'else echo no; fi; '
+            'elif command -v dnf >/dev/null 2>&1; then '
+            'echo "===DNF_SEC==="; '
+            'dnf -q updateinfo list security 2>/dev/null | head -n 500; '
+            'echo "===DNF_ALL==="; '
+            'dnf -q check-update 2>/dev/null | head -n 500; '
+            'echo "===REBOOT==="; '
+            'if command -v needs-restarting >/dev/null 2>&1; then '
+            'if needs-restarting -r >/dev/null 2>&1; then echo no; '
+            'else echo yes; fi; else echo unknown; fi; '
+            'else echo PKG_MANAGER_NOT_SUPPORTED; fi; '
+            'true'
+        )
+        try:
+            stdout, _stderr = await self._exec_ssh(instance, remote, timeout=120)
+        except asyncio.TimeoutError:
+            self._audit.log('pending_updates', args, '', False, 'timeout')
+            return "Error: pending_updates timed out after 120 seconds"
+        except Exception as e:
+            self._audit.log('pending_updates', args, '', False,
+                            f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        head = stdout.strip().splitlines()[0].strip() if stdout.strip() else ""
+        if head == "PKG_MANAGER_NOT_SUPPORTED":
+            self._audit.log('pending_updates', args, '', False,
+                            'pkg_manager_not_supported')
+            return "Error: pkg_manager_not_supported"
+
+        result = json.dumps(parse_pending_updates(stdout))
+        self._audit.log('pending_updates', args, f"{len(result)} chars", True)
         return result
 
     async def tls_cert_check(self, instance_id: str) -> str:

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -142,6 +142,8 @@ _TOOL_GUARDS: Dict[str, Literal["readonly", "standard", "dangerous"]] = {
     "journal_errors": "readonly",
     "tls_cert_check": "readonly",
     "auth_log_summary": "readonly",
+    "disk_usage": "readonly",
+    "pending_updates": "readonly",
 }
 
 # Strict ordering of guard severity. Used by :func:`_escalate_guard` to
@@ -310,6 +312,8 @@ _LOCAL_TOOL_HANDLERS: Dict[str, str] = {
     "journal_errors":             "journal_errors",
     "tls_cert_check":             "tls_cert_check",
     "auth_log_summary":           "auth_log_summary",
+    "disk_usage":                 "disk_usage",
+    "pending_updates":            "pending_updates",
     "enrich_ips":                 "enrich_ips",
     "db_processlist":             "db_processlist",
     "db_top_queries":             "db_top_queries",

--- a/src/servonaut/utils/system_probe.py
+++ b/src/servonaut/utils/system_probe.py
@@ -12,6 +12,11 @@ wire shapes pinned in the proactive-monitoring tool contract:
 - ``auth_log_summary``  → ``{failed_logins: [{ip, user, count,
   method}], invalid_users: [{ip, count}], accepted_logins: [{ip, user,
   count, method}]}``
+- ``disk_usage``        → ``{filesystems: [{mount, size_bytes,
+  used_pct, inodes_used_pct}], fullest_mount, top_consumers: [{path,
+  size_bytes}]}``
+- ``pending_updates``   → ``{manager, security_count, total_count,
+  reboot_required, sample_packages: []}``
 
 Every function tolerates malformed lines — skipped, never raised.
 """
@@ -117,6 +122,19 @@ def parse_journal_errors(stdout: str, top_n: int = 20) -> Dict[str, Any]:
         row["count"] += 1
         row["last_at"] = _syslog_ts(line) or row["last_at"]
 
+    # ``===FAILED===`` — systemctl --failed --plain --no-legend: current
+    # failed-unit STATE, which journal-derived signal alone misses (a
+    # unit that failed before the lookback window has no recent lines).
+    failed_units: List[Dict[str, Any]] = []
+    for line in sections.get("FAILED", []):
+        parts = line.split(None, 4)
+        if not parts or "." not in parts[0]:
+            continue
+        failed_units.append({
+            "unit": parts[0],
+            "description": parts[4].strip() if len(parts) > 4 else "",
+        })
+
     top = max(1, top_n)
     by_count = lambda rows: sorted(  # noqa: E731 — tiny local sort key
         rows, key=lambda r: r["count"], reverse=True,
@@ -125,6 +143,7 @@ def parse_journal_errors(stdout: str, top_n: int = 20) -> Dict[str, Any]:
         "entries": by_count(list(entries.values())),
         "oom_kills": by_count(list(oom.values())),
         "restarts": by_count(list(restarts.values())),
+        "failed_units": failed_units[:top],
     }
 
 
@@ -230,4 +249,124 @@ def summarize_auth_log(stdout: str, top_n: int = 20) -> Dict[str, Any]:
         "failed_logins": by_count(list(failed.values())),
         "invalid_users": by_count(list(invalid.values())),
         "accepted_logins": by_count(list(accepted.values())),
+    }
+
+
+def parse_disk_usage(stdout: str, top_n: int = 20) -> Dict[str, Any]:
+    """``===FS===`` (df -P -B1) + ``===INODES===`` (df -P -i) + ``===TOP===``
+    (du -x -B1 -d 2 under the fullest filesystem, size-sorted)."""
+    sections = _split_sections(stdout)
+
+    filesystems: Dict[str, Dict[str, Any]] = {}
+    for line in sections.get("FS", []):
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        mount = parts[5]
+        try:
+            size_bytes = int(parts[1])
+            used_pct = float(parts[4].rstrip("%"))
+        except ValueError:
+            continue
+        filesystems[mount] = {
+            "mount": mount,
+            "size_bytes": size_bytes,
+            "used_pct": used_pct,
+            "inodes_used_pct": None,
+        }
+
+    for line in sections.get("INODES", []):
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        row = filesystems.get(parts[5])
+        if row is None:
+            continue
+        try:
+            row["inodes_used_pct"] = float(parts[4].rstrip("%"))
+        except ValueError:
+            pass  # xfs prints '-' when inode accounting is dynamic
+
+    top_consumers: List[Dict[str, Any]] = []
+    for line in sections.get("TOP", []):
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        try:
+            size_bytes = int(parts[0])
+        except ValueError:
+            continue
+        top_consumers.append({
+            "path": parts[1].strip(),
+            "size_bytes": size_bytes,
+        })
+
+    ranked = sorted(
+        filesystems.values(), key=lambda r: r["used_pct"], reverse=True,
+    )
+    top = max(1, top_n)
+    return {
+        "filesystems": ranked,
+        "fullest_mount": ranked[0]["mount"] if ranked else None,
+        "top_consumers": top_consumers[:top],
+    }
+
+
+#: apt simulation lines: ``Inst <pkg> [old] (new origin ...)`` — a
+#: security origin marks the row as a security update.
+_APT_INST_RE = re.compile(r"^Inst\s+(\S+)")
+
+
+def parse_pending_updates(stdout: str, sample_n: int = 10) -> Dict[str, Any]:
+    """``===APT===``/``===DNF_SEC===``+``===DNF_ALL===`` + ``===REBOOT===``."""
+    sections = _split_sections(stdout)
+
+    manager: Optional[str] = None
+    total = 0
+    security = 0
+    samples: List[str] = []
+
+    if "APT" in sections:
+        manager = "apt"
+        for line in sections["APT"]:
+            m = _APT_INST_RE.match(line.strip())
+            if not m:
+                continue
+            total += 1
+            if "security" in line.lower():
+                security += 1
+            if len(samples) < sample_n:
+                samples.append(m.group(1))
+    elif "DNF_SEC" in sections or "DNF_ALL" in sections:
+        manager = "dnf"
+        sec_names = set()
+        for line in sections.get("DNF_SEC", []):
+            parts = line.split()
+            # updateinfo rows: <advisory> <severity/type> <pkg-ver-rel.arch>
+            if len(parts) >= 3:
+                sec_names.add(parts[-1])
+        security = len(sec_names)
+        for line in sections.get("DNF_ALL", []):
+            parts = line.split()
+            # check-update rows: <pkg.arch> <version> <repo>
+            if len(parts) == 3 and "." in parts[0]:
+                total += 1
+                if len(samples) < sample_n:
+                    samples.append(parts[0])
+        total = max(total, security)
+
+    reboot_required: Optional[bool] = None
+    for line in sections.get("REBOOT", []):
+        flag = line.strip().lower()
+        if flag == "yes":
+            reboot_required = True
+        elif flag == "no":
+            reboot_required = False
+
+    return {
+        "manager": manager,
+        "security_count": security,
+        "total_count": total,
+        "reboot_required": reboot_required,
+        "sample_packages": samples,
     }

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -90,7 +90,7 @@ class TestLocalToolHandlerMapCompleteness:
             f"from ServonautTools: {missing}"
         )
 
-    def test_new_entries_count_is_79(self):
+    def test_new_entries_count_is_81(self):
         """Local-handler entries beyond the 2 originals.
 
         PR5' seeded 57; incident-response tools added the rest:
@@ -101,14 +101,15 @@ class TestLocalToolHandlerMapCompleteness:
         findings (remember_server_finding, recall_server_findings) → 71;
         docker container probes (docker_ps, docker_stats, docker_logs,
         docker_events_summary) → 75; system-health probes (journal_errors,
-        tls_cert_check, auth_log_summary) → 78; docker_log_summary → 79. All
-        dispatch locally (CLI's own SSH / boto3 / network / memory surface);
-        the server catalog mirror is tracked separately (see
+        tls_cert_check, auth_log_summary) → 78; docker_log_summary → 79;
+        breadth probes (disk_usage, pending_updates) → 81. All dispatch
+        locally (CLI's own SSH / boto3 / network / memory surface); the
+        server catalog mirror is tracked separately (see
         test_catalog_drift::CATALOG_PENDING_SERVER).
         """
         new_entries = {k for k in _LOCAL_TOOL_HANDLERS if k not in _ORIGINAL_TOOLS}
-        assert len(new_entries) == 79, (
-            f"Expected 71 new entries, got {len(new_entries)}: {sorted(new_entries)}"
+        assert len(new_entries) == 81, (
+            f"Expected 81 new entries, got {len(new_entries)}: {sorted(new_entries)}"
         )
 
 

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -31,7 +31,12 @@ CATALOG_EXCLUDED_CLI_ONLY: frozenset[str] = frozenset({
 # CATALOG_EXCLUDED_CLI_ONLY, which is permanently CLI-only): when a tool is
 # added to the server catalog, move it out of here and into the fixture in the
 # same change, keeping the gate honest both ways. Empty = fully converged.
-CATALOG_PENDING_SERVER: frozenset[str] = frozenset()
+CATALOG_PENDING_SERVER: frozenset[str] = frozenset({
+    # Breadth probes shipped CLI-first for the disk/packages detectors —
+    # move into the fixture when the server registers the catalog rows.
+    "disk_usage",
+    "pending_updates",
+})
 
 
 _FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "server_catalog_v1.json"

--- a/tests/test_system_probe_tools.py
+++ b/tests/test_system_probe_tools.py
@@ -67,8 +67,34 @@ class TestParseJournalErrors:
         assert out["restarts"][0]["count"] == 2
 
     def test_empty_output(self):
+        out = parse_journal_errors(
+            "===ERR===\n===OOM===\n===RESTARTS===\n===FAILED===",
+        )
+        assert out == {"entries": [], "oom_kills": [], "restarts": [],
+                       "failed_units": []}
+
+    def test_failed_units_capture_current_state(self):
+        # A unit that failed BEFORE the lookback window has no journal
+        # lines — systemctl --failed still reports it.
+        stdout = "\n".join([
+            "===ERR===", "===OOM===", "===RESTARTS===",
+            "===FAILED===",
+            "snap.certbot.renew.service loaded failed failed "
+            "Automatically renew certificates",
+            "app-worker.service loaded failed failed App background worker",
+            "not a unit line",
+        ])
+        out = parse_journal_errors(stdout)
+        assert out["failed_units"] == [
+            {"unit": "snap.certbot.renew.service",
+             "description": "Automatically renew certificates"},
+            {"unit": "app-worker.service",
+             "description": "App background worker"},
+        ]
+
+    def test_missing_failed_section_is_back_compat(self):
         out = parse_journal_errors("===ERR===\n===OOM===\n===RESTARTS===")
-        assert out == {"entries": [], "oom_kills": [], "restarts": []}
+        assert out["failed_units"] == []
 
 
 class TestParseTlsCerts:
@@ -266,8 +292,107 @@ class TestSystemProbeToolLayer:
 
     def test_probe_policy_allows_new_tools(self):
         from servonaut.services.relay_listener import probe_tool_allowed
-        for tool in ("journal_errors", "tls_cert_check", "auth_log_summary"):
+        for tool in ("journal_errors", "tls_cert_check", "auth_log_summary",
+                     "disk_usage", "pending_updates"):
             assert probe_tool_allowed(tool)
+
+    def test_disk_usage_json(self):
+        tools = _tools()
+        stdout = "\n".join([
+            "===FS===",
+            "/dev/sda1 10737418240 9663676416 1073741824 90% /",
+            "/dev/sdb1 21474836480 2147483648 19327352832 10% /data",
+            "===INODES===",
+            "/dev/sda1 655360 65536 589824 10% /",
+            "===TOP===",
+            "8589934592 /var/log",
+            "1073741824 /var/lib",
+        ])
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.disk_usage("web-1")))
+        assert payload["fullest_mount"] == "/"
+        root = payload["filesystems"][0]
+        assert root["mount"] == "/"
+        assert root["used_pct"] == 90.0
+        assert root["size_bytes"] == 10737418240
+        assert root["inodes_used_pct"] == 10.0
+        assert payload["filesystems"][1]["inodes_used_pct"] is None
+        assert payload["top_consumers"][0] == {
+            "path": "/var/log", "size_bytes": 8589934592,
+        }
+
+    def test_disk_usage_df_missing_is_error(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=("", ""))
+        assert run(tools.disk_usage("web-1")) == "Error: df_not_available"
+
+    def test_pending_updates_apt(self):
+        tools = _tools()
+        stdout = "\n".join([
+            "===APT===",
+            "Inst libssl3 [3.0.2-0ubuntu1.14] "
+            "(3.0.2-0ubuntu1.15 Ubuntu:22.04/jammy-security [amd64])",
+            "Inst vim [2:8.2] (2:8.2.1 Ubuntu:22.04/jammy-updates [amd64])",
+            "===REBOOT===",
+            "yes",
+        ])
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.pending_updates("web-1")))
+        assert payload["manager"] == "apt"
+        assert payload["total_count"] == 2
+        assert payload["security_count"] == 1
+        assert payload["reboot_required"] is True
+        assert payload["sample_packages"] == ["libssl3", "vim"]
+
+    def test_pending_updates_dnf(self):
+        tools = _tools()
+        stdout = "\n".join([
+            "===DNF_SEC===",
+            "FEDORA-2026-abc Important/Sec. openssl-3.0.9-1.x86_64",
+            "===DNF_ALL===",
+            "openssl.x86_64 3.0.9-1 updates",
+            "kernel.x86_64 6.9.1-1 updates",
+            "===REBOOT===",
+            "no",
+        ])
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.pending_updates("web-1")))
+        assert payload["manager"] == "dnf"
+        assert payload["security_count"] == 1
+        assert payload["total_count"] == 2
+        assert payload["reboot_required"] is False
+
+    def test_pending_updates_unsupported_manager(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(
+            return_value=("PKG_MANAGER_NOT_SUPPORTED\n", ""))
+        assert run(tools.pending_updates("web-1")) == (
+            "Error: pkg_manager_not_supported"
+        )
+
+    def test_pending_updates_reboot_unknown_is_null(self):
+        tools = _tools()
+        stdout = "===DNF_SEC===\n===DNF_ALL===\n===REBOOT===\nunknown"
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.pending_updates("web-1")))
+        assert payload["reboot_required"] is None
+
+    def test_journal_errors_probes_current_failed_units(self):
+        tools = _tools()
+        stdout = "\n".join([
+            "===ERR===", "===OOM===", "===RESTARTS===",
+            "===FAILED===",
+            "app-worker.service loaded failed failed App background worker",
+        ])
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.journal_errors("web-1")))
+        assert payload["failed_units"] == [
+            {"unit": "app-worker.service",
+             "description": "App background worker"},
+        ]
+        # The remote script actually asks systemctl for failed units.
+        remote = tools._exec_ssh.await_args.args[1]
+        assert "systemctl --failed" in remote
 
 
 class TestStackSummaryToolFormat:


### PR DESCRIPTION
## Summary
Detector-breadth enablement: read-only probes that give scans signal on any plain Linux box.

- **`disk_usage`** `{instance_id, top_n}` — per-filesystem bytes + inode usage (pseudo-filesystems excluded), fullest mount, and depth-2 top directory consumers under it (`sudo -n` when available). Error sentinel: `df_not_available`.
- **`pending_updates`** `{instance_id}` — security vs total pending package counts, reboot-required state, sample names. apt simulation / dnf updateinfo — read-only, never installs. Error sentinel: `pkg_manager_not_supported`.
- **`journal_errors`** gains an additive `failed_units` field from `systemctl --failed`, catching units whose failure predates the journal lookback window.

All three are readonly-tier on every surface (MCP guard, chat-bridge mirror, unattended-probe policy). The two new tools sit in `CATALOG_PENDING_SERVER` until the server catalog registers them.

## Test plan
- Parser + tool-layer tests for both probes (apt and dnf shapes, sentinels, reboot tri-state), failed-units capture, probe-policy allowance, dispatch-map pin updated.
- Full suite green (6110 passed + the one count-pin converged in this PR).