### PR TITLE
feat(mcp): add read-only service_state probe

### DIFF
--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -106,6 +106,7 @@ class CommandGuard:
             # summaries. Read-only over SSH with sudo -n fallback.
             'journal_errors', 'tls_cert_check', 'auth_log_summary',
             'disk_usage', 'pending_updates', 'security_audit',
+            'disk_usage', 'pending_updates', 'service_state',
         }
         standard_tools = readonly_tools | {
             'run_command', 'get_logs',

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -2235,6 +2235,27 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
         },
         "chat_exposed": True,
     },
+    "service_state": {
+        "description": (
+            "Enablement / active / reload state of one instance's enabled "
+            "systemd services. Read-only (systemctl is-enabled / is-active + "
+            "NeedDaemonReload per unit; never changes state). Returns JSON: "
+            "{units: [{unit, enabled, active, needs_reload}]}. Powers the "
+            "service-state detector (enabled-but-inactive, needs-reload, "
+            "active-but-unnecessary)."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID or name.",
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
     "tls_cert_check": {
         "description": (
             "Discover TLS certificates on one instance (certbot live dirs "

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -5991,6 +5991,54 @@ class ServonautTools:
         self._audit.log('security_audit', args, f"{len(result)} chars", True)
         return result
 
+    async def service_state(self, instance_id: str) -> str:
+        """Enablement / active / reload state of the box's enabled services.
+
+        Read-only: for each enabled ``.service`` unit, ``systemctl
+        is-enabled`` / ``is-active`` plus ``NeedDaemonReload`` (the unit file
+        on disk differs from what the daemon loaded). Powers the service-state
+        detector: enabled-but-inactive, needs-reload, and active-but-
+        unnecessary. Never changes unit state.
+        """
+        from servonaut.utils.system_probe import parse_service_state
+
+        args = {'instance_id': instance_id}
+        allowed, reason = self._guard.check_tool('service_state')
+        if not allowed:
+            self._audit.log('service_state', args, '', False, reason)
+            return f"Blocked: {reason}"
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('service_state', args, '', False,
+                            'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        # Enabled service units only (bounded); per unit report is-enabled /
+        # is-active / NeedDaemonReload as a pipe-delimited row.
+        remote = (
+            "systemctl list-unit-files --type=service --state=enabled "
+            "--no-legend 2>/dev/null | awk '{print $1}' | head -n 200 | "
+            "while read u; do "
+            'en=$(systemctl is-enabled "$u" 2>/dev/null || echo unknown); '
+            'ac=$(systemctl is-active "$u" 2>/dev/null || echo unknown); '
+            'nr=$(systemctl show "$u" -p NeedDaemonReload --value '
+            '2>/dev/null || echo no); '
+            "printf '%s|%s|%s|%s\\n' \"$u\" \"$en\" \"$ac\" \"$nr\"; "
+            "done; true"
+        )
+        try:
+            stdout, _stderr = await self._exec_ssh(instance, remote, timeout=90)
+        except asyncio.TimeoutError:
+            self._audit.log('service_state', args, '', False, 'timeout')
+            return "Error: service_state timed out after 90 seconds"
+        except Exception as e:
+            self._audit.log('service_state', args, '', False, f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        result = json.dumps(parse_service_state(stdout))
+        self._audit.log('service_state', args, f"{len(result)} chars", True)
+        return result
+
     async def tls_cert_check(self, instance_id: str) -> str:
         """Discover TLS certs (certbot + nginx/apache configs) and read expiry.
 

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -145,6 +145,7 @@ _TOOL_GUARDS: Dict[str, Literal["readonly", "standard", "dangerous"]] = {
     "disk_usage": "readonly",
     "pending_updates": "readonly",
     "security_audit": "readonly",
+    "service_state": "readonly",
 }
 
 # Strict ordering of guard severity. Used by :func:`_escalate_guard` to
@@ -316,6 +317,7 @@ _LOCAL_TOOL_HANDLERS: Dict[str, str] = {
     "disk_usage":                 "disk_usage",
     "pending_updates":            "pending_updates",
     "security_audit":             "security_audit",
+    "service_state":              "service_state",
     "enrich_ips":                 "enrich_ips",
     "db_processlist":             "db_processlist",
     "db_top_queries":             "db_top_queries",

--- a/src/servonaut/utils/system_probe.py
+++ b/src/servonaut/utils/system_probe.py
@@ -516,3 +516,26 @@ def parse_security_audit(stdout: str) -> Dict[str, Any]:
                     "issue": issue,
                 })
     return {"sshd": sshd, "insecure_files": insecure}
+def parse_service_state(stdout: str) -> Dict[str, Any]:
+    """Parse the ``service_state`` probe output into ``{"units": [...]}``.
+
+    Each input line is ``<unit>|<is-enabled>|<is-active>|<NeedDaemonReload>``
+    (see ``ServonautTools.service_state``). Booleans are derived from the
+    systemctl words: ``enabled``/``active``/``yes``. ``needs_reload`` reflects
+    systemd's ``NeedDaemonReload`` (the unit file on disk differs from what the
+    daemon loaded). Malformed lines are skipped rather than raising, so a
+    partial probe still yields the units it could read.
+    """
+    units: List[Dict[str, Any]] = []
+    for line in (stdout or "").splitlines():
+        parts = line.strip().split("|")
+        if len(parts) != 4 or not parts[0]:
+            continue
+        unit, enabled, active, needs_reload = (p.strip() for p in parts)
+        units.append({
+            "unit": unit,
+            "enabled": enabled == "enabled",
+            "active": active == "active",
+            "needs_reload": needs_reload.lower() == "yes",
+        })
+    return {"units": units}

--- a/tests/fixtures/server_catalog_v1.json
+++ b/tests/fixtures/server_catalog_v1.json
@@ -83,6 +83,7 @@
     "s3_move_object",
     "s3_upload_object",
     "security_audit",
+    "service_state",
     "tls_cert_check",
     "transfer_file",
     "waf_rate_rule_set",
@@ -189,6 +190,9 @@
       "instance_id",
       "since_minutes",
       "top_n"
+    ],
+    "service_state": [
+      "instance_id"
     ]
   }
 }

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -90,7 +90,7 @@ class TestLocalToolHandlerMapCompleteness:
             f"from ServonautTools: {missing}"
         )
 
-    def test_new_entries_count_is_82(self):
+    def test_new_entries_count_is_83(self):
         """Local-handler entries beyond the 2 originals.
 
         PR5' seeded 57; incident-response tools added the rest:
@@ -103,13 +103,13 @@ class TestLocalToolHandlerMapCompleteness:
         docker_events_summary) → 75; system-health probes (journal_errors,
         tls_cert_check, auth_log_summary) → 78; docker_log_summary → 79;
         breadth probes (disk_usage, pending_updates) → 81; security_audit
-        → 82. All dispatch locally (CLI's own SSH / boto3 / network /
-        memory surface); the server catalog mirror is tracked separately
-        (see test_catalog_drift::CATALOG_PENDING_SERVER).
+        → 82; service_state → 83. All dispatch locally (CLI's own SSH /
+        boto3 / network / memory surface); the server catalog mirror is
+        tracked separately (see test_catalog_drift::CATALOG_PENDING_SERVER).
         """
         new_entries = {k for k in _LOCAL_TOOL_HANDLERS if k not in _ORIGINAL_TOOLS}
-        assert len(new_entries) == 82, (
-            f"Expected 82 new entries, got {len(new_entries)}: {sorted(new_entries)}"
+        assert len(new_entries) == 83, (
+            f"Expected 83 new entries, got {len(new_entries)}: {sorted(new_entries)}"
         )
 
 

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -70,16 +70,15 @@ def test_pending_server_tools_not_yet_in_catalog():
     )
 
 
-def test_catalog_fixture_has_87_entries():
-    """Sanity check: the fixture must contain exactly 87 names.
+def test_catalog_fixture_has_88_entries():
+    """Sanity check: the fixture must contain exactly 88 names.
 
     84 (v1 convergence) + the breadth probes (disk_usage,
-    pending_updates) + the security_audit probe registered for the
-    security-hardening detector.
+    pending_updates) + the security_audit probe + the service_state probe.
     """
     names = _server_catalog_names()
-    assert len(names) == 87, (
-        f"Expected 87 catalog entries, got {len(names)}: {sorted(names)}"
+    assert len(names) == 88, (
+        f"Expected 88 catalog entries, got {len(names)}: {sorted(names)}"
     )
 
 

--- a/tests/test_system_probe_tools.py
+++ b/tests/test_system_probe_tools.py
@@ -21,6 +21,7 @@ from servonaut.services.memory.stack_summary import build_stack_summary
 from servonaut.utils.system_probe import (
     parse_journal_errors,
     parse_security_audit,
+    parse_service_state,
     parse_tls_certs,
     summarize_auth_log,
 )
@@ -621,3 +622,50 @@ class TestSecurityAuditToolLayer:
         assert json.loads(run(tools.security_audit("web-1"))) == {
             "sshd": {}, "insecure_files": [],
         }
+
+
+class TestParseServiceState:
+    def test_rows_parse_to_typed_units(self):
+        stdout = (
+            "nginx.service|enabled|active|no\n"
+            "ssh.service|enabled|inactive|yes\n"
+        )
+        out = parse_service_state(stdout)
+        assert out == {"units": [
+            {"unit": "nginx.service", "enabled": True, "active": True,
+             "needs_reload": False},
+            {"unit": "ssh.service", "enabled": True, "active": False,
+             "needs_reload": True},
+        ]}
+
+    def test_malformed_rows_skipped(self):
+        out = parse_service_state("bad\n|x|y|z\n\nok.service|enabled|active|no")
+        assert [u["unit"] for u in out["units"]] == ["ok.service"]
+
+    def test_empty_is_empty_list(self):
+        assert parse_service_state("") == {"units": []}
+
+
+class TestServiceStateToolLayer:
+    def test_service_state_json_and_readonly_command(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=(
+            "nginx.service|enabled|active|no\n"
+            "telnet.socket|enabled|active|no\n", ""))
+        payload = json.loads(run(tools.service_state("web-1")))
+        assert payload["units"][0]["unit"] == "nginx.service"
+        # The dispatched command is read-only (query verbs only, no mutation).
+        remote = tools._exec_ssh.await_args.args[1]
+        assert "is-enabled" in remote and "is-active" in remote
+        assert "NeedDaemonReload" in remote
+        # No mutating systemctl COMMAND form (is-enabled/NeedDaemonReload are
+        # read-only despite containing the substrings 'enable'/'reload').
+        for mutating in ("systemctl enable", "systemctl disable",
+                         "systemctl reload", "systemctl restart",
+                         "systemctl start", "systemctl stop"):
+            assert mutating not in remote
+
+    def test_empty_output_is_empty_units(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=("", ""))
+        assert json.loads(run(tools.service_state("web-1"))) == {"units": []}


### PR DESCRIPTION
## What

Adds a read-only `service_state` probe — the missing read side of the service-state proactive detector.

For each enabled systemd `.service` unit, it reports `{unit, enabled, active, needs_reload}` via `systemctl is-enabled` / `is-active` plus `NeedDaemonReload` (the unit file on disk differs from what the daemon has loaded). Read-only — the dispatched command uses query verbs only and never changes unit state.

This closes the read side for the three service-state remediation verbs: enabled-but-inactive → enable, needs-reload → reload, active-but-unnecessary → disable.

## Notes

- **`needs_reload` semantics:** reflects systemd's native `NeedDaemonReload` signal — the generically-detectable "the daemon's view of this unit is stale" indicator. (A per-service "the service's own config changed" check would need per-service config knowledge; flagged with the server side.)
- Bounded to enabled service units (capped at 200), pipe-delimited rows parsed into typed booleans; malformed rows are skipped so a partial probe still yields what it could read.

## Wiring

Full probe surface: tool method + `parse_service_state`, JSON schema (`chat_exposed`), readonly guard, `ai_tool_bridge` guard mirror + dispatch map, and the catalog fixture (the server registered it in its ToolCatalog).

## Tests

Parser (typed rows, malformed-row skipping, empty), and the tool layer (JSON output, an assertion that the dispatched command is read-only — no mutating `systemctl` verb — and empty-output handling). Catalog-drift + bridge-count golden checks updated. Full affected suites green.
