### PR TITLE
feat(remediation): add rate_limit / rate_limit_path WAF executors

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -4817,57 +4817,14 @@ class ServonautTools:
     async def _resolve_webacl(self, target: str, region: str = "") -> Dict[str, Any]:
         """Resolve a WebACL from a WebACL ARN, an ALB ARN, or an instance.
 
-        Returns {name, id, scope, region, arn} or {error}. For an instance it
-        walks the ingress path (Group B) to find the WebACL fronting its ALB.
+        Thin wrapper over the shared :func:`resolve_webacl` (in
+        ``waf_management_service``) so the instance→ALB→WebACL walk has one
+        implementation, reused by the ``rate_limit`` remediation executor.
         """
-        from servonaut.services.waf_management_service import (
-            WAFManagementService, parse_wafv2_arn,
+        from servonaut.services.waf_management_service import resolve_webacl
+        return await resolve_webacl(
+            target, region, find_instance=self._find_instance,
         )
-        target = (target or "").strip()
-        if not target:
-            return {"error": "no target (need a WebACL/ALB ARN or instance)."}
-
-        if target.startswith("arn:aws:wafv2:"):
-            parsed = parse_wafv2_arn(target)
-            if not parsed or parsed["kind"] != "webacl":
-                return {"error": f"not a WebACL ARN: {target}"}
-            return {"name": parsed["name"], "id": parsed["id"],
-                    "scope": parsed["scope"], "region": parsed["region"] or region,
-                    "arn": target}
-
-        if target.startswith("arn:aws:elasticloadbalancing:"):
-            alb_region = (target.split(":")[3] if ":" in target else "") or region
-            summ = await WAFManagementService().get_web_acl_for_resource(
-                target, alb_region,
-            )
-            if not summ:
-                return {"error": f"no WebACL attached to {target}"}
-            parsed = parse_wafv2_arn(summ["arn"])
-            return {"name": summ["name"], "id": summ["id"],
-                    "scope": parsed["scope"] if parsed else "REGIONAL",
-                    "region": (parsed["region"] if parsed else alb_region) or region,
-                    "arn": summ["arn"]}
-
-        # Otherwise treat target as an instance id/name → walk its ingress path.
-        instance = await self._find_instance(target)
-        if not instance:
-            return {"error": f"instance not found: {target}"}
-        if instance.get("is_custom") or instance.get("is_ovh") or instance.get("is_hetzner"):
-            return {"error": f"{target} is not an AWS instance"}
-        from servonaut.services.ingress_path_service import IngressPathService
-        eff_region = region or instance.get("region") or ""
-        topo = await IngressPathService().describe(
-            instance.get("id", ""), instance.get("private_ip") or "", eff_region,
-        )
-        for lb in topo.get("load_balancers", []):
-            acl = lb.get("web_acl")
-            if acl and acl.get("arn"):
-                parsed = parse_wafv2_arn(acl["arn"])
-                if parsed:
-                    return {"name": parsed["name"], "id": parsed["id"],
-                            "scope": parsed["scope"],
-                            "region": parsed["region"] or eff_region, "arn": acl["arn"]}
-        return {"error": f"no WebACL found fronting {target}"}
 
     def _collect_ban_targets(self, ip_address, cidr, ip_addresses) -> List[str]:
         """Union ip_address + cidr + ip_addresses[], deduped, order-preserving."""

--- a/src/servonaut/services/findings_service.py
+++ b/src/servonaut/services/findings_service.py
@@ -206,7 +206,7 @@ class FindingsService:
 
     async def remediate_preview(
         self, finding_id: str, action: str, *, dry_run: bool = False,
-        method: Optional[str] = None,
+        method: Optional[str] = None, rate: Optional[str] = None,
     ) -> Dict[str, Any]:
         """GET the server-built preview for one of the finding's own
         remediation actions.
@@ -235,6 +235,12 @@ class FindingsService:
             params["dry_run"] = 1
         if method:
             params["method"] = method
+        if rate:
+            # rate_limit / rate_limit_path: the caller-selected request cap
+            # (req/5min). Folded into the command hash the token signs, so the
+            # same value MUST be replayed on remediate() — same contract as
+            # block_ip's method.
+            params["rate"] = rate
         return await self._api.get(
             f"{_BASE}/{safe_id}/remediate/preview", params=params,
         )
@@ -242,6 +248,7 @@ class FindingsService:
     async def remediate(
         self, finding_id: str, action: str, confirm_token: str,
         *, dry_run: bool = False, method: Optional[str] = None,
+        rate: Optional[str] = None,
     ) -> Dict[str, Any]:
         """POST the confirmed remediation; returns immediately (async).
 
@@ -273,6 +280,10 @@ class FindingsService:
         }
         if method:
             body["method"] = method
+        if rate:
+            # Same replay contract as method: the rate is in the token's
+            # command-hash preimage, so it must match the previewed value.
+            body["rate"] = rate
         return await self._api.post(
             f"{_BASE}/{safe_id}/remediate", json=body,
         )

--- a/src/servonaut/services/relay_executors.py
+++ b/src/servonaut/services/relay_executors.py
@@ -211,6 +211,19 @@ class RelayExecutors:
             self._ip_ban_service = IPBanService(self._config_manager)
         return self._ip_ban_service
 
+    async def resolve_webacl(self, target: str, region: str = "") -> Dict:
+        """Resolve the WebACL fronting ``target`` (instance id/name, ALB ARN,
+        or WebACL ARN) for the ``rate_limit`` remediation executor.
+
+        Delegates to the shared resolver, supplying this executor's own
+        instance lookup so the instance→ALB→WebACL walk runs with the
+        customer's AWS credentials in the customer's context (the SaaS
+        server holds no AWS creds — WebACL resolution is CLI-side)."""
+        from servonaut.services.waf_management_service import resolve_webacl
+        return await resolve_webacl(
+            target, region, find_instance=self.find_instance,
+        )
+
     async def _find_instance(self, identifier: str) -> Optional[Dict]:
         """Find instance by ID or name across all providers (AWS + custom)."""
         aws_instances = await self._aws_service.fetch_instances_cached()

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -1204,9 +1204,22 @@ class RelayListener:
         region = str(payload.get("region") or "") or region_hint
         acl = await self._executors.resolve_webacl(target, region)
         if acl.get("error"):
