### PR TITLE
fix(memory): make background fleet auto-scan run reliably across restarts

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -23,6 +23,12 @@ _S3_NAV_TO_PROVIDER: dict[str, str] = {
     "nav_hetzner_s3": "hetzner",
 }
 
+# Grace period the background fleet auto-scan waits after the loop starts
+# before its first scan pass.  Long enough for the instance list to populate
+# and to absorb rapid app relaunches without hammering the fleet; short enough
+# that an overdue (persisted) scan still catches up promptly on launch.
+_FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS = 90
+
 if TYPE_CHECKING:
     from servonaut.widgets.sidebar import Sidebar
     from servonaut.services.relay_manager import RelayManager, RelayState
@@ -130,7 +136,9 @@ class ServonautApp(App):
     _latest_version: Optional[str] = None
 
     # Timestamp of the last successful auto-scan cycle (epoch seconds).
-    # Zero means no cycle has completed yet this session.
+    # Zero means no cycle has ever completed.  Seeded from the persisted
+    # scan-state file at loop start (``services/memory/scan_state``) so the
+    # schedule and the Fleet Memory countdown survive restarts.
     _fleet_auto_scan_last_run: float = 0.0
 
     # True while the app-owned manual fleet scan worker is running.
@@ -1485,9 +1493,10 @@ class ServonautApp(App):
 
         No-op when ``config.memory.auto_scan_enabled`` is ``False`` or when
         either ``memory_service`` or ``fleet_scan_service`` is unavailable.
-        The worker sleeps for the configured interval before the FIRST scan,
-        so calling this in ``on_mount`` is safe regardless of instance-list
-        readiness.
+        The worker waits a short startup grace before the first scan (so the
+        instance list can populate) and then catches up immediately if the
+        interval has already elapsed since the persisted last run — safe to
+        call in ``on_mount`` regardless of instance-list readiness.
 
         The worker group ``memory_auto_scan`` is exclusive and distinct from
         ``memory_refresh`` and ``memory_sync_background`` so cancelling one
@@ -1498,6 +1507,13 @@ class ServonautApp(App):
             return
         if self.fleet_scan_service is None or self.memory_service is None:
             return
