### PR TITLE
feat(remediation): add raise_container_memory executor

### DIFF
--- a/src/servonaut/services/findings_service.py
+++ b/src/servonaut/services/findings_service.py
@@ -207,6 +207,7 @@ class FindingsService:
     async def remediate_preview(
         self, finding_id: str, action: str, *, dry_run: bool = False,
         method: Optional[str] = None, rate: Optional[str] = None,
+        multiplier: Optional[str] = None,
     ) -> Dict[str, Any]:
         """GET the server-built preview for one of the finding's own
         remediation actions.
@@ -227,6 +228,12 @@ class FindingsService:
         value MUST be replayed on :meth:`remediate`. Omit for verbs the
         server fully specifies (e.g. ``certbot_renew``); a missing
         ``method`` on ``block_ip`` returns 422 ``block_ip_method_required``.
+
+        ``multiplier`` is the analogous caller-parameter for
+        ``raise_container_memory`` (2|3|4 — the factor the operator picks
+        at remediate time). Like ``method`` it is folded into the command
+        hash the token signs, so the same value MUST be replayed on
+        :meth:`remediate`; omit it for verbs the server fully specifies.
         """
         safe_id = _validate_finding_id(finding_id)
         safe_action = _validate_remediation_action(action)
@@ -241,6 +248,8 @@ class FindingsService:
             # same value MUST be replayed on remediate() — same contract as
             # block_ip's method.
             params["rate"] = rate
+        if multiplier:
+            params["multiplier"] = multiplier
         return await self._api.get(
             f"{_BASE}/{safe_id}/remediate/preview", params=params,
         )
@@ -248,7 +257,7 @@ class FindingsService:
     async def remediate(
         self, finding_id: str, action: str, confirm_token: str,
         *, dry_run: bool = False, method: Optional[str] = None,
-        rate: Optional[str] = None,
+        rate: Optional[str] = None, multiplier: Optional[str] = None,
     ) -> Dict[str, Any]:
         """POST the confirmed remediation; returns immediately (async).
 
@@ -259,7 +268,10 @@ class FindingsService:
         preview: the server recomputes the command hash the token is
         signed over, and for ``block_ip`` that hash includes the method
         — replaying it here is what makes the token verify. Omit it for
-        server-specified verbs. The server gates + atomically claims
+        server-specified verbs. ``multiplier`` behaves identically for
+        ``raise_container_memory`` (2|3|4): it is folded into the hashed
+        args, so the value replayed here MUST equal the previewed one.
+        The server gates + atomically claims
         ``remediating`` + audits synchronously, enqueues the (possibly
         long) command to a worker, and returns 202 ``{accepted,
         finding_id, status:"remediating", dry_run, action, poll}`` — it
@@ -284,6 +296,8 @@ class FindingsService:
             # Same replay contract as method: the rate is in the token's
             # command-hash preimage, so it must match the previewed value.
             body["rate"] = rate
+        if multiplier:
+            body["multiplier"] = multiplier
         return await self._api.post(
             f"{_BASE}/{safe_id}/remediate", json=body,
         )

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -788,7 +788,15 @@ def wrap_with_exit_marker(command: str, nonce: str = "") -> str:
     real fix is the server re-probe, not this marker.
     """
     prefix = _marker_prefix(nonce)
-    return f'{command}; rc=$?; echo "{prefix}$rc" >&2'
+    # Wrap the command in a subshell so an ``exit N`` INSIDE it (the
+    # multi-branch config-edit verbs — raise_container_memory,
+    # set_config_value, fix_permissions — use ``exit N`` to signal distinct
+    # outcomes) exits only the SUBSHELL. The epilogue then still runs on the
+    # outer shell and recovers the code via ``$?``. Without the subshell an
+    # ``exit`` in the command pre-empts the epilogue, the marker never echoes,
+    # and the parser reads a clean run as a transport failure (caught by the
+    # raise_container_memory live E2E). Harmless for exit-less commands.
+    return f'({command}); rc=$?; echo "{prefix}$rc" >&2'
 
 
 def parse_exit_marker(

--- a/src/servonaut/services/remediation_executor.py
+++ b/src/servonaut/services/remediation_executor.py
@@ -34,7 +34,8 @@ REMEDIATION_SOURCE = "proactive_remediation"
 #: from validated payload fields, judged via the exit marker).
 SSH_COMMAND_VERBS = frozenset(
     {"certbot_renew", "restart_service", "restart_container", "start_container",
-     "enable_service", "reload_service", "disable_service"}
+     "enable_service", "reload_service", "disable_service",
+     "raise_container_memory"}
 )
 
 #: Verbs handled by a dedicated ``_execute_*`` method rather than the