-            return "error", "", (
-                f"rate_limit_webacl_unresolved: {acl['error']}"
+            # Command-outcome, NOT a relay/transport failure: the resolve step
+            # RAN and reported "no WebACL fronting the target". Surface it as a
+            # clean ok:false result with a specific slug so the finding stays
+            # detected (never false-resolved) rather than the generic
+            # relay-error that an "error" status would map to.
+            output = build_remediation_result(
+                verb=verb, ok=False, exit_code=1,
+                output=(
+                    "no WebACL resolved fronting the target - cannot apply a "
+                    f"rate rule: {acl['error']}"
+                ),
+                payload=payload,
+                slug="rate_limit_webacl_unresolved",
+                extra={"region": region or None},
             )
+            return "success", output, ""
 
         # Deterministic, target-distinct rule name (distinct flooding ips /
         # paths get distinct rules; re-running the same target is idempotent).

--- a/src/servonaut/services/relay_listener.py
+++ b/src/servonaut/services/relay_listener.py
@@ -909,6 +909,7 @@ class RelayListener:
 
         from servonaut.services.remediation_executor import (
             LOCAL_DISPATCH_VERBS,
+            WAF_DISPATCH_VERBS,
         )
 
         if self._executors is None:
@@ -921,6 +922,13 @@ class RelayListener:
             # AWS-vs-on-box split, dispatched on the method from the handle.
             status, output, error_message = await self._execute_unblock_ip(
                 raw, payload,
+            )
+        elif verb in WAF_DISPATCH_VERBS:
+            # rate_limit / rate_limit_path edit the cloud-edge WebACL (boto3
+            # wafv2), never the box. WebACL resolution + the rate rule run
+            # CLI-side with the customer's own AWS creds.
+            status, output, error_message = await self._execute_rate_limit(
+                raw, payload, verb,
             )
         elif verb in LOCAL_DISPATCH_VERBS:
             # block_ip never becomes a command line — it dispatches to
@@ -1137,6 +1145,143 @@ class RelayListener:
         output = build_remediation_result(
             verb="block_ip", ok=False, exit_code=1, output=message,
             payload=payload, slug="block_ip_failed", extra=extra,
+        )
+        return "success", output, ""
+
+    async def _execute_rate_limit(
+        self, raw: dict, payload: dict, verb: str,
+    ) -> tuple:
+        """Execute a confirmed ``rate_limit`` / ``rate_limit_path`` remediation.
+
+        Edits the cloud-edge WebACL (never the box): resolve the WebACL
+        fronting the target CLI-side (customer AWS creds), then add a WAFv2
+        rate-based rule. ``rate_limit`` scopes the rule to the single flooding
+        ip via a dedicated IPSet; ``rate_limit_path`` scopes it to the abused
+        URI path. dry-run is a PURE PREVIEW — it resolves + echoes the planned
+        rule but never creates an IPSet or touches the WebACL.
+        """
+        import re as _re
+
+        from servonaut.services.remediation_executor import (
+            RemediationValidationError,
+            build_remediation_result,
+            coerce_dry_run,
+            validate_rate_limit_payload,
+        )
+
+        is_path = verb == "rate_limit_path"
+
+        # Self-target refusal mirror + region hint (server enforces the ip rail
+        # authoritatively; a failed lookup only loses the local mirror).
+        target = str(raw.get("target_server_id") or "")
+        refused: set = set()
+        region_hint = ""
+        instance = None
+        if target:
+            try:
+                instance = await self._executors.find_instance(target)
+            except Exception:  # noqa: BLE001 — refusal mirror only
+                logger.warning(
+                    "rate_limit: instance lookup failed for %r; continuing "
+                    "without the local self-target mirror", target,
+                )
+        if instance:
+            for key in ("public_ip", "private_ip"):
+                value = instance.get(key)
+                if isinstance(value, str) and value.strip():
+                    refused.add(value.strip())
+            region_hint = str(instance.get("region") or "")
+
+        try:
+            ip, rate, path = validate_rate_limit_payload(
+                payload, frozenset(refused), require_path=is_path,
+            )
+        except RemediationValidationError as exc:
+            return "error", "", str(exc)
+
+        # Resolve the WebACL fronting the target (read-only; runs in both
+        # dry-run and live). CLI-side, customer creds.
+        region = str(payload.get("region") or "") or region_hint
+        acl = await self._executors.resolve_webacl(target, region)
+        if acl.get("error"):
+            return "error", "", (
+                f"rate_limit_webacl_unresolved: {acl['error']}"
+            )
+
+        # Deterministic, target-distinct rule name (distinct flooding ips /
+        # paths get distinct rules; re-running the same target is idempotent).
+        if is_path:
+            slug_src = _re.sub(r"[^A-Za-z0-9]", "-", path or "")[:90]
+            rule_name = f"servonaut-ratep-{slug_src}".strip("-")[:128]
+        else:
+            slug_src = _re.sub(r"[^A-Za-z0-9]", "-", ip or "")
+            rule_name = f"servonaut-rate-{slug_src}"[:128]
+
+        limit = int(rate)
+        human_target = f"path {path}" if is_path else ip
+        base_extra = {
+            "web_acl_arn": acl.get("arn"), "web_acl_name": acl.get("name"),
+            "web_acl_id": acl.get("id"), "scope": acl.get("scope"),
+            "region": acl.get("region"), "rule_name": rule_name,
+            "limit_applied": limit, "rate": rate,
+        }
+        if not is_path:
+            base_extra["ip"] = ip
+        else:
+            base_extra["path"] = path
+
+        if coerce_dry_run(payload):
+            output = build_remediation_result(
+                verb=verb, ok=True, exit_code=0,
+                output=(
+                    f"DRY RUN - would add rate rule {rule_name!r} to WebACL "
+                    f"{acl.get('name')}: {human_target} capped at {limit} "
+                    f"req/5min (no change made)"
+                ),
+                payload=payload,
+                extra={**base_extra, "would_apply": True},
+            )
+            return "success", output, ""
+
+        from servonaut.services.waf_management_service import (
+            WAFManagementService,
+        )
+        try:
+            res = await WAFManagementService().set_rate_rule(
+                acl.get("name"), acl.get("id"), acl.get("scope"),
+                acl.get("region"), rule_name=rule_name, limit=limit,
+                uri_scope=(path or "") if is_path else "",
+                ip_scope="" if is_path else ip,
+                action="block",
+            )
+        except Exception as exc:  # noqa: BLE001 — must still answer
+            logger.exception("rate_limit dispatch failed: %s", exc)
+            res = {"applied": False, "error": str(exc)}
+
+        if res.get("applied"):
+            extra = {
+                **base_extra,
+                "created_or_updated": res.get("created_or_updated"),
+                "previous": res.get("previous"),
+            }
+            if not is_path:
+                extra["ip_set_arn"] = res.get("ip_set_arn")
+                extra["ip_set_name"] = res.get("ip_set_name")
+            output = build_remediation_result(
+                verb=verb, ok=True, exit_code=0,
+                output=(
+                    f"{res.get('created_or_updated', 'applied')} rate rule "
+                    f"{rule_name!r} on WebACL {acl.get('name')}: "
+                    f"{human_target} capped at {limit} req/5min"
+                ),
+                payload=payload, extra=extra,
+            )
+            return "success", output, ""
+
+        output = build_remediation_result(
+            verb=verb, ok=False, exit_code=1,
+            output=str(res.get("error") or "rate rule not applied"),
+            payload=payload, slug=f"{verb}_failed", extra=base_extra,
         )
         return "success", output, ""
 

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -45,13 +45,30 @@ SSH_COMMAND_VERBS = frozenset(
 #: because these verbs never go through :func:`build_remediation_command`.
 LOCAL_DISPATCH_VERBS = frozenset({"block_ip", "unblock_ip"})
 
+#: WAF control-plane verbs — dispatched to :class:`WAFManagementService`
+#: (boto3 ``wafv2`` rate-based rules), like ``block_ip``'s AWS path but on the
+#: WebACL rather than an IP set. ``rate_limit`` throttles a flooding IP;
+#: ``rate_limit_path`` scopes the same rule to a URI path. These never touch
+#: the target box — they edit the cloud-edge WebACL. Handled by a dedicated
+#: ``_execute_rate_limit`` method (never :func:`build_remediation_command`).
+WAF_DISPATCH_VERBS = frozenset({"rate_limit", "rate_limit_path"})
+
+#: Rate-limit thresholds the ``rate_limit`` envelope may request, as strings
+#: (requests per fixed 5-minute window per client IP). Kept in lockstep with
+#: the server-side enum — these are folded into the confirm-token hash
+#: preimage, so they are a protocol contract, not a tunable default. AWS WAF
+#: enforces a floor of 100 for per-IP aggregation, so every value is >= 100.
+RATE_LIMIT_RATES = frozenset({"500", "2000", "10000"})
+
 #: The verbs this CLI knows how to execute. Grows one playbook at a time,
 #: in lockstep with the server-side allowlist — never a generic shell.
-REMEDIATION_VERBS = SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS
+REMEDIATION_VERBS = SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS | WAF_DISPATCH_VERBS
 
-assert not (SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS), (
-    "a remediation verb cannot be both SSH-command and local-dispatch"
-)
+assert (
+    not (SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS)
+    and not (SSH_COMMAND_VERBS & WAF_DISPATCH_VERBS)
+    and not (LOCAL_DISPATCH_VERBS & WAF_DISPATCH_VERBS)
+), "a remediation verb belongs to exactly one dispatch category"
 
 #: AWS control-plane ban methods — dispatched to :class:`IPBanService`
 #: (WAF / security group / NACL boto3 strategies), gated on a configured
@@ -485,6 +502,77 @@ def build_onbox_unblock_command(method: str, ip: str) -> str:
     )
 
 
+# URI paths for rate_limit_path: a leading-slash absolute path, then a
+# conservative unreserved/sub-delim subset. Deliberately excludes whitespace
+# and shell metacharacters. The path is used only as a WAF ScopeDownStatement
+# ByteMatch search string (never a shell argument), but the allowlist is the
+# primary guard, kept in lockstep with the server-side path validator.
+_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~\-/%]{0,255}$")
+
+
+def validate_rate_limit_payload(
+    payload: Dict[str, Any],
+    refused_ips: frozenset[str] = frozenset(),
+    *,
+    require_path: bool = False,
+) -> Tuple[str, str, Optional[str]]:
+    """Validate a ``rate_limit`` / ``rate_limit_path`` payload.
+
+    Returns ``(canonical_ip, rate, path)`` where ``path`` is ``None`` for a
+    plain ``rate_limit`` and the validated URI prefix for ``rate_limit_path``.
+
+    Client-side mirror of the server's rails (defense-in-depth — the server
+    derives the ip from the finding's evidence and enum-validates the rate
+    authoritatively on its side):
+
+    - ip: exactly one globally-routable address, no CIDR, never the target
+      instance's own address — identical rails to :func:`validate_block_ip_payload`
+      (a rate rule on a private/own address is a no-op or a self-throttle).
+    - method: must be ``"waf"`` (the only rate-limit plane; server-fixed).
+    - rate: a string in :data:`RATE_LIMIT_RATES` (req / 5-min / IP). A rate
+      outside the enum, or a non-string, is refused — it is part of the
+      confirm-token preimage, so an off-enum value must never reach the wire.
+    - path (``rate_limit_path`` only): a leading-slash URI prefix matching
+      :data:`_SAFE_PATH_RE`.
+    """
+    # method: server-fixed to "waf"; reject anything else the caller sent.
+    sent_method = payload.get("method")
+    if sent_method is not None and sent_method != "waf":
+        raise RemediationValidationError(
+            f"invalid_rate_limit_method: {sent_method!r} is not 'waf' — "
+            f"rate limiting is WAF/cloud-edge only",
+        )
+    # ip rails: reuse block_ip's exactly (canonical public single address).
+    # "waf" is in BLOCK_IP_METHODS, so this validates + canonicalises the ip.
+    ip, _ = validate_block_ip_payload(
+        {"ip": payload.get("ip"), "method": "waf"}, refused_ips,
+    )
+
+    rate = payload.get("rate")
+    if not isinstance(rate, str) or rate not in RATE_LIMIT_RATES:
+        allowed = ", ".join(sorted(RATE_LIMIT_RATES, key=int))
+        raise RemediationValidationError(
+            f"invalid_rate_limit_rate: {rate!r} is not one of {{{allowed}}} "
+            f"(requests per 5-minute window, as a string)",
+        )
+
+    path: Optional[str] = None
+    raw_path = payload.get("path")
+    if require_path or (raw_path is not None and raw_path != ""):
+        if not isinstance(raw_path, str) or not raw_path:
+            raise RemediationValidationError(
+                "invalid_rate_limit_path: rate_limit_path requires a path",
+            )
+        if ".." in raw_path or not _SAFE_PATH_RE.match(raw_path):
+            raise RemediationValidationError(
+                f"invalid_rate_limit_path: {raw_path!r} is not a valid "
+                f"leading-slash URI path",
+            )
+        path = raw_path
+
+    return ip, rate, path
+
+
 def build_remediation_command(verb: str, payload: Dict[str, Any]) -> str:
     """Build the exact remote command for an allowlisted SSH verb.
 
@@ -492,7 +580,7 @@ def build_remediation_command(verb: str, payload: Dict[str, Any]) -> str:
     unknown verbs, local-dispatch verbs (which never become a command
     line), or payloads that fail shape validation.
     """
