### PR TITLE
feat(remediation): add unblock_ip executor (inverse of block_ip)

### DIFF
--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -916,6 +916,12 @@ class RelayListener:
                 "remediation_executor_unavailable: this CLI session "
                 "cannot execute remediations"
             )
+        elif verb == "unblock_ip":
+            # The inverse of block_ip: undo a ban this fleet applied. Same
+            # AWS-vs-on-box split, dispatched on the method from the handle.
+            status, output, error_message = await self._execute_unblock_ip(
+                raw, payload,
+            )
         elif verb in LOCAL_DISPATCH_VERBS:
             # block_ip never becomes a command line — it dispatches to
             # the local curated IP-ban service (WAF/SG/NACL), which is
@@ -1217,6 +1223,204 @@ class RelayListener:
         slug = classify_failure("block_ip", exit_code, cleaned)
         output = build_remediation_result(
             verb="block_ip", ok=False, exit_code=exit_code, output=cleaned,
+            payload=payload, slug=slug, extra=extra,
+        )
+        return "success", output, ""
+
+    #: AWS unban outcomes whose message means "the ip was already not
+    #: banned" — the idempotent success case (goal state reached). Covers
+    #: WAF/NACL "not found in ... ban list" and the SG revoke that raises
+    #: InvalidPermission.NotFound → "The specified rule does not exist".
+    _UNBAN_IDEMPOTENT_MARKERS = (
+        "not found", "does not exist", "not banned", "no such",
+    )
+
+    async def _execute_unblock_ip(
+        self, raw: dict, payload: dict,
+    ) -> tuple:
+        """Execute a confirmed ``unblock_ip`` remediation locally.
+
+        The inverse of :meth:`_execute_block_ip`, with the same
+        AWS-vs-on-box split dispatched on the method: on-box methods
+        (nftables/ufw/firewalld) remove the box firewall rule over the relay
+        SSH path keyed on the ip; AWS methods (waf/security_group/nacl) go
+        through :class:`IPBanService`, which re-resolves the rule from the ip
+        — so an out-of-band-mutated ``rule_id`` in the payload can't make us
+        delete the wrong rule (the wire ``rule_id`` is informational only).
+
+        Idempotent throughout: unbanning an ip that isn't banned is a
+        ``status="success"`` / ``ok:true`` outcome (the goal state already
+        holds), mirroring the ban path's "already banned".
+        """
+        from servonaut.services.remediation_executor import (
+            ONBOX_BLOCK_METHODS,
+            RemediationValidationError,
+            build_remediation_result,
+            coerce_dry_run,
+            validate_unblock_ip_payload,
+        )
+
+        try:
+            ip, method = validate_unblock_ip_payload(payload)
+        except RemediationValidationError as exc:
+            return "error", "", str(exc)
+
+        if method in ONBOX_BLOCK_METHODS:
+            return await self._execute_onbox_unblock(raw, payload, ip, method)
+
+        # Resolve the IPBanConfig for the method, preferring a region match
+        # (envelope region, else the target instance's region). Best-effort
+        # instance lookup for the region hint only — no self-ban mirror is
+        # needed on the unban path.
+        region_hint = ""
+        target = str(raw.get("target_server_id") or "")
+        if target:
+            try:
+                instance = await self._executors.find_instance(target)
+            except Exception:  # noqa: BLE001 — region hint only
+                instance = None
+            if instance:
+                region_hint = str(instance.get("region") or "")
+
+        svc = self._executors.ip_ban_service
+        candidates = [c for c in svc.get_configs() if c.method == method]
+        region = str(payload.get("region") or "") or region_hint
+        config = None
+        if region:
+            config = next(
+                (c for c in candidates if c.region == region), None,
+            )
+        if config is None and candidates:
+            config = candidates[0]
+        if config is None:
+            return "error", "", (
+                f"unblock_ip_config_missing: no IP-ban configuration with "
+                f"method '{method}' exists on this CLI — cannot undo a "
+                f"'{method}' ban without its config"
+            )
+
+        extra = {"strategy": method, "ip": ip, "ip_ban_config": config.name}
+        if coerce_dry_run(payload):
+            output = build_remediation_result(
+                verb="unblock_ip", ok=True, exit_code=0,
+                output=(
+                    f"DRY RUN - would unban {ip} via {method} config "
+                    f"'{config.name}' (no change made)"
+                ),
+                payload=payload,
+                extra={**extra, "would_unban": True},
+            )
+            return "success", output, ""
+
+        try:
+            result = await svc.unban_ip(ip, config.name)
+        except Exception as exc:  # noqa: BLE001 — must still answer
+            logger.exception("unblock_ip dispatch failed: %s", exc)
+            result = {"success": False, "message": str(exc)}
+
+        message = str(result.get("message") or "")
+        if result.get("success"):
+            output = build_remediation_result(
+                verb="unblock_ip", ok=True, exit_code=0, output=message,
+                payload=payload, extra=extra,
+            )
+            return "success", output, ""
+        if any(m in message.lower() for m in self._UNBAN_IDEMPOTENT_MARKERS):
+            # Idempotent: the goal state (ip not banned) already holds.
+            output = build_remediation_result(
+                verb="unblock_ip", ok=True, exit_code=0, output=message,
+                payload=payload,
+                extra={**extra, "already_unbanned": True},
+            )
+            return "success", output, ""
+        output = build_remediation_result(
+            verb="unblock_ip", ok=False, exit_code=1, output=message,
+            payload=payload, slug="unblock_ip_failed", extra=extra,
+        )
+        return "success", output, ""
+
+    async def _execute_onbox_unblock(
+        self, raw: dict, payload: dict, ip: str, method: str,
+    ) -> tuple:
+        """Execute an on-box firewall UNBAN (nftables / ufw / firewalld).
+
+        Inverse of :meth:`_execute_onbox_block`: runs the box's own firewall
+        tool over the relay SSH path — argv built LOCALLY from the validated
+        ip, never server text — and judges success on the remote exit code.
+        The command's final VERIFY step (ip is NO LONGER in the ruleset →
+        exit 0) makes removing a non-existent rule an idempotent success.
+        """
+        from servonaut.services.remediation_executor import (
+            build_onbox_unblock_command,
+            build_remediation_result,
+            classify_failure,
+            coerce_dry_run,
+            parse_exit_marker,
+            wrap_with_exit_marker,
+        )
+
+        extra = {"strategy": method, "ip": ip}
+        if coerce_dry_run(payload):
+            output = build_remediation_result(
+                verb="unblock_ip", ok=True, exit_code=0,
+                output=f"DRY RUN - would unban {ip} via {method} (no change made)",
+                payload=payload,
+                extra={**extra, "would_unban": True},
+            )
+            return "success", output, ""
+
+        target = str(raw.get("target_server_id") or "")
+        if not target:
+            return "error", "", (
+                "unblock_ip_target_missing: on-box firewall unban needs a "
+                "target instance to run the command on"
+            )
+
+        command = build_onbox_unblock_command(method, ip)
+        try:
+            ttl = int(payload.get("timeout_seconds") or 120)
+        except (TypeError, ValueError):
+            ttl = 120
+        marker_nonce = secrets.token_hex(8)
+        request = CommandRequest(
+            id=str(raw.get("id") or ""),
+            user_id=str(raw.get("user_id") or self._user_id),
+            type=CommandType.RUN_COMMAND,
+            target_server_id=target,
+            payload={"command": wrap_with_exit_marker(command, marker_nonce)},
+            ttl_seconds=ttl,
+        )
+        try:
+            response = await self._executors.execute(request)
+        except Exception as exc:  # noqa: BLE001 — must still answer
+            logger.exception("on-box unblock_ip failed to execute: %s", exc)
+            return "error", "", f"remediation_execution_failed: {exc}"
+
+        if response.status == "timeout":
+            output = build_remediation_result(
+                verb="unblock_ip", ok=False, exit_code=None, output="",
+                payload=payload, slug="remediation_timeout", extra=extra,
+            )
+            return "success", output, ""
+        if response.status != "success":
+            return "error", "", (
+                "remediation_execution_failed: "
+                f"{response.error_message or response.status}"
+            )
+
+        exit_code, cleaned = parse_exit_marker(response.output, marker_nonce)
+        # The command's VERIFY step exits 0 iff the ip is NO LONGER in the
+        # active ruleset — so exit 0 = unbanned (whether freshly removed or
+        # never present).
+        if exit_code == 0:
+            output = build_remediation_result(
+                verb="unblock_ip", ok=True, exit_code=0, output=cleaned,
+                payload=payload, extra=extra,
+            )
+            return "success", output, ""
+        slug = classify_failure("unblock_ip", exit_code, cleaned)
+        output = build_remediation_result(
+            verb="unblock_ip", ok=False, exit_code=exit_code, output=cleaned,
             payload=payload, slug=slug, extra=extra,
         )
         return "success", output, ""

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -34,11 +34,14 @@ REMEDIATION_SOURCE = "proactive_remediation"
 #: from validated payload fields, judged via the exit marker).
 SSH_COMMAND_VERBS = frozenset({"certbot_renew"})
 