@@ -319,6 +320,94 @@ def _build_start_container(payload: Dict[str, Any]) -> str:
     return " ".join(shlex.quote(a) for a in argv)
 
 
+#: Multipliers the ``raise_container_memory`` envelope may request, as strings.
+#: A multiplier (× current limit) is always an INCREASE — an absolute value
+#: risks the operator picking below the current limit (a decrease on an OOM
+#: finding). Kept in lockstep with the server-side enum.
+RAISE_MEM_MULTIPLIERS = frozenset({"2", "3", "4"})
+
+
+def _require_multiplier(payload: Dict[str, Any]) -> str:
+    m = payload.get("multiplier")
+    if not isinstance(m, str) or m not in RAISE_MEM_MULTIPLIERS:
+        allowed = ", ".join(sorted(RAISE_MEM_MULTIPLIERS))
+        raise RemediationValidationError(
+            f"invalid_raise_mem_multiplier: {m!r} is not one of {{{allowed}}}",
+        )
+    return m
+
+
+def _build_raise_container_memory(payload: Dict[str, Any]) -> str:
+    """Raise a compose-managed container's memory limit by a multiplier and
+    recreate it. A Tier-2 config-edit primitive, so the whole thing is a
+    guarded on-box script: read the CURRENT limit and multiply it (always an
+    increase, never a footgun), edit ONLY the target service's mem_limit (v2)
+    or deploy.resources.limits.memory (v3) via ``yq`` (an in-place,
+    formatting-preserving edit — never ``sed`` on YAML), validate the compose
+    file BEFORE recreating (a bad edit restores the backup and aborts WITHOUT
+    touching the running container), then recreate just that service. Every
+    mutation is preceded by a ``.bak`` copy, and any failure after the edit
+    restores it. Refuses cleanly (no change) when: the container has no limit,
+    it is not compose-managed, or no safe YAML editor is present.
+
+    The container name is validated + shlex-quoted; the multiplier is a single
+    digit from :data:`RAISE_MEM_MULTIPLIERS`. Failure paths echo an uppercase
+    token that :func:`classify_failure` maps to a curated slug.
+    """
+    name = _require_container(payload)
+    mult = _require_multiplier(payload)
+    c = shlex.quote(name)
+    inspect_mem = f"docker inspect -f '{{{{.HostConfig.Memory}}}}' {c}"
+    inspect_file = (
+        f"docker inspect -f "
+        f"'{{{{index .Config.Labels \"com.docker.compose.project.config_files\"}}}}' "
+        f"{c} 2>/dev/null | cut -d, -f1"
+    )
+    inspect_svc = (
+        f"docker inspect -f "
+        f"'{{{{index .Config.Labels \"com.docker.compose.service\"}}}}' {c} 2>/dev/null"
+    )
+    if _coerce_dry_run(payload):
+        # Read-only: report current + computed limit + the compose file; change
+        # nothing. No sudo (same docker-group access as the read probe).
+        return (
+            f'CUR=$({inspect_mem} 2>/dev/null); '
+            f'if [ -z "$CUR" ]; then echo INSPECT_FAIL; exit 0; fi; '
+            f'if [ "$CUR" = "0" ]; then echo "NO_LIMIT current=0 (unlimited)"; exit 0; fi; '
+            f'NEW=$((CUR * {mult})); '
+            f'FILE=$({inspect_file}); SVC=$({inspect_svc}); '
+            f'if [ -z "$FILE" ] || [ "$FILE" = "<no value>" ] || [ -z "$SVC" ] || [ "$SVC" = "<no value>" ]; '
+            f'then echo NOT_COMPOSE; exit 0; fi; '
+            f'echo "DRY RUN would raise {name} (service $SVC) mem_limit $CUR -> $NEW bytes (x{mult}) in $FILE; no change"; '
+            f'true'
+        )
+    return (
+        f'CUR=$({inspect_mem} 2>/dev/null); '
+        f'if [ -z "$CUR" ]; then echo INSPECT_FAIL; exit 3; fi; '
+        f'if [ "$CUR" = "0" ]; then echo NO_LIMIT; exit 4; fi; '
+        f'NEW=$((CUR * {mult})); '
+        f'FILE=$({inspect_file}); SVC=$({inspect_svc}); '
+        f'if [ -z "$FILE" ] || [ "$FILE" = "<no value>" ] || [ -z "$SVC" ] || [ "$SVC" = "<no value>" ]; '
+        f'then echo NOT_COMPOSE; exit 5; fi; '
+        f'if ! command -v yq >/dev/null 2>&1; then echo NO_YAML_EDITOR; exit 6; fi; '
+        f'BAK="$FILE.servonaut.bak.$(date +%s)"; '
+        f'cp "$FILE" "$BAK" || {{ echo BACKUP_FAIL; exit 7; }}; '
+        # Edit ONLY the target service's existing key: deploy.resources.limits.memory
+        # (v3) if it declares one, else mem_limit (v2). Never add a conflicting key.
+        f'if yq -e ".services.\\"$SVC\\".deploy.resources.limits.memory" "$FILE" >/dev/null 2>&1; then '
+        f'yq -i ".services.\\"$SVC\\".deploy.resources.limits.memory = \\"$NEW\\"" "$FILE"; '
+        f'else yq -i ".services.\\"$SVC\\".mem_limit = \\"$NEW\\"" "$FILE"; fi || '
+        f'{{ cp "$BAK" "$FILE"; echo EDIT_FAIL; exit 7; }}; '
+        # Validate the edited file BEFORE touching the running container.
+        f'if ! docker compose -f "$FILE" config >/dev/null 2>&1; then '
+        f'cp "$BAK" "$FILE"; echo VALIDATE_FAIL_RESTORED; exit 8; fi; '
+        # Recreate only the target service.
+        f'if ! docker compose -f "$FILE" up -d --no-deps "$SVC" >/dev/null 2>&1; then '
+        f'cp "$BAK" "$FILE"; echo RECREATE_FAIL_RESTORED; exit 9; fi; '
+        f'echo "OK raised {name} ($SVC) mem $CUR -> $NEW backup=$BAK"; exit 0'
+    )
+
+
 _VERB_BUILDERS = {
     "certbot_renew": _build_certbot_renew,
     "restart_service": _build_restart_service,
@@ -327,6 +416,7 @@ _VERB_BUILDERS = {
     "enable_service": _build_enable_service,
     "reload_service": _build_reload_service,
     "disable_service": _build_disable_service,
+    "raise_container_memory": _build_raise_container_memory,
 }
 
 # A builder registered here without a matching entry in SSH_COMMAND_VERBS
@@ -766,6 +856,24 @@ def classify_failure(verb: str, exit_code: Optional[int], output: str) -> str:
         if "no such container" in lowered or "not found" in lowered:
             return "container_not_found"
         return f"{verb}_failed"
+    # raise_container_memory: the on-box script echoes an uppercase token on
+    # each failure path (the .bak is already restored where relevant).
+    if verb == "raise_container_memory":
+        if "inspect_fail" in lowered:
+            return "container_not_found"
+        if "no_limit" in lowered:
+            return "raise_mem_no_limit"
+        if "not_compose" in lowered:
+            return "raise_mem_not_compose"
+        if "no_yaml_editor" in lowered:
+            return "raise_mem_no_yaml_editor"
+        if "validate_fail" in lowered:
+            return "raise_mem_validate_failed"
+        if "recreate_fail" in lowered:
+            return "raise_mem_recreate_failed"
+        if "backup_fail" in lowered or "edit_fail" in lowered:
+            return "raise_mem_edit_failed"
+        return "raise_container_memory_failed"
     if "a password is required" in lowered or (
         "sudo:" in lowered
         and ("password" in lowered or "not allowed" in lowered)

--- a/tests/test_findings_service.py
+++ b/tests/test_findings_service.py
@@ -291,6 +291,34 @@ class TestRemediation:
         run(svc.remediate("fnd_01abc", "renew_certificate", "tok-signed"))
         assert "rate" not in api.post.await_args.kwargs["json"]
 
+    def test_preview_sends_multiplier_for_raise_container_memory(self):
+        # raise_container_memory's command hash includes the caller-selected
+        # multiplier (2|3|4) — the preview GET must carry multiplier= (same
+        # contract as block_ip's method / rate_limit's rate).
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate_preview(
+            "fnd_01abc", "raise_container_memory", dry_run=True, multiplier="3",
+        ))
+        params = api.get.await_args.kwargs["params"]
+        assert params["multiplier"] == "3"
+        assert params["action"] == "raise_container_memory"
+
+    def test_execute_replays_multiplier_in_body(self):
+        # Same multiplier must be replayed so the token's command hash verifies.
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate(
+            "fnd_01abc", "raise_container_memory", "tok-signed", multiplier="2",
+        ))
+        assert api.post.await_args.kwargs["json"]["multiplier"] == "2"
+
+    def test_execute_omits_multiplier_when_none(self):
+        api = _mock_api()
+        svc = FindingsService(api)
+        run(svc.remediate("fnd_01abc", "renew_certificate", "tok-signed"))
+        assert "multiplier" not in api.post.await_args.kwargs["json"]
+
     def test_execute_post_shape(self):
         api = _mock_api()
         svc = FindingsService(api)

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -2196,3 +2196,126 @@ class TestServiceStateRouting:
         result = json.loads(posted_response(listener).output)
         assert result["ok"] is False
         assert result["slug"] == "reload_unsupported"