-    if verb in LOCAL_DISPATCH_VERBS:
+    if verb in LOCAL_DISPATCH_VERBS or verb in WAF_DISPATCH_VERBS:
         raise RemediationValidationError(
             f"local_dispatch_verb: {verb!r} executes via a local curated "
             f"service call, never an SSH command",

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -517,25 +517,28 @@ def validate_rate_limit_payload(
     refused_ips: frozenset[str] = frozenset(),
     *,
     require_path: bool = False,
-) -> Tuple[str, str, Optional[str]]:
+) -> Tuple[Optional[str], str, Optional[str]]:
     """Validate a ``rate_limit`` / ``rate_limit_path`` payload.
 
-    Returns ``(canonical_ip, rate, path)`` where ``path`` is ``None`` for a
-    plain ``rate_limit`` and the validated URI prefix for ``rate_limit_path``.
+    Returns ``(ip, rate, path)``. For ``rate_limit`` (``require_path=False``)
+    ``ip`` is a validated public address and ``path`` is ``None``. For
+    ``rate_limit_path`` (``require_path=True``) ``path`` is the validated URI
+    prefix and ``ip`` is ``None`` — a path rule throttles every client on that
+    path, so no ip is carried (matching the server envelope).
 
     Client-side mirror of the server's rails (defense-in-depth — the server
-    derives the ip from the finding's evidence and enum-validates the rate
+    derives ip/path from the finding's evidence and enum-validates the rate
     authoritatively on its side):
 
-    - ip: exactly one globally-routable address, no CIDR, never the target
-      instance's own address — identical rails to :func:`validate_block_ip_payload`
-      (a rate rule on a private/own address is a no-op or a self-throttle).
     - method: must be ``"waf"`` (the only rate-limit plane; server-fixed).
     - rate: a string in :data:`RATE_LIMIT_RATES` (req / 5-min / IP). A rate
       outside the enum, or a non-string, is refused — it is part of the
       confirm-token preimage, so an off-enum value must never reach the wire.
+    - ip (``rate_limit`` only): exactly one globally-routable address, no CIDR,
+      never the target instance's own address — identical rails to
+      :func:`validate_block_ip_payload`.
     - path (``rate_limit_path`` only): a leading-slash URI prefix matching
-      :data:`_SAFE_PATH_RE`.
+      :data:`_SAFE_PATH_RE` (1-255 chars — a bare ``/`` is refused).
     """
     # method: server-fixed to "waf"; reject anything else the caller sent.
     sent_method = payload.get("method")
