### PR TITLE
feat(remediation): add enable_service, reload_service, disable_service executors

### DIFF
--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -33,7 +33,8 @@ REMEDIATION_SOURCE = "proactive_remediation"
 #: Verbs executed as an SSH command on the target box (built locally
 #: from validated payload fields, judged via the exit marker).
 SSH_COMMAND_VERBS = frozenset(
-    {"certbot_renew", "restart_service", "restart_container", "start_container"}
+    {"certbot_renew", "restart_service", "restart_container", "start_container",
+     "enable_service", "reload_service"}
 )
 
 #: Verbs handled by a dedicated ``_execute_*`` method rather than the
@@ -207,6 +208,45 @@ def _build_restart_service(payload: Dict[str, Any]) -> str:
     return " ".join(shlex.quote(a) for a in argv)
 
 
+def _build_enable_service(payload: Dict[str, Any]) -> str:
+    unit = _require_unit(payload)
+    if _coerce_dry_run(payload):
+        # Report enablement + active state, change nothing (read-only, no
+        # sudo). Trailing ``true`` forces exit 0 — ``is-enabled`` /
+        # ``is-active`` exit non-zero for a disabled/inactive unit, which is
+        # exactly the state this verb fixes, so it must not read as failure.
+        argv_enabled = ["systemctl", "is-enabled", unit]
+        argv_active = ["systemctl", "is-active", unit]
+        return (
+            " ".join(shlex.quote(a) for a in argv_enabled)
+            + "; "
+            + " ".join(shlex.quote(a) for a in argv_active)
+            + "; true"
+        )
+    # ``--now`` also starts the unit; idempotent (enabling an enabled unit is
+    # a no-op success).
+    argv = ["sudo", "-n", "systemctl", "enable", "--now", unit]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
+def _build_reload_service(payload: Dict[str, Any]) -> str:
+    unit = _require_unit(payload)
+    if _coerce_dry_run(payload):
+        argv_active = ["systemctl", "is-active", unit]
+        argv_status = ["systemctl", "status", unit, "--no-pager"]
+        return (
+            " ".join(shlex.quote(a) for a in argv_active)
+            + "; "
+            + " ".join(shlex.quote(a) for a in argv_status)
+            + "; true"
+        )
+    # Plain reload (not reload-or-restart): a ``needs_reload`` finding wants a
+    # config re-read, not a restart's downtime. A unit with no reload support
+    # fails cleanly and is surfaced as reload_unsupported.
+    argv = ["sudo", "-n", "systemctl", "reload", unit]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
 # Docker/OCI container names: an alphanumeric first char, then up to 127 more
 # of alphanumerics plus ``_``, ``.``, ``-`` (128 total, the server's bound).
 # STRICTER than the systemd unit rail on purpose — a container name has NO
@@ -267,6 +307,8 @@ _VERB_BUILDERS = {
     "restart_service": _build_restart_service,
     "restart_container": _build_restart_container,
     "start_container": _build_start_container,
+    "enable_service": _build_enable_service,
+    "reload_service": _build_reload_service,
 }
 
 # A builder registered here without a matching entry in SSH_COMMAND_VERBS
@@ -675,15 +717,23 @@ def classify_failure(verb: str, exit_code: Optional[int], output: str) -> str:
     # so the finding evidence reads cleanly: unit_not_found /
     # restart_permission_denied / restart_failed. (A timeout is surfaced by
     # the relay path as ``remediation_timeout`` before it reaches here.)
-    if verb == "restart_service":
+    if verb in ("restart_service", "enable_service", "reload_service"):
         if "a password is required" in lowered or (
             "sudo:" in lowered
             and ("password" in lowered or "not allowed" in lowered)
         ):
-            return "restart_permission_denied"
+            return f"{verb.split('_')[0]}_permission_denied"
         if "not found" in lowered or "not loaded" in lowered:
             return "unit_not_found"
