### PR TITLE
feat(remediation): add restart_container and start_container executors

### DIFF
--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -32,7 +32,9 @@ REMEDIATION_SOURCE = "proactive_remediation"
 
 #: Verbs executed as an SSH command on the target box (built locally
 #: from validated payload fields, judged via the exit marker).
-SSH_COMMAND_VERBS = frozenset({"certbot_renew", "restart_service"})
+SSH_COMMAND_VERBS = frozenset(
+    {"certbot_renew", "restart_service", "restart_container", "start_container"}
+)
 
 #: Verbs handled by a dedicated ``_execute_*`` method rather than the
 #: generic SSH-command builder. ``block_ip`` / ``unblock_ip`` each dispatch
@@ -188,9 +190,66 @@ def _build_restart_service(payload: Dict[str, Any]) -> str:
     return " ".join(shlex.quote(a) for a in argv)
 
 
+# Docker/OCI container names: an alphanumeric first char, then up to 127 more
+# of alphanumerics plus ``_``, ``.``, ``-`` (128 total, the server's bound).
+# STRICTER than the systemd unit rail on purpose — a container name has NO
+# ``:``, ``@``, ``/``, or whitespace, so this rail must NOT reuse the
+# ``@``-bearing unit validator. Excluding ``:`` also means the
+# ``:``-delimiter class of evidence-membership bug that hit unit names cannot
+# occur for containers. Kept in lockstep with the server-side
+# ``CONTAINER_NAME_PATTERN``.
+_SAFE_CONTAINER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _require_container(payload: Dict[str, Any]) -> str:
+    name = payload.get("container")
+    if not isinstance(name, str) or not name:
+        raise RemediationValidationError(
+            "invalid_container_name: payload is missing a container",
+        )
+    if ".." in name or "/" in name or not _SAFE_CONTAINER_RE.match(name):
+        raise RemediationValidationError(
+            f"invalid_container_name: {name!r} is not a valid container name",
+        )
+    return name
+
+
+def _build_container_dry_run(name: str) -> str:
+    # No native ``docker`` dry-run: report the container's current status and
+    # restart count and change nothing (read-only ``inspect``). A trailing
+    # ``true`` forces exit 0 so inspecting a stopped/absent container never
+    # reads as a failure (dry-run is always ``ok:true`` per the contract). The
+    # relay user is in the ``docker`` group (same access path as the read-side
+    # ``docker ps`` probe), so no ``sudo`` is needed. ``.State.Status`` and
+    # ``.RestartCount`` are always present, so the Go template can't hit a nil.
+    fmt = "status={{.State.Status}} restarts={{.RestartCount}}"
+    argv = ["docker", "inspect", "-f", fmt, name]
+    return " ".join(shlex.quote(a) for a in argv) + "; true"
+
+
+def _build_restart_container(payload: Dict[str, Any]) -> str:
+    name = _require_container(payload)
+    if _coerce_dry_run(payload):
+        return _build_container_dry_run(name)
+    argv = ["docker", "restart", name]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
+def _build_start_container(payload: Dict[str, Any]) -> str:
+    name = _require_container(payload)
+    if _coerce_dry_run(payload):
+        return _build_container_dry_run(name)
+    # Idempotent: ``docker start`` on an already-running container exits 0
+    # (goal state reached) — the same idempotence contract as the on-box unban.
+    argv = ["docker", "start", name]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
 _VERB_BUILDERS = {
     "certbot_renew": _build_certbot_renew,
     "restart_service": _build_restart_service,
+    "restart_container": _build_restart_container,
+    "start_container": _build_start_container,
 }
 
 # A builder registered here without a matching entry in SSH_COMMAND_VERBS
@@ -530,6 +589,19 @@ def classify_failure(verb: str, exit_code: Optional[int], output: str) -> str:
         if "not found" in lowered or "not loaded" in lowered:
             return "unit_not_found"
         return "restart_failed"