@@ -544,11 +547,13 @@ def validate_rate_limit_payload(
             f"invalid_rate_limit_method: {sent_method!r} is not 'waf' — "
             f"rate limiting is WAF/cloud-edge only",
         )
-    # ip rails: reuse block_ip's exactly (canonical public single address).
-    # "waf" is in BLOCK_IP_METHODS, so this validates + canonicalises the ip.
-    ip, _ = validate_block_ip_payload(
-        {"ip": payload.get("ip"), "method": "waf"}, refused_ips,
-    )
+    # ip: required for rate_limit (reuse block_ip's public-address rails),
+    # absent for rate_limit_path (path rule spans all clients).
+    ip: Optional[str] = None
+    if not require_path:
+        ip, _ = validate_block_ip_payload(
+            {"ip": payload.get("ip"), "method": "waf"}, refused_ips,
+        )
 
     rate = payload.get("rate")
     if not isinstance(rate, str) or rate not in RATE_LIMIT_RATES:

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -502,12 +502,14 @@ def build_onbox_unblock_command(method: str, ip: str) -> str:
     )
 
 
-# URI paths for rate_limit_path: a leading-slash absolute path, then a
-# conservative unreserved/sub-delim subset. Deliberately excludes whitespace
-# and shell metacharacters. The path is used only as a WAF ScopeDownStatement
-# ByteMatch search string (never a shell argument), but the allowlist is the
-# primary guard, kept in lockstep with the server-side path validator.
-_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~\-/%]{0,255}$")
+# URI paths for rate_limit_path: a leading slash then 1-255 chars of a
+# conservative unreserved/sub-delim subset. The ``{1,255}`` floor rejects a
+# bare ``/`` (a whole-site scope-down defeats the point of the path verb) —
+# matching the server's minimum-specificity floor. Deliberately excludes
+# whitespace and shell metacharacters; the path is only ever a WAF
+# ScopeDownStatement ByteMatch search string (never a shell argument), but the
+# allowlist is the primary guard, kept in lockstep with the server validator.
+_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~\-/%]{1,255}$")
 
 
 def validate_rate_limit_payload(

--- a/src/servonaut/services/waf_management_service.py
+++ b/src/servonaut/services/waf_management_service.py
@@ -51,6 +51,72 @@ def parse_wafv2_arn(arn: str) -> Optional[Dict[str, str]]:
     return d
 
 
+async def resolve_webacl(
+    target: str, region: str = "", *, find_instance=None,
+) -> Dict[str, Any]:
+    """Resolve a WebACL from a WebACL ARN, an ALB ARN, or an instance.
+
+    Returns ``{name, id, scope, region, arn}`` or ``{error}``. For an instance
+    it walks the ingress path to find the WebACL fronting its ALB, which needs
+    an async ``find_instance(identifier) -> instance dict | None`` callable
+    (the MCP tools and the relay executors each supply their own).
+
+    Shared by ``waf_rate_rule_set`` (MCP) and the ``rate_limit`` remediation
+    executor so the instance→ALB→WebACL walk has a single implementation. AWS
+    resolution runs with the CALLER's credentials, in the caller's context —
+    the SaaS server never resolves WebACLs (it holds no AWS creds).
+    """
+    target = (target or "").strip()
+    if not target:
+        return {"error": "no target (need a WebACL/ALB ARN or instance)."}
+
+    if target.startswith("arn:aws:wafv2:"):
+        parsed = parse_wafv2_arn(target)
+        if not parsed or parsed["kind"] != "webacl":
+            return {"error": f"not a WebACL ARN: {target}"}
+        return {"name": parsed["name"], "id": parsed["id"],
+                "scope": parsed["scope"], "region": parsed["region"] or region,
+                "arn": target}
+
+    if target.startswith("arn:aws:elasticloadbalancing:"):
+        alb_region = (target.split(":")[3] if ":" in target else "") or region
+        summ = await WAFManagementService().get_web_acl_for_resource(
+            target, alb_region,
+        )
+        if not summ:
+            return {"error": f"no WebACL attached to {target}"}
+        parsed = parse_wafv2_arn(summ["arn"])
+        return {"name": summ["name"], "id": summ["id"],
+                "scope": parsed["scope"] if parsed else "REGIONAL",
+                "region": (parsed["region"] if parsed else alb_region) or region,
+                "arn": summ["arn"]}
+
+    # Otherwise treat target as an instance id/name → walk its ingress path.
+    if find_instance is None:
+        return {"error": "no instance resolver available for target"}
+    instance = await find_instance(target)
+    if not instance:
+        return {"error": f"instance not found: {target}"}
+    if (instance.get("is_custom") or instance.get("is_ovh")
+            or instance.get("is_hetzner")):
+        return {"error": f"{target} is not an AWS instance"}
+    from servonaut.services.ingress_path_service import IngressPathService
+    eff_region = region or instance.get("region") or ""
+    topo = await IngressPathService().describe(
+        instance.get("id", ""), instance.get("private_ip") or "", eff_region,
+    )
+    for lb in topo.get("load_balancers", []):
+        acl = lb.get("web_acl")
+        if acl and acl.get("arn"):
+            parsed = parse_wafv2_arn(acl["arn"])
+            if parsed:
+                return {"name": parsed["name"], "id": parsed["id"],
+                        "scope": parsed["scope"],
+                        "region": parsed["region"] or eff_region,
+                        "arn": acl["arn"]}
+    return {"error": f"no WebACL found fronting {target}"}
+
+
 class WAFManagementService:
     """Add IPs to a WebACL's block IP set, and add/remove rate-based rules."""
 

--- a/src/servonaut/services/waf_management_service.py
+++ b/src/servonaut/services/waf_management_service.py
@@ -19,6 +19,7 @@ an ARN (from ``get_web_acl_for_resource`` or ``describe_ingress_path``);
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import re
 from typing import Any, Dict, List, Optional
@@ -265,14 +266,60 @@ class WAFManagementService:
     async def set_rate_rule(
         self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
         rule_name: str, limit: int = 2000, uri_scope: str = "",
-        action: str = "block", remove: bool = False,
+        action: str = "block", remove: bool = False, ip_scope: str = "",
     ) -> Dict[str, Any]:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             None, self._set_rate_rule_sync,
             web_acl_name, web_acl_id, scope, region,
-            rule_name, limit, uri_scope, action, remove,
+            rule_name, limit, uri_scope, action, remove, ip_scope,
         )
