### PR TITLE
perf(settings): build panels lazily so the screen opens ~8x faster

### DIFF
--- a/src/servonaut/screens/settings/shell.py
+++ b/src/servonaut/screens/settings/shell.py
@@ -1,11 +1,19 @@
 """Settings shell — master/detail side-menu screen.
 
 A left nav rail of grouped category buttons + a content pane that shows ONLY
-the selected panel. All panels are instantiated once (via registry factories,
-each wrapped in a per-panel try/except so one broken panel can't break the
-screen) and mounted hidden except the active one; switching toggles ``display``
-and the ``--active`` nav class. A search box filters nav buttons by title +
-keywords, and an unsaved-changes guard intercepts panel switches and back.
+the selected panel. Panels are built and mounted LAZILY — on first selection —
+via registry factories, each wrapped in a per-panel try/except so one broken
+panel can't break the screen. Switching toggles ``display`` and the
+``--active`` nav class. A search box filters nav buttons by title + keywords
+(nav buttons come from static spec metadata, so search works for panels that
+have never been built), and an unsaved-changes guard intercepts panel switches
+and back.
+
+Why lazy: mounting all panels up front cost ~4 s before the screen could
+paint. Each ``mount()`` re-applies the stylesheet against a growing widget
+tree, so 24 panels (~1100 widgets) was far more than 24× the cost of one —
+and 23 of them were mounted only to be hidden immediately. Building on demand
+restores the laziness the registry's factories were already written for.
 """
 
 from __future__ import annotations
@@ -18,6 +26,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen, Screen
+from textual.widget import Widget
 from textual.widgets import Button, Footer, Header, Input, Static
 
 from servonaut.screens.settings.base import SettingsPanel
@@ -100,10 +109,16 @@ class SettingsScreen(Screen):
         super().__init__()
         # panel_id -> mounted SettingsPanel (only successfully-built panels).
         self._panels: Dict[str, SettingsPanel] = {}
+        # panel_id -> the mounted widget shown for it: the panel itself, or an
+        # "unavailable" placeholder when its factory raised. Drives display
+        # toggling; _panels stays panels-only so the dirty guard never sees a
+        # placeholder.
+        self._content_of: Dict[str, Widget] = {}
         self._active_id: Optional[str] = None
         # group name -> its collapsible SidebarSection, and panel id -> group.
         self._sections: Dict[str, SidebarSection] = {}
         self._group_of: Dict[str, str] = {spec.id: spec.group for spec in PANELS}
+        self._spec_of: Dict[str, PanelSpec] = {spec.id: spec for spec in PANELS}
 
     # ------------------------------------------------------------------
     # Composition
@@ -170,33 +185,67 @@ class SettingsScreen(Screen):
             nav.mount(section)
 
     def _mount_panels(self) -> None:
-        """Instantiate + mount panels; first visible, rest hidden.
+        """Build + show only the initial panel; the rest mount on first use.
 