-#: Verbs executed by a LOCAL curated service call (no SSH, no shell) —
-#: ``block_ip`` dispatches to :class:`IPBanService` (WAF / security
-#: group / NACL strategies), which is already audited via the IP-ban
-#: audit trail.
-LOCAL_DISPATCH_VERBS = frozenset({"block_ip"})
+#: Verbs handled by a dedicated ``_execute_*`` method rather than the
+#: generic SSH-command builder. ``block_ip`` / ``unblock_ip`` each dispatch
+#: to :class:`IPBanService` (WAF / security group / NACL) for the AWS
+#: methods — already audited via the IP-ban audit trail — and fall back to
+#: an on-box firewall command over the relay SSH path for the on-box
+#: methods (see :data:`ONBOX_BLOCK_METHODS`). Named "local dispatch"
+#: because these verbs never go through :func:`build_remediation_command`.
+LOCAL_DISPATCH_VERBS = frozenset({"block_ip", "unblock_ip"})
 
 #: The verbs this CLI knows how to execute. Grows one playbook at a time,
 #: in lockstep with the server-side allowlist — never a generic shell.
@@ -272,6 +275,107 @@ def build_onbox_block_command(method: str, ip: str) -> str:
         f"sudo -n nft add element inet servonaut_ban {set_name} "
         f"'{{ {ip} }}' 2>/dev/null; "
         f"sudo -n nft list set inet servonaut_ban {set_name} "