+
+    def _ensure_scope_ipset_sync(
+        self, client, scope: str, ip_set_name: str, ip: str,
+    ) -> Dict[str, Any]:
+        """Find-or-create a dedicated IPSet holding exactly ``ip`` and return
+        ``{arn, id, name}`` (or ``{error}``). Used to scope a rate rule to a
+        single client IP via an IPSetReferenceStatement — a rate rule with no
+        scope-down throttles EVERY ip, so the ip-scoped ``rate_limit`` needs
+        its own IPSet, distinct from the shared block IPSet.
+
+        Idempotent: reusing the same ``ip_set_name`` updates its address to the
+        current ip rather than creating a duplicate."""
+        version = "IPV6" if ipaddress.ip_address(ip).version == 6 else "IPV4"
+        addr = f"{ip}/128" if version == "IPV6" else f"{ip}/32"
+        try:
+            existing = next(
+                (s for s in client.list_ip_sets(Scope=scope).get("IPSets", [])
+                 if s.get("Name") == ip_set_name),
+                None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"list_ip_sets: {exc}"}
+        if existing:
+            try:
+                got = client.get_ip_set(
+                    Name=ip_set_name, Scope=scope, Id=existing["Id"],
+                )
+                if list(got["IPSet"]["Addresses"]) != [addr]:
+                    client.update_ip_set(
+                        Name=ip_set_name, Scope=scope, Id=existing["Id"],
+                        Addresses=[addr], LockToken=got["LockToken"],
+                    )
+            except Exception as exc:  # noqa: BLE001
+                return {"error": f"update_ip_set: {exc}"}
+            return {"arn": existing["ARN"], "id": existing["Id"],
+                    "name": ip_set_name}
+        try:
+            created = client.create_ip_set(
+                Name=ip_set_name, Scope=scope, IPAddressVersion=version,
+                Addresses=[addr],
+                Description="servonaut rate_limit scope (auto-managed)",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"create_ip_set: {exc}"}
+        summary = created["Summary"]
+        return {"arn": summary["ARN"], "id": summary["Id"], "name": ip_set_name}
 
     def _rate_rule_state(self, rule: Dict[str, Any]) -> Dict[str, Any]:
         """Snapshot an existing rate rule's reversible state."""
@@ -286,10 +333,12 @@ class WAFManagementService:
     def _set_rate_rule_sync(
         self, web_acl_name: str, web_acl_id: str, scope: str, region: str,
         rule_name: str, limit: int, uri_scope: str, action: str, remove: bool,
+        ip_scope: str = "",
     ) -> Dict[str, Any]:
         out: Dict[str, Any] = {
             "applied": False, "error": "", "rule_name": rule_name,
             "created_or_updated": "", "previous": None,
+            "ip_set_arn": "", "ip_set_name": "",
         }
         kwargs = {"region_name": region} if region else {}
         try:
@@ -329,7 +378,22 @@ class WAFManagementService:
             rate_stmt: Dict[str, Any] = {
                 "Limit": int(limit), "AggregateKeyType": "IP",
             }
-            if uri_scope:
+            # Scope-down: an ip (rate_limit → throttle only that client, via a
+            # dedicated IPSet) OR a uri path (rate_limit_path → throttle each
+            # ip's rate on that path). Mutually exclusive per verb.
+            if ip_scope:
+                ipset = self._ensure_scope_ipset_sync(
+                    client, scope, f"{rule_name}-scope", ip_scope,
+                )
+                if ipset.get("error"):
+                    out["error"] = ipset["error"]
+                    return out
+                out["ip_set_arn"] = ipset["arn"]
+                out["ip_set_name"] = ipset["name"]
+                rate_stmt["ScopeDownStatement"] = {
+                    "IPSetReferenceStatement": {"ARN": ipset["arn"]},
+                }
+            elif uri_scope:
                 rate_stmt["ScopeDownStatement"] = {
                     "ByteMatchStatement": {
                         "SearchString": uri_scope.encode("utf-8"),

--- a/tests/test_findings_service.py
+++ b/tests/test_findings_service.py
@@ -264,6 +264,33 @@ class TestRemediation:
         run(svc.remediate("fnd_01abc", "renew_certificate", "tok-signed"))
         assert "method" not in api.post.await_args.kwargs["json"]
 
+    def test_preview_sends_rate_for_rate_limit(self):
+        # rate_limit's command hash includes the caller-selected rate — the
+        # preview GET must carry rate= (same contract as block_ip's method).
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate_preview(
+            "fnd_01abc", "rate_limit", dry_run=True, rate="2000",
+        ))
+        params = api.get.await_args.kwargs["params"]
+        assert params["rate"] == "2000"
+        assert params["action"] == "rate_limit"
+
+    def test_execute_replays_rate_in_body(self):
+        # Same rate must be replayed so the token's command hash verifies.
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate(
+            "fnd_01abc", "rate_limit_path", "tok-signed", rate="500",
+        ))
+        assert api.post.await_args.kwargs["json"]["rate"] == "500"
+
+    def test_execute_omits_rate_when_none(self):
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate("fnd_01abc", "renew_certificate", "tok-signed"))
+        assert "rate" not in api.post.await_args.kwargs["json"]
+
     def test_execute_post_shape(self):
         api = _mock_api()
         svc = FindingsService(api)

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -476,9 +476,15 @@ class TestVerbSets:
         assert "block_ip" in LOCAL_DISPATCH_VERBS
         assert "block_ip" not in SSH_COMMAND_VERBS
 