-        return "restart_failed"
+        # A unit with no ExecReload= can't be reloaded — a distinct, actionable
+        # outcome (the operator likely wants restart, not reload). systemctl
+        # reports "Job type reload is not applicable for unit ...".
+        if verb == "reload_service" and (
+            "not applicable" in lowered or "not support" in lowered
+            or "cannot be reloaded" in lowered or "cannot reload" in lowered
+        ):
+            return "reload_unsupported"
+        return f"{verb.split('_')[0]}_failed"
     # Container verbs get curated slugs too: container_not_found /
     # docker_permission_denied / {verb}_failed. Docker prints "No such
     # container" for an unknown name and a daemon permission error when the

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -34,7 +34,7 @@ REMEDIATION_SOURCE = "proactive_remediation"
 #: from validated payload fields, judged via the exit marker).
 SSH_COMMAND_VERBS = frozenset(
     {"certbot_renew", "restart_service", "restart_container", "start_container",
-     "enable_service", "reload_service"}
+     "enable_service", "reload_service", "disable_service"}
 )
 
 #: Verbs handled by a dedicated ``_execute_*`` method rather than the
@@ -247,6 +247,23 @@ def _build_reload_service(payload: Dict[str, Any]) -> str:
     return " ".join(shlex.quote(a) for a in argv)
 
 
+def _build_disable_service(payload: Dict[str, Any]) -> str:
+    unit = _require_unit(payload)
+    if _coerce_dry_run(payload):
+        argv_enabled = ["systemctl", "is-enabled", unit]
+        argv_active = ["systemctl", "is-active", unit]
+        return (
+            " ".join(shlex.quote(a) for a in argv_enabled)
+            + "; "
+            + " ".join(shlex.quote(a) for a in argv_active)
+            + "; true"
+        )
+    # ``--now`` also stops the unit; the Tier-1 inverse of enable_service.
+    # Idempotent (disabling a disabled unit is a no-op success).
+    argv = ["sudo", "-n", "systemctl", "disable", "--now", unit]
+    return " ".join(shlex.quote(a) for a in argv)
+
+
 # Docker/OCI container names: an alphanumeric first char, then up to 127 more
 # of alphanumerics plus ``_``, ``.``, ``-`` (128 total, the server's bound).
 # STRICTER than the systemd unit rail on purpose — a container name has NO
@@ -309,6 +326,7 @@ _VERB_BUILDERS = {
     "start_container": _build_start_container,
     "enable_service": _build_enable_service,
     "reload_service": _build_reload_service,
+    "disable_service": _build_disable_service,
 }
 
 # A builder registered here without a matching entry in SSH_COMMAND_VERBS
@@ -717,7 +735,8 @@ def classify_failure(verb: str, exit_code: Optional[int], output: str) -> str:
     # so the finding evidence reads cleanly: unit_not_found /
     # restart_permission_denied / restart_failed. (A timeout is surfaced by
     # the relay path as ``remediation_timeout`` before it reaches here.)
-    if verb in ("restart_service", "enable_service", "reload_service"):
+    if verb in ("restart_service", "enable_service", "reload_service",
+                "disable_service"):
         if "a password is required" in lowered or (
             "sudo:" in lowered
             and ("password" in lowered or "not allowed" in lowered)

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -2064,7 +2064,7 @@ class TestRateLimitRouting:
 
 
 class TestServiceStateVerbSet:
-    @pytest.mark.parametrize("verb", ["enable_service", "reload_service"])
+    @pytest.mark.parametrize("verb", ["enable_service", "reload_service", "disable_service"])
     def test_is_an_ssh_command_verb(self, verb):
         assert verb in REMEDIATION_VERBS
         assert verb in SSH_COMMAND_VERBS
@@ -2084,6 +2084,17 @@ class TestBuildServiceStateCommand:
         cmd = build_remediation_command("reload_service", {"unit": "nginx.service"})
         assert cmd == "sudo -n systemctl reload nginx.service"
 
+    def test_disable_live_uses_disable_now(self):
+        cmd = build_remediation_command("disable_service", {"unit": "telnet.socket"})
+        assert cmd == "sudo -n systemctl disable --now telnet.socket"
+
+    def test_disable_dry_run_reports_state_no_change(self):
+        cmd = build_remediation_command(
+            "disable_service", {"unit": "telnet.socket", "dry_run": True})
+        assert "systemctl is-enabled telnet.socket" in cmd
+        assert cmd.rstrip().endswith("; true")
+        assert "disable --now" not in cmd
+
     def test_enable_dry_run_reports_state_no_change(self):
         cmd = build_remediation_command(
             "enable_service", {"unit": "nginx", "dry_run": True})
@@ -2099,7 +2110,7 @@ class TestBuildServiceStateCommand:
         assert cmd.rstrip().endswith("; true")
         assert "systemctl reload" not in cmd
 
-    @pytest.mark.parametrize("verb", ["enable_service", "reload_service"])
+    @pytest.mark.parametrize("verb", ["enable_service", "reload_service", "disable_service"])
     @pytest.mark.parametrize("bad", ["a/b.service", "..x", "n;id", "$(id)", "a b", "", None, 42])
     def test_hostile_unit_rejected(self, verb, bad):
         with pytest.raises(RemediationValidationError) as exc:
@@ -2122,6 +2133,9 @@ class TestClassifyServiceStateFailure:
          "reload_unsupported"),
         ("enable_service", "some other error", "enable_failed"),
         ("reload_service", "some other error", "reload_failed"),