+        f"| grep -qF '{ip}'"
+    )
+
+
+def validate_unblock_ip_payload(payload: Dict[str, Any]) -> Tuple[str, str]:
+    """Validate an ``unblock_ip`` payload; return ``(canonical_ip, method)``.
+
+    The inverse of :func:`validate_block_ip_payload`, and its client-side
+    mirror of the server's rails — the server derives the ip and method
+    from the ban's captured handle and applies the same floor authoritatively:
+
+    - exactly ONE ip address, no CIDR
+    - globally routable only (private / loopback / link-local / multicast /
+      reserved / unspecified are refused, same floor as the ban path)
+    - ``method`` from :data:`BLOCK_IP_METHODS`
+
+    Unlike the ban validator this takes no ``refused_ips`` set: the self-ban
+    guard exists to stop a ban cutting the box off; *unbanning* an address is
+    never a lock-out, so there is nothing to refuse.
+    """
+    raw_ip = payload.get("ip")
+    if not isinstance(raw_ip, str) or not raw_ip.strip():
+        raise RemediationValidationError(
+            "invalid_unblock_ip_address: payload is missing an ip",
+        )
+    candidate = raw_ip.strip()
+    if "/" in candidate:
+        raise RemediationValidationError(
+            f"invalid_unblock_ip_address: {candidate!r} is a network — "
+            f"unblock_ip takes exactly one address (no CIDR)",
+        )
+    try:
+        addr = ipaddress.ip_address(candidate)
+    except ValueError:
+        raise RemediationValidationError(
+            f"invalid_unblock_ip_address: {candidate!r} is not a valid "
+            f"IPv4/IPv6 address",
+        ) from None
+    if (addr.is_multicast or addr.is_loopback or addr.is_link_local
+            or addr.is_private or addr.is_reserved or addr.is_unspecified
+            or not addr.is_global):
+        raise RemediationValidationError(
+            f"unblock_ip_address_not_public: {addr} is private, loopback, "
+            f"link-local, multicast, or reserved — never a valid ban target",
+        )
+    method = payload.get("method")
+    if not isinstance(method, str) or method not in BLOCK_IP_METHODS:
+        allowed = ", ".join(sorted(BLOCK_IP_METHODS))
+        raise RemediationValidationError(
+            f"invalid_unblock_ip_method: {method!r} is not one of {allowed}",
+        )
+    return str(addr), method
+
+
+def build_onbox_unblock_command(method: str, ip: str) -> str:
+    """Build the on-box firewall UNBAN command for an on-box method.
+
+    The exact inverse of :func:`build_onbox_block_command`: remove the box
+    firewall rule for *ip*, then VERIFY the ip is **no longer** in the active
+    ruleset so exit 0 means "the ip is not blocked". This makes the operation
+    idempotent by construction — unbanning an ip that was never banned removes
+    nothing and still verifies clean (exit 0), so a double Undo, or undoing a
+    ban that already expired, is a success rather than an error.
+
+    *ip* MUST already be canonicalised + validated by
+    :func:`validate_unblock_ip_payload` (single public address, no CIDR, no
+    shell metacharacters) — this builder interpolates it and does NOT
+    re-parse it. All writes go through non-interactive ``sudo -n``; a
+    password prompt fails closed. Rule-removal exit codes are swallowed
+    (``2>/dev/null``) so only the VERIFY step decides success.
+    """
+    if method not in ONBOX_BLOCK_METHODS:
+        raise RemediationValidationError(
+            f"invalid_unblock_ip_method: {method!r} is not an on-box "
+            f"firewall method",
+        )
+    is_v6 = ipaddress.ip_address(ip).version == 6
+    if method == "ufw":
+        return (
+            f"sudo -n ufw delete deny from {ip} to any 2>/dev/null; "
+            f"! sudo -n ufw status | grep -qF '{ip}'"
+        )
+    if method == "firewalld":
+        fam = "ipv6" if is_v6 else "ipv4"
+        rule = f'rule family="{fam}" source address="{ip}" drop'
+        return (
+            f"sudo -n firewall-cmd --remove-rich-rule='{rule}' 2>/dev/null; "
+            f"sudo -n firewall-cmd --permanent --remove-rich-rule='{rule}' "
+            f"2>/dev/null; "
+            f"! sudo -n firewall-cmd --list-rich-rules 2>/dev/null "
+            f"| grep -qF '{ip}'"
+        )
+    # nftables: drop the ip from the servonaut_ban set (the ban added it as
+    # a set element). The set/table may not exist if the ip was never banned
+    # via servonaut — delete + list both tolerate that (2>/dev/null → empty),
+    # so VERIFY finds nothing and exits 0.
+    set_name = "banned6" if is_v6 else "banned4"
+    return (
+        f"sudo -n nft delete element inet servonaut_ban {set_name} "
+        f"'{{ {ip} }}' 2>/dev/null; "
+        f"! sudo -n nft list set inet servonaut_ban {set_name} 2>/dev/null "
         f"| grep -qF '{ip}'"
     )
 

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -962,3 +962,369 @@ class TestOnboxBlockRouting:
         response = posted_response(listener)
         assert response.status == "error"
         assert response.error_message.startswith("block_ip_target_missing:")