-    def test_ssh_and_local_sets_partition_the_allowlist(self):
-        assert SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS == REMEDIATION_VERBS
+    def test_dispatch_sets_partition_the_allowlist(self):
+        from servonaut.services.remediation_executor import WAF_DISPATCH_VERBS
+        assert (
+            SSH_COMMAND_VERBS | LOCAL_DISPATCH_VERBS | WAF_DISPATCH_VERBS
+            == REMEDIATION_VERBS
+        )
         assert not SSH_COMMAND_VERBS & LOCAL_DISPATCH_VERBS
+        assert not SSH_COMMAND_VERBS & WAF_DISPATCH_VERBS
+        assert not LOCAL_DISPATCH_VERBS & WAF_DISPATCH_VERBS
 
     def test_block_ip_never_becomes_a_command_line(self):
         with pytest.raises(RemediationValidationError) as exc:
@@ -1747,3 +1753,112 @@ class TestContainerRouting:
         result = json.loads(posted_response(listener).output)
         assert result["ok"] is True
         assert result["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# rate_limit / rate_limit_path — WAF control-plane verbs (validation rail).
+# Dispatch (_execute_rate_limit) lands once the WebACL-resolution contract is
+# settled; these pin the pure, frozen validation half.
+# ---------------------------------------------------------------------------
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    WAF_DISPATCH_VERBS,
+    RATE_LIMIT_RATES,
+    validate_rate_limit_payload,
+)
+
+
+class TestWafVerbSet:
+    @pytest.mark.parametrize("verb", ["rate_limit", "rate_limit_path"])
+    def test_waf_verbs_are_recognised_but_not_ssh_or_local(self, verb):
+        assert verb in REMEDIATION_VERBS
+        assert verb in WAF_DISPATCH_VERBS
+        assert verb not in SSH_COMMAND_VERBS
+        assert verb not in LOCAL_DISPATCH_VERBS
+
+    def test_dispatch_categories_are_pairwise_disjoint(self):
+        assert not (SSH_COMMAND_VERBS & WAF_DISPATCH_VERBS)
+        assert not (LOCAL_DISPATCH_VERBS & WAF_DISPATCH_VERBS)
+
+    def test_rates_respect_the_aws_floor_of_100(self):
+        # AWS WAF per-IP aggregation refuses a Limit below 100.
+        assert all(int(r) >= 100 for r in RATE_LIMIT_RATES)
+        assert RATE_LIMIT_RATES == {"500", "2000", "10000"}
+
+
+class TestValidateRateLimitPayload:
+    def test_valid_rate_limit_returns_ip_rate_and_no_path(self):
+        ip, rate, path = validate_rate_limit_payload(
+            {"ip": "9.9.9.9", "method": "waf", "rate": "2000"},
+        )
+        assert (ip, rate, path) == ("9.9.9.9", "2000", None)
+
+    def test_valid_rate_limit_path_returns_the_path(self):
+        ip, rate, path = validate_rate_limit_payload(
+            {"ip": "9.9.9.9", "method": "waf", "rate": "500",
+             "path": "/api/login"},
+            require_path=True,
+        )
+        assert (ip, rate, path) == ("9.9.9.9", "500", "/api/login")
+
+    @pytest.mark.parametrize("rate", ["50", "100", "999", "2001", "", "abc"])
+    def test_off_enum_rate_rejected(self, rate):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": rate},
+            )
+        assert str(exc.value).startswith("invalid_rate_limit_rate:")
+
+    @pytest.mark.parametrize("rate", [2000, 2000.0, True, None])
+    def test_non_string_rate_rejected(self, rate):
+        # The rate is folded into the confirm-token preimage as a string; a
+        # non-string must never reach the wire.
+        with pytest.raises(RemediationValidationError):
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": rate},
+            )
+
+    @pytest.mark.parametrize("method", ["nacl", "security_group", "nftables", "ufw"])
+    def test_non_waf_method_rejected(self, method):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": method, "rate": "2000"},
+            )
+        assert str(exc.value).startswith("invalid_rate_limit_method:")
+
+    @pytest.mark.parametrize("ip", ["10.0.0.1", "127.0.0.1", "169.254.1.1", "1.2.3.4/24"])
+    def test_non_public_or_cidr_ip_rejected(self, ip):
+        with pytest.raises(RemediationValidationError):
+            validate_rate_limit_payload(
+                {"ip": ip, "method": "waf", "rate": "2000"},
+            )
+
+    def test_self_ip_refused(self):
+        with pytest.raises(RemediationValidationError):
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": "2000"},
+                frozenset({"9.9.9.9"}),
+            )
+
+    @pytest.mark.parametrize("path", ["a b", "../etc", "no-leading-slash", "/x;y", "/a`b`"])
+    def test_hostile_path_rejected(self, path):
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": "2000", "path": path},
+                require_path=True,
+            )
+        assert str(exc.value).startswith("invalid_rate_limit_path:")
+
+    def test_require_path_but_missing_rejected(self):
+        with pytest.raises(RemediationValidationError):
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": "2000"},
+                require_path=True,
+            )
+
+    def test_plain_rate_limit_ignores_absent_path(self):
+        # rate_limit (require_path=False) with no path is valid.
+        _, _, path = validate_rate_limit_payload(
+            {"ip": "9.9.9.9", "method": "waf", "rate": "10000"},
+        )
+        assert path is None

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -1886,14 +1886,14 @@ from servonaut.services.waf_management_service import (  # noqa: E402
 
 class TestResolveWebacl:
     def test_webacl_arn_parsed_without_aws(self):
-        arn = ("arn:aws:wafv2:eu-west-2:123456789012:regional/webacl/"
+        arn = ("arn:aws:wafv2:eu-west-2:EXAMPLE-ACCT:regional/webacl/"
                "myacl/abc-123")
         out = run(resolve_webacl(arn))
         assert out == {"name": "myacl", "id": "abc-123", "scope": "REGIONAL",
                        "region": "eu-west-2", "arn": arn}
 
     def test_non_webacl_arn_rejected(self):
-        ipset = ("arn:aws:wafv2:eu-west-2:123456789012:regional/ipset/"
+        ipset = ("arn:aws:wafv2:eu-west-2:EXAMPLE-ACCT:regional/ipset/"
                  "s/i-1")
         assert "error" in run(resolve_webacl(ipset))
 
@@ -1925,7 +1925,7 @@ from unittest.mock import patch  # noqa: E402
 def _webacl(**over):
     base = {"name": "acl", "id": "acl-1", "scope": "REGIONAL",
             "region": "eu-west-2",
-            "arn": "arn:aws:wafv2:eu-west-2:123456789012:regional/webacl/acl/acl-1"}
+            "arn": "arn:aws:wafv2:eu-west-2:EXAMPLE-ACCT:regional/webacl/acl/acl-1"}
     base.update(over)
     return base
 
@@ -1942,7 +1942,7 @@ def make_rate_limit_listener(*, acl=None, set_result=None, instance=None):
         return_value=set_result if set_result is not None else {
             "applied": True, "error": "", "rule_name": "servonaut-rate-9-9-9-9",
             "created_or_updated": "created", "previous": None,
-            "ip_set_arn": "arn:aws:wafv2:eu-west-2:123456789012:regional/"
+            "ip_set_arn": "arn:aws:wafv2:eu-west-2:EXAMPLE-ACCT:regional/"
                           "ipset/servonaut-rate-9-9-9-9-scope/is-1",
             "ip_set_name": "servonaut-rate-9-9-9-9-scope",
         },

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -2015,7 +2015,11 @@ class TestRateLimitRouting:
         assert result["path"] == "/api/login"
         assert "ip" not in result
 
-    def test_unresolved_webacl_is_error(self):
+    def test_unresolved_webacl_is_command_outcome_not_relay_error(self):
+        # An unresolved WebACL is a command-OUTCOME ("nothing to rate-limit"),
+        # not a relay/transport failure: status stays "success" so the server
+        # reads ok:false + the specific slug and keeps the finding detected,
+        # rather than mislabelling it remediation_relay_error.
         listener, ex, svc = make_rate_limit_listener(
             acl={"error": "no WebACL found fronting web-1"},
         )
@@ -2024,8 +2028,11 @@ class TestRateLimitRouting:
             run(listener._handle_event(rate_limit_event()))
         svc.set_rate_rule.assert_not_awaited()
         response = posted_response(listener)
-        assert response.status == "error"
-        assert response.error_message.startswith("rate_limit_webacl_unresolved:")
+        assert response.status == "success"
+        assert response.error_message == ""
+        result = json.loads(response.output)
+        assert result["ok"] is False
+        assert result["slug"] == "rate_limit_webacl_unresolved"
 
     def test_off_enum_rate_refused_before_resolve(self):
         listener, ex, svc = make_rate_limit_listener()

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -1840,6 +1840,16 @@ class TestValidateRateLimitPayload:
                 frozenset({"9.9.9.9"}),
             )
 
+    def test_bare_root_path_rejected(self):
+        # A whole-site "/" scope-down defeats the point of the path verb —
+        # the {1,255} floor rejects it (matches the server's floor).
+        with pytest.raises(RemediationValidationError) as exc:
+            validate_rate_limit_payload(
+                {"ip": "9.9.9.9", "method": "waf", "rate": "2000", "path": "/"},
+                require_path=True,
+            )
+        assert str(exc.value).startswith("invalid_rate_limit_path:")
+
     @pytest.mark.parametrize("path", ["a b", "../etc", "no-leading-slash", "/x;y", "/a`b`"])
     def test_hostile_path_rejected(self, path):
         with pytest.raises(RemediationValidationError) as exc:
@@ -1862,3 +1872,43 @@ class TestValidateRateLimitPayload:
             {"ip": "9.9.9.9", "method": "waf", "rate": "10000"},
         )
         assert path is None
