### PR TITLE
feat(mcp): fail2ban-awareness in auth_log_summary

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -6055,7 +6055,34 @@ class ServonautTools:
             '{ journalctl -u ssh -u sshd --since "$S" --no-pager 2>/dev/null '
             '|| sudo -n journalctl -u ssh -u sshd --since "$S" --no-pager '
             '2>/dev/null; } | tail -n 20000; '
-            'else echo AUTH_LOG_NOT_AVAILABLE; fi; true'
+            'else echo AUTH_LOG_NOT_AVAILABLE; fi; '
+            # Additive fail2ban block — what's ALREADY mitigated, so the
+            # detector can separate already-banned IPs from the ones still
+            # getting through. A fail2ban read failure NULLs the block; it
+            # must never sink the auth-log data above.
+            'echo "===FAIL2BAN==="; '
+            'if command -v fail2ban-client >/dev/null 2>&1; then '
+            'echo "INSTALLED=true"; '
+            'echo "ACTIVE=$(systemctl is-active fail2ban 2>/dev/null '
+            '|| echo unknown)"; '
+            'FB=""; '
+            'if fail2ban-client status >/dev/null 2>&1; then '
+            'FB="fail2ban-client"; '
+            'elif sudo -n fail2ban-client status >/dev/null 2>&1; then '
+            'FB="sudo -n fail2ban-client"; fi; '
+            'if [ -n "$FB" ]; then '
+            'echo "MAXRETRY=$($FB get sshd maxretry 2>/dev/null)"; '
+            'echo "FINDTIME=$($FB get sshd findtime 2>/dev/null)"; '
+            'echo "BANTIME=$($FB get sshd bantime 2>/dev/null)"; '
+            'ST=$($FB status sshd 2>/dev/null); '
+            'if [ -n "$ST" ]; then echo "JAIL_ACTIVE=true"; '
+            'else echo "JAIL_ACTIVE=false"; fi; '
+            'echo "$ST" | grep -i "banned ip list" '
+            '| sed "s/.*[Bb]anned IP list:[[:space:]]*//" '
+            '| sed "s/^/BANNED=/"; '
+            'else echo "CLIENT_UNREADABLE=true"; fi; '
+            'else echo "INSTALLED=false"; fi; '
+            'true'
         )
         try:
             stdout, _stderr = await self._exec_ssh(instance, remote, timeout=90)

--- a/src/servonaut/utils/system_probe.py
+++ b/src/servonaut/utils/system_probe.py
@@ -11,7 +11,8 @@ wire shapes pinned in the proactive-monitoring tool contract:
   days_left, issuer, self_signed}]}``
 - ``auth_log_summary``  → ``{failed_logins: [{ip, user, count,
   method}], invalid_users: [{ip, count}], accepted_logins: [{ip, user,
-  count, method}]}``
+  count, method}], fail2ban?: {installed, active, ssh_jail, banned_ips}}``
+  (``fail2ban`` present only when the probe emitted the section)
 - ``disk_usage``        → ``{filesystems: [{mount, size_bytes,
   used_pct, inodes_used_pct}], fullest_mount, top_consumers: [{path,
   size_bytes}]}``
