### PR TITLE
feat(findings): on-box block_ip methods (nftables/ufw/firewalld)

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -6110,6 +6110,42 @@ class ServonautTools:
         self._audit.log('auth_log_summary', args, f"{len(result)} chars", True)
         return result
 
+    async def detect_onbox_firewall(self, instance_id: str) -> str:
+        """Detect the box's ACTIVE firewall for on-box IP blocking.
+
+        Returns one of ``"ufw"`` / ``"firewalld"`` / ``"nftables"`` (the
+        block_ip on-box method to use) or ``"none"`` when no usable
+        firewall is active, or ``"unknown"`` when the box can't be
+        reached. Read-only — probes tool availability + active state, in
+        preference order ufw → firewalld → nftables (ufw/firewalld are
+        managed frontends and preferred when running; nftables is the
+        universal fallback). Not a registered MCP tool: a helper the
+        findings screen calls to parameterise a block_ip preview on a
+        non-AWS instance.
+        """
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            return "unknown"
+        remote = (
+            'if command -v ufw >/dev/null 2>&1 && '
+            '{ ufw status 2>/dev/null || sudo -n ufw status 2>/dev/null; } '
+            '| grep -qi "status: active"; then echo ufw; '
+            'elif command -v firewall-cmd >/dev/null 2>&1 && '
+            '{ firewall-cmd --state 2>/dev/null '
+            '|| sudo -n firewall-cmd --state 2>/dev/null; } '
+            '| grep -qi running; then echo firewalld; '
+            'elif command -v nft >/dev/null 2>&1; then echo nftables; '
+            'else echo none; fi'
+        )
+        try:
+            stdout, _stderr = await self._exec_ssh(instance, remote, timeout=30)
+        except Exception:  # noqa: BLE001 — detection is best-effort
+            return "unknown"
+        token = stdout.strip().splitlines()[-1].strip() if stdout.strip() else ""
+        return token if token in {
+            "ufw", "firewalld", "nftables", "none",
+        } else "unknown"
+
     async def docker_log_summary(
         self, instance_id: str, container: str,
         since_minutes: int = 1440, top_n: int = 20,

--- a/src/servonaut/screens/findings.py
+++ b/src/servonaut/screens/findings.py
@@ -1071,28 +1071,63 @@ class FindingDetailScreen(Screen[bool]):
     #: server-side from the finding, never sent by us.
     _ACTIONS_REQUIRING_METHOD = frozenset({"block_ip"})
 
-    def _resolve_block_ip_method(self) -> tuple:
+    def _find_finding_instance(self) -> Optional[Dict[str, Any]]:
+        """Locate the finding's instance in the merged fleet list."""
+        instance_id = str(self._finding.get("instance_id") or "")
+        for inst in getattr(self.app, "instances", None) or []:
+            if inst.get("id") == instance_id or inst.get("name") == instance_id:
+                return inst
+        return None
+
+    async def _resolve_block_ip_method(self) -> tuple:
         """Return ``(method, error)`` for a block_ip remediation.
 
-        Reads the user's configured IP-ban planes. Exactly one method →
-        use it. Several → pick deterministically; the confirm modal
-        renders the server's ``ban <ip> via <method>`` string and gates
-        on a typed confirmation, so the chosen plane is always visible
-        and cancellable before anything runs. None configured → a
-        slug-style error the caller surfaces instead of calling preview.
+        AWS instances ban at the control plane — the method comes from a
+        configured IP-ban plane (WAF/SG/NACL). Non-AWS/custom instances
+        (OVH, bare metal) can't be shielded by AWS WAF, so we SSH-detect
+        the box's active firewall and ban ON the box (nftables/ufw/
+        firewalld). Either way the confirm modal renders the server's
+        ``ban <ip> via <method>`` string and gates on a typed
+        confirmation, so the chosen plane is always visible and
+        cancellable. A resolution failure returns a slug-style error the
+        caller surfaces instead of calling preview.
         """
-        svc = getattr(self.app, "ip_ban_service", None)
-        configs = svc.get_configs() if svc is not None else []
-        methods = sorted({
-            c.method for c in configs
-            if getattr(c, "method", None)
-        })
-        if not methods:
+        instance = self._find_finding_instance()
+        is_custom = bool(instance and instance.get("is_custom"))
+
+        if not is_custom:
+            svc = getattr(self.app, "ip_ban_service", None)
+            configs = svc.get_configs() if svc is not None else []
+            methods = sorted({
+                c.method for c in configs if getattr(c, "method", None)
+            })
+            if not methods:
+                return None, (
+                    "No IP-ban configuration found — add one under "
+                    "Settings ▸ IP Ban before blocking an address."
+                )
+            return methods[0], None
+
+        # On-box: detect the active firewall on the target.
+        tools = getattr(self.app, "servonaut_tools", None)
+        if tools is None or not hasattr(tools, "detect_onbox_firewall"):
             return None, (
-                "No IP-ban configuration found — add one under "
-                "Settings ▸ IP Ban before blocking an address."
+                "Can't detect the box's firewall in this session — "
+                "on-box blocking is unavailable here."
             )
-        return methods[0], None
+        instance_id = str(self._finding.get("instance_id") or "")
+        detected = await tools.detect_onbox_firewall(instance_id)
+        if detected in ("nftables", "ufw", "firewalld"):
+            return detected, None
+        if detected == "none":
+            return None, (
+                "No active firewall found on this box (ufw/firewalld/"
+                "nftables) — can't apply an on-box IP ban."
+            )
+        return None, (
+            "Couldn't reach the box to detect its firewall — check the "
+            "connection and try again."
+        )
 
     def _launch_remediation(
         self, remediation: Dict[str, Any], *, dry_run: bool,
@@ -1133,7 +1168,7 @@ class FindingDetailScreen(Screen[bool]):
         # is a clear message, not a server 422.
         method: Optional[str] = None
         if action in self._ACTIONS_REQUIRING_METHOD:
-            method, method_error = self._resolve_block_ip_method()
+            method, method_error = await self._resolve_block_ip_method()
             if method_error:
                 self.app.notify(
                     method_error, severity="warning", markup=False,

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -1066,6 +1066,14 @@ class RelayListener:
         except RemediationValidationError as exc:
             return "error", "", str(exc)
 
+        from servonaut.services.remediation_executor import (
+            ONBOX_BLOCK_METHODS,
+        )
+        if method in ONBOX_BLOCK_METHODS:
+            return await self._execute_onbox_block(
+                raw, payload, ip, method,
+            )
+
         # Resolve the IPBanConfig for the requested method, preferring a
         # region match (envelope region, else the instance's region).
         svc = self._executors.ip_ban_service
@@ -1123,6 +1131,93 @@ class RelayListener:
         output = build_remediation_result(
             verb="block_ip", ok=False, exit_code=1, output=message,
             payload=payload, slug="block_ip_failed", extra=extra,
+        )
+        return "success", output, ""
+
+    async def _execute_onbox_block(
+        self, raw: dict, payload: dict, ip: str, method: str,
+    ) -> tuple:
+        """Execute an on-box firewall ban (nftables / ufw / firewalld).
+
+        Unlike the AWS methods (IPBanService/boto3), this runs the box's
+        own firewall tool over the relay SSH path — argv built LOCALLY
+        from the validated ip, never server text — and judges success on
+        the remote exit code via the exit marker (the command's final
+        VERIFY step makes a repeat ban an idempotent success). The unban
+        handle is the ip itself.
+        """
+        from servonaut.services.remediation_executor import (
+            build_onbox_block_command,
+            build_remediation_result,
+            classify_failure,
+            coerce_dry_run,
+            parse_exit_marker,
+            wrap_with_exit_marker,
+        )
+
+        extra = {"strategy": method, "ip": ip}
+        if coerce_dry_run(payload):
+            output = build_remediation_result(
+                verb="block_ip", ok=True, exit_code=0,
+                output=f"DRY RUN - would ban {ip} via {method} (no change made)",
+                payload=payload,
+                extra={**extra, "rule_id": None, "would_ban": True},
+            )
+            return "success", output, ""
+
+        target = str(raw.get("target_server_id") or "")
+        if not target:
+            return "error", "", (
+                "block_ip_target_missing: on-box firewall ban needs a "
+                "target instance to run the command on"
+            )
+
+        command = build_onbox_block_command(method, ip)
+        try:
+            ttl = int(payload.get("timeout_seconds") or 120)
+        except (TypeError, ValueError):
+            ttl = 120
+        marker_nonce = secrets.token_hex(8)
+        request = CommandRequest(
+            id=str(raw.get("id") or ""),
+            user_id=str(raw.get("user_id") or self._user_id),
+            type=CommandType.RUN_COMMAND,
+            target_server_id=target,
+            payload={"command": wrap_with_exit_marker(command, marker_nonce)},
+            ttl_seconds=ttl,
+        )
+        try:
+            response = await self._executors.execute(request)
+        except Exception as exc:  # noqa: BLE001 — must still answer
+            logger.exception("on-box block_ip failed to execute: %s", exc)
+            return "error", "", f"remediation_execution_failed: {exc}"
+
+        if response.status == "timeout":
+            output = build_remediation_result(
+                verb="block_ip", ok=False, exit_code=None, output="",
+                payload=payload, slug="remediation_timeout", extra=extra,
+            )
+            return "success", output, ""
+        if response.status != "success":
+            return "error", "", (
+                "remediation_execution_failed: "
+                f"{response.error_message or response.status}"
+            )
+
+        exit_code, cleaned = parse_exit_marker(response.output, marker_nonce)
+        # The command's VERIFY step exits 0 iff the ip is now in the active
+        # ruleset — so exit 0 = banned (whether freshly or already), and
+        # the ip is its own stable unban handle.
+        if exit_code == 0:
+            output = build_remediation_result(
+                verb="block_ip", ok=True, exit_code=0, output=cleaned,
+                payload=payload, extra={**extra, "rule_id": ip},
+            )
+            return "success", output, ""
+        slug = classify_failure("block_ip", exit_code, cleaned)
+        output = build_remediation_result(
+            verb="block_ip", ok=False, exit_code=exit_code, output=cleaned,
+            payload=payload, slug=slug, extra=extra,
         )
         return "success", output, ""
 

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -48,10 +48,26 @@ assert not (SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS), (
     "a remediation verb cannot be both SSH-command and local-dispatch"
 )
 
-#: Ban mechanisms the ``block_ip`` envelope may request. Must name an
-#: :class:`IPBanConfig` method this CLI actually has configured — the
-#: listener resolves the config and refuses when none matches.
-BLOCK_IP_METHODS = frozenset({"waf", "security_group", "nacl"})
+#: AWS control-plane ban methods — dispatched to :class:`IPBanService`
+#: (WAF / security group / NACL boto3 strategies), gated on a configured
+#: :class:`IPBanConfig`. These never touch the target box.
+AWS_BLOCK_METHODS = frozenset({"waf", "security_group", "nacl"})
+
+#: On-box firewall ban methods — dispatched as an SSH command that runs
+#: the box's own firewall tool (like ``certbot_renew``'s SSH path), argv
+#: built LOCALLY from the validated IP, never server text. These are the
+#: only methods that actually protect a non-AWS box (WAF can't shield an
+#: OVH/bare-metal host). The unban handle is the IP itself.
+ONBOX_BLOCK_METHODS = frozenset({"nftables", "ufw", "firewalld"})
+
+#: Ban mechanisms the ``block_ip`` envelope may request. AWS methods
+#: resolve an :class:`IPBanConfig`; on-box methods run on the target via
+#: the relay. Kept in lockstep with the server-side method enum.
+BLOCK_IP_METHODS = AWS_BLOCK_METHODS | ONBOX_BLOCK_METHODS
+
+assert not (AWS_BLOCK_METHODS & ONBOX_BLOCK_METHODS), (
+    "a block_ip method cannot be both AWS-plane and on-box"
+)
 
 #: Marker echoed after the remote command so the caller can recover the
 #: exit code from stdout (the SSH seam doesn't expose it directly).
@@ -196,6 +212,68 @@ def validate_block_ip_payload(
             f"{allowed}",
         )
     return canonical, method
+
+
+def build_onbox_block_command(method: str, ip: str) -> str:
+    """Build the on-box firewall ban command for an ON-BOX ``block_ip``
+    method (nftables / ufw / firewalld).
+
+    ``ip`` MUST already be canonicalised + validated by
+    :func:`validate_block_ip_payload` (a strict single public address, no
+    CIDR, no shell metacharacters) — this builder interpolates it into
+    the firewall syntax and does NOT re-parse it. Every method ends with
+    a VERIFY step (``grep`` the active ruleset for the ip) so the exit
+    code means "the ip is now blocked" — making a repeat ban an
+    idempotent success rather than a duplicate-rule error, and a
+    silently-failed ban (e.g. no ``sudo -n``) a clean failure.
+
+    All firewall writes go through ``sudo -n`` (non-interactive) with the
+    same posture as the other probes; a password prompt fails closed.
+    """
+    if method not in ONBOX_BLOCK_METHODS:
+        raise RemediationValidationError(
+            f"invalid_block_ip_method: {method!r} is not an on-box "
+            f"firewall method",
+        )
+    is_v6 = ipaddress.ip_address(ip).version == 6
+    if method == "ufw":
+        # ufw takes v4/v6 transparently; it skips a duplicate rule (exit 0).
+        return (
+            f"sudo -n ufw deny from {ip} to any; "
+            f"sudo -n ufw status | grep -qF '{ip}'"
+        )
+    if method == "firewalld":
+        fam = "ipv6" if is_v6 else "ipv4"
+        rule = f'rule family="{fam}" source address="{ip}" drop'
+        return (
+            f"sudo -n firewall-cmd --add-rich-rule='{rule}'; "
+            f"sudo -n firewall-cmd --permanent --add-rich-rule='{rule}'; "
+            f"sudo -n firewall-cmd --list-rich-rules | grep -qF '{ip}'"
+        )
+    # nftables: a dedicated servonaut_ban table/set/chain/drop-rule,
+    # bootstrapped ONCE (guarded on table existence so a repeat ban never
+    # appends a duplicate drop rule), then the ip added as a set element
+    # (idempotent). Separate v4/v6 sets keep the address types clean.
+    set_name = "banned6" if is_v6 else "banned4"
+    addr_type = "ipv6_addr" if is_v6 else "ipv4_addr"
+    saddr = "ip6 saddr" if is_v6 else "ip saddr"
+    bootstrap = (
+        "sudo -n nft add table inet servonaut_ban; "
+        f"sudo -n nft add set inet servonaut_ban {set_name} "
+        f"'{{ type {addr_type}; flags interval; }}'; "
+        "sudo -n nft add chain inet servonaut_ban input "
+        "'{ type filter hook input priority -100; policy accept; }'; "
+        f"sudo -n nft add rule inet servonaut_ban input {saddr} "
+        f"@{set_name} drop; "
+    )
+    return (
+        "if ! sudo -n nft list table inet servonaut_ban "
+        f">/dev/null 2>&1; then {bootstrap}fi; "
+        f"sudo -n nft add element inet servonaut_ban {set_name} "
+        f"'{{ {ip} }}' 2>/dev/null; "
+        f"sudo -n nft list set inet servonaut_ban {set_name} "
+        f"| grep -qF '{ip}'"
+    )
 
 
 def build_remediation_command(verb: str, payload: Dict[str, Any]) -> str:

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -122,13 +122,15 @@ class _WrapperApp(App):
     """Minimal host exposing the services the screens read off self.app."""
 
     def __init__(self, *, screen, auth, findings_service,
-                 ip_ban_service=None, **kwargs):
+                 ip_ban_service=None, servonaut_tools=None,
+                 instances=None, **kwargs):
         super().__init__(**kwargs)
         self._initial_screen = screen
         self.auth_service = auth
         self.findings_service = findings_service
         self.ip_ban_service = ip_ban_service
-        self.instances = [
+        self.servonaut_tools = servonaut_tools
+        self.instances = instances if instances is not None else [
             {"id": "i-0000test01", "name": "web-1"},
         ]
         self.demo_mode = False
@@ -487,6 +489,81 @@ class TestFindingDetailScreen:
                 "fnd_01abc", "block_ip",
                 dry_run=False, method="security_group",
             )
+
+    @pytest.mark.asyncio
+    async def test_block_ip_on_custom_instance_detects_onbox_firewall(self):
+        # A finding on a non-AWS/custom box resolves the method by
+        # SSH-detecting the box's firewall — NOT from an AWS IP-ban
+        # config. This is what makes OVH findings actionable.
+        finding = _finding(
+            instance_id="custom-web-1",
+            remediations=[{
+                "label": "Block the source IP", "description": "Block it.",
+                "action": "block_ip", "risk_tier": "medium",
+                "reversible": True, "automatable": True,
+            }],
+        )
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock(return_value={
+            "finding_id": "fnd_01abc", "action": "block_ip",
+            "exec_risk": "low", "reversible": True, "dry_run": False,
+            "command": {"verb": "block_ip",
+                        "human": "ban 9.9.9.9 via nftables"},
+            "confirm_token": "tok-signed",
+            "expires_at": "2026-07-04T14:00:00Z",
+        })
+        tools = MagicMock()
+        tools.detect_onbox_firewall = AsyncMock(return_value="nftables")
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            servonaut_tools=tools,
+            instances=[{"id": "custom-web-1", "name": "custom-web-1",
+                        "is_custom": True, "provider": "ovh"}],
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            tools.detect_onbox_firewall.assert_awaited_once_with("custom-web-1")
+            svc.remediate_preview.assert_awaited_once_with(
+                "fnd_01abc", "block_ip", dry_run=False, method="nftables",
+            )
+
+    @pytest.mark.asyncio
+    async def test_block_ip_custom_no_firewall_skips_preview(self):
+        finding = _finding(
+            instance_id="custom-web-1",
+            remediations=[{
+                "label": "Block the source IP", "description": "Block it.",
+                "action": "block_ip", "risk_tier": "medium",
+                "reversible": True, "automatable": True,
+            }],
+        )
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock()
+        tools = MagicMock()
+        tools.detect_onbox_firewall = AsyncMock(return_value="none")
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            servonaut_tools=tools,
+            instances=[{"id": "custom-web-1", "name": "custom-web-1",
+                        "is_custom": True}],
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            svc.remediate_preview.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_block_ip_without_config_warns_and_skips_preview(self):

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -552,7 +552,7 @@ class TestValidateBlockIpPayload:
         assert str(exc.value).startswith("block_ip_self_ban_refused:")
 
     @pytest.mark.parametrize("bad_method", [
-        None, "", "ufw", "iptables", "WAF", 42,
+        None, "", "iptables", "WAF", 42, "pf",
     ])
     def test_unknown_method_rejected(self, bad_method):
         with pytest.raises(RemediationValidationError) as exc:
@@ -561,9 +561,10 @@ class TestValidateBlockIpPayload:
             )
         assert str(exc.value).startswith("invalid_block_ip_method:")
 
-    def test_method_enum_matches_ip_ban_strategies(self):
+    def test_aws_method_enum_matches_ip_ban_strategies(self):
         from servonaut.services.ip_ban_service import IPBanService
-        assert BLOCK_IP_METHODS == frozenset(IPBanService.STRATEGIES)
+        from servonaut.services.remediation_executor import AWS_BLOCK_METHODS
+        assert AWS_BLOCK_METHODS == frozenset(IPBanService.STRATEGIES)
 
 
 class TestBuildResultExtras:
@@ -764,3 +765,200 @@ class TestBlockIpRouting:
         ip_ban.ban_ip.assert_awaited_once()
         response = posted_response(listener)
         assert response.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# On-box block_ip methods (nftables / ufw / firewalld)
+# ---------------------------------------------------------------------------
+
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    AWS_BLOCK_METHODS,
+    ONBOX_BLOCK_METHODS,
+    build_onbox_block_command,
+)
+
+
+class TestOnboxBlockCommand:
+    def test_method_sets_partition(self):
+        assert AWS_BLOCK_METHODS | ONBOX_BLOCK_METHODS == BLOCK_IP_METHODS
+        assert not AWS_BLOCK_METHODS & ONBOX_BLOCK_METHODS
+        assert ONBOX_BLOCK_METHODS == {"nftables", "ufw", "firewalld"}
+
+    def test_onbox_methods_pass_validation(self):
+        for m in ONBOX_BLOCK_METHODS:
+            ip, method = validate_block_ip_payload({"ip": "9.9.9.9", "method": m})
+            assert (ip, method) == ("9.9.9.9", m)
+
+    def test_aws_method_rejected_by_onbox_builder(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_onbox_block_command("waf", "9.9.9.9")
+        assert str(exc.value).startswith("invalid_block_ip_method:")
+
+    @pytest.mark.parametrize("method", ["nftables", "ufw", "firewalld"])
+    def test_command_bans_and_verifies_the_ip(self, method):
+        cmd = build_onbox_block_command(method, "9.9.9.9")
+        # Every method runs under non-interactive sudo and ends by
+        # VERIFYING the ip is in the active ruleset (idempotent success).
+        assert "sudo -n" in cmd
+        assert cmd.rstrip().endswith("grep -qF '9.9.9.9'")
+        assert "9.9.9.9" in cmd
+
+    def test_nftables_bootstrap_is_guarded_against_duplicate_rule(self):
+        cmd = build_onbox_block_command("nftables", "9.9.9.9")
+        # The table/set/chain/rule bootstrap only runs when the table is
+        # absent — a repeat ban never appends a duplicate drop rule.
+        assert "if ! sudo -n nft list table inet servonaut_ban" in cmd
+        assert "add element inet servonaut_ban banned4 '{ 9.9.9.9 }'" in cmd
+
+    def test_ipv6_uses_v6_set_and_family(self):
+        cmd = build_onbox_block_command("nftables", "2606:4700:4700::1111")
+        assert "banned6" in cmd
+        assert "ip6 saddr" in cmd
+        assert "ipv6_addr" in cmd
+
+    def test_firewalld_writes_runtime_and_permanent(self):
+        cmd = build_onbox_block_command("firewalld", "9.9.9.9")
+        assert cmd.count("--add-rich-rule") == 2
+        assert "--permanent" in cmd
+        assert 'family="ipv4"' in cmd
+
+    def test_validated_ip_has_no_shell_metacharacters(self):
+        # Defense-in-depth: validate_block_ip_payload only ever yields a
+        # canonical inet address, so nothing a shell could interpret can
+        # reach the builder. A hostile method payload is refused upstream.
+        for bad in ["9.9.9.9; rm x", "9.9.9.9$(id)", "9.9.9.9 && x"]:
+            with pytest.raises(RemediationValidationError):
+                validate_block_ip_payload({"ip": bad, "method": "ufw"})
+
+
+def onbox_block_event(*, method="nftables", payload=None, target="custom-web-1"):
+    return remediation_event(
+        req_id="rmd-onbox-1", verb="block_ip", target=target,
+        payload=payload if payload is not None else {
+            "finding_id": "fnd-3", "action": "block_ip",
+            "ip": "9.9.9.9", "method": method, "dry_run": False,
+        },
+    )
+
+
+def _onbox_listener(*, instance=None):
+    listener = make_listener()
+    listener._executors.find_instance = AsyncMock(return_value=instance)
+    # An on-box ban must NOT touch IPBanService.
+    ip_ban = MagicMock()
+    ip_ban.ban_ip = AsyncMock()
+    ip_ban.get_configs = MagicMock(return_value=[])
+    listener._executors.ip_ban_service = ip_ban
+    return listener, ip_ban
+
+
+class TestOnboxBlockRouting:
+    def test_success_runs_firewall_cmd_over_ssh_not_ipbanservice(self):
+        listener, ip_ban = _onbox_listener()
+
+        def _echo_marker(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            # VERIFY grep succeeds → exit 0 (ip is banned).
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(onbox_block_event(method="nftables")))
+
+        ip_ban.ban_ip.assert_not_awaited()
+        request = listener._executors.execute.await_args.args[0]
+        assert request.type == CommandType.RUN_COMMAND
+        assert "nft add element" in request.payload["command"]
+
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is True
+        assert result["strategy"] == "nftables"
+        # The ip is its own stable unban handle.
+        assert result["rule_id"] == "9.9.9.9"
+        assert result["ip"] == "9.9.9.9"
+
+    def test_dry_run_makes_no_ssh_call(self):
+        listener, _ip_ban = _onbox_listener()
+        listener._executors.execute = AsyncMock()
+        run(listener._handle_event(onbox_block_event(payload={
+            "finding_id": "fnd-3", "action": "block_ip",
+            "ip": "9.9.9.9", "method": "ufw", "dry_run": True,
+        })))
+        listener._executors.execute.assert_not_awaited()
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        assert result["would_ban"] is True
+        assert result["rule_id"] is None
+
+    def test_verify_failure_reports_slug(self):
+        listener, _ip_ban = _onbox_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            # VERIFY grep fails → exit 1 (ban did not take).
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(onbox_block_event(method="ufw")))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "block_ip_failed"
+
+    def test_sudo_denied_classified_as_permission(self):
+        listener, _ip_ban = _onbox_listener()
+
+        def _echo_denied(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"sudo: a password is required\n{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_denied)
+        run(listener._handle_event(onbox_block_event()))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "block_ip_permission_denied"
+
+    def test_timeout_is_a_command_outcome(self):
+        listener, _ip_ban = _onbox_listener()
+        listener._executors.execute = AsyncMock(return_value=CommandResponse(
+            request_id="rmd-onbox-1", status="timeout", output="",
+        ))
+        run(listener._handle_event(onbox_block_event()))
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["slug"] == "remediation_timeout"
+
+    def test_transport_failure_is_error_status(self):
+        listener, _ip_ban = _onbox_listener()
+        listener._executors.execute = AsyncMock(return_value=CommandResponse(
+            request_id="rmd-onbox-1", status="error", output="",
+            error_message="ssh channel closed",
+        ))
+        run(listener._handle_event(onbox_block_event()))
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("remediation_execution_failed:")
+
+    def test_missing_target_refuses(self):
+        listener, _ip_ban = _onbox_listener()
+        listener._executors.execute = AsyncMock()
+        run(listener._handle_event(onbox_block_event(target="")))
+        listener._executors.execute.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("block_ip_target_missing:")

--- a/tests/test_system_probe_tools.py
+++ b/tests/test_system_probe_tools.py
@@ -388,6 +388,24 @@ class TestSystemProbeToolLayer:
         assert "fail2ban-client" in remote
         assert "===FAIL2BAN===" in remote
 
+    @pytest.mark.parametrize("detected", ["ufw", "firewalld", "nftables", "none"])
+    def test_detect_onbox_firewall_returns_detected(self, detected):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=(detected + "\n", ""))
+        assert run(tools.detect_onbox_firewall("web-1")) == detected
+        remote = tools._exec_ssh.await_args.args[1]
+        assert "ufw status" in remote and "firewall-cmd" in remote and "nft" in remote
+
+    def test_detect_onbox_firewall_unreachable_is_unknown(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(side_effect=RuntimeError("ssh down"))
+        assert run(tools.detect_onbox_firewall("web-1")) == "unknown"
+
+    def test_detect_onbox_firewall_garbage_is_unknown(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=("something weird\n", ""))
+        assert run(tools.detect_onbox_firewall("web-1")) == "unknown"
+
     def test_probe_policy_allows_new_tools(self):
         from servonaut.services.relay_listener import probe_tool_allowed
         for tool in ("journal_errors", "tls_cert_check", "auth_log_summary",


### PR DESCRIPTION
## Summary
The write-side of the on-box-protection cycle. AWS WAF/SG/NACL can't shield a non-AWS box, so `block_ip` gains on-box firewall methods that ban the attacker on the box itself — making OVH / bare-metal findings actionable for the first time.

- **Command builders** (`remediation_executor`): `nftables` / `ufw` / `firewalld`, argv built locally from the validated IP (never server text). Each ends by **verifying** the IP is in the active ruleset, so a repeat ban is an idempotent success and a silently-failed ban (no `sudo -n`) is a clean failure. nftables bootstraps a dedicated `servonaut_ban` table/set/chain **once** (guarded on table existence — no duplicate drop rule); v4/v6 use separate sets. Unban handle = the IP itself.
- **Dispatch branch** (`relay_listener`): `block_ip` branches on method — AWS methods → IPBanService (boto3, unchanged); on-box methods → run the firewall command over the relay SSH path and judge the exit marker (mirrors `certbot_renew`). Dry-run makes zero mutation.
- **Method resolution** (findings screen): now instance-type aware — AWS instances use a configured IP-ban plane; non-AWS/custom boxes **SSH-detect** the active firewall (`ufw` > `firewalld` > `nftables`) via a read-only `detect_onbox_firewall` helper and ban on-box. No firewall found / unreachable → a clear message, no server round-trip.

The method enum is kept in lockstep with the server-side registration (nftables/ufw/firewalld now accepted, exec_risk medium-live/low-dry). The IP still derives server-side from the finding; all rails (evidence-membership, private/reserved/multicast, self-ban) apply regardless of method.

## Test plan
- Command builders: each method + v4/v6, verify-step present, sudo -n, guarded nft bootstrap, firewalld runtime+permanent, no shell metacharacters reach the builder.
- Dispatch: on-box routes to SSH (not IPBanService), success/verify-failure/sudo-denied/timeout/transport-failure, dry-run zero-SSH, missing-target refusal.
- Detection: returns detected firewall / none / unknown-on-unreachable.
- Screen: custom instance detects firewall and sends the method; no-firewall skips preview.
- Shell syntax of every wrapped command validated; full suite green (6198 passed).