+
+
+# ---------------------------------------------------------------------------
+# Shared WebACL resolver (extracted from the MCP tool for the rate_limit
+# executor). ARN paths need no AWS/instance lookup and are unit-testable.
+# ---------------------------------------------------------------------------
+
+from servonaut.services.waf_management_service import (  # noqa: E402
+    resolve_webacl,
+)
+
+
+class TestResolveWebacl:
+    def test_webacl_arn_parsed_without_aws(self):
+        arn = ("arn:aws:wafv2:eu-west-2:123456789012:regional/webacl/"
+               "myacl/abc-123")
+        out = run(resolve_webacl(arn))
+        assert out == {"name": "myacl", "id": "abc-123", "scope": "REGIONAL",
+                       "region": "eu-west-2", "arn": arn}
+
+    def test_non_webacl_arn_rejected(self):
+        ipset = ("arn:aws:wafv2:eu-west-2:123456789012:regional/ipset/"
+                 "s/i-1")
+        assert "error" in run(resolve_webacl(ipset))
+
+    def test_empty_target_errors(self):
+        assert "error" in run(resolve_webacl(""))
+
+    def test_instance_target_without_resolver_errors(self):
+        # An instance id/name needs a find_instance callable; absent one,
+        # resolution fails closed rather than raising.
+        out = run(resolve_webacl("web-1", find_instance=None))
+        assert "error" in out
+
+    def test_instance_resolver_reaches_ingress_walk(self):
+        # A non-AWS instance is refused before any ingress walk.
+        async def _fake_find(_):
+            return {"id": "web-1", "is_ovh": True}
+        out = run(resolve_webacl("web-1", find_instance=_fake_find))
+        assert "not an AWS instance" in out["error"]

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -1793,13 +1793,13 @@ class TestValidateRateLimitPayload:
         )
         assert (ip, rate, path) == ("9.9.9.9", "2000", None)
 
-    def test_valid_rate_limit_path_returns_the_path(self):
+    def test_valid_rate_limit_path_returns_path_and_no_ip(self):
+        # A path rule spans all clients — no ip is carried.
         ip, rate, path = validate_rate_limit_payload(
-            {"ip": "9.9.9.9", "method": "waf", "rate": "500",
-             "path": "/api/login"},
+            {"method": "waf", "rate": "500", "path": "/api/login"},
             require_path=True,
         )
-        assert (ip, rate, path) == ("9.9.9.9", "500", "/api/login")
+        assert (ip, rate, path) == (None, "500", "/api/login")
 
     @pytest.mark.parametrize("rate", ["50", "100", "999", "2001", "", "abc"])
     def test_off_enum_rate_rejected(self, rate):
@@ -1912,3 +1912,139 @@ class TestResolveWebacl:
             return {"id": "web-1", "is_ovh": True}
         out = run(resolve_webacl("web-1", find_instance=_fake_find))
         assert "not an AWS instance" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# rate_limit / rate_limit_path — WAF dispatch (_execute_rate_limit).