+        # Seed the in-memory marker from disk so the Fleet Memory countdown is
+        # correct from the first render, before the loop's first cycle.
+        try:
+            from servonaut.services.memory import scan_state
+            self._fleet_auto_scan_last_run = scan_state.read_last_run()
+        except Exception:  # noqa: BLE001
+            pass
         self.run_worker(
             self._fleet_auto_scan_loop(),
             name="fleet_auto_scan_loop",
@@ -1508,40 +1524,127 @@ class ServonautApp(App):
     async def _fleet_auto_scan_loop(self) -> None:
         """Long-running background fleet auto-scan coroutine.
 
-        Sleeps for ``auto_scan_interval_seconds`` (minimum 60 s), then
-        probes eligible instances via ``FleetScanService``.  Re-reads config
-        before each cycle so operators can disable the loop without a restart.
-        Exceptions inside a scan cycle are logged and swallowed so the loop
-        survives transient SSH failures — ``asyncio.CancelledError`` is
-        always re-raised.
+        Reliability model — the last-run timestamp is persisted to disk
+        (``services/memory/scan_state``) so the schedule survives the frequent,
+        short-lived sessions typical of a TUI.  The loop:
+
+        1. Waits a short startup grace so the instance list can populate and
+           rapid relaunches don't hammer the fleet.
+        2. If the interval has already elapsed since the persisted last run
+           (or there is none), runs a catch-up scan *immediately* — rather
+           than sleeping a full interval first, which with a 24 h default
+           meant the scan never ran for users who never keep the app open
+           that long.
+        3. Otherwise sleeps only the remaining time, then scans.
+        4. Between cycles sleeps a full interval; when a cycle is skipped
+           because the instance list hasn't loaded yet it retries after the
+           grace instead of burning a whole interval.
+
+        Re-reads config before every cycle so operators can disable the loop
+        without a restart.  Per-cycle exceptions are logged and swallowed so
+        the loop survives transient SSH failures; ``asyncio.CancelledError``
+        is always re-raised.
         """
         import asyncio
         import time
+
+        from servonaut.services.memory import scan_state
+
+        # Defensive early-out (``_start_fleet_auto_scan_loop`` already gates):
+        # never burn the startup grace when the feature is disabled on entry.
+        cfg = self.config_manager.get().memory
+        if not (cfg.enabled and cfg.auto_scan_enabled):
+            return
+
+        # Startup grace: let the instance list populate and absorb rapid
+        # relaunches before the first scan pass.
+        try:
+            await asyncio.sleep(_FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS)
+        except asyncio.CancelledError:
+            return
 
         while True:
             cfg = self.config_manager.get().memory
             if not (cfg.enabled and cfg.auto_scan_enabled):
                 return
             interval = max(60, cfg.auto_scan_interval_seconds)
-            try:
-                await asyncio.sleep(interval)
-            except asyncio.CancelledError:
-                return
-            # Re-read config after the sleep in case it changed.
+
+            last_run = scan_state.read_last_run()
+            if last_run > 0:
+                remaining = (last_run + interval) - time.time()
+                if remaining > 0:
+                    # Not due yet — sleep only the remaining time, then re-loop
+                    # (config is re-read at the top so a mid-wait disable takes
+                    # effect on the next iteration).
+                    try:
+                        await asyncio.sleep(remaining)
+                    except asyncio.CancelledError:
+                        return
+                    continue
+
+            # Due (or never run): re-check config, then run one cycle.
             cfg = self.config_manager.get().memory
             if not (cfg.enabled and cfg.auto_scan_enabled):
                 return
+            ran = await self._run_fleet_auto_scan_cycle(cfg.auto_scan_stale_only)
+
+            # A skipped cycle (instances not loaded) retries after the grace;
+            # a completed cycle waits the full interval.
+            next_sleep = interval if ran else _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
             try:
-                await self.fleet_scan_service.scan(
-                    self.instances or [],
-                    stale_only=cfg.auto_scan_stale_only,
-                )
-                self._fleet_auto_scan_last_run = time.time()
+                await asyncio.sleep(next_sleep)
             except asyncio.CancelledError:
                 return
-            except Exception:
-                logger.exception("fleet auto-scan cycle failed")
-                # Loop MUST survive individual cycle failures.
+
+    async def _run_fleet_auto_scan_cycle(self, stale_only: bool) -> bool:
+        """Run one background fleet auto-scan pass and refresh the UI + state.
+
+        Probes eligible instances via ``FleetScanService`` (routing live
+        progress to whichever memory screen is mounted), then persists the
+        last-run timestamp and refreshes the mounted panels.
+
+        Returns ``True`` when a scan pass actually ran (the instance list was
+        loaded and the fleet was evaluated), ``False`` when it was skipped
+        because the instance list has not populated yet — the caller uses this
+        to decide whether to wait a full interval or retry after the grace.
+        The last-run timestamp is advanced only when a pass ran, so a skipped
+        cycle never moves the schedule forward.
+
+        ``asyncio.CancelledError`` propagates so worker cancellation unwinds
+        cleanly; all other exceptions are logged and treated as a completed
+        (but failed) pass so the loop backs off a full interval rather than
+        hammering a fleet that is currently unreachable.
+        """
+        import asyncio
+        import time
+
+        from servonaut.services.memory import scan_state
+
+        if self.fleet_scan_service is None or self.memory_service is None:
+            return False
+        instances = self.instances or []
+        if not instances:
+            logger.debug("fleet auto-scan: instances not loaded yet; will retry")
+            return False
+
+        try:
+            result = await self.fleet_scan_service.scan(
+                instances,
+                stale_only=stale_only,
+                on_progress=self._fleet_manual_scan_progress,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("fleet auto-scan cycle failed")
+            # A pass ran; a transient failure must not tighten the retry loop.
+            return True
+
+        now = time.time()
+        self._fleet_auto_scan_last_run = now
+        scan_state.write_last_run(now)
+        self._refresh_fleet_panels_after_scan(result, quiet=True)
+        return True
 
     # ------------------------------------------------------------------
     # App-owned manual fleet scan (survives screen navigation)
@@ -1633,13 +1736,41 @@ class ServonautApp(App):
             f"{len(result.failed)} failed.",
             markup=False,
         )
+        self._refresh_fleet_panels_after_scan(result, quiet=False)
+
+    def _refresh_fleet_panels_after_scan(self, result: object, *, quiet: bool) -> None:
+        """Refresh whichever memory panel is mounted after a fleet scan.
+
+        Shared by the app-owned manual scan and the background auto-scan loop
+        so both update the UI identically.  Duck-typed and exception-safe: a
+        no-op when the mounted screen exposes no memory hooks.
+
+        Args:
+            result: The ``FleetScanResult`` from the completed scan.
+            quiet: When ``True`` (background auto-scan) the Fleet Memory screen
+                is refreshed via ``on_fleet_auto_scan_done`` — which repopulates
+                the table but never pushes the summary modal, so an unattended
+                cycle cannot interrupt the user with a dialog.  When ``False``
+                (user-initiated scan) the ``on_fleet_manual_scan_done`` hook is
+                used, which surfaces the failure summary.
+        """
         screen = getattr(self, "screen", None)
-        done_hook = getattr(screen, "on_fleet_manual_scan_done", None)
-        if callable(done_hook):
+        hook_name = "on_fleet_auto_scan_done" if quiet else "on_fleet_manual_scan_done"
+        hook = getattr(screen, hook_name, None)
+        if callable(hook):
             try:
-                done_hook(result)
+                hook(result)
             except Exception:
-                logger.exception("on_fleet_manual_scan_done raised")
+                logger.exception("%s raised", hook_name)
+        # Instance-list memory column derives from compute_memory_status; a
+        # re-render reflects freshly-probed servers immediately.  No-op on
+        # screens that don't expose it (e.g. the Fleet Memory screen).
+        refresh_mem = getattr(screen, "refresh_memory_status", None)
+        if callable(refresh_mem):
+            try:
+                refresh_mem()
+            except Exception:
+                logger.debug("refresh_memory_status raised", exc_info=True)
 
     def _fleet_manual_scan_progress(self, progress: object) -> None:
         """Route a scan progress event to the currently mounted Fleet Memory screen.

--- a/src/servonaut/screens/fleet_memory.py
+++ b/src/servonaut/screens/fleet_memory.py
@@ -951,6 +951,20 @@ class FleetMemoryScreen(Screen):
                 FleetScanSummaryModal(result.succeeded, result.failed)
             )
 
+    def on_fleet_auto_scan_done(self, result: Any) -> None:
+        """Quiet completion hook for a background auto-scan cycle.
+
+        Called (duck-typed) by ``app._refresh_fleet_panels_after_scan`` when a
+        background cycle finishes and this screen is mounted.  Unlike
+        :meth:`on_fleet_manual_scan_done` it never pushes the summary modal — a
+        background cycle must not interrupt the user with a dialog — it only
+        clears the progress line, updates the auto-scan status line (so the
+        countdown reflects the just-completed run), and repopulates the table.
+        """
+        self._set_progress("")
+        self._refresh_auto_scan_status()
+        self._launch_populate()
+
     def on_fleet_manual_scan_done(self, result: Any) -> None:
         """Completion hook invoked by the app-owned manual scan worker.
 

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -386,6 +386,20 @@ class InstanceListScreen(Screen):
             self._update_table()
             self._update_status_bar()
 
+    def refresh_memory_status(self) -> None:
+        """Refresh the instance table's memory column after a fleet auto-scan.
+
+        Called duck-typed by ``app._refresh_fleet_panels_after_scan`` when a
+        background auto-scan cycle completes while this screen is mounted, so
+        the "Mem" status column reflects freshly-probed servers in real time.
+        Exception-safe: a no-op if the table isn't mounted yet.
+        """
+        try:
+            table = self.query_one(InstanceTable)
+        except Exception:
+            return
+        table.refresh_memory_status()
+
     def _update_table(self) -> None:
         """Update instance table with current data, preserving active filter."""
         table = self.query_one(InstanceTable)

--- a/src/servonaut/services/memory/scan_state.py
+++ b/src/servonaut/services/memory/scan_state.py
@@ -1,0 +1,91 @@
+"""Persistent runtime state for the background fleet memory auto-scan.
+
+The auto-scan loop's "last run" timestamp must survive process restarts.
+Without persistence a long interval (the 24 h default) never elapses for the
+common usage pattern of opening the TUI for short sessions — every restart
+would reset an in-memory clock to zero and the first scan would never arrive.
+
+This is runtime state, not user configuration, so it lives in its own small
+JSON file under ``~/.servonaut/`` (following the existing ``cache.json`` /
+``keywords.json`` runtime-files convention) rather than churning
+``config.json`` on every scan.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILENAME = "memory_scan_state.json"
+
+# Epoch-seconds timestamp of the last completed auto-scan cycle.
+_LAST_RUN_KEY = "auto_scan_last_run_at"
+
+
+def _default_dir() -> Path:
+    """Return the base runtime directory (``~/.servonaut``)."""
+    return Path.home() / ".servonaut"
+
+
+def state_path(base_dir: Optional[Path] = None) -> Path:
+    """Return the full path to the scan-state file.
+
+    Args:
+        base_dir: Override the default ``~/.servonaut`` directory (tests pass
+            a temp dir here).
+    """
+    return (base_dir or _default_dir()) / _STATE_FILENAME
+
+
+def read_last_run(base_dir: Optional[Path] = None) -> float:
+    """Return the persisted last auto-scan timestamp in epoch seconds.
+
+    Fails soft: a missing, unreadable, or malformed file yields ``0.0`` —
+    which callers treat as "never run" — so a corrupt state file can never
+    crash startup or the scan loop.
+
+    Args:
+        base_dir: Override the default ``~/.servonaut`` directory.
+
+    Returns:
+        Epoch seconds of the last completed cycle, or ``0.0`` when unknown.
+    """
+    path = state_path(base_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return 0.0
+    except (OSError, ValueError) as exc:
+        logger.debug("memory scan-state read failed (%s); treating as never-run", exc)
+        return 0.0
+    val = data.get(_LAST_RUN_KEY) if isinstance(data, dict) else None
+    # Reject bools (isinstance(True, int) is True) and non-positive values.
+    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
+        return float(val)
+    return 0.0
+
+
+def write_last_run(ts: float, base_dir: Optional[Path] = None) -> None:
+    """Persist *ts* (epoch seconds) as the last auto-scan completion time.
+
+    Best-effort and atomic: writes to a temp file then renames, so a reader
+    never sees a half-written file.  Write errors (read-only or full disk)
+    are logged and swallowed so persistence failure never propagates into
+    the scan loop.
+
+    Args:
+        ts: Epoch seconds to persist.
+        base_dir: Override the default ``~/.servonaut`` directory.
+    """
+    path = state_path(base_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps({_LAST_RUN_KEY: float(ts)}), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        logger.debug("memory scan-state write failed (%s)", exc)

--- a/src/servonaut/widgets/instance_table.py
+++ b/src/servonaut/widgets/instance_table.py
@@ -67,6 +67,25 @@ class InstanceTable(DataTable):
             ]
         self._refresh_table()
 
+    def refresh_memory_status(self) -> None:
+        """Re-render rows so the memory status column recomputes, keeping cursor.
+
+        Called (via the screen) after a background fleet auto-scan cycle so the
+        "Mem" column reflects freshly-probed servers immediately.  Re-renders
+        from the current ``_filtered_instances`` (so the active filter is
+        preserved) and restores the cursor row so a background refresh never
+        yanks the user's selection to the top.  A no-op when the table is empty.
+        """
+        if not self._filtered_instances:
+            return
+        saved_row = self.cursor_row
+        self._refresh_table()
+        try:
+            if 0 <= saved_row < len(self._filtered_instances):
+                self.move_cursor(row=saved_row)
+        except Exception:
+            pass
+
     def get_selected_instance(self) -> Optional[dict]:
         """Get the currently selected instance.
 

--- a/tests/test_app_fleet_auto_scan.py
+++ b/tests/test_app_fleet_auto_scan.py
@@ -84,10 +84,20 @@ def _make_stub(
         instances=[],
         _fleet_auto_scan_last_run=0.0,
         run_worker=run_worker_mock,
+        # Cycle collaborators — the loop-body tests mock the whole cycle, the
+        # cycle tests bind the real method and use these.
+        _fleet_manual_scan_progress=MagicMock(),
+        _refresh_fleet_panels_after_scan=MagicMock(),
     )
     # Bind the real loop coroutine so _start_fleet_auto_scan_loop can call it.
     stub._fleet_auto_scan_loop = (
         lambda: ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+    )
+    # Bind the real cycle method so loop-body tests that don't mock it work too.
+    stub._run_fleet_auto_scan_cycle = (
+        lambda stale_only: ServonautApp._run_fleet_auto_scan_cycle(  # type: ignore[arg-type]
+            stub, stale_only
+        )
     )
     return stub
 
@@ -170,14 +180,25 @@ class TestStartFleetAutoScanLoop:
 class TestFleetAutoScanLoopBody:
     """Drive _fleet_auto_scan_loop directly by monkeypatching asyncio.sleep.
 
+    The loop now persists its schedule (``services/memory/scan_state``) and is
+    compute-then-sleep: a startup grace first, then a catch-up scan when the
+    interval has elapsed since the persisted last run, else a partial sleep.
+    Loop-body tests mock ``_run_fleet_auto_scan_cycle`` to isolate scheduling
+    and patch ``scan_state.read_last_run`` to control "due" vs "not due".
+
     ``_fleet_auto_scan_loop`` does ``import asyncio`` locally, so the correct
-    patch target is ``asyncio.sleep`` (the real module attribute), not any
-    ``servonaut.app.*`` path.
+    patch target is ``asyncio.sleep`` (the real module attribute).
     """
 
+    def _bind_cycle_mock(self, stub, *, ran: bool = True):
+        """Replace the bound cycle with an AsyncMock returning *ran*."""
+        cycle = AsyncMock(return_value=ran)
+        stub._run_fleet_auto_scan_cycle = cycle
+        return cycle
+
     @pytest.mark.asyncio
-    async def test_loop_exits_when_auto_scan_disabled_before_sleep(self) -> None:
-        """If config has auto_scan_enabled=False on entry, exit immediately."""
+    async def test_loop_exits_when_auto_scan_disabled_before_grace(self) -> None:
+        """auto_scan_enabled=False on entry → exit before even the grace sleep."""
         config = _make_config(auto_scan_enabled=False)
         stub = _make_stub(config=config)
         with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
@@ -185,171 +206,341 @@ class TestFleetAutoScanLoopBody:
         mock_sleep.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_loop_uses_configured_interval(self) -> None:
-        """sleep() must be called with the configured interval (min 60)."""
-        config = _make_config(auto_scan_interval_seconds=180)
-        scan_service = MagicMock()
-        scan_service.scan = AsyncMock(return_value=MagicMock())
-        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+    async def test_grace_sleep_precedes_first_cycle(self) -> None:
+        """The first sleep is the startup grace, not the interval."""
+        from servonaut.app import _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
+
+        config = _make_config(auto_scan_interval_seconds=300)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        cycle = self._bind_cycle_mock(stub, ran=True)
 
         sleep_calls: List[float] = []
 
         async def _fake_sleep(seconds):
             sleep_calls.append(seconds)
-            # After first sleep, flip the flag so the loop exits.
-            off_config = _make_config(auto_scan_enabled=False)
-            stub.config_manager.get = MagicMock(return_value=off_config)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
-
-        assert len(sleep_calls) >= 1
-        assert sleep_calls[0] == 180
-
-    @pytest.mark.asyncio
-    async def test_loop_enforces_minimum_interval_of_60(self) -> None:
-        """Interval below 60 is clamped to 60."""
-        config = _make_config(auto_scan_interval_seconds=5)
-        scan_service = MagicMock()
-        scan_service.scan = AsyncMock(return_value=MagicMock())
-        stub = _make_stub(config=config, fleet_scan_service=scan_service)
-
-        sleep_calls: List[float] = []
-
-        async def _fake_sleep(seconds):
-            sleep_calls.append(seconds)
-            off_config = _make_config(auto_scan_enabled=False)
-            stub.config_manager.get = MagicMock(return_value=off_config)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
-
-        assert sleep_calls[0] == 60
-
-    @pytest.mark.asyncio
-    async def test_scan_called_with_stale_only_from_config(self) -> None:
-        """scan() receives stale_only from config.memory.auto_scan_stale_only."""
-        for expected_stale_only in (True, False):
-            config = _make_config(auto_scan_stale_only=expected_stale_only)
-            scan_service = MagicMock()
-            scan_service.scan = AsyncMock(return_value=MagicMock())
-            stub = _make_stub(
-                config=config, fleet_scan_service=scan_service
+            # Disable after the grace so the loop exits before scanning.
+            stub.config_manager.get = MagicMock(
+                return_value=_make_config(auto_scan_enabled=False)
             )
-            stub.instances = [{"id": "web-1", "name": "web-1"}]
 
-            # One sleep then exit.
-            cycle_count = 0
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=0.0
+        ):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
 
-            async def _fake_sleep_one_cycle(seconds):
-                nonlocal cycle_count
-                cycle_count += 1
-                if cycle_count == 1:
-                    # First sleep: return normally so the scan runs.
-                    return
-                # Second sleep: flip flag off so loop exits cleanly.
-                off_config = _make_config(auto_scan_enabled=False)
-                stub.config_manager.get = MagicMock(return_value=off_config)
+        assert sleep_calls[0] == _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
+        cycle.assert_not_called()  # disabled before the first cycle
 
-            with patch("asyncio.sleep", side_effect=_fake_sleep_one_cycle):
-                await ServonautApp._fleet_auto_scan_loop(  # type: ignore[arg-type]
-                    stub
+    @pytest.mark.asyncio
+    async def test_catch_up_scan_runs_when_overdue(self) -> None:
+        """No persisted last_run → a cycle runs right after the grace."""
+        config = _make_config(auto_scan_stale_only=True)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        cycle = self._bind_cycle_mock(stub, ran=True)
+
+        n = 0
+
+        async def _fake_sleep(seconds):
+            nonlocal n
+            n += 1
+            # grace (1), then post-cycle interval sleep (2) → exit.
+            if n >= 2:
+                stub.config_manager.get = MagicMock(
+                    return_value=_make_config(auto_scan_enabled=False)
                 )
 
-            scan_service.scan.assert_called_with(
-                stub.instances,
-                stale_only=expected_stale_only,
-            )
-
-    @pytest.mark.asyncio
-    async def test_last_run_updated_after_successful_scan(self) -> None:
-        """_fleet_auto_scan_last_run is updated after a scan completes."""
-        config = _make_config()
-        scan_service = MagicMock()
-        scan_service.scan = AsyncMock(return_value=MagicMock())
-        stub = _make_stub(config=config, fleet_scan_service=scan_service)
-        stub._fleet_auto_scan_last_run = 0.0
-
-        cycle_count = 0
-
-        async def _fake_sleep(seconds):
-            nonlocal cycle_count
-            cycle_count += 1
-            if cycle_count >= 2:
-                off_config = _make_config(auto_scan_enabled=False)
-                stub.config_manager.get = MagicMock(return_value=off_config)
-
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=0.0
+        ):
             await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
 
-        assert stub._fleet_auto_scan_last_run > 0.0
+        cycle.assert_awaited_once_with(True)
 
     @pytest.mark.asyncio
-    async def test_loop_survives_scan_exception_and_continues(self) -> None:
-        """A scan() that raises must not kill the loop — it keeps iterating."""
-        config = _make_config()
-        scan_service = MagicMock()
-        scan_calls: List[int] = []
+    async def test_not_due_sleeps_remaining_and_skips_scan(self) -> None:
+        """A recent persisted last_run → sleep the remaining time, no scan yet."""
+        import time as _time
 
-        async def _scan(instances, *, stale_only):
-            scan_calls.append(1)
-            raise RuntimeError("ssh error")
+        config = _make_config(auto_scan_interval_seconds=1000)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        cycle = self._bind_cycle_mock(stub, ran=True)
 
-        scan_service.scan = AsyncMock(side_effect=_scan)
-        stub = _make_stub(config=config, fleet_scan_service=scan_service)
-        stub._fleet_auto_scan_last_run = 0.0
-
-        # Run 2 cycles then exit.
-        cycle_count = 0
+        # last_run 200s ago, interval 1000 → ~800s remaining.
+        recent = _time.time() - 200
+        sleep_calls: List[float] = []
 
         async def _fake_sleep(seconds):
-            nonlocal cycle_count
-            cycle_count += 1
-            if cycle_count >= 3:
-                off_config = _make_config(auto_scan_enabled=False)
-                stub.config_manager.get = MagicMock(return_value=off_config)
+            sleep_calls.append(seconds)
+            # After grace + the partial sleep, disable so the loop exits.
+            if len(sleep_calls) >= 2:
+                stub.config_manager.get = MagicMock(
+                    return_value=_make_config(auto_scan_enabled=False)
+                )
 
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=recent
+        ):
             await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
 
