### PR TITLE
feat(mcp): add read-only security_audit probe

### DIFF
--- a/src/servonaut/mcp/guards.py
+++ b/src/servonaut/mcp/guards.py
@@ -105,7 +105,7 @@ class CommandGuard:
             # aggregation, TLS cert expiry discovery, and SSH auth-log
             # summaries. Read-only over SSH with sudo -n fallback.
             'journal_errors', 'tls_cert_check', 'auth_log_summary',
-            'disk_usage', 'pending_updates',
+            'disk_usage', 'pending_updates', 'security_audit',
         }
         standard_tools = readonly_tools | {
             'run_command', 'get_logs',

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -2211,6 +2211,30 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
         },
         "chat_exposed": True,
     },
+    "security_audit": {
+        "description": (
+            "Baseline security posture of one instance. Read-only, two "
+            "signals: sshd effective config (sshd -T: permit-root-login, "
+            "password-authentication, permit-empty-passwords, x11-forwarding) "
+            "and a stat of a curated list of sensitive paths "
+            "(sshd/sudoers/cron/passwd-family/root keys), flagging only those "
+            "that are world-writable or not root-owned. Never changes sshd "
+            "config or file permissions. Returns JSON: {sshd: {directive: "
+            "value}, insecure_files: [{path, mode, owner, issue}]}. Powers "
+            "the security-hardening detector (weak-sshd, insecure-perms)."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "instance_id": {
+                    "type": "string",
+                    "description": "Instance ID or name.",
+                },
+            },
+            "required": ["instance_id"],
+        },
+        "chat_exposed": True,
+    },
     "tls_cert_check": {
         "description": (
             "Discover TLS certificates on one instance (certbot live dirs "

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -5968,6 +5968,72 @@ class ServonautTools:
         self._audit.log('pending_updates', args, f"{len(result)} chars", True)
         return result
 
+    async def security_audit(self, instance_id: str) -> str:
+        """Baseline security posture of one instance (sshd + file perms).
+
+        Read-only. Two signals, both non-mutating:
+
+        * **sshd** — effective values of four hardening directives via
+          ``sshd -T`` (the authoritative merged config, not a file grep):
+          permit-root-login, password-authentication, permit-empty-passwords,
+          x11-forwarding. Keys are passed through in ``sshd -T`` form; the
+          server normalises them to canonical directive names.
+        * **insecure_files** — a ``stat`` of a CURATED candidate list of
+          sensitive paths (sshd/sudoers/cron/passwd-family/root's keys),
+          reporting only those that are world-writable or not root-owned.
+          The curated list is the safety boundary on what the paired
+          fix_permissions remediation can ever target.
+
+        Returns JSON ``{sshd: {directive: value}, insecure_files: [{path,
+        mode, owner, issue}]}``. Never changes sshd config or file perms.
+        """
+        from servonaut.utils.system_probe import parse_security_audit
+
+        args = {'instance_id': instance_id}
+        allowed, reason = self._guard.check_tool('security_audit')
+        if not allowed:
+            self._audit.log('security_audit', args, '', False, reason)
+            return f"Blocked: {reason}"
+        instance = await self._find_instance(instance_id)
+        if not instance:
+            self._audit.log('security_audit', args, '', False,
+                            'instance_not_found')
+            return f"Instance not found: {instance_id}"
+
+        # sshd -T needs root (sudo -n fallback to a root ssh session); the
+        # stat loop reads inode metadata only (no content), so it works for
+        # any path the ssh user can see. Both sections degrade to partial
+        # rather than erroring. All read-only: sshd -T dumps config, stat
+        # reads metadata, no redirects/writes anywhere.
+        remote = (
+            "( sudo -n sshd -T 2>/dev/null || sshd -T 2>/dev/null ) | "
+            "awk '{k=tolower($1)} "
+            'k=="permitrootlogin"||k=="passwordauthentication"||'
+            'k=="permitemptypasswords"||k=="x11forwarding"'
+            '{v=$2; for(i=3;i<=NF;i++)v=v" "$i; print "SSHD|"k"|"v}\'; '
+            "for f in /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* "
+            "/etc/ssh/ssh_host_*_key /etc/sudoers /etc/sudoers.d/* "
+            "/etc/crontab /etc/cron.d/* /etc/passwd /etc/shadow /etc/group "
+            "/etc/gshadow /root/.ssh/*; do "
+            '[ -e "$f" ] || continue; '
+            "meta=$(stat -c '%a|%U|%G' \"$f\" 2>/dev/null) || continue; "
+            "printf 'FILE|%s|%s\\n' \"$f\" \"$meta\"; "
+            "done; true"
+        )
+        try:
+            stdout, _stderr = await self._exec_ssh(instance, remote, timeout=90)
+        except asyncio.TimeoutError:
+            self._audit.log('security_audit', args, '', False, 'timeout')
+            return "Error: security_audit timed out after 90 seconds"
+        except Exception as e:
+            self._audit.log('security_audit', args, '', False,
+                            f"ssh_error: {e}")
+            return f"Error: {e}"
+
+        result = json.dumps(parse_security_audit(stdout))
+        self._audit.log('security_audit', args, f"{len(result)} chars", True)
+        return result
+
     async def tls_cert_check(self, instance_id: str) -> str:
         """Discover TLS certs (certbot + nginx/apache configs) and read expiry.
 

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -144,6 +144,7 @@ _TOOL_GUARDS: Dict[str, Literal["readonly", "standard", "dangerous"]] = {
     "auth_log_summary": "readonly",
     "disk_usage": "readonly",
     "pending_updates": "readonly",
+    "security_audit": "readonly",
 }
 
 # Strict ordering of guard severity. Used by :func:`_escalate_guard` to
@@ -314,6 +315,7 @@ _LOCAL_TOOL_HANDLERS: Dict[str, str] = {
     "auth_log_summary":           "auth_log_summary",
     "disk_usage":                 "disk_usage",
     "pending_updates":            "pending_updates",
+    "security_audit":             "security_audit",
     "enrich_ips":                 "enrich_ips",
     "db_processlist":             "db_processlist",
     "db_top_queries":             "db_top_queries",

--- a/src/servonaut/utils/system_probe.py
+++ b/src/servonaut/utils/system_probe.py
@@ -442,3 +442,77 @@ def parse_pending_updates(stdout: str, sample_n: int = 10) -> Dict[str, Any]:
         "reboot_required": reboot_required,
         "sample_packages": samples,
     }
+
+
+def _classify_file_perm(path: str, mode: str, owner: str) -> Optional[str]:
+    """Flag a curated sensitive path as insecure, or return ``None``.
+
+    Two checks only (the curated candidate list is the safety boundary):
+
+    * **world-writable** — the ``other`` write bit is set. On any of these
+      system paths that is a privilege-escalation red flag with no benign
+      cause.
+    * **bad owner** — the file is not owned by ``root``. These paths
+      (sshd/sudoers/cron/passwd-family/root's keys) are all root-owned on a
+      correctly configured host; a non-root owner is a tampering signal.
+
+    ``mode`` is the octal string from ``stat -c %a`` and may carry a leading
+    special-bits digit (e.g. ``4755``); only the trailing three permission
+    digits are inspected. A malformed mode yields ``None`` (skip, never
+    raise) so a partial probe still reports the rows it could read.
+    """
+    triad = mode[-3:] if len(mode) >= 3 else mode.rjust(3, "0")
+    try:
+        _owner_bits, _group_bits, other_bits = (int(d) for d in triad)
+    except ValueError:
+        return None
+
+    issues: List[str] = []
+    if other_bits & 0b010:  # world-writable
+        issues.append("world-writable")
+    if owner and owner != "root":
+        issues.append(f"not owned by root (owner={owner})")
+    return "; ".join(issues) if issues else None
+
+
+def parse_security_audit(stdout: str) -> Dict[str, Any]:
+    """Parse the ``security_audit`` probe output into the frozen wire shape.
+
+    ``{"sshd": {<directive>: <value>}, "insecure_files": [{path, mode,
+    owner, issue}]}``.
+
+    Input is two kinds of marker lines (see ``ServonautTools.security_audit``):
+
+    * ``SSHD|<directive>|<value>`` — effective sshd settings straight from
+      ``sshd -T``. Keys stay in ``sshd -T`` form (lowercase, no separators);
+      the server normalises them to canonical directive names, so they are
+      passed through UNREMAPPED here.
+    * ``FILE|<path>|<mode>|<owner>|<group>`` — a stat of one curated
+      candidate path. Only paths that :func:`_classify_file_perm` flags are
+      emitted into ``insecure_files`` (a clean host yields an empty list).
+
+    Malformed lines are skipped rather than raising, so a partial probe still
+    yields what it could read.
+    """
+    sshd: Dict[str, str] = {}
+    insecure: List[Dict[str, Any]] = []
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if line.startswith("SSHD|"):
+            parts = line.split("|", 2)
+            if len(parts) == 3 and parts[1]:
+                sshd[parts[1].strip()] = parts[2].strip()
+        elif line.startswith("FILE|"):
+            parts = line.split("|")
+            if len(parts) != 5 or not parts[1]:
+                continue
+            _, path, mode, owner, _group = (p.strip() for p in parts)
+            issue = _classify_file_perm(path, mode, owner)
+            if issue:
+                insecure.append({
+                    "path": path,
+                    "mode": mode,
+                    "owner": owner,
+                    "issue": issue,
+                })
+    return {"sshd": sshd, "insecure_files": insecure}

--- a/tests/fixtures/server_catalog_v1.json
+++ b/tests/fixtures/server_catalog_v1.json
@@ -82,6 +82,7 @@
     "s3_list_objects",
     "s3_move_object",
     "s3_upload_object",
+    "security_audit",
     "tls_cert_check",
     "transfer_file",
     "waf_rate_rule_set",
@@ -170,6 +171,9 @@
       "top_n"
     ],
     "pending_updates": [
+      "instance_id"
+    ],
+    "security_audit": [
       "instance_id"
     ],
     "tls_cert_check": [

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -90,7 +90,7 @@ class TestLocalToolHandlerMapCompleteness:
             f"from ServonautTools: {missing}"
         )
 
-    def test_new_entries_count_is_81(self):
+    def test_new_entries_count_is_82(self):
         """Local-handler entries beyond the 2 originals.
 
         PR5' seeded 57; incident-response tools added the rest:
@@ -102,14 +102,14 @@ class TestLocalToolHandlerMapCompleteness:
         docker container probes (docker_ps, docker_stats, docker_logs,
         docker_events_summary) → 75; system-health probes (journal_errors,
         tls_cert_check, auth_log_summary) → 78; docker_log_summary → 79;
-        breadth probes (disk_usage, pending_updates) → 81. All dispatch
-        locally (CLI's own SSH / boto3 / network / memory surface); the
-        server catalog mirror is tracked separately (see
-        test_catalog_drift::CATALOG_PENDING_SERVER).
+        breadth probes (disk_usage, pending_updates) → 81; security_audit
+        → 82. All dispatch locally (CLI's own SSH / boto3 / network /
+        memory surface); the server catalog mirror is tracked separately
+        (see test_catalog_drift::CATALOG_PENDING_SERVER).
         """
         new_entries = {k for k in _LOCAL_TOOL_HANDLERS if k not in _ORIGINAL_TOOLS}
-        assert len(new_entries) == 81, (
-            f"Expected 81 new entries, got {len(new_entries)}: {sorted(new_entries)}"
+        assert len(new_entries) == 82, (
+            f"Expected 82 new entries, got {len(new_entries)}: {sorted(new_entries)}"
         )
 
 

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -70,15 +70,16 @@ def test_pending_server_tools_not_yet_in_catalog():
     )
 
 
-def test_catalog_fixture_has_86_entries():
-    """Sanity check: the fixture must contain exactly 86 names.
+def test_catalog_fixture_has_87_entries():
+    """Sanity check: the fixture must contain exactly 87 names.
 
     84 (v1 convergence) + the breadth probes (disk_usage,
-    pending_updates) registered for the disk/packages detectors.
+    pending_updates) + the security_audit probe registered for the
+    security-hardening detector.
     """
     names = _server_catalog_names()
-    assert len(names) == 86, (
-        f"Expected 86 catalog entries, got {len(names)}: {sorted(names)}"
+    assert len(names) == 87, (
+        f"Expected 87 catalog entries, got {len(names)}: {sorted(names)}"
     )
 
 

--- a/tests/test_system_probe_tools.py
+++ b/tests/test_system_probe_tools.py
@@ -20,6 +20,7 @@ from servonaut.mcp.tools import ServonautTools
 from servonaut.services.memory.stack_summary import build_stack_summary
 from servonaut.utils.system_probe import (
     parse_journal_errors,
+    parse_security_audit,
     parse_tls_certs,
     summarize_auth_log,
 )
@@ -528,3 +529,95 @@ class TestStackSummaryToolFormat:
         assert payload["docker"] == {"present": True, "container_count": 1}
         assert payload["os"] == "Ubuntu 22.04.5 LTS"
         assert "_trust_notice" in payload
+
+
+class TestParseSecurityAudit:
+    def test_sshd_directives_passed_through_unremapped(self):
+        stdout = (
+            "SSHD|permitrootlogin|without-password\n"
+            "SSHD|passwordauthentication|yes\n"
+            "SSHD|permitemptypasswords|no\n"
+            "SSHD|x11forwarding|no\n"
+        )
+        out = parse_security_audit(stdout)
+        assert out["sshd"] == {
+            "permitrootlogin": "without-password",
+            "passwordauthentication": "yes",
+            "permitemptypasswords": "no",
+            "x11forwarding": "no",
+        }
+        assert out["insecure_files"] == []
+
+    def test_world_writable_file_flagged(self):
+        out = parse_security_audit("FILE|/etc/crontab|646|root|root")
+        assert out["insecure_files"] == [{
+            "path": "/etc/crontab", "mode": "646", "owner": "root",
+            "issue": "world-writable",
+        }]
+
+    def test_non_root_owner_flagged(self):
+        out = parse_security_audit("FILE|/etc/sudoers|440|deploy|root")
+        assert out["insecure_files"][0]["issue"] == (
+            "not owned by root (owner=deploy)"
+        )
+
+    def test_both_issues_joined(self):
+        out = parse_security_audit("FILE|/etc/passwd|666|deploy|deploy")
+        issue = out["insecure_files"][0]["issue"]
+        assert "world-writable" in issue
+        assert "not owned by root (owner=deploy)" in issue
+
+    def test_special_bits_prefix_ignored(self):
+        # A leading setuid/sticky digit must not derail the triad read: 1755
+        # is world-readable+executable (sticky), NOT world-writable.
+        assert parse_security_audit("FILE|/tmp/x|1755|root|root") == {
+            "sshd": {}, "insecure_files": [],
+        }
+
+    def test_secure_files_not_listed(self):
+        stdout = (
+            "FILE|/etc/ssh/sshd_config|644|root|root\n"
+            "FILE|/etc/shadow|640|root|shadow\n"
+            "FILE|/etc/ssh/ssh_host_ed25519_key|600|root|root\n"
+        )
+        assert parse_security_audit(stdout)["insecure_files"] == []
+
+    def test_malformed_rows_skipped(self):
+        stdout = (
+            "garbage\n"
+            "FILE|onlythree|644\n"
+            "FILE||644|root|root\n"
+            "FILE|/etc/passwd|xyz|root|root\n"  # non-octal mode → skipped
+            "FILE|/etc/crontab|646|root|root\n"
+        )
+        out = parse_security_audit(stdout)
+        assert [f["path"] for f in out["insecure_files"]] == ["/etc/crontab"]
+
+    def test_empty_is_empty_shape(self):
+        assert parse_security_audit("") == {"sshd": {}, "insecure_files": []}
+
+
+class TestSecurityAuditToolLayer:
+    def test_security_audit_json_and_readonly_command(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=(
+            "SSHD|permitrootlogin|yes\n"
+            "FILE|/etc/crontab|646|root|root\n", ""))
+        payload = json.loads(run(tools.security_audit("web-1")))
+        assert payload["sshd"]["permitrootlogin"] == "yes"
+        assert payload["insecure_files"][0]["path"] == "/etc/crontab"
+        # The dispatched command is read-only: sshd -T dumps config, stat
+        # reads metadata; nothing mutates config or perms.
+        remote = tools._exec_ssh.await_args.args[1]
+        assert "sshd -T" in remote and "stat -c" in remote
+        for mutating in ("chmod", "chown", "sed -i", "tee ", ">>", "systemctl"):
+            assert mutating not in remote
+        # No output redirection into any of the probed paths.
+        assert " > /etc" not in remote
+
+    def test_empty_output_is_empty_shape(self):
+        tools = _tools()
+        tools._exec_ssh = AsyncMock(return_value=("", ""))
+        assert json.loads(run(tools.security_audit("web-1"))) == {
+            "sshd": {}, "insecure_files": [],
+        }


### PR DESCRIPTION
## Summary

Adds a new **read-only** MCP probe, `security_audit`, reporting one instance's baseline security posture. Additive and dormant — same class as the other read-only system-health probes; changes no existing behavior.

Two non-mutating signals:

- **sshd** — effective values of four hardening directives via `sshd -T` (the authoritative merged config, not a file grep): permit-root-login, password-authentication, permit-empty-passwords, x11-forwarding. Keys are surfaced in `sshd -T` form; canonicalisation to directive names happens server-side.
- **insecure_files** — a `stat` of a curated list of sensitive paths (`/etc/ssh/*`, `/etc/sudoers*`, `/etc/cron*`, the passwd/shadow/group family, `/root/.ssh/*`), flagging only those that are **world-writable** or **not root-owned**. The curated candidate list bounds what a permission-fixing remediation could ever target.

Returns `{sshd: {directive: value}, insecure_files: [{path, mode, owner, issue}]}`. Never mutates sshd config or file permissions; both sections degrade to a partial result (rather than erroring) when a section can't be read.

## Wiring

- Guard: `readonly` tier.
- Registered in the tool-schema catalog (`chat_exposed`) and the chat tool bridge.
- Catalog fixture + drift/count guards updated.

## Tests

- Pure-parser tests: sshd pass-through, world-writable + bad-owner flagging, both-issues joined, special-bit mode prefix ignored, secure files not listed, malformed rows skipped, empty shape.
- Tool-layer tests: JSON shape, read-only command assertion (no `chmod`/`chown`/`sed -i`/redirects), empty-output shape.
- Probe shell one-liner executed against a real host + fed through the parser end-to-end (clean host → empty; tampered → flagged).

All green locally.
