### PR TITLE
feat(remediation): add restart_service executor (systemd unit restart)

### DIFF
--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -32,7 +32,7 @@ REMEDIATION_SOURCE = "proactive_remediation"
 
 #: Verbs executed as an SSH command on the target box (built locally
 #: from validated payload fields, judged via the exit marker).
-SSH_COMMAND_VERBS = frozenset({"certbot_renew"})
+SSH_COMMAND_VERBS = frozenset({"certbot_renew", "restart_service"})
 
 #: Verbs handled by a dedicated ``_execute_*`` method rather than the
 #: generic SSH-command builder. ``block_ip`` / ``unblock_ip`` each dispatch
@@ -143,8 +143,54 @@ def _build_certbot_renew(payload: Dict[str, Any]) -> str:
     return " ".join(shlex.quote(a) for a in argv)
 
 
+# systemd unit names: alnum plus ``: _ . @ -`` (the ``@`` is required for
+# systemd template/instance unit names), with an optional known unit-type
+# suffix. Deliberately excludes ``/``, ``..``, whitespace,
+# and every shell metacharacter — the unit is interpolated into an argv that
+# is shlex-quoted, but the allowlist is the primary guard. Kept in lockstep
+# with the server-side unit validator.
+_SAFE_UNIT_RE = re.compile(
+    r"^[A-Za-z0-9:_.@-]+"
+    r"(?:\.(service|socket|timer|target|mount|path|slice|scope))?$"
+)
+
+
+def _require_unit(payload: Dict[str, Any]) -> str:
+    unit = payload.get("unit")
+    if not isinstance(unit, str) or not unit:
+        raise RemediationValidationError(
+            "invalid_unit_name: payload is missing a unit",
+        )
+    if ".." in unit or "/" in unit or not _SAFE_UNIT_RE.match(unit):
+        raise RemediationValidationError(
+            f"invalid_unit_name: {unit!r} is not a valid systemd unit name",
+        )
+    return unit
+
+
+def _build_restart_service(payload: Dict[str, Any]) -> str:
+    unit = _require_unit(payload)
+    if _coerce_dry_run(payload):
+        # No native ``systemctl --dry-run``: report the unit's current state
+        # and change nothing. Read-only queries (no sudo). A trailing ``true``
+        # forces exit 0 so the informational output — ``is-active`` exits
+        # non-zero for an inactive/failed unit — is never judged a failure
+        # (dry-run is always ``ok:true`` per the contract).
+        argv_active = ["systemctl", "is-active", unit]
+        argv_status = ["systemctl", "status", unit, "--no-pager"]
+        return (
+            " ".join(shlex.quote(a) for a in argv_active)
+            + "; "
+            + " ".join(shlex.quote(a) for a in argv_status)
+            + "; true"
+        )
+    argv = ["sudo", "-n", "systemctl", "restart", unit]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
 _VERB_BUILDERS = {
     "certbot_renew": _build_certbot_renew,
+    "restart_service": _build_restart_service,
 }
 
 # A builder registered here without a matching entry in SSH_COMMAND_VERBS
@@ -471,6 +517,19 @@ def classify_failure(verb: str, exit_code: Optional[int], output: str) -> str:
     lowered = output.lower()
     if exit_code is None:
         return "remediation_transport_failed"