-        A factory that raises (panel not built / broken) mounts a placeholder
-        Static instead so a single bad panel never breaks the whole screen.
+        Walks ``PANELS`` in order and stops at the first one that builds, so a
+        broken leading panel still falls through to the next (its placeholder is
+        mounted by :meth:`_ensure_content`, as before). Every other panel is
+        deferred to :meth:`_ensure_content` on first selection — see the module
+        docstring for why mounting all of them here was the wrong trade.
         """
-        content = self.query_one("#settings-content", Vertical)
-        first = True
         for spec in PANELS:
-            try:
-                panel = spec.factory()()
-            except Exception as exc:
-                logger.error("Settings panel %s failed to build: %s", spec.id, exc)
-                content.mount(
-                    Static(
-                        escape(f"⚠ {spec.title}: unavailable"),
-                        id=f"placeholder_{spec.id}",
-                        classes="settings-panel panel-unavailable",
-                    )
-                )
-                continue
-            panel.display = first
-            content.mount(panel)
-            self._panels[spec.id] = panel
-            if first:
-                self._active_id = spec.id
-                self._set_nav_active(spec.id)
-                first = False
+            self._ensure_content(spec.id)
+            panel = self._panels.get(spec.id)
+            if panel is None:
+                continue  # factory raised — try the next one for the initial view
+            panel.display = True
+            self._active_id = spec.id
+            self._set_nav_active(spec.id)
+            return
+
+    def _ensure_content(self, panel_id: str) -> Optional[Widget]:
+        """Return the mounted widget for *panel_id*, building it on first use.
+
+        Idempotent and cached: a panel is only ever constructed once, so
+        revisiting a panel is a pure ``display`` toggle with no rebuild cost.
+        Newly built widgets are mounted hidden — the caller owns visibility.
+
+        A factory that raises (panel not built / broken) mounts an
+        "unavailable" placeholder in its place so one bad panel never breaks
+        the screen; the failure is cached too, so a broken factory is not
+        retried on every click.
+
+        Args:
+            panel_id: A ``PanelSpec.id`` from the registry.
+
+        Returns:
+            The mounted panel, the placeholder standing in for a broken one, or
+            ``None`` when *panel_id* is not a known panel.
+        """
+        existing = self._content_of.get(panel_id)
+        if existing is not None:
+            return existing
+        spec = self._spec_of.get(panel_id)
+        if spec is None:
+            return None
+
+        content = self.query_one("#settings-content", Vertical)
+        try:
+            widget: Widget = spec.factory()()
+        except Exception as exc:
+            logger.error("Settings panel %s failed to build: %s", spec.id, exc)
+            widget = Static(
+                escape(f"⚠ {spec.title}: unavailable"),
+                id=f"placeholder_{spec.id}",
+                classes="settings-panel panel-unavailable",
+            )
+        else:
+            self._panels[spec.id] = widget  # type: ignore[assignment]
+
+        widget.display = False
+        content.mount(widget)
+        self._content_of[panel_id] = widget
+        return widget
 
     # ------------------------------------------------------------------
     # Navigation + switching
@@ -212,8 +261,12 @@ class SettingsScreen(Screen):
         self._request_switch(target_id)
 
     def _request_switch(self, target_id: str) -> None:
-        """Switch to *target_id*, guarding unsaved changes in the current panel."""
-        if target_id == self._active_id or target_id not in self._panels:
+        """Switch to *target_id*, guarding unsaved changes in the current panel.
+
+        Validity is checked against the static spec catalog, not ``_panels`` —
+        with lazy mounting a valid target legitimately has no instance yet.
+        """
+        if target_id == self._active_id or target_id not in self._spec_of:
             return
         current = self._current_panel()
         if current is not None and current.is_dirty():
@@ -234,12 +287,21 @@ class SettingsScreen(Screen):
         self._switch_to(target_id)
 
     def _switch_to(self, target_id: str) -> None:
-        """Hide the current panel, show *target_id*, update nav highlight."""
-        current = self._current_panel()
+        """Hide the current panel, show *target_id*, update nav highlight.
+
+        Builds *target_id* on first visit (see :meth:`_ensure_content`), so the
+        first switch to a panel costs its mount and every later one is a plain
+        ``display`` toggle.
+        """
+        widget = self._ensure_content(target_id)
+        if widget is None:
+            return
+        # Hide by mounted widget, not _current_panel(), so an active
+        # "unavailable" placeholder is hidden too.
+        current = self._content_of.get(self._active_id or "")
         if current is not None:
             current.display = False
-        panel = self._panels[target_id]
-        panel.display = True
+        widget.display = True
         self._active_id = target_id
         self._set_nav_active(target_id)
         # Keep only the active group expanded (sections are mounted by now, so

--- a/tests/test_settings_shell_boot.py
+++ b/tests/test_settings_shell_boot.py
@@ -44,18 +44,64 @@ class _SettingsBootApp(App):
 
 
 @pytest.mark.asyncio
-async def test_all_panels_mount_no_placeholders():
-    """Every registry panel mounts as a real panel — no placeholder fallback."""
+async def test_only_the_initial_panel_is_built_on_open():
+    """Opening settings builds ONE panel, not the whole catalog.
+
+    Performance guard: mounting every panel up front cost ~4 s before the
+    screen could paint (each mount re-applies the stylesheet against a growing
+    tree). Panels must stay lazy — built on first selection.
+    """
     app = _SettingsBootApp()
     async with app.run_test(size=(140, 45)) as pilot:
         await pilot.pause()
         screen = app.screen
+        assert list(screen._panels.keys()) == [PANELS[0].id]
+        # Nav buttons are spec-driven, so every panel is still reachable.
+        for spec in PANELS:
+            assert screen.query_one(f"#navbtn_{spec.id}") is not None
+
+
+@pytest.mark.asyncio
+async def test_all_panels_build_no_placeholders():
+    """Every registry panel builds as a real panel — no placeholder fallback.
+
+    Panels are lazy now, so force each one through the shell's own build path
+    rather than relying on open to have mounted them.
+    """
+    app = _SettingsBootApp()
+    async with app.run_test(size=(140, 45)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        for spec in PANELS:
+            screen._ensure_content(spec.id)
+        await pilot.pause()
         # The shell records successfully-built panels keyed by id.
         assert set(screen._panels.keys()) == {spec.id for spec in PANELS}
         assert len(screen._panels) == len(PANELS)
         # No placeholder widgets were mounted (those signal a broken factory).
         placeholders = screen.query(".panel-unavailable")
         assert len(placeholders) == 0
+
+
+@pytest.mark.asyncio
+async def test_panels_are_built_once_and_cached():
+    """Revisiting a panel reuses the instance — no rebuild cost, no state loss."""
+    app = _SettingsBootApp()
+    async with app.run_test(size=(140, 45)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+
+        screen._switch_to("aws")
+        await pilot.pause()
+        first_instance = screen._panels["aws"]
+
+        screen._switch_to("mcp")
+        await pilot.pause()
+        screen._switch_to("aws")
+        await pilot.pause()
+
+        assert screen._panels["aws"] is first_instance
+        assert first_instance.display is True
 
 
 @pytest.mark.asyncio
@@ -157,7 +203,11 @@ async def test_nav_sections_collapsible_and_search_aware():
 
 @pytest.mark.asyncio
 async def test_preview_panels_show_banner_and_nav_tag():
-    """Scaffolded providers (GCP/Azure) carry a preview banner + nav tag."""
+    """Scaffolded providers (GCP/Azure) carry a preview banner + nav tag.
+
+    The nav tag is spec-driven so it is asserted before the panel is built;
+    the banner needs the panel, so it is built on demand first.
+    """
     from servonaut.screens.settings.widgets import PreviewBanner
 
     app = _SettingsBootApp()
@@ -166,8 +216,11 @@ async def test_preview_panels_show_banner_and_nav_tag():
         await pilot.pause()
         screen = app.screen
         for pid in ("gcp", "azure"):
-            assert len(screen._panels[pid].query(PreviewBanner)) == 1
+            # Nav tag is available without building the panel.
             assert "preview" in str(screen.query_one(f"#navbtn_{pid}").label).lower()
+            screen._ensure_content(pid)
+            await pilot.pause()
+            assert len(screen._panels[pid].query(PreviewBanner)) == 1
         # A live provider is NOT tagged.
         assert "preview" not in str(screen.query_one("#navbtn_aws").label).lower()
 


### PR DESCRIPTION
## Description of Changes

Opening **Settings** took ~4 seconds before the screen could paint. This makes it open in ~0.5 s.

### It wasn't slow IO
Worth stating up front, because it's the non-obvious part: every blocking-IO candidate is **already correctly deferred**. The wafv2 IP-set discovery is button-triggered and wrapped in `run_in_executor`; the Bitwarden CLI, entitlements lookup, and Memory Sync status all dispatch via `run_worker`; there's no `keyring`, no `~/.ssh` glob, no sync `httpx` on the open path; `config_manager.get()` is cached. The import tree costs only ~0.2 s, mostly Textual that's already loaded.

### The actual cause
`shell.py::_mount_panels` built and mounted **all 24 panels (~1100 widgets)** on open — then immediately hid 23 of them. Each `mount()` re-applies the stylesheet against a growing widget tree, so the total is closer to *(mounts × tree size)* than to 24× one panel. Profiled: `stylesheet.apply` at **5.9 s cumulative across 3365 calls**, `css/parse.py:parse` at 15868 calls.

Notably, `registry.py`'s factories were already written to import lazily ("so importing this module does not import every panel eagerly") — the shell defeated that by calling all 24 factories immediately. This restores the design intent.

### Changes
- **`_ensure_content(panel_id)`** — builds + mounts a panel on demand and caches it, so a revisit is a pure `display` toggle with no rebuild and no state loss. The broken-factory placeholder path is preserved, and the failure is cached so a bad factory isn't retried on every click.
- **`_mount_panels`** — builds only the initial panel, still falling through to the next spec if a leading panel's factory raises.
- **`_request_switch`** — validates against the static spec catalog instead of built panels (with lazy mounting, a valid target legitimately has no instance yet).
- **`_switch_to`** — hides by mounted widget, so an active placeholder is hidden too.

### Why this is safe
- **No global "Save All" exists** — each panel owns its own `persist()` behind its own Save button, so an unbuilt panel has no state anything expects.
- **Nav + search are spec-driven** — every panel stays reachable and searchable before it's ever built (verified: search finds `hetzner` while `hetzner` is unbuilt, and clicking through builds it).
- The unsaved-changes guard still works; `_panels` stays panels-only so it never sees a placeholder.

### Measured (real app, Textual headless pilot — not theory)
| | before | after |
|---|---|---|
| **Open Settings** | 3996 ms | **524 ms (~8.5×)** |
| First visit to a panel | — | 335–647 ms (pays its own mount) |
| Revisit (cached) | — | 98–242 ms (display toggle) |

**The cost is moved, not erased:** you now pay per panel you actually open, and never for the ones you don't.

### Testing
Full suite green (**6272 passed, 6 skipped**). Rewrote the two tests that encoded the eager contract — preserving their "every panel builds, no placeholders" guard by forcing builds through the shell's own path — and added guards that only one panel builds on open (so eager mounting can't be silently reintroduced) and that panels are built once and cached.