-        # Should have attempted 2 scans despite both raising.
-        assert len(scan_calls) == 2
-        # last_run NOT updated on failure.
-        assert stub._fleet_auto_scan_last_run == 0.0
+        # Second sleep is the "remaining" partial sleep (roughly 800s), and no
+        # cycle ran because the schedule wasn't due yet.
+        assert 700 < sleep_calls[1] <= 800
+        cycle.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cancelled_error_during_sleep_exits_loop(self) -> None:
-        """CancelledError from asyncio.sleep causes clean loop exit."""
+    async def test_skipped_cycle_retries_after_grace(self) -> None:
+        """When a cycle is skipped (ran=False) the next sleep is the grace."""
+        from servonaut.app import _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
+
+        config = _make_config(auto_scan_interval_seconds=1000)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        cycle = self._bind_cycle_mock(stub, ran=False)  # instances not loaded
+
+        sleep_calls: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            if len(sleep_calls) >= 2:
+                stub.config_manager.get = MagicMock(
+                    return_value=_make_config(auto_scan_enabled=False)
+                )
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=0.0
+        ):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        # grace, then (because the cycle was skipped) another grace-length sleep.
+        assert sleep_calls[0] == _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
+        assert sleep_calls[1] == _FLEET_AUTO_SCAN_STARTUP_GRACE_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_completed_cycle_sleeps_full_interval(self) -> None:
+        """After a completed cycle the post-cycle sleep is the full interval."""
+        config = _make_config(auto_scan_interval_seconds=222)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        self._bind_cycle_mock(stub, ran=True)
+
+        sleep_calls: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            if len(sleep_calls) >= 2:
+                stub.config_manager.get = MagicMock(
+                    return_value=_make_config(auto_scan_enabled=False)
+                )
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=0.0
+        ):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        assert sleep_calls[1] == 222  # interval, min-60 clamp not triggered
+
+    @pytest.mark.asyncio
+    async def test_interval_clamped_to_minimum_60(self) -> None:
+        """Interval below 60 is clamped to 60 for the post-cycle sleep."""
+        config = _make_config(auto_scan_interval_seconds=5)
+        stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        self._bind_cycle_mock(stub, ran=True)
+
+        sleep_calls: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            if len(sleep_calls) >= 2:
+                stub.config_manager.get = MagicMock(
+                    return_value=_make_config(auto_scan_enabled=False)
+                )
+
+        with patch("asyncio.sleep", side_effect=_fake_sleep), patch(
+            "servonaut.services.memory.scan_state.read_last_run", return_value=0.0
+        ):
+            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
+
+        assert sleep_calls[1] == 60
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_grace_exits_loop(self) -> None:
+        """CancelledError from the grace sleep causes a clean loop exit."""
         config = _make_config()
         stub = _make_stub(config=config, fleet_scan_service=MagicMock())
