### PR TITLE
fix(findings): send method= on block_ip preview + execute

### DIFF
--- a/src/servonaut/screens/findings.py
+++ b/src/servonaut/screens/findings.py
@@ -1065,6 +1065,35 @@ class FindingDetailScreen(Screen[bool]):
     # Remediation (Phase 3): preview → typed confirm → execute
     # ------------------------------------------------------------------
 
+    #: Remediation actions the CALLER parameterises — the server needs
+    #: the extra field to build the command + confirm-token hash. block_ip
+    #: needs ``method`` (which IP-ban plane); the ip is derived
+    #: server-side from the finding, never sent by us.
+    _ACTIONS_REQUIRING_METHOD = frozenset({"block_ip"})
+
+    def _resolve_block_ip_method(self) -> tuple:
+        """Return ``(method, error)`` for a block_ip remediation.
+
+        Reads the user's configured IP-ban planes. Exactly one method →
+        use it. Several → pick deterministically; the confirm modal
+        renders the server's ``ban <ip> via <method>`` string and gates
+        on a typed confirmation, so the chosen plane is always visible
+        and cancellable before anything runs. None configured → a
+        slug-style error the caller surfaces instead of calling preview.
+        """
+        svc = getattr(self.app, "ip_ban_service", None)
+        configs = svc.get_configs() if svc is not None else []
+        methods = sorted({
+            c.method for c in configs
+            if getattr(c, "method", None)
+        })
+        if not methods:
+            return None, (
+                "No IP-ban configuration found — add one under "
+                "Settings ▸ IP Ban before blocking an address."
+            )
+        return methods[0], None
+
     def _launch_remediation(
         self, remediation: Dict[str, Any], *, dry_run: bool,
     ) -> None:
@@ -1098,9 +1127,22 @@ class FindingDetailScreen(Screen[bool]):
             return
         finding_id = str(self._finding.get("id") or "")
         action = str(remediation.get("action") or "")
