### PR TITLE
fix(mcp): decode JSON-string body in api_request POST

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -1061,6 +1061,19 @@ class ServonautTools:
             "timeout": 10.0,
         }
         if body is not None:
+            # Some MCP clients serialise a schema-less object argument to a
+            # JSON *string* rather than a nested object. Passing that straight
+            # to httpx's json= would double-encode it into a quoted string
+            # literal, which the server decodes to a scalar (so an expected
+            # {"action": ...} body arrives empty). Parse a JSON string back to
+            # the object/array it encodes; leave genuine scalar bodies as-is.
+            if isinstance(body, str):
+                try:
+                    decoded = json.loads(body)
+                except (ValueError, TypeError):
+                    decoded = None
+                if isinstance(decoded, (dict, list)):
+                    body = decoded
             request_kwargs["json"] = body
 
         try:

--- a/tests/test_mcp_api_request.py
+++ b/tests/test_mcp_api_request.py
@@ -140,6 +140,45 @@ class TestHappyPath:
         assert req.headers["content-type"].startswith("application/json")
 
 
+class TestBodyCoercion:
+    """A JSON-string body (some MCP clients stringify schema-less object args)
+    must be decoded to the object/array it encodes, not double-encoded into a
+    quoted string literal that the server would read as a scalar."""
+
+    def _capture_post(self, monkeypatch, body):
+        captured = _Capture()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.requests.append(request)
+            return httpx.Response(204, headers={"Content-Type": "application/json"})
+        _install_transport(monkeypatch, handler)
+
+        svc = _authed_stub()
+        tools, _ = _make_tools(auth_service=svc)
+        _run(tools.api_request("POST", "/api/v1/thing", body=body))
+        return captured.requests[-1]
+
+    def test_json_string_object_body_is_decoded(self, monkeypatch):
+        req = self._capture_post(monkeypatch, '{"action": "block_ip", "dry_run": true}')
+        # Sent as a real object, not a quoted string literal.
+        assert json.loads(req.content) == {"action": "block_ip", "dry_run": True}
+        assert req.headers["content-type"].startswith("application/json")
+
+    def test_json_string_array_body_is_decoded(self, monkeypatch):
+        req = self._capture_post(monkeypatch, '[1, 2, 3]')
+        assert json.loads(req.content) == [1, 2, 3]
+
+    def test_dict_body_still_forwarded_as_object(self, monkeypatch):
+        req = self._capture_post(monkeypatch, {"action": "block_ip"})
+        assert json.loads(req.content) == {"action": "block_ip"}
+
+    def test_plain_string_body_left_as_scalar(self, monkeypatch):
+        # A body that is genuinely a string (not JSON object/array) is passed
+        # through unchanged — httpx encodes it as a JSON string literal.
+        req = self._capture_post(monkeypatch, "just-a-string")
+        assert json.loads(req.content) == "just-a-string"
+
+
 class TestValidation:
     def test_reject_absolute_url(self):
         svc = _authed_stub()


### PR DESCRIPTION
## Problem

The MCP `api_request` tool silently dropped POST request bodies. A `POST` with `body={"action": "block_ip", ...}` reached the server with an empty body, so body-dependent validation failed (surfaced as `remediation_action_unknown` with an empty `action`). GET+query worked fine, making the tool effectively GET-only for any endpoint that reads its body.

## Root cause

`api_request`'s `body` parameter has no `type` in its JSON Schema. Some MCP clients serialise such a schema-less object argument to a **JSON string** rather than a nested object. The impl passed that straight to httpx's `json=`, which double-encodes a string into a quoted JSON literal (`b'"{\\"action\\":...}"'`). The server's `json_decode` then reads a scalar string, not an object — so `$body['action']` is empty.

The server side was never at fault (direct object-body POSTs work — proven by the on-box remediation E2E).

## Fix

Coerce a JSON-string `body` back to the object/array it encodes before handing it to httpx. Genuine scalar string bodies pass through unchanged.

## Verification

- New `TestBodyCoercion` covers JSON-string-object, JSON-string-array, dict, and plain-scalar bodies (21/21 in the file pass).
- Verified **live against staging**: a JSON-string body now reaches the server as an object — `/remediate` reads `action` and advances to token validation instead of failing with an empty action.