+        ("disable_service", "sudo: a password is required", "disable_permission_denied"),
+        ("disable_service", "Unit x.service not found.", "unit_not_found"),
+        ("disable_service", "boom", "disable_failed"),
     ])
     def test_slugs(self, verb, output, slug):
         assert classify_failure(verb, 1, output) == slug
@@ -2147,6 +2161,7 @@ class TestServiceStateRouting:
     @pytest.mark.parametrize("verb,frag", [
         ("enable_service", "sudo -n systemctl enable --now nginx.service"),
         ("reload_service", "sudo -n systemctl reload nginx.service"),
+        ("disable_service", "sudo -n systemctl disable --now nginx.service"),
     ])
     def test_success_builds_systemctl_over_ssh(self, verb, frag):
         listener = make_listener()

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -2055,3 +2055,129 @@ class TestRateLimitRouting:
         result = json.loads(posted_response(listener).output)
         assert result["ok"] is False
         assert result["slug"] == "rate_limit_failed"
+
+
+# ---------------------------------------------------------------------------
+# enable_service / reload_service — SSH-command verbs (systemctl variants of
+# restart_service, same unit binding + envelope).
+# ---------------------------------------------------------------------------
+
+
+class TestServiceStateVerbSet:
+    @pytest.mark.parametrize("verb", ["enable_service", "reload_service"])
+    def test_is_an_ssh_command_verb(self, verb):
+        assert verb in REMEDIATION_VERBS
+        assert verb in SSH_COMMAND_VERBS
+        assert verb not in LOCAL_DISPATCH_VERBS
+
+    def test_builders_and_ssh_verbs_stay_in_sync(self):
+        from servonaut.services.remediation_executor import _VERB_BUILDERS
+        assert set(_VERB_BUILDERS) == SSH_COMMAND_VERBS
+
+
+class TestBuildServiceStateCommand:
+    def test_enable_live_uses_enable_now(self):
+        cmd = build_remediation_command("enable_service", {"unit": "nginx.service"})
+        assert cmd == "sudo -n systemctl enable --now nginx.service"
+
+    def test_reload_live_uses_reload(self):
+        cmd = build_remediation_command("reload_service", {"unit": "nginx.service"})
+        assert cmd == "sudo -n systemctl reload nginx.service"
+
+    def test_enable_dry_run_reports_state_no_change(self):
+        cmd = build_remediation_command(
+            "enable_service", {"unit": "nginx", "dry_run": True})
+        assert "systemctl is-enabled nginx" in cmd
+        assert "systemctl is-active nginx" in cmd
+        assert cmd.rstrip().endswith("; true")
+        assert "enable --now" not in cmd
+
+    def test_reload_dry_run_reports_state_no_change(self):
+        cmd = build_remediation_command(
+            "reload_service", {"unit": "nginx", "dry_run": True})
+        assert "systemctl is-active nginx" in cmd
+        assert cmd.rstrip().endswith("; true")
+        assert "systemctl reload" not in cmd
+
+    @pytest.mark.parametrize("verb", ["enable_service", "reload_service"])
+    @pytest.mark.parametrize("bad", ["a/b.service", "..x", "n;id", "$(id)", "a b", "", None, 42])
+    def test_hostile_unit_rejected(self, verb, bad):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command(verb, {"unit": bad})
+        assert str(exc.value).startswith("invalid_unit_name:")
+
+    @pytest.mark.parametrize("unit", [
+        "getty@tty1.service",  # leak-guard:allow  systemd template unit, not an email
+    ])
+    def test_template_units_accepted(self, unit):
+        assert unit in build_remediation_command("enable_service", {"unit": unit})
+
+
+class TestClassifyServiceStateFailure:
+    @pytest.mark.parametrize("verb,output,slug", [
+        ("enable_service", "sudo: a password is required", "enable_permission_denied"),
+        ("reload_service", "sudo: a password is required", "reload_permission_denied"),
+        ("enable_service", "Unit x.service not found.", "unit_not_found"),
+        ("reload_service", "Failed to reload x: Job type reload is not applicable for unit x.",
+         "reload_unsupported"),
+        ("enable_service", "some other error", "enable_failed"),
+        ("reload_service", "some other error", "reload_failed"),
+    ])
+    def test_slugs(self, verb, output, slug):
+        assert classify_failure(verb, 1, output) == slug
+
+    def test_restart_service_slugs_unchanged(self):
+        # The shared branch must not regress restart_service's slugs.
+        assert classify_failure("restart_service", 1, "sudo: a password is required") == (
+            "restart_permission_denied")
+        assert classify_failure("restart_service", 1, "Unit x.service not found.") == (
+            "unit_not_found")
+        assert classify_failure("restart_service", 1, "boom") == "restart_failed"
+
+
+def service_state_event(*, verb="enable_service", unit="nginx.service", dry_run=False):
+    return remediation_event(
+        req_id="rmd-svc-1", verb=verb, target="web-1",
+        payload={"finding_id": "fnd-8", "action": verb, "unit": unit,
+                 "dry_run": dry_run, "timeout_seconds": 60},
+    )
+
+
+class TestServiceStateRouting:
+    @pytest.mark.parametrize("verb,frag", [
+        ("enable_service", "sudo -n systemctl enable --now nginx.service"),
+        ("reload_service", "sudo -n systemctl reload nginx.service"),
+    ])
+    def test_success_builds_systemctl_over_ssh(self, verb, frag):
+        listener = make_listener()
+
+        def _echo(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(request_id=request.id, status="success",
+                                   output=f"ok\n{marker}0\n")
+
+        listener._executors.execute = AsyncMock(side_effect=_echo)
+        run(listener._handle_event(service_state_event(verb=verb)))
+        request = listener._executors.execute.await_args.args[0]
+        assert request.payload["command"].startswith(frag)
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == verb
+        assert result["ok"] is True
+
+    def test_reload_unsupported_slug(self):
+        listener = make_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.split('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(
+                request_id=request.id, status="success",
+                output=("Failed to reload nginx.service: Job type reload is "
+                        f"not applicable for unit nginx.service.\n{marker}1\n"))
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(service_state_event(verb="reload_service")))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "reload_unsupported"


