### PR TITLE
fix(mcp): a throwing tool handler must not crash the server

### DIFF
--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -255,6 +255,49 @@ def build_headless_tools(config_manager=None):
     return tools
 
 
+async def _dispatch_tool(tools, name: str, arguments: dict):
+    """Dispatch one tool call, converting any handler failure into an error
+    result instead of letting it crash the server loop.
+
+    This is the reliability backstop for the stdio transport: an unhandled
+    exception raised inside a tool handler (e.g. a transient network error in
+    ``relay_status``) propagates out of the ``call_tool`` callback, tears down
+    the stdio read/write loop, and drops the ENTIRE session — every in-flight
+    tool call with it. Catching here keeps the connection alive: the tool that
+    failed returns a bounded error string, everything else keeps working.
+
+    ``asyncio.CancelledError`` is a ``BaseException`` (not ``Exception``), so
+    it is deliberately NOT caught — cooperative cancellation still propagates.
+
+    Args:
+        tools: The ``ServonautTools`` instance (method name == tool name).
+        name: Requested tool name.
+        arguments: Keyword arguments for the handler.
+
+    Returns:
+        A list with a single ``TextContent`` — the handler's result, or an
+        error string for an unknown/unavailable/throwing tool.
+    """
+    from mcp.types import TextContent
+    from servonaut.mcp.tool_schemas import TOOL_SCHEMAS
+
+    if name not in TOOL_SCHEMAS:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+    handler = getattr(tools, name, None)
+    if handler is None:
+        return [TextContent(type="text", text=f"Tool handler not available: {name}")]
+    try:
+        result = await handler(**arguments)
+    except Exception as exc:  # noqa: BLE001 — a throwing tool must NOT crash
+        # the stdio loop (which would drop the whole session). Log the full
+        # traceback for diagnosis; return a bounded error to the caller.
+        logger.exception("MCP tool %r raised", name)
+        return [TextContent(
+            type="text", text=f"tool '{name}' failed: {str(exc)[:500]}",
+        )]
+    return [TextContent(type="text", text=result)]
+
+
 def create_mcp_server():
     """Create and configure the MCP server."""
     try:
@@ -351,18 +394,11 @@ def create_mcp_server():
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict):
-        # Dispatch is just method lookup on the shared ServonautTools instance
-        # — the tool name always matches the method name. tool_schemas.py is
-        # the sole registry, so adding a new tool only needs an entry there
-        # plus the implementation on ServonautTools.
-        from servonaut.mcp.tool_schemas import TOOL_SCHEMAS
-        if name not in TOOL_SCHEMAS:
-            return [TextContent(type="text", text=f"Unknown tool: {name}")]
-        handler = getattr(tools, name, None)
-        if handler is None:
-            return [TextContent(type="text", text=f"Tool handler not available: {name}")]
-        result = await handler(**arguments)
-        return [TextContent(type="text", text=result)]
+        # Dispatch is method lookup on the shared ServonautTools instance (tool
+        # name == method name; tool_schemas.py is the sole registry). Delegated
+        # to _dispatch_tool so a throwing handler returns an error instead of
+        # crashing the stdio loop and dropping the whole session.
+        return await _dispatch_tool(tools, name, arguments)
 
     return server
 

--- a/tests/test_mcp_dispatch_hardening.py
+++ b/tests/test_mcp_dispatch_hardening.py
@@ -1,0 +1,70 @@
+"""The MCP tool dispatch must never let a handler crash the server loop.
+
+Regression guard: an unhandled exception raised inside a tool handler used to
+propagate out of the ``call_tool`` callback and tear down the stdio transport,
+dropping the whole session (observed live: a transient failure in
+``relay_status`` disconnected the server). ``_dispatch_tool`` now converts any
+handler failure into a bounded error result while letting cooperative
+cancellation propagate.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from servonaut.mcp.server import _dispatch_tool
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestDispatchHardening:
+    def test_throwing_handler_returns_error_not_raised(self):
+        # A handler that raises (e.g. a network blip in relay_status) must be
+        # caught — the server loop, and every other in-flight call, survive.
+        tools = SimpleNamespace(
+            whoami=AsyncMock(side_effect=RuntimeError("backend unreachable")),
+        )
+        out = _run(_dispatch_tool(tools, "whoami", {}))
+        assert len(out) == 1
+        assert out[0].text.startswith("tool 'whoami' failed:")
+        assert "backend unreachable" in out[0].text
+
+    def test_error_text_is_bounded(self):
+        tools = SimpleNamespace(whoami=AsyncMock(side_effect=RuntimeError("x" * 5000)))
+        out = _run(_dispatch_tool(tools, "whoami", {}))
+        # Message is truncated so a huge exception can't flood the transport.
+        assert len(out[0].text) < 600
+
+    def test_success_path_unchanged(self):
+        tools = SimpleNamespace(whoami=AsyncMock(return_value="session ok"))
+        out = _run(_dispatch_tool(tools, "whoami", {}))
+        assert out[0].text == "session ok"
+
+    def test_unknown_tool_reported(self):
+        out = _run(_dispatch_tool(SimpleNamespace(), "not_a_real_tool_xyz", {}))
+        assert out[0].text.startswith("Unknown tool:")
+
+    def test_missing_handler_reported(self):
+        # Name is in the schema registry but the tools object lacks the method.
+        out = _run(_dispatch_tool(SimpleNamespace(), "whoami", {}))
+        assert out[0].text.startswith("Tool handler not available:")
+
+    def test_cancellation_propagates(self):
+        # CancelledError is a BaseException, not Exception — cooperative
+        # cancellation must NOT be swallowed by the crash guard.
+        tools = SimpleNamespace(whoami=AsyncMock(side_effect=asyncio.CancelledError()))
+        with pytest.raises(asyncio.CancelledError):
+            _run(_dispatch_tool(tools, "whoami", {}))
+
+    def test_arguments_forwarded(self):
+        handler = AsyncMock(return_value="ok")
+        tools = SimpleNamespace(whoami=handler)
+        _run(_dispatch_tool(tools, "whoami", {"foo": 1, "bar": "x"}))
+        handler.assert_awaited_once_with(foo=1, bar="x")


### PR DESCRIPTION
## What this fixes

An unhandled exception raised inside an MCP tool handler propagated out of the `call_tool` callback, tore down the stdio read/write loop, and **dropped the entire session** — every in-flight call with it. This was hit live: a transient failure in a handler that makes a network call disconnected the server mid-use, and it took a manual reconnect to recover.

The transport isn't the problem — a crashing handler would take down an HTTP server just the same. The gap was that the dispatch had **no error boundary**.

## The fix

Extract the dispatch into a testable `_dispatch_tool` helper that wraps the handler call in `try/except`:

- A throwing tool now **logs its traceback and returns a bounded error string**, so the connection survives and only the failing call is affected.
- `asyncio.CancelledError` (a `BaseException`, not `Exception`) is deliberately **not** caught, so cooperative cancellation still propagates correctly.
- Everything else is unchanged: unknown-tool / missing-handler messages, argument forwarding, and the success path all behave exactly as before.

## Testing

7 focused tests: a throwing handler returns an error instead of raising, the error text is bounded (a huge exception can't flood the transport), cancellation propagates, and the unknown / missing-handler / success / argument-forwarding paths are pinned. Existing MCP suites unaffected.

## Note

This is the crash-resistance half of MCP reliability and is transport-independent. It's the highest-leverage fix regardless of whether the server ever moves off stdio.