+    # restart_service uses curated slugs (not the generic ``{verb}_*`` shape)
+    # so the finding evidence reads cleanly: unit_not_found /
+    # restart_permission_denied / restart_failed. (A timeout is surfaced by
+    # the relay path as ``remediation_timeout`` before it reaches here.)
+    if verb == "restart_service":
+        if "a password is required" in lowered or (
+            "sudo:" in lowered
+            and ("password" in lowered or "not allowed" in lowered)
+        ):
+            return "restart_permission_denied"
+        if "not found" in lowered or "not loaded" in lowered:
+            return "unit_not_found"
+        return "restart_failed"
     if "a password is required" in lowered or (
         "sudo:" in lowered
         and ("password" in lowered or "not allowed" in lowered)

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -1328,3 +1328,215 @@ class TestOnboxUnblockRouting:
         response = posted_response(listener)
         assert response.status == "error"
         assert response.error_message.startswith("unblock_ip_target_missing:")
+
+
+# ---------------------------------------------------------------------------
+# restart_service — SSH-command verb (mirror of certbot_renew)
+# ---------------------------------------------------------------------------
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    SSH_COMMAND_VERBS,
+    LOCAL_DISPATCH_VERBS,
+)
+
+
+class TestRestartServiceVerbSet:
+    def test_restart_service_is_an_ssh_command_verb(self):
+        assert "restart_service" in REMEDIATION_VERBS
+        assert "restart_service" in SSH_COMMAND_VERBS
+        assert "restart_service" not in LOCAL_DISPATCH_VERBS
+
+    def test_builders_and_ssh_verbs_stay_in_sync(self):
+        from servonaut.services.remediation_executor import _VERB_BUILDERS
+        assert set(_VERB_BUILDERS) == SSH_COMMAND_VERBS
+
+
+class TestBuildRestartServiceCommand:
+    def test_live_restart_fixed_argv(self):
+        cmd = build_remediation_command("restart_service", {"unit": "nginx.service"})
+        assert cmd == "sudo -n systemctl restart nginx.service"
+
+    def test_bare_unit_name_accepted(self):
+        # systemctl accepts a bare name (implies .service).
+        cmd = build_remediation_command("restart_service", {"unit": "nginx"})
+        assert cmd == "sudo -n systemctl restart nginx"
+
+    @pytest.mark.parametrize("unit", [
+        "getty@tty1.service",              # leak-guard:allow  systemd template unit, not an email
+        "user@1000.service",               # leak-guard:allow  systemd template unit, not an email
+        "systemd-fsck@dev-sda1.service",   # leak-guard:allow  systemd template unit, not an email
+    ])
+    def test_template_instance_units_accepted(self, unit):
+        # The '@' in template/instance units must not be rejected — the
+        # server allows them, so the client floor must too (never a shell
+        # risk: the argv is shlex-quoted).
+        cmd = build_remediation_command("restart_service", {"unit": unit})
+        assert unit in cmd
+
+    @pytest.mark.parametrize("suffix_unit", [
+        "foo.socket", "bar.timer", "baz.target", "m.mount", "p.path",
+        "s.slice", "sc.scope",
+    ])
+    def test_known_unit_type_suffixes_accepted(self, suffix_unit):
+        cmd = build_remediation_command("restart_service", {"unit": suffix_unit})
+        assert suffix_unit in cmd
+
+    def test_dry_run_reports_state_and_forces_zero_exit(self):
+        cmd = build_remediation_command(
+            "restart_service", {"unit": "nginx", "dry_run": True},
+        )
+        assert "systemctl is-active nginx" in cmd
+        assert "systemctl status nginx --no-pager" in cmd
+        assert cmd.rstrip().endswith("; true")
+        # A dry run must never mutate.
+        assert "systemctl restart" not in cmd
+
+    @pytest.mark.parametrize("falsy", ["false", "False", "0", "", "no"])
+    def test_string_falsy_dry_run_builds_live_command(self, falsy):
+        cmd = build_remediation_command(
+            "restart_service", {"unit": "nginx", "dry_run": falsy},
+        )
+        assert cmd == "sudo -n systemctl restart nginx"
+
+    @pytest.mark.parametrize("bad", [
+        "a/b.service",        # path separator
+        "..up.service",       # traversal
+        "nginx;id",           # command separator
+        "$(id)",              # command substitution
+        "a b.service",        # whitespace
+        "n`id`",              # backtick
+        "unit\nname",         # newline
+        "",                   # empty
+        None,                 # missing
+        42,                   # wrong type
+    ])
+    def test_hostile_or_malformed_unit_rejected(self, bad):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command("restart_service", {"unit": bad})
+        assert str(exc.value).startswith("invalid_unit_name:")
+
+
+class TestClassifyRestartFailure:
+    @pytest.mark.parametrize("output,slug", [
+        ("Unit foo.service not found.", "unit_not_found"),
+        ("Failed to restart x: Unit x.service not loaded.", "unit_not_found"),
+        ("sudo: a password is required", "restart_permission_denied"),
+        ("Job for nginx.service failed", "restart_failed"),
+        ("some other error", "restart_failed"),
+    ])
+    def test_restart_slugs(self, output, slug):
+        assert classify_failure("restart_service", 1, output) == slug
+
+    def test_transport_failure_still_generic(self):
+        assert classify_failure("restart_service", None, "") == (
+            "remediation_transport_failed"
+        )
+
+    def test_certbot_classification_unaffected(self):
+        assert classify_failure("certbot_renew", 1, "no certificate found") == (
+            "cert_name_not_found"
+        )
+
+
+def restart_service_event(*, unit="nginx.service", dry_run=False, target="web-1"):
+    return remediation_event(
+        req_id="rmd-restart-1", verb="restart_service", target=target,
+        payload={
+            "finding_id": "fnd-5", "action": "restart_service",
+            "unit": unit, "dry_run": dry_run,
+        },
+    )
+
+
+class TestRestartServiceRouting:
+    def test_success_builds_systemctl_over_ssh(self):
+        listener = make_listener()
+
+        def _echo_marker(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"Restarted nginx.service\n{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(restart_service_event()))
+
+        request = listener._executors.execute.await_args.args[0]
+        assert request.type == CommandType.RUN_COMMAND
+        assert request.payload["command"].startswith(
+            "sudo -n systemctl restart nginx.service",
+        )
+        assert EXIT_MARKER in request.payload["command"]
+
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == "restart_service"
+        assert result["ok"] is True
+        assert result["exit_code"] == 0
+
+    def test_unit_not_found_answers_with_slug(self):
+        listener = make_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"Unit bogus.service not found.\n{marker}5\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(restart_service_event(unit="bogus.service")))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "unit_not_found"
+
+    def test_sudo_denied_classified_as_permission(self):
+        listener = make_listener()
+
+        def _echo_denied(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"sudo: a password is required\n{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_denied)
+        run(listener._handle_event(restart_service_event()))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "restart_permission_denied"
+
+    def test_dry_run_reports_state_and_makes_no_restart(self):
+        listener = make_listener()
+        captured = {}
+
+        def _echo_marker(request):
+            captured["command"] = request.payload["command"]
+            marker = request.payload["command"].split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"active\n{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(restart_service_event(dry_run=True)))
+        # The dispatched command inspects state, never restarts.
+        assert "systemctl restart" not in captured["command"]
+        assert "is-active" in captured["command"]
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+
+    def test_timeout_is_a_command_outcome(self):
+        listener = make_listener()
+        listener._executors.execute = AsyncMock(return_value=CommandResponse(
+            request_id="rmd-restart-1", status="timeout", output="",
+        ))
+        run(listener._handle_event(restart_service_event()))
+        response = posted_response(listener)
+        assert response.status == "success"
+        result = json.loads(response.output)
+        assert result["slug"] == "remediation_timeout"


### PR DESCRIPTION
## What this does

Adds the **`restart_service`** remediation verb — restarts a systemd unit on the target box. It's a close mirror of the `certbot_renew` SSH-command path and rides the existing forward remediation flow (preview → confirm → execute → poll), so only the executor module changes; there's no new route or dispatch logic.

## How it works

- `restart_service` joins `certbot_renew` in `SSH_COMMAND_VERBS`, with a `_build_restart_service` builder.
- **`_require_unit`** validates the systemd unit locally (defense-in-depth alongside the server's own validation): a unit name only, **allowing template/instance units** (names containing `@`), and rejecting path separators, traversal, whitespace, and shell metacharacters with an `invalid_unit_name` slug.
- **Live run** builds argv locally from the validated unit — `sudo -n systemctl restart <unit>`, shlex-quoted, never server text — judged on the exit code via the existing exit marker.
- **Dry run** has no native `systemctl --dry-run`, so it reports current state (`is-active` + `status --no-pager`) and forces a zero exit, so the informational output is never misjudged as a failure (a dry run is always `ok:true`).
- **`classify_failure`** emits curated slugs for `restart_service` — `unit_not_found` / `restart_permission_denied` / `restart_failed` — leaving certbot's classification untouched. (Timeouts surface as `remediation_timeout` from the shared relay path, as for certbot.)

Not idempotent (a restart always restarts) and no revert (a restart can't be un-restarted); the server gates re-dispatch, so nothing special is needed on this side.

## Testing

Full suite green (+42 tests). Coverage: verb-set membership and builder/verb sync, command building (live argv, template `@` units, unit-type suffixes, dry-run-reports-state-and-forces-zero-exit, string-falsy `dry_run`, hostile/malformed unit rejection), the curated failure slugs, and full relay routing through the real dispatch (success, unit-not-found, sudo-denied, dry-run-makes-no-restart, timeout). Only the SSH executor is mocked.

## Scope note

Dormant until the server authors `restart_service` on a finding and dispatches it. Old CLIs without this verb fail closed (`unknown_remediation_verb` → `status:error`, no wrong action), so it's safe to ship ahead of the server side.