@@ -212,12 +213,80 @@ def parse_tls_certs(stdout: str, *, now: Optional[datetime] = None) -> List[Dict
     return certs
 
 
+def _int_or_none(value: str) -> Optional[int]:
+    try:
+        return int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_fail2ban(lines: List[str], top_n: int = 20) -> Dict[str, Any]:
+    """Parse the ``===FAIL2BAN===`` section (key=value lines the probe
+    emits) into the additive block.
+
+    ``active``/``ssh_jail`` are ``None`` when undeterminable (fail2ban
+    installed but the client socket is unreadable even via ``sudo -n``)
+    — never a misleading ``False``. ``banned_ips`` is bounded to
+    ``top_n``.
+    """
+    block: Dict[str, Any] = {
+        "installed": False, "active": None,
+        "ssh_jail": None, "banned_ips": [],
+    }
+    jail: Dict[str, Any] = {}
+    banned: List[str] = []
+    jail_readable = False
+    for raw in lines:
+        line = raw.strip()
+        if line == "INSTALLED=true":
+            block["installed"] = True
+        elif line == "INSTALLED=false":
+            block["installed"] = False
+        elif line.startswith("ACTIVE="):
+            state = line.split("=", 1)[1].strip()
+            block["active"] = True if state == "active" else (
+                False if state in ("inactive", "failed") else None
+            )
+        elif line == "CLIENT_UNREADABLE=true":
+            jail_readable = False
+        elif line.startswith("MAXRETRY="):
+            jail["maxretry"] = _int_or_none(line.split("=", 1)[1])
+            jail_readable = True
+        elif line.startswith("FINDTIME="):
+            jail["findtime"] = _int_or_none(line.split("=", 1)[1])
+        elif line.startswith("BANTIME="):
+            jail["bantime"] = _int_or_none(line.split("=", 1)[1])
+        elif line.startswith("JAIL_ACTIVE="):
+            jail["active"] = line.split("=", 1)[1].strip() == "true"
+        elif line.startswith("BANNED="):
+            banned.extend(line.split("=", 1)[1].split())
+    if jail_readable:
+        block["ssh_jail"] = {
+            "active": jail.get("active", False),
+            "maxretry": jail.get("maxretry"),
+            "findtime": jail.get("findtime"),
+            "bantime": jail.get("bantime"),
+        }
+    block["banned_ips"] = banned[:max(1, top_n)]
+    return block
+
+
 def summarize_auth_log(stdout: str, top_n: int = 20) -> Dict[str, Any]:
-    """sshd auth-log lines → grouped failed / invalid-user / accepted rows."""
+    """sshd auth-log lines → grouped failed / invalid-user / accepted rows.
+
+    When the probe emits a ``===FAIL2BAN===`` section, an additive
+    ``fail2ban`` block is included (what's already mitigated on the box).
+    Older probes omit the section → no ``fail2ban`` key (the detector
+    reads it as "not probed").
+    """
     failed: Dict[tuple, Dict[str, Any]] = {}
     invalid: Dict[str, Dict[str, Any]] = {}
     accepted: Dict[tuple, Dict[str, Any]] = {}
 
+    sections = _split_sections(stdout)
+    # The auth regexes are specific enough that scanning the whole stream
+    # (markers + fail2ban lines never match them) is safe and keeps the
+    # journald/file paths identical.
     for line in stdout.splitlines():
         m = _FAILED_RE.search(line)
         if m:
@@ -245,11 +314,14 @@ def summarize_auth_log(stdout: str, top_n: int = 20) -> Dict[str, Any]:
     by_count = lambda rows: sorted(  # noqa: E731 — tiny local sort key
         rows, key=lambda r: r["count"], reverse=True,
     )[:top]
-    return {
+    result: Dict[str, Any] = {
         "failed_logins": by_count(list(failed.values())),
         "invalid_users": by_count(list(invalid.values())),
         "accepted_logins": by_count(list(accepted.values())),
     }
+    if "FAIL2BAN" in sections:
+        result["fail2ban"] = _parse_fail2ban(sections["FAIL2BAN"], top_n)
+    return result
 
 
 def parse_disk_usage(stdout: str, top_n: int = 20) -> Dict[str, Any]:

--- a/tests/test_system_probe_tools.py
+++ b/tests/test_system_probe_tools.py
@@ -173,6 +173,86 @@ class TestSummarizeAuthLog:
         out = summarize_auth_log("\n".join(lines), top_n=5)
         assert len(out["failed_logins"]) == 5
 
+    def test_no_fail2ban_section_omits_key(self):
+        # Older probe / no section → the detector reads absence as
+        # "not probed", so we must NOT invent an empty block.
+        out = summarize_auth_log("sshd[1]: Failed password for x from 9.9.9.9 port 1 ssh2")
+        assert "fail2ban" not in out
+
+    def test_fail2ban_installed_active_with_bans(self):
+        stdout = "\n".join([
+            "sshd[1]: Failed password for root from 9.9.9.9 port 1 ssh2",
+            "===FAIL2BAN===",
+            "INSTALLED=true",
+            "ACTIVE=active",
+            "MAXRETRY=5",
+            "FINDTIME=600",
+            "BANTIME=3600",
+            "JAIL_ACTIVE=true",
+            "BANNED=1.2.3.4 5.6.7.8 9.9.9.9",
+        ])
+        f2b = summarize_auth_log(stdout)["fail2ban"]
+        assert f2b["installed"] is True
+        assert f2b["active"] is True
+        assert f2b["ssh_jail"] == {
+            "active": True, "maxretry": 5, "findtime": 600, "bantime": 3600,
+        }
+        assert f2b["banned_ips"] == ["1.2.3.4", "5.6.7.8", "9.9.9.9"]
+        # The auth data is untouched by the added section.
+        assert summarize_auth_log(stdout)["failed_logins"][0]["ip"] == "9.9.9.9"
+
+    def test_fail2ban_not_installed(self):
+        stdout = "===FAIL2BAN===\nINSTALLED=false"
+        f2b = summarize_auth_log(stdout)["fail2ban"]
+        assert f2b["installed"] is False
+        assert f2b["ssh_jail"] is None
+        assert f2b["banned_ips"] == []
+
+    def test_fail2ban_client_unreadable_nulls_jail_not_active(self):
+        # Installed + service active, but the client socket needs root we
+        # don't have → active known, jail unreadable (null), never a
+        # misleading empty jail.
+        stdout = "\n".join([
+            "===FAIL2BAN===",
+            "INSTALLED=true",
+            "ACTIVE=active",
+            "CLIENT_UNREADABLE=true",
+        ])
+        f2b = summarize_auth_log(stdout)["fail2ban"]
+        assert f2b["installed"] is True
+        assert f2b["active"] is True
+        assert f2b["ssh_jail"] is None
+        assert f2b["banned_ips"] == []
+
+    def test_fail2ban_inactive_service(self):
+        stdout = "===FAIL2BAN===\nINSTALLED=true\nACTIVE=inactive"
+        f2b = summarize_auth_log(stdout)["fail2ban"]
+        assert f2b["active"] is False
+
+    def test_fail2ban_unparseable_jail_values_are_null(self):
+        stdout = "\n".join([
+            "===FAIL2BAN===",
+            "INSTALLED=true",
+            "ACTIVE=active",
+            "MAXRETRY=",
+            "FINDTIME=notanumber",
+            "BANTIME=3600",
+            "JAIL_ACTIVE=true",
+        ])
+        jail = summarize_auth_log(stdout)["fail2ban"]["ssh_jail"]
+        assert jail["maxretry"] is None
+        assert jail["findtime"] is None
+        assert jail["bantime"] == 3600
+
+    def test_fail2ban_banned_ips_bounded(self):
+        bans = " ".join(f"10.0.0.{i}" for i in range(30))
+        stdout = "\n".join([
+            "===FAIL2BAN===", "INSTALLED=true", "ACTIVE=active",
+            "JAIL_ACTIVE=true", "MAXRETRY=5", f"BANNED={bans}",
+        ])
+        f2b = summarize_auth_log(stdout, top_n=10)["fail2ban"]
+        assert len(f2b["banned_ips"]) == 10
+
 
 # ---------------------------------------------------------------------------
 # Stack-summary projection
@@ -289,6 +369,24 @@ class TestSystemProbeToolLayer:
         tools._exec_ssh = AsyncMock(
             return_value=("AUTH_LOG_NOT_AVAILABLE\n", ""))
         assert run(tools.auth_log_summary("web-1")) == "Error: auth_log_not_available"
+
+    def test_auth_log_probe_queries_fail2ban(self):
+        tools = _tools()
+        stdout = "\n".join([
+            "===AUTHLOG:/var/log/auth.log===",
+            "sshd[1]: Failed password for root from 9.9.9.9 port 1 ssh2",
+            "===FAIL2BAN===",
+            "INSTALLED=true", "ACTIVE=active", "JAIL_ACTIVE=true",
+            "MAXRETRY=5", "BANNED=1.2.3.4 5.6.7.8",
+        ])
+        tools._exec_ssh = AsyncMock(return_value=(stdout, ""))
+        payload = json.loads(run(tools.auth_log_summary("web-1")))
+        assert payload["fail2ban"]["banned_ips"] == ["1.2.3.4", "5.6.7.8"]
+        assert payload["failed_logins"][0]["ip"] == "9.9.9.9"
+        # The probe actually asks the box about fail2ban.
+        remote = tools._exec_ssh.await_args.args[1]
+        assert "fail2ban-client" in remote
+        assert "===FAIL2BAN===" in remote
 
     def test_probe_policy_allows_new_tools(self):
         from servonaut.services.relay_listener import probe_tool_allowed


### PR DESCRIPTION
## Summary
The brute-force detector is currently fail2ban-blind: it surfaces attack attempts with no awareness of what the box already blocks. On a box running fail2ban, that means nagging to `block_ip` addresses fail2ban already bans, while the genuinely-unmitigated low-volume sweeps get buried in the same list.

This adds an **additive `fail2ban` block** to the `auth_log_summary` probe so the (server-side) detector can demote already-banned IPs to informational and elevate the ones still getting through.

- Probe reads `systemctl is-active fail2ban` + `fail2ban-client status sshd` / `get sshd maxretry|findtime|bantime` with a `sudo -n` fallback. A fail2ban read failure **nulls the block and never sinks the auth-log data**.
- **Arg schema unchanged** — no ToolCatalog or relay-contract change. Older probes omit the section; the detector reads absence as "not probed."
- Wire shape (pinned with the backend): `{installed, active: bool|null, ssh_jail: {active, maxretry, findtime, bantime}|null, banned_ips: []}`. `active`/`ssh_jail` are null when undeterminable (client socket unreadable even via sudo) — never a misleading false/empty.

## Test plan
- Parser tests: installed+active with bans, not-installed, client-unreadable (nulls jail, keeps active), inactive service, unparseable jail values → null, banned-IP bounding, and no-section → key omitted.
- Tool-layer test: the probe emits the `===FAIL2BAN===` section and end-to-end parse works alongside the auth data.
- Full suite green (6173 passed).