+
+        # Caller-parameterised verbs need an extra field the server folds
+        # into the command hash. Resolve it BEFORE preview so a config gap
+        # is a clear message, not a server 422.
+        method: Optional[str] = None
+        if action in self._ACTIONS_REQUIRING_METHOD:
+            method, method_error = self._resolve_block_ip_method()
+            if method_error:
+                self.app.notify(
+                    method_error, severity="warning", markup=False,
+                )
+                return
+
         try:
             preview = await svc.remediate_preview(
-                finding_id, action, dry_run=dry_run,
+                finding_id, action, dry_run=dry_run, method=method,
             )
         except NotFoundError:
             self.app.notify(
@@ -1150,7 +1192,8 @@ class FindingDetailScreen(Screen[bool]):
                 token = str(preview.get("confirm_token") or "")
                 self.run_worker(
                     self._remediation_execute_worker(
-                        finding_id, action, token, dry_run=dry_run,
+                        finding_id, action, token,
+                        dry_run=dry_run, method=method,
                     ),
                     name="finding_remediation_execute",
                     group="findings_remediation",
@@ -1166,7 +1209,7 @@ class FindingDetailScreen(Screen[bool]):
 
     async def _remediation_execute_worker(
         self, finding_id: str, action: str, confirm_token: str,
-        *, dry_run: bool,
+        *, dry_run: bool, method: Optional[str] = None,
     ) -> None:
         from servonaut.services.api_client import APIError, NotFoundError
 
@@ -1190,7 +1233,8 @@ class FindingDetailScreen(Screen[bool]):
             # the outcome settles in a server-side worker (off the HTTP
             # edge timeout) and is read back by polling the finding.
             await svc.remediate(
-                finding_id, action, confirm_token, dry_run=dry_run,
+                finding_id, action, confirm_token,
+                dry_run=dry_run, method=method,
             )
             self.app.notify(
                 "Remediation is running server-side — waiting for the "

--- a/src/servonaut/services/findings_service.py
+++ b/src/servonaut/services/findings_service.py
@@ -206,6 +206,7 @@ class FindingsService:
 
     async def remediate_preview(
         self, finding_id: str, action: str, *, dry_run: bool = False,
+        method: Optional[str] = None,
     ) -> Dict[str, Any]:
         """GET the server-built preview for one of the finding's own
         remediation actions.
@@ -218,45 +219,62 @@ class FindingsService:
         execute a live run. 422 for an action the finding's playbook
         doesn't offer or that isn't automatable; 403
         ``remediation_tier_not_permitted`` above the configured ceiling.
+
+        ``method`` is required for verbs whose command the CALLER
+        parameterises (``block_ip``: waf|security_group|nacl — the ip
+        itself is derived server-side from the finding, never sent). It
+        is folded into the command hash the token signs, so the same
+        value MUST be replayed on :meth:`remediate`. Omit for verbs the
+        server fully specifies (e.g. ``certbot_renew``); a missing
+        ``method`` on ``block_ip`` returns 422 ``block_ip_method_required``.
         """
         safe_id = _validate_finding_id(finding_id)
         safe_action = _validate_remediation_action(action)
         params: Dict[str, Any] = {"action": safe_action}
         if dry_run:
             params["dry_run"] = 1
+        if method:
+            params["method"] = method
         return await self._api.get(
             f"{_BASE}/{safe_id}/remediate/preview", params=params,
         )
 
     async def remediate(
         self, finding_id: str, action: str, confirm_token: str,
-        *, dry_run: bool = False,
+        *, dry_run: bool = False, method: Optional[str] = None,
     ) -> Dict[str, Any]:
         """POST the confirmed remediation; returns immediately (async).
 
         ``confirm_token`` must be the token issued by
         :meth:`remediate_preview` and ``dry_run`` must match the
         previewed variant (it is bound into the token's command hash).
-        The server gates + atomically claims ``remediating`` + audits
-        synchronously, enqueues the (possibly long) command to a worker,
-        and returns 202 ``{accepted, finding_id, status:"remediating",
-        dry_run, action, poll}`` — it no longer blocks on the relay
-        round-trip (which would exceed the HTTP edge timeout on a slow
-        renew). Read the outcome via :meth:`await_remediation_outcome`.
-        Synchronous gate failures still raise before the 202: 402
-        (entitlement), 403 (tier/disabled), 409 (bad status / token used).
+        ``method`` MUST be the same value passed to the matching
+        preview: the server recomputes the command hash the token is
+        signed over, and for ``block_ip`` that hash includes the method
+        — replaying it here is what makes the token verify. Omit it for
+        server-specified verbs. The server gates + atomically claims
+        ``remediating`` + audits synchronously, enqueues the (possibly
+        long) command to a worker, and returns 202 ``{accepted,
+        finding_id, status:"remediating", dry_run, action, poll}`` — it
+        no longer blocks on the relay round-trip (which would exceed the
+        HTTP edge timeout on a slow renew). Read the outcome via
+        :meth:`await_remediation_outcome`. Synchronous gate failures
+        still raise before the 202: 402 (entitlement), 403
+        (tier/disabled), 409 (bad status / token used).
         """
         safe_id = _validate_finding_id(finding_id)
         safe_action = _validate_remediation_action(action)
         if not isinstance(confirm_token, str) or not confirm_token:
             raise ValueError("confirm_token is required")
+        body: Dict[str, Any] = {
+            "action": safe_action,
+            "dry_run": bool(dry_run),
+            "confirm_token": confirm_token,
+        }
+        if method:
+            body["method"] = method
         return await self._api.post(
-            f"{_BASE}/{safe_id}/remediate",
-            json={
-                "action": safe_action,
-                "dry_run": bool(dry_run),
-                "confirm_token": confirm_token,
-            },
+            f"{_BASE}/{safe_id}/remediate", json=body,
         )
 
     async def get_finding(self, finding_id: str) -> Dict[str, Any]:

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -121,11 +121,13 @@ def _mock_findings_service(findings=None, total=None) -> MagicMock:
 class _WrapperApp(App):
     """Minimal host exposing the services the screens read off self.app."""
 
-    def __init__(self, *, screen, auth, findings_service, **kwargs):
+    def __init__(self, *, screen, auth, findings_service,
+                 ip_ban_service=None, **kwargs):
         super().__init__(**kwargs)
         self._initial_screen = screen
         self.auth_service = auth
         self.findings_service = findings_service
+        self.ip_ban_service = ip_ban_service
         self.instances = [
             {"id": "i-0000test01", "name": "web-1"},
         ]
@@ -429,7 +431,8 @@ class TestFindingDetailScreen:
             button.press()
             await pilot.pause(0.1)
             svc.remediate_preview.assert_awaited_once_with(
-                "fnd_01abc", "harden_sshd_password_auth", dry_run=False,
+                "fnd_01abc", "harden_sshd_password_auth",
+                dry_run=False, method=None,
             )
             # The confirm modal is on top; nothing has executed.
             from servonaut.screens.remediation_confirm import (
@@ -440,6 +443,80 @@ class TestFindingDetailScreen:
             # The server's byte-for-byte command string renders verbatim.
             text = _rendered_text(app)
             assert "sudo -n sshd-harden --password-auth no" in text
+
+    @pytest.mark.asyncio
+    async def test_block_ip_resolves_method_from_config_and_sends_it(self):
+        # Regression: block_ip preview must carry method= (the ban plane)
+        # or the server 422s block_ip_method_required. The method comes
+        # from the user's configured IP-ban plane, not the finding.
+        finding = _finding(remediations=[{
+            "label": "Block the source IP",
+            "description": "Block the offending ip at the firewall.",
+            "action": "block_ip",
+            "risk_tier": "medium",
+            "reversible": True,
+            "automatable": True,
+        }])
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock(return_value={
+            "finding_id": "fnd_01abc", "action": "block_ip",
+            "exec_risk": "low", "reversible": True, "dry_run": False,
+            "command": {"verb": "block_ip",
+                        "human": "ban 9.9.9.9 via security_group"},
+            "confirm_token": "tok-signed",
+            "expires_at": "2026-07-04T14:00:00Z",
+        })
+        ip_ban = MagicMock()
+        ip_ban.get_configs = MagicMock(return_value=[
+            MagicMock(method="security_group"),
+        ])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            ip_ban_service=ip_ban,
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            svc.remediate_preview.assert_awaited_once_with(
+                "fnd_01abc", "block_ip",
+                dry_run=False, method="security_group",
+            )
+
+    @pytest.mark.asyncio
+    async def test_block_ip_without_config_warns_and_skips_preview(self):
+        finding = _finding(remediations=[{
+            "label": "Block the source IP",
+            "description": "Block the offending ip at the firewall.",
+            "action": "block_ip",
+            "risk_tier": "medium",
+            "reversible": True,
+            "automatable": True,
+        }])
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock()
+        ip_ban = MagicMock()
+        ip_ban.get_configs = MagicMock(return_value=[])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            ip_ban_service=ip_ban,
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            # No config → no server round-trip that would 422.
+            svc.remediate_preview.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_confirm_modal_executes_only_after_typed_phrase(self):
@@ -491,7 +568,7 @@ class TestFindingDetailScreen:
             await pilot.pause(0.1)
             svc.remediate.assert_awaited_once_with(
                 "fnd_01abc", "harden_sshd_password_auth", "tok-signed",
-                dry_run=False,
+                dry_run=False, method=None,
             )
             svc.await_remediation_outcome.assert_awaited_once_with(
                 "fnd_01abc", instance="i-0000test01",
@@ -550,7 +627,7 @@ class TestFindingDetailScreen:
             await pilot.pause(0.1)
             svc.remediate.assert_awaited_once_with(
                 "fnd_01abc", "harden_sshd_password_auth", "tok-dry",
-                dry_run=True,
+                dry_run=True, method=None,
             )
             # Status untouched; a dry run never mutates.
             assert screen._finding["status"] == "detected"

--- a/tests/test_findings_service.py
+++ b/tests/test_findings_service.py
@@ -230,6 +230,40 @@ class TestRemediation:
         params = api.get.await_args.kwargs["params"]
         assert params["dry_run"] == 1
 
+    def test_preview_sends_method_for_block_ip(self):
+        # block_ip's command hash includes the ban plane — the preview
+        # GET must carry method= or the server 422s block_ip_method_required.
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate_preview(
+            "fnd_01abc", "block_ip", method="security_group",
+        ))
+        params = api.get.await_args.kwargs["params"]
+        assert params["method"] == "security_group"
+        assert params["action"] == "block_ip"
+
+    def test_preview_omits_method_when_none(self):
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate_preview("fnd_01abc", "renew_certificate"))
+        assert "method" not in api.get.await_args.kwargs["params"]
+
+    def test_execute_replays_method_in_body(self):
+        # Same method must be replayed so the server recomputes the hash
+        # the confirm_token was signed over.
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate(
+            "fnd_01abc", "block_ip", "tok-signed", method="waf",
+        ))
+        assert api.post.await_args.kwargs["json"]["method"] == "waf"
+
+    def test_execute_omits_method_when_none(self):
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate("fnd_01abc", "renew_certificate", "tok-signed"))
+        assert "method" not in api.post.await_args.kwargs["json"]
+
     def test_execute_post_shape(self):
         api = _mock_api()
         svc = FindingsService(api)


### PR DESCRIPTION
## Root cause
`block_ip` is the first remediation verb the **caller** parameterises: the server folds the ban plane (`method`) into the command hash the confirm token is signed over. But `remediate_preview`/`remediate` only sent `{action, dry_run}`, so every `block_ip` preview returned **422 `block_ip_method_required`** — the verb was uninvokable despite the executor (PR #63) being fully wired.

Verified against staging by hitting the preview endpoint directly: the same GET that 422'd returns a **200 signed preview** (`ban <ip> via <method>`, confirm token) the moment `method` is supplied.

## Fix
- `remediate_preview`/`remediate` accept an optional `method`, sent on the preview query and replayed in the execute body (so the server's hash recompute verifies the token). Omitted for server-specified verbs like `certbot_renew` — no regression.
- The findings screen resolves `method` from the user's configured IP-ban plane **before** previewing; no config → a clear "add an IP-ban configuration" message instead of a server 422. When several planes are configured it picks deterministically and the confirm modal's visible `via <method>` + typed-RUN gate keeps the choice cancellable.
- The IP itself stays **server-derived** from the finding's evidence — never sent by the client.

## Test plan
- New service tests: method sent on block_ip preview + execute, omitted when None.
- New screen tests: block_ip resolves method from config and sends it; no config warns and skips the preview round-trip.
- Existing preview/execute assertions updated for the new `method=None` kwarg. Full suite green.