+
+
+# ---------------------------------------------------------------------------
+# raise_container_memory — Tier-2 compose-edit executor (guarded on-box script)
+# ---------------------------------------------------------------------------
+
+from servonaut.services.remediation_executor import (  # noqa: E402
+    RAISE_MEM_MULTIPLIERS,
+)
+
+
+class TestRaiseContainerMemoryVerbSet:
+    def test_is_an_ssh_command_verb(self):
+        assert "raise_container_memory" in REMEDIATION_VERBS
+        assert "raise_container_memory" in SSH_COMMAND_VERBS
+        assert "raise_container_memory" not in LOCAL_DISPATCH_VERBS
+
+    def test_builders_in_sync(self):
+        from servonaut.services.remediation_executor import _VERB_BUILDERS
+        assert set(_VERB_BUILDERS) == SSH_COMMAND_VERBS
+
+    def test_multipliers_are_ge_2(self):
+        assert RAISE_MEM_MULTIPLIERS == {"2", "3", "4"}
+
+
+class TestBuildRaiseContainerMemory:
+    def test_live_has_full_guardrail_chain(self):
+        cmd = build_remediation_command(
+            "raise_container_memory", {"container": "web-1", "multiplier": "3"})
+        # read current -> compute -> locate compose -> yq edit -> validate
+        # BEFORE recreate -> recreate -> restore-on-fail.
+        assert "docker inspect -f '{{.HostConfig.Memory}}' web-1" in cmd
+        assert "CUR * 3" in cmd
+        assert 'com.docker.compose.project.config_files' in cmd
+        assert "command -v yq" in cmd                    # safe editor, never sed
+        assert "sed -i" not in cmd
+        assert 'cp "$FILE" "$BAK"' in cmd                # backup first
+        assert "docker compose -f" in cmd and "config" in cmd  # validate
+        # validate must precede recreate in the script text
+        assert cmd.index('config >/dev/null') < cmd.index("up -d --no-deps")
+        assert 'cp "$BAK" "$FILE"' in cmd                # restore-on-fail
+        assert "up -d --no-deps" in cmd
+
+    def test_dry_run_makes_no_mutation(self):
+        cmd = build_remediation_command(
+            "raise_container_memory",
+            {"container": "web-1", "multiplier": "2", "dry_run": True})
+        assert "DRY RUN" in cmd
+        assert "yq -i" not in cmd
+        assert "up -d" not in cmd
+        assert "cp " not in cmd  # no backup/edit in a dry run
+
+    @pytest.mark.parametrize("mult", ["1", "5", "0", "", "2x", 2, 2.0, None])
+    def test_bad_multiplier_rejected(self, mult):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command(
+                "raise_container_memory", {"container": "web-1", "multiplier": mult})
+        assert str(exc.value).startswith("invalid_raise_mem_multiplier:")
+
+    @pytest.mark.parametrize("bad", ["a b", "../x", "a/b", "x@y", ""])
+    def test_bad_container_rejected(self, bad):
+        with pytest.raises(RemediationValidationError) as exc:
+            build_remediation_command(
+                "raise_container_memory", {"container": bad, "multiplier": "2"})
+        assert str(exc.value).startswith("invalid_container_name:")
+
+
+class TestClassifyRaiseMemFailure:
+    @pytest.mark.parametrize("out,slug", [
+        ("INSPECT_FAIL", "container_not_found"),
+        ("NO_LIMIT", "raise_mem_no_limit"),
+        ("NOT_COMPOSE", "raise_mem_not_compose"),
+        ("NO_YAML_EDITOR", "raise_mem_no_yaml_editor"),
+        ("VALIDATE_FAIL_RESTORED", "raise_mem_validate_failed"),
+        ("RECREATE_FAIL_RESTORED", "raise_mem_recreate_failed"),
+        ("EDIT_FAIL", "raise_mem_edit_failed"),
+        ("something else", "raise_container_memory_failed"),
+    ])
+    def test_slugs(self, out, slug):
+        assert classify_failure("raise_container_memory", 1, out) == slug
+
+
+def raise_mem_event(*, container="web-1", multiplier="3", dry_run=False):
+    return remediation_event(
+        req_id="rmd-mem-1", verb="raise_container_memory", target="web-1",
+        payload={"finding_id": "fnd-m", "action": "raise_container_memory",
+                 "container": container, "multiplier": multiplier,
+                 "dry_run": dry_run, "timeout_seconds": 60})
+
+
+class TestRaiseContainerMemoryRouting:
+    def test_success_builds_script_over_ssh(self):
+        listener = make_listener()
+
+        def _echo(request):
+            command = request.payload["command"]
+            marker = command.rsplit('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(request_id=request.id, status="success",
+                                   output=f"OK raised web-1\n{marker}0\n")
+
+        listener._executors.execute = AsyncMock(side_effect=_echo)
+        run(listener._handle_event(raise_mem_event()))
+        request = listener._executors.execute.await_args.args[0]
+        assert request.type == CommandType.RUN_COMMAND
+        assert "com.docker.compose.service" in request.payload["command"]
+        result = json.loads(posted_response(listener).output)
+        assert result["verb"] == "raise_container_memory"
+        assert result["ok"] is True
+
+    def test_no_limit_answers_with_slug(self):
+        listener = make_listener()
+
+        def _echo_fail(request):
+            command = request.payload["command"]
+            marker = command.rsplit('echo "', 1)[1].split("$rc", 1)[0]
+            return CommandResponse(request_id=request.id, status="success",
+                                   output=f"NO_LIMIT\n{marker}4\n")
+
+        listener._executors.execute = AsyncMock(side_effect=_echo_fail)
+        run(listener._handle_event(raise_mem_event()))
+        result = json.loads(posted_response(listener).output)
+        assert result["ok"] is False
+        assert result["slug"] == "raise_mem_no_limit"