### PR DESCRIPTION
## What

Adds two one-click remediation executors for systemd service state, extending the proactive-remediation flow — trivial systemctl variants of the existing service-restart executor:

- **enable_service** → `sudo -n systemctl enable --now <unit>` (enables and starts; idempotent)
- **reload_service** → `sudo -n systemctl reload <unit>` (re-reads config without a restart's downtime)

When a proactive scan finds a unit that's enabled-but-inactive or whose config is newer than what's loaded, Servonaut can fix it for you — with the same safety flow as every other remediation: server-signed preview, a dry-run, and a typed confirmation.

## Notes

- Reuses the exact unit validation + envelope shape as service-restart (same `unit` field, same rail).
- **Dry-run changes nothing** — it reports enablement/active state via read-only `systemctl is-enabled`/`is-active` queries and always exits 0.
- Plain `reload` (not reload-or-restart): a "needs reload" finding wants a config re-read, not a surprise restart. A unit with no `ExecReload=` fails cleanly and is surfaced as `reload_unsupported`.
- Failure slugs: `unit_not_found`, `enable_permission_denied` / `reload_permission_denied`, `reload_unsupported`, `enable_failed` / `reload_failed`. The shared classifier preserves service-restart's existing slugs unchanged.

## Rollout

Ships dormant/additive — activates only once the server's service-state detector offers these on a finding. Routes through the existing SSH-command path (no relay change).

## Tests

Verb set, both builders (live + dry-run), hostile/template unit handling, the full slug set (including `reload_unsupported` and a regression check that service-restart's slugs are unchanged), and relay routing. Full remediation + relay suites green.