+
+
+# ---------------------------------------------------------------------------
+# unblock_ip — the inverse verb (Phase 2 one-click Undo executor)
+# ---------------------------------------------------------------------------
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    AWS_BLOCK_METHODS,
+    BLOCK_IP_METHODS,
+    ONBOX_BLOCK_METHODS,
+    build_onbox_unblock_command,
+    validate_unblock_ip_payload,
+)
+
+
+class TestUnblockIpVerbSet:
+    def test_unblock_ip_is_a_local_dispatch_verb(self):
+        from servonaut.services.remediation_executor import (
+            LOCAL_DISPATCH_VERBS, SSH_COMMAND_VERBS,
+        )
+        assert "unblock_ip" in REMEDIATION_VERBS
+        assert "unblock_ip" in LOCAL_DISPATCH_VERBS
+        assert "unblock_ip" not in SSH_COMMAND_VERBS
+
+    def test_unblock_ip_never_becomes_a_command_line(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command("unblock_ip", {"ip": "9.9.9.9"})
+        assert str(exc.value).startswith("local_dispatch_verb:")
+
+
+class TestValidateUnblockIpPayload:
+    def test_valid_payload_returns_canonical_ip_and_method(self):
+        for method in BLOCK_IP_METHODS:
+            ip, m = validate_unblock_ip_payload({"ip": "9.9.9.9", "method": method})
+            assert (ip, m) == ("9.9.9.9", method)
+
+    def test_ip_is_canonicalised(self):
+        ip, _ = validate_unblock_ip_payload(
+            {"ip": "2606:4700:4700::0001", "method": "waf"},
+        )
+        assert ip == "2606:4700:4700::1"
+
+    def test_missing_ip_rejected(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_unblock_ip_payload({"method": "waf"})
+        assert str(exc.value).startswith("invalid_unblock_ip_address:")
+
+    def test_cidr_rejected(self):
+        # Any '/' is rejected before the address is parsed (no CIDR in v1),
+        # so a neutral host literal with a prefix exercises the same guard.
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_unblock_ip_payload({"ip": "9.9.9.9/24", "method": "waf"})
+        assert str(exc.value).startswith("invalid_unblock_ip_address:")
+
+    @pytest.mark.parametrize("ip", ["192.168.1.5", "127.0.0.1", "10.0.0.1"])
+    def test_private_ip_rejected(self, ip):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_unblock_ip_payload({"ip": ip, "method": "waf"})
+        assert str(exc.value).startswith("unblock_ip_address_not_public:")
+
+    @pytest.mark.parametrize("bad_method", ["", "iptables", "block", None])
+    def test_unknown_method_rejected(self, bad_method):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_unblock_ip_payload({"ip": "9.9.9.9", "method": bad_method})
+        assert str(exc.value).startswith("invalid_unblock_ip_method:")
+
+    def test_no_self_ban_refusal_on_unban(self):
+        # Unlike the ban validator, unban takes no refused_ips set — the
+        # signature has exactly one argument. Unbanning is never a lock-out.
+        import inspect
+        params = inspect.signature(validate_unblock_ip_payload).parameters
+        assert list(params) == ["payload"]
+
+
+class TestOnboxUnblockCommand:
+    def test_method_partition_matches_block(self):
+        assert AWS_BLOCK_METHODS | ONBOX_BLOCK_METHODS == BLOCK_IP_METHODS
+        assert ONBOX_BLOCK_METHODS == {"nftables", "ufw", "firewalld"}
+
+    def test_aws_method_rejected_by_onbox_builder(self):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_onbox_unblock_command("waf", "9.9.9.9")
+        assert str(exc.value).startswith("invalid_unblock_ip_method:")
+
+    @pytest.mark.parametrize("method", ["nftables", "ufw", "firewalld"])
+    def test_command_removes_then_verifies_absence(self, method):
+        cmd = build_onbox_unblock_command(method, "9.9.9.9")
+        assert "sudo -n" in cmd
+        # Ends with a NEGATED verify: exit 0 iff the ip is no longer present.
+        assert cmd.rstrip().endswith("grep -qF '9.9.9.9'")
+        assert "! sudo -n" in cmd
+        assert "9.9.9.9" in cmd
+
+    @pytest.mark.parametrize("method", ["nftables", "ufw", "firewalld"])
+    def test_rule_removal_is_error_tolerant(self, method):
+        # Removing a rule that was never there must not fail the command —
+        # only the VERIFY step judges success — so removals swallow errors.
+        cmd = build_onbox_unblock_command(method, "9.9.9.9")
+        assert "2>/dev/null" in cmd
+
+    def test_ipv6_uses_v6_set(self):
+        cmd = build_onbox_unblock_command("nftables", "2606:4700:4700::1111")
+        assert "banned6" in cmd
+
+    def test_firewalld_removes_runtime_and_permanent(self):
+        cmd = build_onbox_unblock_command("firewalld", "9.9.9.9")
+        assert cmd.count("--remove-rich-rule") == 2
+        assert "--permanent" in cmd
+
+    def test_validated_ip_has_no_shell_metacharacters(self):
+        for bad in ["9.9.9.9; rm x", "9.9.9.9$(id)", "9.9.9.9 && x"]:
+            with pytest.raises(RemediationValidationError):
+                validate_unblock_ip_payload({"ip": bad, "method": "ufw"})
+
+
+# --- AWS unblock routing (IPBanService, never SSH) -------------------------
+
+
+def make_unblock_ip_listener(*, configs=None, unban_result=None, instance=None):
+    listener = make_listener()
+    executors = listener._executors
+    executors.find_instance = AsyncMock(return_value=instance)
+    ip_ban = MagicMock()
+    ip_ban.get_configs = MagicMock(
+        return_value=configs if configs is not None else [_ip_ban_config()],
+    )
+    ip_ban.unban_ip = AsyncMock(
+        return_value=unban_result if unban_result is not None else {
+            "success": True,
+            "message": "Unbanned 9.9.9.9 from WAF IP set",
+        },
+    )
+    executors.ip_ban_service = ip_ban
+    return listener, ip_ban
+
+
+def unblock_ip_event(*, payload=None, target="web-1"):
+    return remediation_event(
+        req_id="rmd-unban-1", verb="unblock_ip", target=target,
+        payload=payload if payload is not None else {
+            "finding_id": "fnd-2", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": "waf", "applied_strategy": "waf",
+            "rule_id": "9.9.9.9/32", "dry_run": False,
+        },
+    )
+
+
+class TestUnblockIpRouting:
+    def test_success_dispatches_to_ipbanservice_never_ssh(self):
+        listener, ip_ban = make_unblock_ip_listener()
+        run(listener._handle_event(unblock_ip_event()))
+        listener._executors.execute.assert_not_awaited()
+        ip_ban.unban_ip.assert_awaited_once_with("9.9.9.9", "ban-waf")
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["verb"] == "unblock_ip"
+        assert result["ok"] is True
+        assert result["strategy"] == "waf"
+        assert result["ip"] == "9.9.9.9"
+
+    def test_ipbanservice_reresolves_from_ip_not_wire_rule_id(self):
+        # The wire rule_id is informational — unban_ip receives (ip, config),
+        # never the payload rule_id, so an out-of-band-mutated id can't make
+        # us delete the wrong rule.
+        listener, ip_ban = make_unblock_ip_listener()
+        run(listener._handle_event(unblock_ip_event(payload={
+            "finding_id": "fnd-2", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": "waf",
+            "rule_id": "stale-rule-id-from-a-mutated-sg",
+        })))
+        # Only (ip, config_name) — the stale rule_id is never passed through.
+        ip_ban.unban_ip.assert_awaited_once_with("9.9.9.9", "ban-waf")
+
+    def test_dry_run_makes_no_mutation(self):
+        listener, ip_ban = make_unblock_ip_listener()
+        run(listener._handle_event(unblock_ip_event(payload={
+            "finding_id": "fnd-2", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": "waf", "dry_run": True,
+        })))
+        ip_ban.unban_ip.assert_not_awaited()
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        assert result["would_unban"] is True
+
+    @pytest.mark.parametrize("message", [
+        "9.9.9.9 not found in WAF ban list",
+        "9.9.9.9 not found in NACL ban list",
+        "Failed to unban 9.9.9.9: The specified rule does not exist in this security group",
+    ])
+    def test_already_unbanned_is_idempotent_success(self, message):
+        listener, ip_ban = make_unblock_ip_listener(
+            unban_result={"success": False, "message": message},
+        )
+        run(listener._handle_event(unblock_ip_event()))
+        response = posted_response(listener)
+        # Goal state (ip not banned) already holds → success, not error.
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["ok"] is True
+        assert result["already_unbanned"] is True
+
+    def test_missing_config_for_method_is_cant_process(self):
+        listener, ip_ban = make_unblock_ip_listener(configs=[])
+        run(listener._handle_event(unblock_ip_event()))
+        ip_ban.unban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("unblock_ip_config_missing:")
+
+    def test_region_match_preferred_over_first_config(self):
+        listener, ip_ban = make_unblock_ip_listener(configs=[
+            _ip_ban_config(name="ban-us", method="waf", region="us-east-1"),
+            _ip_ban_config(name="ban-eu", method="waf", region="eu-west-1"),
+        ])
+        run(listener._handle_event(unblock_ip_event(payload={
+            "finding_id": "fnd-2", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": "waf", "region": "eu-west-1",
+        })))
+        ip_ban.unban_ip.assert_awaited_once_with("9.9.9.9", "ban-eu")
+
+    def test_ran_but_failed_unban_reports_slug_in_payload(self):
+        listener, ip_ban = make_unblock_ip_listener(
+            unban_result={"success": False, "message": "AccessDenied: not authorized"},
+        )
+        run(listener._handle_event(unblock_ip_event()))
+        response = posted_response(listener)
+        assert response.status == "success"  # transport fine
+        result = json.loads(response.output)
+        assert result["ok"] is False
+        assert result["slug"] == "unblock_ip_failed"
+
+    def test_validation_refusal_is_cant_process(self):
+        listener, ip_ban = make_unblock_ip_listener()
+        run(listener._handle_event(unblock_ip_event(payload={
+            "finding_id": "fnd-2", "action": "unblock_ip",
+            "ip": "192.168.1.9", "method": "waf",
+        })))
+        ip_ban.unban_ip.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("unblock_ip_address_not_public:")
+
+
+# --- on-box unblock routing (SSH firewall command) -------------------------
+
+
+def _onbox_unblock_listener(*, instance=None):
+    listener = make_listener()
+    listener._executors.find_instance = AsyncMock(return_value=instance)
+    ip_ban = MagicMock()
+    ip_ban.unban_ip = AsyncMock()
+    ip_ban.get_configs = MagicMock(return_value=[])
+    listener._executors.ip_ban_service = ip_ban
+    return listener, ip_ban
+
+
+def onbox_unblock_event(*, method="nftables", payload=None, target="custom-web-1"):
+    return remediation_event(
+        req_id="rmd-onbox-unban-1", verb="unblock_ip", target=target,
+        payload=payload if payload is not None else {
+            "finding_id": "fnd-3", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": method, "dry_run": False,
+        },
+    )
+
+
+class TestOnboxUnblockRouting:
+    def test_success_runs_firewall_over_ssh_not_ipbanservice(self):
+        listener, ip_ban = _onbox_unblock_listener()
+
+        def _echo_marker(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success", output=f"{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(onbox_unblock_event(method="nftables")))
+
+        ip_ban.unban_ip.assert_not_awaited()
+        request = listener._executors.execute.await_args.args[0]
+        assert "nft delete element" in request.payload["command"]
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == "unblock_ip"
+        assert result["ok"] is True
+        assert result["strategy"] == "nftables"
+
+    def test_dry_run_makes_no_ssh_call(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+        listener._executors.execute = AsyncMock()
+        run(listener._handle_event(onbox_unblock_event(payload={
+            "finding_id": "fnd-3", "action": "unblock_ip",
+            "ip": "9.9.9.9", "method": "ufw", "dry_run": True,
+        })))
+        listener._executors.execute.assert_not_awaited()
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["would_unban"] is True
+
+    def test_verify_absence_failure_reports_slug(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            # VERIFY still finds the ip → exit 1 (unban did not take).
+            return CommandResponse(
+                request_id=request.id, status="success", output=f"{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(onbox_unblock_event(method="ufw")))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "unblock_ip_failed"
+
+    def test_sudo_denied_classified_as_permission(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+
+        def _echo_denied(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"sudo: a password is required\n{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_denied)
+        run(listener._handle_event(onbox_unblock_event()))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "unblock_ip_permission_denied"
+
+    def test_timeout_is_a_command_outcome(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+        listener._executors.execute = AsyncMock(return_value=CommandResponse(
+            request_id="rmd-onbox-unban-1", status="timeout", output="",
+        ))
+        run(listener._handle_event(onbox_unblock_event()))
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["slug"] == "remediation_timeout"
+
+    def test_transport_failure_is_error_status(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+        listener._executors.execute = AsyncMock(return_value=CommandResponse(
+            request_id="rmd-onbox-unban-1", status="error", output="",
+            error_message="ssh channel closed",
+        ))
+        run(listener._handle_event(onbox_unblock_event()))
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("remediation_execution_failed:")
+
+    def test_missing_target_refuses(self):
+        listener, _ip_ban = _onbox_unblock_listener()
+        listener._executors.execute = AsyncMock()
+        run(listener._handle_event(onbox_unblock_event(target="")))
+        listener._executors.execute.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("unblock_ip_target_missing:")


### PR DESCRIPTION
## What this does

Adds the **`unblock_ip`** remediation executor — the inverse of `block_ip`, so an IP ban applied by the proactive-remediation flow can be reverted. It mirrors `block_ip`'s structure with the same AWS-vs-on-box split, dispatched on the ban method carried in the handle.

## How it works

### Executor (`remediation_executor.py`)
- `unblock_ip` joins `block_ip` in `LOCAL_DISPATCH_VERBS` (handled by a dedicated `_execute_*` method, never the generic SSH command builder). The `certbot_renew`/`block_ip` allowlist behaviour is unchanged, and **unknown verbs still fail closed** (`unknown_remediation_verb`).
- **`validate_unblock_ip_payload`** — the ban validator's inverse: same public-only rail and six-method enum, but **no self-ban refusal** (unbanning is never a lock-out, so there's nothing to refuse).
- **`build_onbox_unblock_command`** — inverse of `build_onbox_block_command`: removes the box firewall rule (nftables/ufw/firewalld), swallows removal errors, then **verifies the ip is no longer in the ruleset** so exit 0 means "not blocked". Idempotent by construction — removing a rule that was never there still verifies clean.

### Relay routing (`relay_listener.py`)
- Dispatch routes `unblock_ip` to `_execute_unblock_ip` (before the `block_ip` branch).
- **`_execute_unblock_ip`** — AWS methods (waf/security_group/nacl) go through `IPBanService`, which **re-resolves the rule from the ip** (WAF removes the CIDR, SG revokes by CIDR, NACL finds the entry) rather than trusting a stored `rule_id` — so an out-of-band-mutated id can't make us delete the wrong rule. "not found / does not exist" outcomes are treated as **idempotent success**, mirroring `block_ip`'s "already banned".
- **`_execute_onbox_unblock`** — inverse of `_execute_onbox_block` over the SSH path; the verify-absence step makes a repeat unban an idempotent success.

## Idempotency

Unbanning an ip that isn't banned is `status=success` / `ok=true` (goal state already holds), never an error — so repeating the operation, or reverting a ban that already expired, doesn't fail. Verified for both the AWS ("not found") and on-box (verify-absence) paths; the shell semantics of the negated verify were checked directly.

## Testing

Full suite green (+42 new tests). Coverage: verb-set membership, the unblock validator (public-only, CIDR, method), on-box command shape (negated verify, error-tolerant removal, IPv6, no shell metacharacters), AWS routing (success, dry-run, idempotent not-found, missing config, region preference, ran-but-failed slug, validation refusal, and re-resolve-from-ip-not-`rule_id`), and on-box routing (success, dry-run, verify failure, sudo-denied, timeout, transport failure, missing target). The full round-trip runs through the real dispatch path; only the SSH executor and boto3 are mocked.