+    # Container verbs get curated slugs too: container_not_found /
+    # docker_permission_denied / {verb}_failed. Docker prints "No such
+    # container" for an unknown name and a daemon permission error when the
+    # relay user can't reach the socket.
+    if verb in ("restart_container", "start_container"):
+        if (
+            "permission denied" in lowered
+            or "cannot connect to the docker daemon" in lowered
+        ):
+            return "docker_permission_denied"
+        if "no such container" in lowered or "not found" in lowered:
+            return "container_not_found"
+        return f"{verb}_failed"
     if "a password is required" in lowered or (
         "sudo:" in lowered
         and ("password" in lowered or "not allowed" in lowered)

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -1540,3 +1540,210 @@ class TestRestartServiceRouting:
         assert response.status == "success"
         result = json.loads(response.output)
         assert result["slug"] == "remediation_timeout"
+
+
+# ---------------------------------------------------------------------------
+# restart_container / start_container — SSH-command verbs (docker <verb> <name>)
+# ---------------------------------------------------------------------------
+
+
+class TestContainerVerbSet:
+    @pytest.mark.parametrize("verb", ["restart_container", "start_container"])
+    def test_container_verbs_are_ssh_command_verbs(self, verb):
+        assert verb in REMEDIATION_VERBS
+        assert verb in SSH_COMMAND_VERBS
+        assert verb not in LOCAL_DISPATCH_VERBS
+
+    def test_builders_and_ssh_verbs_stay_in_sync(self):
+        from servonaut.services.remediation_executor import _VERB_BUILDERS
+        assert set(_VERB_BUILDERS) == SSH_COMMAND_VERBS
+
+
+class TestBuildContainerCommand:
+    def test_live_restart_fixed_argv(self):
+        cmd = build_remediation_command(
+            "restart_container", {"container": "web-1"},
+        )
+        # No sudo: the relay user reaches the docker socket directly, the same
+        # access path as the read-side docker probe.
+        assert cmd == "docker restart web-1"
+
+    def test_live_start_fixed_argv(self):
+        cmd = build_remediation_command(
+            "start_container", {"container": "web-1"},
+        )
+        assert cmd == "docker start web-1"
+
+    @pytest.mark.parametrize("name", [
+        "web-1", "myapp_web_1", "db.cache-2", "svc.worker_3-a", "R2",
+    ])
+    def test_valid_docker_names_accepted(self, name):
+        cmd = build_remediation_command(
+            "restart_container", {"container": name},
+        )
+        assert cmd == f"docker restart {name}"
+
+    @pytest.mark.parametrize("verb", ["restart_container", "start_container"])
+    def test_dry_run_inspects_and_forces_zero_exit(self, verb):
+        cmd = build_remediation_command(
+            verb, {"container": "web-1", "dry_run": True},
+        )
+        assert "docker inspect -f" in cmd
+        assert "{{.State.Status}}" in cmd
+        assert "{{.RestartCount}}" in cmd
+        assert "web-1" in cmd
+        assert cmd.rstrip().endswith("; true")
+        # A dry run must never mutate.
+        assert "docker restart" not in cmd
+        assert "docker start" not in cmd
+
+    def test_name_at_128_chars_accepted_129_rejected(self):
+        # Server bound is 128 chars total (leading char + up to 127 more).
+        ok = "a" + "b" * 127
+        assert len(ok) == 128
+        cmd = build_remediation_command(
+            "restart_container", {"container": ok},
+        )
+        assert ok in cmd
+        too_long = "a" + "b" * 128  # 129 chars
+        with pytest.raises(RemediationValidationError):
+            build_remediation_command("restart_container", {"container": too_long})
+
+    @pytest.mark.parametrize("falsy", ["false", "False", "0", "", "no"])
+    def test_string_falsy_dry_run_builds_live_command(self, falsy):
+        cmd = build_remediation_command(
+            "restart_container", {"container": "web-1", "dry_run": falsy},
+        )
+        assert cmd == "docker restart web-1"
+
+    @pytest.mark.parametrize("bad", [
+        "a/b",             # path separator
+        "..up",            # traversal
+        "web;id",          # command separator
+        "$(id)",           # command substitution
+        "a b",             # whitespace
+        "n`id`",           # backtick
+        "name\nx",         # newline
+        "a:b",             # colon — not a valid docker name char
+        "x@y",             # at-sign
+        "-leading",        # must start alphanumeric
+        ".dotfirst",       # must start alphanumeric
+        "_underfirst",     # must start alphanumeric
+        "",                # empty
+        None,              # missing
+        42,                # wrong type
+    ])
+    @pytest.mark.parametrize("verb", ["restart_container", "start_container"])
+    def test_hostile_or_malformed_container_rejected(self, verb, bad):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command(verb, {"container": bad})
+        assert str(exc.value).startswith("invalid_container_name:")
+
+
+class TestClassifyContainerFailure:
+    @pytest.mark.parametrize("output,slug", [
+        ("Error: No such container: web-1", "container_not_found"),
+        ("Error response from daemon: No such container: x", "container_not_found"),
+        ("permission denied while trying to connect to the Docker daemon socket",
+         "docker_permission_denied"),
+        ("Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+         "docker_permission_denied"),
+        ("some other docker error", "restart_container_failed"),
+    ])
+    def test_restart_slugs(self, output, slug):
+        assert classify_failure("restart_container", 1, output) == slug
+
+    def test_start_generic_slug_uses_verb(self):
+        assert classify_failure("start_container", 1, "boom") == (
+            "start_container_failed"
+        )
+
+    def test_transport_failure_still_generic(self):
+        assert classify_failure("restart_container", None, "") == (
+            "remediation_transport_failed"
+        )
+
+    def test_restart_service_classification_unaffected(self):
+        assert classify_failure("restart_service", 1, "Unit x.service not found.") == (
+            "unit_not_found"
+        )
+
+
+def container_event(
+    *, verb="restart_container", container="web-1", dry_run=False, target="web-1",
+):
+    return remediation_event(
+        req_id="rmd-container-1", verb=verb, target=target,
+        payload={
+            "finding_id": "fnd-6", "action": verb,
+            "container": container, "dry_run": dry_run,
+        },
+    )
+
+
+class TestContainerRouting:
+    @pytest.mark.parametrize("verb,docker_verb", [
+        ("restart_container", "docker restart"),
+        ("start_container", "docker start"),
+    ])
+    def test_success_builds_docker_over_ssh(self, verb, docker_verb):
+        listener = make_listener()
+
+        def _echo_marker(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"web-1\n{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(container_event(verb=verb)))
+
+        request = listener._executors.execute.await_args.args[0]
+        assert request.type == CommandType.RUN_COMMAND
+        assert request.payload["command"].startswith(f"{docker_verb} web-1")
+        assert EXIT_MARKER in request.payload["command"]
+
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == verb
+        assert result["ok"] is True
+        assert result["exit_code"] == 0
+
+    def test_no_such_container_answers_with_slug(self):
+        listener = make_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"Error: No such container: web-1\n{marker}1\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(container_event(container="web-1")))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "container_not_found"
+
+    def test_dry_run_inspects_and_makes_no_mutation(self):
+        listener = make_listener()
+        captured = {}
+
+        def _echo_marker(request):
+            captured["command"] = request.payload["command"]
+            marker = request.payload["command"].split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=f"running\n{marker}0\n",
+            )
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_marker)
+        run(listener._handle_event(container_event(dry_run=True)))
+        # The dispatched command inspects state, never restarts/starts.
+        assert "docker inspect" in captured["command"]
+        assert "docker restart" not in captured["command"]
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True


### PR DESCRIPTION
## What

Adds two one-click remediation executors for Docker containers, extending the proactive-remediation flow that already covers certificate renewal, IP bans, and systemd service restarts:

- **restart_container** → `docker restart <name>`
- **start_container** → `docker start <name>`

When a proactive scan finds an unhealthy or stopped container, Servonaut can restart or start it for you — with the same safety flow as every other remediation: a server-signed preview, a dry-run that inspects the container before anything changes, and a typed confirmation before the live command runs.

## Safety

- **Fixed argv, never a shell string.** The container name comes from the finding and is validated against a strict rail (`^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$`) — no path separators, no shell metacharacters, 128-char max. This rail is intentionally stricter than the systemd-unit one: a Docker container name has no `:`, `@`, `/`, or whitespace.
- **Dry-run mutates nothing** — it reports the container's current status and restart count via a read-only `docker inspect` and always exits 0.
- **No `sudo`** — uses the same Docker socket access path as the read-side container probe.
- `start_container` is idempotent (starting a running container is a no-op, exit 0); `restart_container` is single-shot with no retry.
- Failures map to clear slugs: `container_not_found` / `docker_permission_denied`.

## Rollout

Ships dormant/additive — the executor only activates once the server offers these actions on a finding. No behavior change until then. Routes through the existing SSH-command path, so there is no relay change.

## Tests

+40 tests covering both verbs: argv shape, dry-run read-only-ness, the name rail (rejects space/`:`/`@`/`/`/traversal/leading-dash/over-128), curated failure slugs, and relay routing (success, not-found, dry-run). Full executor + relay suites green (307 passing).