+        cycle = self._bind_cycle_mock(stub, ran=True)
 
         async def _cancel(seconds):
             raise asyncio.CancelledError()
 
         with patch("asyncio.sleep", side_effect=_cancel):
-            # _fleet_auto_scan_loop catches CancelledError during sleep and returns.
             await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
 
-        # Reaching here means the loop returned cleanly (did not re-raise).
+        cycle.assert_not_called()  # cancelled before any cycle ran
+
+
+# ---------------------------------------------------------------------------
+# _run_fleet_auto_scan_cycle — one scan pass + persistence + panel refresh
+# ---------------------------------------------------------------------------
+
+class TestRunFleetAutoScanCycle:
+    """The cycle probes eligible instances, persists last_run, refreshes panels."""
 
     @pytest.mark.asyncio
-    async def test_loop_exits_when_flag_toggled_off_after_sleep(self) -> None:
-        """If auto_scan_enabled is flipped to False after the sleep, loop exits."""
-        config = _make_config(auto_scan_enabled=True)
+    async def test_skips_and_returns_false_when_no_instances(self) -> None:
+        """Empty instance list → skipped (ran=False), nothing persisted."""
         scan_service = MagicMock()
         scan_service.scan = AsyncMock(return_value=MagicMock())
-        stub = _make_stub(config=config, fleet_scan_service=scan_service)
+        stub = _make_stub(fleet_scan_service=scan_service, memory_service=MagicMock())
+        stub.instances = []
 