--- a/tests/test_remediation_executor.py
+++ b/tests/test_remediation_executor.py
@@ -185,6 +185,26 @@ class TestExitMarker:
         code, _ = parse_exit_marker(combined, nonce)
         assert code == 0
 
+    def test_internal_exit_does_not_preempt_marker(self):
+        # A command that calls ``exit N`` internally (raise_container_memory /
+        # set_config_value / fix_permissions signal outcomes with ``exit``)
+        # must STILL emit the marker: the subshell wrap keeps the ``exit``
+        # from killing the outer shell before the epilogue runs. Executed in a
+        # real bash so the fix is proven at the shell level, not just asserted.
+        # (Regression: the raise_container_memory live E2E reported a clean run
+        # as remediation_transport_failed because ``exit 0`` pre-empted the
+        # epilogue and the marker never echoed.)
+        import subprocess
+        nonce = "e2e0badc0de00001"
+        wrapped = wrap_with_exit_marker('echo "OK did the thing"; exit 7', nonce)
+        proc = subprocess.run(
+            ["bash", "-c", wrapped], capture_output=True, text=True,
+        )
+        combined = proc.stdout + "\nSTDERR:\n" + proc.stderr
+        code, cleaned = parse_exit_marker(combined, nonce)
+        assert code == 7, f"marker lost after internal exit; got {combined!r}"
+        assert "OK did the thing" in cleaned
+
 
 class TestPreviewCommandLines:
     """The confirm modal renders command.human verbatim, with a
@@ -335,8 +355,9 @@ class TestRemediationRouting:
         # The executor received a locally-built command, not server text.
         request = listener._executors.execute.await_args.args[0]
         assert request.type == CommandType.RUN_COMMAND
+        # Subshell-wrapped so an internal ``exit`` can't pre-empt the epilogue.
         assert request.payload["command"].startswith(
-            "sudo -n certbot renew --cert-name example.com",
+            "(sudo -n certbot renew --cert-name example.com",
         )
         assert EXIT_MARKER in request.payload["command"]
 
@@ -1472,7 +1493,7 @@ class TestRestartServiceRouting:
         request = listener._executors.execute.await_args.args[0]
         assert request.type == CommandType.RUN_COMMAND
         assert request.payload["command"].startswith(
-            "sudo -n systemctl restart nginx.service",
+            "(sudo -n systemctl restart nginx.service",
         )
         assert EXIT_MARKER in request.payload["command"]
 
@@ -1708,7 +1729,7 @@ class TestContainerRouting:
 
         request = listener._executors.execute.await_args.args[0]
         assert request.type == CommandType.RUN_COMMAND
-        assert request.payload["command"].startswith(f"{docker_verb} web-1")
+        assert request.payload["command"].startswith(f"({docker_verb} web-1")
         assert EXIT_MARKER in request.payload["command"]
 
         result = json.loads(posted_response(listener).output)
@@ -2175,7 +2196,8 @@ class TestServiceStateRouting:
         listener._executors.execute = AsyncMock(side_effect=_echo)
         run(listener._handle_event(service_state_event(verb=verb)))
         request = listener._executors.execute.await_args.args[0]
-        assert request.payload["command"].startswith(frag)
+        # Subshell-wrapped so an internal ``exit`` can't pre-empt the epilogue.
+        assert request.payload["command"].startswith(f"({frag}")
         result = json.loads(posted_response(listener).output)
         assert result["verb"] == verb
         assert result["ok"] is True


### PR DESCRIPTION
## What

Adds a one-click remediation executor that raises a container's memory limit when a proactive scan finds it OOM-killed or under memory pressure:

- **raise_container_memory** → multiply the compose-managed container's memory limit by a caller-selected factor (2× / 3× / 4× the current limit) and recreate it.

A multiplier (not an absolute value) means the result is always an *increase* — the operator can't accidentally pick a limit below the current one on an OOM finding.

## Design — Tier-2, backup-first, validate-before-recreate

Because this edits the customer's production compose file, it's a single guarded on-box script:

1. **Read the current limit and multiply.** Refuse cleanly (no change) if the container has no limit (unlimited) or isn't compose-managed.
2. **Edit only the target service's existing key** — `deploy.resources.limits.memory` (v3) or `mem_limit` (v2) — via **`yq`** (an in-place, formatting-preserving edit; **never `sed` on YAML**). Refuse cleanly if no safe YAML editor is present.
3. **Back up first** (`.bak`), then **validate `docker compose config` BEFORE recreating** — a bad edit restores the backup and aborts *without* ever touching the running container.
4. **Recreate only the target service** (`up -d --no-deps`); restore the backup on any recreate failure.

Failures map to clear slugs: `raise_mem_no_limit` / `_not_compose` / `_no_yaml_editor` / `_validate_failed` / `_recreate_failed` / `_edit_failed`.

## Rollout

Ships dormant/additive — activates only once the server offers the action on a finding. Routes through the existing SSH-command path.

## Tests

Verb set, the full guardrail chain in the generated script (read→compute→locate→yq-edit→validate-before-recreate→restore-on-fail), dry-run makes no mutation, multiplier/container rejection, the curated failure slugs, and relay routing. Both generated scripts pass `bash -n`. Full executor + relay suites green (335).