+# Mocks the WebACL resolver + WAFManagementService.set_rate_rule.
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch  # noqa: E402
+
+
+def _webacl(**over):
+    base = {"name": "acl", "id": "acl-1", "scope": "REGIONAL",
+            "region": "eu-west-2",
+            "arn": "arn:aws:wafv2:eu-west-2:123456789012:regional/webacl/acl/acl-1"}
+    base.update(over)
+    return base
+
+
+def make_rate_limit_listener(*, acl=None, set_result=None, instance=None):
+    listener = make_listener()
+    ex = listener._executors
+    ex.find_instance = AsyncMock(return_value=instance)
+    ex.resolve_webacl = AsyncMock(
+        return_value=acl if acl is not None else _webacl(),
+    )
+    svc = MagicMock()
+    svc.set_rate_rule = AsyncMock(
+        return_value=set_result if set_result is not None else {
+            "applied": True, "error": "", "rule_name": "servonaut-rate-9-9-9-9",
+            "created_or_updated": "created", "previous": None,
+            "ip_set_arn": "arn:aws:wafv2:eu-west-2:123456789012:regional/"
+                          "ipset/servonaut-rate-9-9-9-9-scope/is-1",
+            "ip_set_name": "servonaut-rate-9-9-9-9-scope",
+        },
+    )
+    return listener, ex, svc
+
+
+def rate_limit_event(*, verb="rate_limit", ip="9.9.9.9", rate="2000",
+                     path=None, dry_run=False, target="web-1"):
+    payload = {"finding_id": "fnd-9", "action": verb, "method": "waf",
+               "rate": rate, "dry_run": dry_run, "timeout_seconds": 60}
+    if verb == "rate_limit_path":
+        payload["path"] = path or "/api/login"
+    else:
+        payload["ip"] = ip
+    return remediation_event(req_id="rmd-rate-1", verb=verb, target=target,
+                             payload=payload)
+
+
+class TestRateLimitRouting:
+    def test_ip_scoped_success_never_ssh(self):
+        listener, ex, svc = make_rate_limit_listener()
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(rate_limit_event()))
+
+        listener._executors.execute.assert_not_awaited()  # WAF, never SSH
+        ex.resolve_webacl.assert_awaited_once()
+        # set_rate_rule called with ip_scope (not uri_scope) for rate_limit.
+        _, kwargs = svc.set_rate_rule.await_args
+        assert kwargs["ip_scope"] == "9.9.9.9"
+        assert kwargs["uri_scope"] == ""
+        assert kwargs["limit"] == 2000
+
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == "rate_limit"
+        assert result["ok"] is True
+        assert result["ip"] == "9.9.9.9"
+        assert result["ip_set_arn"].endswith("is-1")
+        assert result["rule_name"] == "servonaut-rate-9-9-9-9"
+        assert result["limit_applied"] == 2000
+
+    def test_dry_run_makes_no_mutation(self):
+        listener, ex, svc = make_rate_limit_listener()
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(rate_limit_event(dry_run=True)))
+        svc.set_rate_rule.assert_not_awaited()  # pure preview
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is True
+        assert result["dry_run"] is True
+        assert result["would_apply"] is True
+
+    def test_path_scoped_uses_uri_scope_no_ipset(self):
+        listener, ex, svc = make_rate_limit_listener(set_result={
+            "applied": True, "error": "", "rule_name": "servonaut-ratep-api",
+            "created_or_updated": "created", "previous": None,
+            "ip_set_arn": "", "ip_set_name": "",
+        })
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(
+                rate_limit_event(verb="rate_limit_path", path="/api/login")))
+        _, kwargs = svc.set_rate_rule.await_args
+        assert kwargs["uri_scope"] == "/api/login"
+        assert kwargs["ip_scope"] == ""
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == "rate_limit_path"
+        assert result["ok"] is True
+        assert result["path"] == "/api/login"
+        assert "ip" not in result
+
+    def test_unresolved_webacl_is_error(self):
+        listener, ex, svc = make_rate_limit_listener(
+            acl={"error": "no WebACL found fronting web-1"},
+        )
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(rate_limit_event()))
+        svc.set_rate_rule.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("rate_limit_webacl_unresolved:")
+
+    def test_off_enum_rate_refused_before_resolve(self):
+        listener, ex, svc = make_rate_limit_listener()
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(rate_limit_event(rate="50")))
+        ex.resolve_webacl.assert_not_awaited()
+        svc.set_rate_rule.assert_not_awaited()
+        response = posted_response(listener)
+        assert response.status == "error"
+        assert response.error_message.startswith("invalid_rate_limit_rate:")
+
+    def test_set_rate_rule_failure_reports_slug(self):
+        listener, ex, svc = make_rate_limit_listener(set_result={
+            "applied": False, "error": "update_web_acl: boom",
+        })
+        with patch("servonaut.services.waf_management_service."
+                   "WAFManagementService", return_value=svc):
+            run(listener._handle_event(rate_limit_event()))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "rate_limit_failed"


### PR DESCRIPTION
## What

Adds two one-click remediation executors that throttle abusive traffic at the WAF edge, extending the proactive-remediation flow:

- **rate_limit** → adds a WAF rate-based rule that caps **the flooding IP** at a chosen rate (500 / 2000 / 10000 requests per 5-minute window)
- **rate_limit_path** → caps **each client's rate on an abused URL path**

When a proactive scan flags a traffic flood, Servonaut can rate-limit it for you — with the same safety flow as every other remediation: a server-signed preview, a dry-run, and a typed confirmation before anything changes.

## Design

- **IP-scoped, no collateral throttling.** A WAF rate rule with no scope-down throttles *every* client IP. `rate_limit` instead attaches a dedicated per-rule IPSet holding just the flooding address, so **only that IP** is capped — legitimate high-traffic clients are untouched. `rate_limit_path` scopes by URI path instead.
- **WebACL resolution is CLI-side**, with the customer's own AWS credentials (the hosted service holds none). The `instance → ALB → WebACL` resolver was extracted into a shared function reused by the existing WAF tooling (zero behavior change there).
- **Dry-run is a pure preview** — it resolves the WebACL and echoes the planned rule but never creates an IPSet or edits the WebACL.
- Rules are named deterministically per target, so distinct IPs/paths get distinct rules and re-running one target is idempotent. The settle payload carries the WebACL + rule + IPSet identity for a clean future revert.

## Rollout

Ships dormant/additive — activates only once the server offers these actions on a finding.

## Tests

Validation rail (IP/rate/path, enum + AWS-floor + path-floor), the shared resolver, and the full dispatch (IP-scoped success, path-scoped success, pure-preview dry-run, unresolved-WebACL error, off-enum refusal, failure slug) — all mocked, no live AWS. Full remediation + relay + WAF suites green.