-        async def _fake_sleep(seconds):
-            # After sleeping, flip the flag off so the post-sleep re-read exits.
-            off_config = _make_config(auto_scan_enabled=False)
-            stub.config_manager.get = MagicMock(return_value=off_config)
+        with patch(
+            "servonaut.services.memory.scan_state.write_last_run"
+        ) as mock_write:
+            ran = await ServonautApp._run_fleet_auto_scan_cycle(stub, True)  # type: ignore[arg-type]
 
-        with patch("asyncio.sleep", side_effect=_fake_sleep):
-            await ServonautApp._fleet_auto_scan_loop(stub)  # type: ignore[arg-type]
-
-        # Loop should have exited before calling scan.
+        assert ran is False
         scan_service.scan.assert_not_called()
+        mock_write.assert_not_called()
+        stub._refresh_fleet_panels_after_scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_scan_with_progress_and_stale_only(self) -> None:
+        """scan() gets stale_only + the app's progress router as on_progress."""
+        for expected_stale_only in (True, False):
+            result = MagicMock()
+            scan_service = MagicMock()
+            scan_service.scan = AsyncMock(return_value=result)
+            stub = _make_stub(
+                fleet_scan_service=scan_service, memory_service=MagicMock()
+            )
+            stub.instances = [{"id": "web-1", "name": "web-1"}]
+
+            with patch("servonaut.services.memory.scan_state.write_last_run"):
+                ran = await ServonautApp._run_fleet_auto_scan_cycle(  # type: ignore[arg-type]
+                    stub, expected_stale_only
+                )
+
+            assert ran is True
+            scan_service.scan.assert_awaited_once_with(
+                stub.instances,
+                stale_only=expected_stale_only,
+                on_progress=stub._fleet_manual_scan_progress,
+            )
+
+    @pytest.mark.asyncio
+    async def test_persists_last_run_and_refreshes_panels_on_success(self) -> None:
+        """A successful pass writes last_run (disk + memory) and refreshes panels."""
+        result = MagicMock()
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(return_value=result)
+        stub = _make_stub(fleet_scan_service=scan_service, memory_service=MagicMock())
+        stub.instances = [{"id": "web-1", "name": "web-1"}]
+        stub._fleet_auto_scan_last_run = 0.0
+
+        with patch(
+            "servonaut.services.memory.scan_state.write_last_run"
+        ) as mock_write:
+            await ServonautApp._run_fleet_auto_scan_cycle(stub, True)  # type: ignore[arg-type]
+
+        assert stub._fleet_auto_scan_last_run > 0.0
+        mock_write.assert_called_once()
+        # persisted value matches the in-memory marker
+        assert mock_write.call_args.args[0] == stub._fleet_auto_scan_last_run
+        stub._refresh_fleet_panels_after_scan.assert_called_once_with(
+            result, quiet=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_scan_exception_does_not_persist_but_reports_ran(self) -> None:
+        """A scan that raises: ran=True (back off a full interval), last_run intact."""
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(side_effect=RuntimeError("ssh down"))
+        stub = _make_stub(fleet_scan_service=scan_service, memory_service=MagicMock())
+        stub.instances = [{"id": "web-1", "name": "web-1"}]
+        stub._fleet_auto_scan_last_run = 0.0
+
+        with patch(
+            "servonaut.services.memory.scan_state.write_last_run"
+        ) as mock_write:
+            ran = await ServonautApp._run_fleet_auto_scan_cycle(stub, True)  # type: ignore[arg-type]
+
+        assert ran is True
+        assert stub._fleet_auto_scan_last_run == 0.0
+        mock_write.assert_not_called()
+        stub._refresh_fleet_panels_after_scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates(self) -> None:
+        """CancelledError from scan() propagates so the worker unwinds."""
+        scan_service = MagicMock()
+        scan_service.scan = AsyncMock(side_effect=asyncio.CancelledError())
+        stub = _make_stub(fleet_scan_service=scan_service, memory_service=MagicMock())
+        stub.instances = [{"id": "web-1", "name": "web-1"}]
+
+        with patch("servonaut.services.memory.scan_state.write_last_run"):
+            with pytest.raises(asyncio.CancelledError):
+                await ServonautApp._run_fleet_auto_scan_cycle(stub, True)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# scan_state — persisted last-run round-trip + fail-soft
+# ---------------------------------------------------------------------------
+
+class TestScanStatePersistence:
+    """read_last_run / write_last_run survive restarts and never crash on bad data."""
+
+    def test_missing_file_returns_zero(self, tmp_path) -> None:
+        from servonaut.services.memory import scan_state
+        assert scan_state.read_last_run(tmp_path) == 0.0
+
+    def test_round_trip(self, tmp_path) -> None:
+        from servonaut.services.memory import scan_state
+        scan_state.write_last_run(1_700_000_000.5, tmp_path)
+        assert scan_state.read_last_run(tmp_path) == 1_700_000_000.5
+
+    def test_corrupt_file_returns_zero(self, tmp_path) -> None:
+        from servonaut.services.memory import scan_state
+        scan_state.state_path(tmp_path).write_text("{not json", encoding="utf-8")
+        assert scan_state.read_last_run(tmp_path) == 0.0
+
+    def test_bool_and_nonpositive_rejected(self, tmp_path) -> None:
+        from servonaut.services.memory import scan_state
+        p = scan_state.state_path(tmp_path)
+        p.write_text('{"auto_scan_last_run_at": true}', encoding="utf-8")
+        assert scan_state.read_last_run(tmp_path) == 0.0
+        p.write_text('{"auto_scan_last_run_at": -5}', encoding="utf-8")
+        assert scan_state.read_last_run(tmp_path) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _refresh_fleet_panels_after_scan — shared post-scan UI refresh
+# ---------------------------------------------------------------------------
+
+class TestRefreshFleetPanelsAfterScan:
+    """Routes to the right screen hook (quiet vs manual) and the memory column."""
+
+    def _make_app_stub(self, screen) -> SimpleNamespace:
+        return SimpleNamespace(screen=screen)
+
+    def test_quiet_uses_auto_hook(self) -> None:
+        screen = MagicMock(spec=["on_fleet_auto_scan_done", "refresh_memory_status"])
+        app = self._make_app_stub(screen)
+        result = MagicMock()
+        ServonautApp._refresh_fleet_panels_after_scan(app, result, quiet=True)  # type: ignore[arg-type]
+        screen.on_fleet_auto_scan_done.assert_called_once_with(result)
+        screen.refresh_memory_status.assert_called_once_with()
+
+    def test_non_quiet_uses_manual_hook(self) -> None:
+        screen = MagicMock(spec=["on_fleet_manual_scan_done", "refresh_memory_status"])
+        app = self._make_app_stub(screen)
+        result = MagicMock()
+        ServonautApp._refresh_fleet_panels_after_scan(app, result, quiet=False)  # type: ignore[arg-type]
+        screen.on_fleet_manual_scan_done.assert_called_once_with(result)
+
+    def test_noop_when_screen_lacks_hooks(self) -> None:
+        """A screen without memory hooks (e.g. some other view) → no crash."""
+        screen = MagicMock(spec=[])  # no memory methods
+        app = self._make_app_stub(screen)
+        # Must not raise.
+        ServonautApp._refresh_fleet_panels_after_scan(app, MagicMock(), quiet=True)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description of Changes

Fixes a bug where the **background fleet memory auto-scan never ran** under normal usage, so servers stayed perpetually stale even with auto-scan enabled.

### Root cause
- The loop slept the full configured interval (24h default) **before** its first scan, and the last-run marker lived only in memory (reset to `0` on every boot).
- A TUI process rarely stays up for a whole interval, so the first cycle never arrived — every restart restarted the clock.

### Changes
- **Persistent schedule** — new `services/memory/scan_state.py` stores the last-run timestamp in `~/.servonaut/memory_scan_state.json` (atomic write, fails soft) so the schedule survives restarts.
- **Compute-then-sleep loop with catch-up** — after a short startup grace, if the interval has already elapsed since the persisted last run the loop scans immediately instead of sleeping a full interval first. A skipped cycle (instances not loaded yet) retries after the grace rather than burning a full interval. The countdown marker is seeded from disk at loop start.
- **Live panel updates** — extracted `_run_fleet_auto_scan_cycle` and `_refresh_fleet_panels_after_scan` (shared by manual + auto scans) so a background cycle updates the Fleet Memory table live (progress + repopulate) and the instance-list memory column, without an interrupting summary modal. Adds `on_fleet_auto_scan_done` (quiet refresh) and `refresh_memory_status` (cursor-preserving re-render).

### Testing
- Full memory/fleet/instance-list suites pass (1274 tests); loop-body tests rewritten for the new scheduling model, with added coverage for the scan cycle, `scan_state` persistence/fail-soft, and the shared panel-refresh routing.
- End-to-end smoke of the real loop coroutine (real service, real persistence, real event loop — no mocked sleep) confirms catch-up fires + persists, no duplicate while not due, and re-fires after a simulated restart when overdue.

**Net effect:** shortly after launch, a stale fleet gets its catch-up memory scan, and it stays reliable across the frequent restarts that previously defeated it.
