### PR TITLE
feat(voice): opt-in local voice input for the AI chat panel, with a streaming engine option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All screenshots and the launch video were recorded with `--demo` active, which r
 - **Bring your own key** — OpenAI / Anthropic / Gemini / Ollama keys configured per-provider in Settings → AI Provider (local Ollama needs none). All coexist with Servonaut AI, switchable per-session.
 - **Built-in AI chat** — LLM assistant with tool-calling against your instances (the same MCP tool surface below).
 - **AI log analysis** — analyze logs with OpenAI, Anthropic, Gemini, or Ollama, with cost estimation.
+- **Voice input** — dictate into the chat panel with `ctrl+t`. Transcribed entirely on your machine, so audio never leaves the workstation. Two engines: a batch one, or a streaming one that shows words as you speak. Opt-in — nothing is downloaded until you enable it in Settings. → [docs](docs/voice-input.md)
 
 ### Memory & secrets
 
@@ -298,9 +299,18 @@ pipx inject servonaut mcp
 pip install 'servonaut[hetzner]'
 pip install 'servonaut[ovh]'
 
+# Voice input — dictate into the AI chat panel, transcribed locally
+pip install 'servonaut[voice]'            # batch engine
+pip install 'servonaut[voice-streaming]'  # live text as you speak
+
 # Install everything
 pip install 'servonaut[all]'
 ```
+
+Voice input also needs the PortAudio system library (`sudo apt install
+libportaudio2`, `brew install portaudio`) and a one-time model download,
+both surfaced in Settings → AI → Voice Input. See
+[docs/voice-input.md](docs/voice-input.md).
 
 AI log analysis (OpenAI, Anthropic, Gemini, Ollama) needs no extra install —
 `httpx` ships as a base dependency.

--- a/docs/voice-input.md
+++ b/docs/voice-input.md
@@ -1,0 +1,148 @@
+# Voice Input
+
+Dictate into the AI chat panel instead of typing. Speech is transcribed
+**entirely on your machine** — audio never leaves the workstation and no
+transcription service is contacted.
+
+The feature is off by default. It needs a few hundred megabytes of packages
+and model weights, so nothing is installed or downloaded until you ask for
+it in Settings.
+
+## Enabling it
+
+Open **Settings → AI → Voice Input**. The panel reports each requirement
+separately and offers the action for whichever one is missing:
+
+| Requirement | How it is satisfied |
+|---|---|
+| Python packages | The **Install packages** button, or the command it shows for source installs |
+| PortAudio library | A system package — the panel shows the command for your distribution |
+| Microphone | Any capture device the audio system reports |
+| Model weights | The **Download model** button, which states the size first |
+
+Turn on **Enable voice input**, press Save, then work down the card. When
+every row reads `OK`, a microphone button appears in the chat input row.
+
+PortAudio cannot be installed by pip because it is a system library, so that
+one row always hands you a command to run yourself:
+
+```bash
+sudo apt install libportaudio2     # Debian / Ubuntu
+sudo dnf install portaudio         # Fedora
+brew install portaudio             # macOS
+```
+
+## Choosing an engine
+
+Two engines are available, selected in the panel.
+
+### Whisper (default)
+
+Records first, then transcribes the whole utterance. Smaller download,
+very accurate, and the wait is visible on longer dictations — a spinner
+runs on the microphone button while the model decodes.
+
+```bash
+pip install 'servonaut[voice]'
+```
+
+Model sizes range from `tiny` (~75 MB) to `medium` (~1.5 GB); `small`
+(~490 MB) is the default and the best balance for dictation.
+
+### Nemotron streaming
+
+Decodes as the audio arrives, so words appear in the input box while you
+are still speaking, and already-shown words are never rewritten. Costs a
+larger download (~683 MB) and more memory while running.
+
+```bash
+pip install 'servonaut[voice-streaming]'
+```
+
+The **Latency** setting picks the chunk size (80–1120 ms). Smaller values
+show words sooner at a small accuracy cost; every variant is the same
+download size, so the choice is free. 320 ms is a good default.
+
+## Using it
+
+Press the microphone button, or `ctrl+t` while the chat input is focused.
+Press again to stop.
+
+The transcript lands in the input box for you to **review and send**. It is
+never sent automatically unless you switch on **Send dictation
+automatically**, which is off by default — the assistant can run commands,
+and with auto-submit on a misheard word reaches it unedited.
+
+Recordings are capped (60 seconds by default) so a control left on cannot
+fill memory. If a dictation hits the cap you are told that the tail was
+dropped rather than left to notice a truncated sentence.
+
+### Accuracy with server names
+
+Small speech models fumble hostnames and instance IDs. Servonaut biases the
+transcription with the names of the instances currently on screen, which
+helps with proper nouns, but `i-0abc123def` will not survive being spoken.
+Dictate the conversational part of a question and type the identifiers.
+
+## Managing disk space
+
+Each model is several hundred megabytes, and switching engine or model size
+leaves the previous download in place. The panel lists every model on disk
+with its size and marks which one is in use.
+
+When you switch, it offers to remove what is no longer needed and shows how
+much that would reclaim. Nothing is deleted unless you confirm — keeping
+both is reasonable if you switch back and forth. You can also prune at any
+time with the **Remove unused** button.
+
+Streaming model weights live in `~/.servonaut/voice_models/`. Whisper
+weights are managed by its own downloader and land in the Hugging Face
+cache (`~/.cache/huggingface/hub`, or wherever `HF_HOME` points).
+
+## Configuration
+
+The panel writes to the `voice` section of `~/.servonaut/config.json`:
+
+```json
+{
+  "voice": {
+    "enabled": false,
+    "engine": "whisper",
+    "model_size": "small",
+    "nemotron_latency_ms": 320,
+    "language": "en",
+    "input_device": null,
+    "max_recording_seconds": 60,
+    "auto_submit": false
+  }
+}
+```
+
+Set `language` to an ISO 639-1 code, or `"auto"` to let the model detect it
+— detection costs an extra pass and misfires on short phrases, so pin the
+language when you know it. Leave `input_device` as `null` to use the system
+default; set it to a device name only when the default picks the wrong
+microphone.
+
+## Troubleshooting
+
+**The microphone button is missing.** Voice input is switched off, or the
+setup is incomplete. Check Settings → AI → Voice Input.
+
+**The button is greyed out.** Hover it — the tooltip names what is missing.
+The usual causes are absent packages, no PortAudio, or an undownloaded
+model.
+
+**Settings says ready but the button disagrees.** Press **Re-check**. This
+reconciles the two after an install performed outside the app.
+
+**No microphone detected over SSH.** Expected: audio devices are not
+forwarded. Voice input only works where Servonaut runs locally.
+
+**macOS never prompts for microphone access.** The prompt is issued to the
+*terminal emulator*, not to Servonaut. Grant microphone access to your
+terminal in System Settings → Privacy & Security → Microphone.
+
+**Transcription is slow.** Try a smaller Whisper model, or switch to the
+streaming engine, which shows text as you speak rather than making you wait
+for the whole utterance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ hetzner = ["hcloud>=2.0"]
 # declares it (it arrives transitively via onnxruntime), so relying on
 # that would break the import the day the chain changes.
 voice = ["faster-whisper>=1.0", "sounddevice>=0.4", "numpy>=1.24"]
+# Streaming voice input (words appear while you speak). A separate extra
+# because it is a different engine with its own runtime, not an add-on to
+# the batch one — installing both is supported but rarely wanted.
+voice-streaming = ["sherpa-onnx>=1.13.3", "sounddevice>=0.4", "numpy>=1.24"]
 # Deprecated aliases kept for compatibility — deps are now required.
 ai = []
 sync = []
@@ -67,6 +71,7 @@ all = [
     "faster-whisper>=1.0",
     "sounddevice>=0.4",
     "numpy>=1.24",
+    "sherpa-onnx>=1.13.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,26 @@ test = [
 mcp = ["mcp>=1.0.0"]
 ovh = ["ovh"]
 hetzner = ["hcloud>=2.0"]
+# Local speech-to-text for voice input. sounddevice needs the PortAudio
+# system library, so this stays optional rather than a hard requirement.
+# numpy is listed explicitly because the capture buffer and the model
+# handoff both use it directly: neither sounddevice nor faster-whisper
+# declares it (it arrives transitively via onnxruntime), so relying on
+# that would break the import the day the chain changes.
+voice = ["faster-whisper>=1.0", "sounddevice>=0.4", "numpy>=1.24"]
 # Deprecated aliases kept for compatibility — deps are now required.
 ai = []
 sync = []
 keyring = []
-all = ["mcp>=1.0.0", "ovh", "hcloud>=2.0", "keyring>=24"]
+all = [
+    "mcp>=1.0.0",
+    "ovh",
+    "hcloud>=2.0",
+    "keyring>=24",
+    "faster-whisper>=1.0",
+    "sounddevice>=0.4",
+    "numpy>=1.24",
+]
 
 [project.urls]
 Homepage = "https://github.com/zb-ss/ec2-ssh"

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -70,6 +70,8 @@ class ServonautApp(App):
     memory_service = None
     ai_analysis_service = None
     chat_service = None
+    voice_input_service = None  # local speech-to-text, optional deps
+    voice_setup_service = None  # readiness probing + guided install for voice input
     update_service = None
     bug_report_service = None
     redaction_service = None
@@ -379,6 +381,16 @@ class ServonautApp(App):
         # for cached readable paths. Wire the back-reference here.
         self.log_viewer_service.set_memory_service(self.memory_service)
         self.ai_analysis_service = AIAnalysisService(self.config_manager)
+        # Voice input — always constructed; the service itself reports whether
+        # the optional audio/STT libraries and a microphone are present, and
+        # its device probe is lazy so boot never waits on PortAudio.
+        try:
+            from servonaut.services.voice_input_service import VoiceInputService
+            from servonaut.services.voice_setup_service import build_voice_setup_service
+            self.voice_input_service = VoiceInputService(config.voice)
+            self.voice_setup_service = build_voice_setup_service(config.voice)
+        except Exception as e:
+            logger.warning("Voice input unavailable: %s", e)
         # OVH — optional, requires python-ovh and enabled config
         try:
             ovh_config = config.ovh

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -385,9 +385,9 @@ class ServonautApp(App):
         # the optional audio/STT libraries and a microphone are present, and
         # its device probe is lazy so boot never waits on PortAudio.
         try:
-            from servonaut.services.voice_input_service import VoiceInputService
+            from servonaut.services.voice_engines import build_voice_input_service
             from servonaut.services.voice_setup_service import build_voice_setup_service
-            self.voice_input_service = VoiceInputService(config.voice)
+            self.voice_input_service = build_voice_input_service(config.voice)
             self.voice_setup_service = build_voice_setup_service(config.voice)
         except Exception as e:
             logger.warning("Voice input unavailable: %s", e)

--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -30,6 +30,7 @@ from .schema import (
     ConnectionProfile,
     ConnectionRule,
     SSHConfig,
+    VoiceConfig,
     CONFIG_VERSION,
 )
 from .migration import migrate_to_latest, create_backup
@@ -631,6 +632,7 @@ class ConfigManager:
         azure = _coerce(AzureConfig, raw_data.get('azure', {}), 'azure')
         memory = _coerce(MemoryConfig, raw_data.get('memory', {}), 'memory')
         ssh_config = _coerce(SSHConfig, raw_data.get('ssh', {}), 'ssh')
+        voice = _coerce(VoiceConfig, raw_data.get('voice', {}), 'voice')
 
         # Build AppConfig with converted objects, filtering out unknown keys
         valid_fields = {f.name for f in fields(AppConfig)}
@@ -651,6 +653,7 @@ class ConfigManager:
         config_dict['azure'] = azure
         config_dict['memory'] = memory
         config_dict['ssh'] = ssh_config
+        config_dict['voice'] = voice
 
         # Warn about dropped keys for debugging
         unknown_keys = set(raw_data.keys()) - valid_fields

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -20,6 +20,18 @@ CONFIG_VERSION = 5
 # downstream.
 _KNOWN_SECRET_PROVIDERS: frozenset = frozenset({"local", "bitwarden"})
 
+# Speech-to-text model sizes this release is known to work with. Unlike
+# the secret providers above this is NOT a closed set — the transcription
+# backend also accepts the larger sizes, the English-only variants and a
+# path to a locally converted model — so it only drives a WARNING. The
+# value is never rewritten: config is serialised wholesale on every save,
+# so coercing here would delete the user's choice from disk.
+_KNOWN_VOICE_MODEL_SIZES: frozenset = frozenset({
+    "tiny", "tiny.en", "base", "base.en", "small", "small.en",
+    "medium", "medium.en", "large-v2", "large-v3",
+    "distil-small.en", "distil-medium.en", "distil-large-v3",
+})
+
 
 @dataclass
 class ScanRule:
@@ -423,6 +435,61 @@ class SSHConfig:
     server_alive_count_max: int = 5
     tcp_keepalive: bool = True
     connect_timeout: int = 15
+
+
+@dataclass
+class VoiceConfig:
+    """Voice input (speech-to-text) settings for the chat panel.
+
+    Transcription runs entirely on the local machine — audio never leaves
+    the box — so the knobs here trade accuracy against CPU and model
+    download size rather than cost. The feature degrades to unavailable
+    when its optional dependencies are missing; these settings are still
+    loaded and saved so a later install picks up the user's choices.
+
+    Attributes:
+        enabled: Whether the microphone control is offered at all. Defaults
+            to off: the feature needs a few hundred megabytes of packages
+            and model weights, so it is opted into from the Voice Input
+            settings panel rather than fetched on the chance it is wanted.
+            While off, the chat panel shows no microphone control and
+            nothing is ever downloaded.
+        model_size: Whisper model to load. Larger models are more accurate
+            but slower and bigger to download. ``distil-small.en`` is
+            English-only and roughly twice as fast as ``small``. Values
+            outside :data:`_KNOWN_VOICE_MODEL_SIZES` are logged and used
+            as-is, so a size added by a newer backend still works.
+        language: Spoken language hint as an ISO 639-1 code. ``"auto"``
+            lets the model detect it, which costs an extra pass over the
+            first seconds of audio and misfires on short utterances —
+            pin the language when it is known.
+        input_device: Name of the capture device to record from. ``None``
+            uses the system default, which is what almost every user
+            wants; set it only when the default picks the wrong mic.
+        max_recording_seconds: Hard cap on a single recording. Guards
+            against a toggle-style control being left on indefinitely and
+            filling memory with unwanted audio.
+    """
+    enabled: bool = False
+    model_size: str = "small"
+    language: str = "en"
+    input_device: Optional[str] = None
+    max_recording_seconds: int = 60
+
+    def __post_init__(self) -> None:
+        """Log an unrecognised ``model_size`` without rewriting it.
+
+        Raising would take the whole config load down, and replacing the
+        value would destroy the user's choice on the next save, so an
+        unfamiliar size is passed through: if the backend really cannot
+        load it, that surfaces as an error on the first dictation.
+        """
+        if self.model_size not in _KNOWN_VOICE_MODEL_SIZES:
+            logger.warning(
+                "VoiceConfig: model_size %r is not one of the sizes this "
+                "release knows (%s); using it as given.",
+                self.model_size, sorted(_KNOWN_VOICE_MODEL_SIZES),
+            )
 
 
 @dataclass
@@ -1043,6 +1110,10 @@ class AppConfig:
     # server-side ``/api/v1/me/ssh-config`` contract is unchanged; this drives
     # only the client-side discovery UX. Additive default, no migration needed.
     bw_vault_folder: str = "Servonaut"
+    # Local speech-to-text settings for the chat panel's microphone control.
+    # Additive default — old configs without this key load cleanly (uses
+    # VoiceConfig() defaults) and no config migration is required.
+    voice: VoiceConfig = field(default_factory=VoiceConfig)
 
     def db_profile_for(
         self, instance_id: str, instance_name: str = "",

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -454,11 +454,21 @@ class VoiceConfig:
             settings panel rather than fetched on the chance it is wanted.
             While off, the chat panel shows no microphone control and
             nothing is ever downloaded.
-        model_size: Whisper model to load. Larger models are more accurate
+        engine: Which speech-to-text engine to run. ``whisper`` records
+            then transcribes; ``nemotron`` decodes as you speak and shows
+            words live, at the cost of a larger model download. An
+            unrecognised value falls back to ``whisper`` rather than
+            leaving the feature unusable.
+        model_size: Whisper model to load. Ignored by the streaming engine,
+            which is published in one size. Larger models are more accurate
             but slower and bigger to download. ``distil-small.en`` is
             English-only and roughly twice as fast as ``small``. Values
             outside :data:`_KNOWN_VOICE_MODEL_SIZES` are logged and used
             as-is, so a size added by a newer backend still works.
+        nemotron_latency_ms: Streaming chunk size. Smaller shows words
+            sooner and costs a little accuracy; every published variant is
+            the same download size, so this is a free choice. Values off
+            the published list snap to the nearest one.
         language: Spoken language hint as an ISO 639-1 code. ``"auto"``
             lets the model detect it, which costs an extra pass over the
             first seconds of audio and misfires on short utterances —
@@ -475,7 +485,9 @@ class VoiceConfig:
             and the assistant can run tools.
     """
     enabled: bool = False
+    engine: str = "whisper"
     model_size: str = "small"
+    nemotron_latency_ms: int = 320
     language: str = "en"
     input_device: Optional[str] = None
     max_recording_seconds: int = 60

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -469,12 +469,17 @@ class VoiceConfig:
         max_recording_seconds: Hard cap on a single recording. Guards
             against a toggle-style control being left on indefinitely and
             filling memory with unwanted audio.
+        auto_submit: Send the transcript as soon as it is ready instead of
+            leaving it in the input box to review. Off by default:
+            recognition mistakes reach the assistant unedited with this on,
+            and the assistant can run tools.
     """
     enabled: bool = False
     model_size: str = "small"
     language: str = "en"
     input_device: Optional[str] = None
     max_recording_seconds: int = 60
+    auto_submit: bool = False
 
     def __post_init__(self) -> None:
         """Log an unrecognised ``model_size`` without rewriting it.

--- a/src/servonaut/screens/settings/panels/voice.py
+++ b/src/servonaut/screens/settings/panels/voice.py
@@ -24,6 +24,12 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Input, Select, Static, Switch
 
 from servonaut.screens.settings.base import SettingsPanel, ValidationError
+from servonaut.services.voice_engines import (
+    ENGINES,
+    NEMOTRON_LATENCY_OPTIONS,
+    engine_spec,
+    human_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +51,23 @@ _MISSING = "[red]--[/red]"
 
 _MAX_RECORDING_CEILING = 600
 
+# Engine choices, ordered so the lighter download comes first.
+_ENGINE_OPTIONS = [
+    (ENGINES["whisper"].label, "whisper"),
+    (ENGINES["nemotron"].label, "nemotron"),
+]
 
-def requirement_note(requirement: str, readiness: Any) -> str:
+# Streaming chunk sizes. Smaller shows words sooner; all are the same
+# download, so the only trade is latency against a little accuracy.
+_LATENCY_OPTIONS = [
+    (f"{ms} ms" + (" — recommended" if ms == 320 else ""), ms)
+    for ms in NEMOTRON_LATENCY_OPTIONS
+]
+
+
+def requirement_note(
+    requirement: str, readiness: Any, *, download_hint: str = "~200 MB"
+) -> str:
     """Short note shown beside a requirement's OK/missing state.
 
     Kept as a pure function of the readiness verdict because the wording
@@ -58,12 +79,14 @@ def requirement_note(requirement: str, readiness: Any) -> str:
     Args:
         requirement: One of ``packages``, ``portaudio``, ``device``.
         readiness: The current :class:`VoiceReadiness`.
+        download_hint: Install footprint shown for missing packages. Differs
+            per engine, so the caller supplies it.
 
     Returns:
         The note, or an empty string for an unknown requirement.
     """
     if requirement == "packages":
-        return "installed" if readiness.packages_ok else "~200 MB download"
+        return "installed" if readiness.packages_ok else f"{download_hint} download"
     if requirement == "portaudio":
         return "found" if readiness.portaudio_ok else "system package, needs sudo"
     if requirement == "device":
@@ -142,6 +165,11 @@ class VoicePanel(SettingsPanel):
         # True while an install or download worker is in flight, so the
         # action buttons cannot be double-fired.
         self._busy = False
+        # The model the panel was loaded with, so a save can tell whether
+        # the user switched away from weights that are still on disk.
+        self._loaded_engine = "whisper"
+        self._loaded_model_size = "small"
+        self._loaded_latency = 320
 
     # ------------------------------------------------------------------
     # Composition
@@ -178,8 +206,19 @@ class VoicePanel(SettingsPanel):
 
         yield Static("Transcription", classes="voice-section-header")
         yield Horizontal(
-            Static("Model size", classes="label"),
+            Static("Engine", classes="label"),
+            Select(_ENGINE_OPTIONS, id="voice_engine", allow_blank=False),
+            classes="setting_row",
+        )
+        yield Static("", id="voice_engine_summary", classes="voice-help")
+        yield Horizontal(
+            Static("Model size (Whisper only)", classes="label"),
             Select(_MODEL_OPTIONS, id="voice_model_size", allow_blank=False),
+            classes="setting_row",
+        )
+        yield Horizontal(
+            Static("Latency (streaming only)", classes="label"),
+            Select(_LATENCY_OPTIONS, id="voice_latency", allow_blank=False),
             classes="setting_row",
         )
         yield Horizontal(
@@ -224,6 +263,15 @@ class VoicePanel(SettingsPanel):
         voice = config.voice
 
         self.query_one("#voice_enabled", Switch).value = bool(voice.enabled)
+        self.query_one("#voice_engine", Select).value = engine_spec(voice.engine).id
+
+        latency = int(getattr(voice, "nemotron_latency_ms", 320) or 320)
+        latency_select = self.query_one("#voice_latency", Select)
+        offered_latencies = {value for _label, value in _LATENCY_OPTIONS}
+        if latency not in offered_latencies:
+            latency_select.set_options([(f"{latency} ms (from config)", latency),
+                                        *_LATENCY_OPTIONS])
+        latency_select.value = latency
 
         size = voice.model_size
         offered = {value for _label, value in _MODEL_OPTIONS}
@@ -243,6 +291,13 @@ class VoicePanel(SettingsPanel):
         )
         self.query_one("#voice_auto_submit", Switch).value = bool(voice.auto_submit)
 
+        # Remembered so persist() can tell whether the user switched away
+        # from a model that is still occupying disk.
+        self._loaded_engine = engine_spec(voice.engine).id
+        self._loaded_model_size = voice.model_size
+        self._loaded_latency = latency
+
+        self._sync_engine_rows()
         self._refresh_readiness()
         self._snapshot_now()
 
@@ -257,6 +312,8 @@ class VoicePanel(SettingsPanel):
                 "#voice_max_recording_seconds", Input
             ).value.strip(),
             "auto_submit": self.query_one("#voice_auto_submit", Switch).value,
+            "engine": str(self.query_one("#voice_engine", Select).value),
+            "nemotron_latency_ms": int(self.query_one("#voice_latency", Select).value),
         }
 
     def collect(self) -> Dict[str, Any]:
@@ -297,6 +354,8 @@ class VoicePanel(SettingsPanel):
             "input_device": values["input_device"] or None,
             "max_recording_seconds": seconds,
             "auto_submit": bool(values["auto_submit"]),
+            "engine": engine_spec(values["engine"]).id,
+            "nemotron_latency_ms": int(values["nemotron_latency_ms"]),
         }
 
     def persist(self) -> None:
@@ -317,6 +376,8 @@ class VoicePanel(SettingsPanel):
             input_device=fields["input_device"],
             max_recording_seconds=fields["max_recording_seconds"],
             auto_submit=fields["auto_submit"],
+            engine=fields["engine"],
+            nemotron_latency_ms=fields["nemotron_latency_ms"],
         )
         self.app.config_manager.update(voice=updated)
 
@@ -325,10 +386,102 @@ class VoicePanel(SettingsPanel):
         # the user just replaced.
         self._rebind_services(updated)
         self._finish_save()
-        self._refresh_readiness()
+        self._refresh_readiness(force=True)
+
+        switched = (
+            fields["engine"] != self._loaded_engine
+            or fields["model_size"] != self._loaded_model_size
+            or fields["nemotron_latency_ms"] != self._loaded_latency
+        )
+        self._loaded_engine = fields["engine"]
+        self._loaded_model_size = fields["model_size"]
+        self._loaded_latency = fields["nemotron_latency_ms"]
+        if switched:
+            # Offer to reclaim the previous download rather than leaving
+            # several hundred megabytes stranded in a cache nobody checks.
+            self._offer_model_cleanup()
+
+    def _offer_model_cleanup(self) -> None:
+        """Ask whether to delete models the new configuration no longer uses."""
+        service = self._setup_service()
+        if service is None:
+            return
+        try:
+            stale = service.stale_models(
+                active_engine=self._selected_engine(),
+                active_model_size=self._selected_model_size(),
+                active_latency_ms=self._selected_latency(),
+            )
+        except Exception:  # noqa: BLE001 — an inventory failure must not break the save
+            logger.debug("Could not inventory voice models", exc_info=True)
+            return
+        if not stale:
+            return
+
+        from servonaut.screens.voice_model_cleanup_modal import VoiceModelCleanupModal
+
+        def _resolve(remove: Optional[bool]) -> None:
+            if not remove:
+                return
+            freed = 0
+            failures = []
+            for model in stale:
+                ok, message = service.remove_installed(model)
+                if ok:
+                    freed += model.size_bytes
+                else:
+                    failures.append(message)
+            if failures:
+                self.app.notify("; ".join(failures), severity="error", markup=False)
+            else:
+                self.app.notify(
+                    f"Removed {len(stale)} unused model(s), freeing {human_bytes(freed)}.",
+                    severity="information",
+                    markup=False,
+                )
+            self._refresh_readiness(force=True)
+
+        self.app.push_screen(
+            VoiceModelCleanupModal(stale, self._pending_model_label()),
+            _resolve,
+        )
+
+    def _sync_engine_rows(self) -> None:
+        """Show only the rows that apply to the selected engine.
+
+        A latency control means nothing for the batch engine and a model
+        size means nothing for the streaming one, so the irrelevant row is
+        hidden rather than left to be set and silently ignored.
+        """
+        try:
+            engine_id = str(self.query_one("#voice_engine", Select).value)
+            summary = self.query_one("#voice_engine_summary", Static)
+            size_row = self.query_one("#voice_model_size", Select).parent
+            latency_row = self.query_one("#voice_latency", Select).parent
+        except Exception:  # noqa: BLE001 — called before compose completes
+            return
+
+        spec = engine_spec(engine_id)
+        summary.update(escape(spec.summary))
+        if size_row is not None:
+            size_row.display = not spec.streaming
+        if latency_row is not None:
+            latency_row.display = spec.streaming
 
     def _rebind_services(self, updated: Any) -> None:
-        """Point the live voice services at the saved config."""
+        """Point the live voice services at the saved config.
+
+        An engine change replaces the input service outright: the two
+        engines are different classes, so reconfiguring the old instance
+        would leave the batch engine running under a streaming label.
+        """
+        if engine_spec(updated.engine).id != self._loaded_engine:
+            try:
+                from servonaut.services.voice_engines import build_voice_input_service
+                self.app.voice_input_service = build_voice_input_service(updated)
+            except Exception:  # noqa: BLE001 — a rebuild failure must not fail the save
+                logger.error("Could not rebuild the voice input service", exc_info=True)
+
         for attr in ("voice_input_service", "voice_setup_service"):
             service = getattr(self.app, attr, None)
             if service is None:
@@ -348,6 +501,30 @@ class VoicePanel(SettingsPanel):
     def _setup_service(self) -> Optional[Any]:
         """The voice setup service, or None when it is not wired up."""
         return getattr(self.app, "voice_setup_service", None)
+
+    def _selected_engine(self) -> str:
+        """Engine currently chosen in the dropdown, saved or not."""
+        try:
+            return engine_spec(str(self.query_one("#voice_engine", Select).value)).id
+        except Exception:  # noqa: BLE001 — called before compose finishes
+            return engine_spec(self.app.config_manager.get().voice.engine).id
+
+    def _selected_latency(self) -> int:
+        """Streaming chunk size currently chosen in the dropdown."""
+        try:
+            return int(self.query_one("#voice_latency", Select).value)
+        except Exception:  # noqa: BLE001 — called before compose finishes
+            return int(getattr(self.app.config_manager.get().voice,
+                               "nemotron_latency_ms", 320) or 320)
+
+    def _pending_model_label(self) -> str:
+        """Name of the model the current dropdown selection would use."""
+        from servonaut.services.voice_engines import model_label
+        return model_label(
+            self._selected_engine(),
+            model_size=self._selected_model_size(),
+            latency_ms=self._selected_latency(),
+        )
 
     def _selected_model_size(self) -> str:
         """The size currently chosen in the dropdown, saved or not.
@@ -458,7 +635,13 @@ class VoicePanel(SettingsPanel):
             self._requirement_row(
                 "Python packages",
                 readiness.packages_ok,
-                requirement_note("packages", readiness),
+                requirement_note(
+                    "packages", readiness,
+                    download_hint=(
+                        service.packages_size_hint(self._selected_engine())
+                        if service is not None else "~200 MB"
+                    ),
+                ),
             )
         )
         if not readiness.packages_ok and service is not None:
@@ -517,23 +700,32 @@ class VoicePanel(SettingsPanel):
         )
 
         # --- Model weights ---
+        engine_id = self._selected_engine()
         size = self._selected_model_size()
-        cached = bool(service and service.is_model_cached(size))
+        label = self._pending_model_label()
+        cached = bool(service and service.is_model_present_for(
+            engine_id, model_size=size, latency_ms=self._selected_latency()
+        ))
         if cached and service is not None:
-            footprint = service.model_cache_bytes(size)
+            footprint = service.model_bytes_for(
+                engine_id, model_size=size, latency_ms=self._selected_latency()
+            )
             note = f"cached, {self._human_bytes(footprint)} on disk"
         elif service is not None:
-            note = f"{service.download_size_hint(size)} download"
+            note = f"{service.download_size_hint_for(engine_id, model_size=size)} download"
         else:
             note = ""
-        container.mount(self._requirement_row(f"Model ({size})", cached, note))
+        container.mount(self._requirement_row(label, cached, note))
+
+        self._render_installed_models(container, service)
 
         if service is not None and readiness.packages_ok:
             buttons = []
             if not cached:
                 buttons.append(
                     Button(
-                        f"Download model ({service.download_size_hint(size)})",
+                        "Download model "
+                        f"({service.download_size_hint_for(engine_id, model_size=size)})",
                         id="voice_btn_download",
                         variant="primary",
                     )
@@ -541,6 +733,50 @@ class VoicePanel(SettingsPanel):
             else:
                 buttons.append(Button("Remove model", id="voice_btn_remove_model", variant="error"))
             container.mount(Horizontal(*buttons, classes="voice-action-row"))
+
+    def _render_installed_models(self, container: Vertical, service: Optional[Any]) -> None:
+        """List every model on disk so disk use is visible, not a surprise."""
+        if service is None:
+            return
+        try:
+            installed = service.installed_models(
+                active_engine=self._selected_engine(),
+                active_model_size=self._selected_model_size(),
+                active_latency_ms=self._selected_latency(),
+            )
+        except Exception:  # noqa: BLE001 — inventory is informational
+            logger.debug("Could not inventory voice models", exc_info=True)
+            return
+        if not installed:
+            return
+
+        total = sum(model.size_bytes for model in installed)
+        container.mount(Static(
+            f"On disk: {escape(human_bytes(total))} across "
+            f"{len(installed)} model(s)",
+            classes="voice-section-header",
+        ))
+        for model in installed:
+            suffix = " [dim](in use)[/dim]" if model.in_use else ""
+            container.mount(Horizontal(
+                Static(escape(model.label), classes="voice-req-label"),
+                Static(
+                    f"{escape(model.human_size)}{suffix}",
+                    classes="voice-req-state",
+                ),
+                classes="voice-req-row",
+            ))
+        stale = [model for model in installed if not model.in_use]
+        if stale:
+            freed = human_bytes(sum(model.size_bytes for model in stale))
+            container.mount(Horizontal(
+                Button(
+                    f"Remove {len(stale)} unused ({freed})",
+                    id="voice_btn_prune",
+                    variant="warning",
+                ),
+                classes="voice-action-row",
+            ))
 
     def _requirement_row(self, label: str, ok: bool, note: str = "") -> Horizontal:
         """Build one 'requirement — state — note' row."""
@@ -586,6 +822,9 @@ class VoicePanel(SettingsPanel):
         elif button_id == "voice_btn_remove_model":
             event.stop()
             self._remove_model()
+        elif button_id == "voice_btn_prune":
+            event.stop()
+            self._offer_model_cleanup()
         elif button_id == "voice_btn_copy_install":
             event.stop()
             service = self._setup_service()
@@ -715,9 +954,14 @@ class VoicePanel(SettingsPanel):
     def on_select_changed(self, event: Select.Changed) -> None:
         """Refresh the dirty marker, and the model row for the new size."""
         self._dirty_watch()
-        if event.select.id == "voice_model_size":
-            # The card tracks the dropdown, so switching size must repaint
-            # the model row even though nothing has been saved yet.
+        if event.select.id == "voice_engine":
+            # A different engine means different packages and a different
+            # model, so the whole card is re-derived, not just one row.
+            self._sync_engine_rows()
+            self._refresh_readiness(force=True)
+        elif event.select.id in ("voice_model_size", "voice_latency"):
+            # The card tracks the dropdowns, so switching must repaint the
+            # model row even though nothing has been saved yet.
             self._render_requirements()
             self._render_banner()
 

--- a/src/servonaut/screens/settings/panels/voice.py
+++ b/src/servonaut/screens/settings/panels/voice.py
@@ -345,6 +345,26 @@ class VoicePanel(SettingsPanel):
         except Exception:  # noqa: BLE001 — called before compose finishes
             return self.app.config_manager.get().voice.model_size
 
+    def _notify_chat_panels(self) -> None:
+        """Tell any mounted chat panel that voice setup may have changed.
+
+        Without this, a chat panel that was mounted while the feature was
+        unusable keeps its greyed-out microphone until the app restarts,
+        even though this panel now reports the feature ready.
+        """
+        # Walk the screen stack rather than calling ``app.query``: the app
+        # node does not traverse into screens, so an app-level query finds
+        # nothing even when a chat panel is mounted on the active screen.
+        # The chat dock also usually lives on the screen *underneath* this
+        # one, which an active-screen-only search would miss anyway.
+        try:
+            from servonaut.widgets.chat_panel import ChatPanel
+            for screen in self.app.screen_stack:
+                for panel in screen.query(ChatPanel):
+                    panel.refresh_voice_affordance()
+        except Exception:  # noqa: BLE001 — a chat panel is optional, never required
+            logger.debug("Could not refresh a chat panel's mic state", exc_info=True)
+
     def _refresh_readiness(self, *, force: bool = False) -> None:
         """Re-probe and repaint the banner and requirement rows."""
         service = self._setup_service()
@@ -361,6 +381,10 @@ class VoicePanel(SettingsPanel):
 
         self._render_banner()
         self._render_requirements()
+        if force:
+            # A forced re-probe follows a setup action or an explicit
+            # re-check — exactly the moments a stale mic button matters.
+            self._notify_chat_panels()
 
     def _render_unavailable(self, detail: str = "") -> None:
         """Show that setup cannot be inspected on this build."""

--- a/src/servonaut/screens/settings/panels/voice.py
+++ b/src/servonaut/screens/settings/panels/voice.py
@@ -1,0 +1,688 @@
+"""Voice Input settings panel — opt-in switch plus a guided setup card.
+
+Voice input is the one feature that cannot be turned on by flipping a
+config value: it needs a few hundred megabytes of Python packages, a
+system library pip cannot provide, a microphone, and model weights. So
+this panel is built around a readiness card that names each requirement
+and offers the action for the first unmet one, instead of a single
+button that would silently half-succeed.
+
+Nothing here downloads on its own. Every fetch is behind a button whose
+label states the size first — the same opt-in stance the rest of the app
+takes toward anything that leaves or enters the machine.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any, Dict, Optional
+
+from rich.markup import escape
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Input, Select, Static, Switch
+
+from servonaut.screens.settings.base import SettingsPanel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# Offered model sizes, ordered fastest → most accurate. Kept to the sizes
+# worth choosing from a TUI: the multi-gigabyte ones are reachable by
+# editing config.json but do not belong in a dropdown on a laptop.
+_MODEL_OPTIONS = [
+    ("tiny — fastest, least accurate", "tiny"),
+    ("base — fast", "base"),
+    ("small — recommended", "small"),
+    ("distil-small.en — English only, ~2x faster than small", "distil-small.en"),
+    ("medium — slow, most accurate here", "medium"),
+]
+
+# Glyphs for the readiness rows. Plain characters only: emoji carrying a
+# VS16 variant selector corrupt row rendering in some terminals.
+_OK = "[green]OK[/green]"
+_MISSING = "[red]--[/red]"
+
+_MAX_RECORDING_CEILING = 600
+
+
+def requirement_note(requirement: str, readiness: Any) -> str:
+    """Short note shown beside a requirement's OK/missing state.
+
+    Kept as a pure function of the readiness verdict because the wording
+    has to stay honest about what was actually established: the device
+    check only runs once the audio stack imports, so an unmet microphone
+    requirement means "not checked yet" until PortAudio resolves — saying
+    "none found" there would invent a cause.
+
+    Args:
+        requirement: One of ``packages``, ``portaudio``, ``device``.
+        readiness: The current :class:`VoiceReadiness`.
+
+    Returns:
+        The note, or an empty string for an unknown requirement.
+    """
+    if requirement == "packages":
+        return "installed" if readiness.packages_ok else "~200 MB download"
+    if requirement == "portaudio":
+        return "found" if readiness.portaudio_ok else "system package, needs sudo"
+    if requirement == "device":
+        if readiness.device_ok:
+            return "detected"
+        if not readiness.portaudio_ok:
+            return "not checked yet"
+        return "none found — expected when running over SSH"
+    return ""
+
+
+class VoicePanel(SettingsPanel):
+    """Settings panel for local speech-to-text.
+
+    Fields covered
+    --------------
+    - voice.enabled               — bool switch, the opt-in
+    - voice.model_size            — select
+    - voice.language              — str, ISO 639-1 or "auto"
+    - voice.input_device          — Optional[str], capture device name
+    - voice.max_recording_seconds — int, hard cap per dictation
+
+    Setup actions (immediate, not saved with the form): install the
+    packages, download the model, remove the model, re-check readiness.
+    """
+
+    PANEL_ID = "voice"
+    TITLE = "Voice Input"
+
+    DEFAULT_CSS = """
+    VoicePanel .voice-section-header {
+        margin: 1 0 0 0;
+        text-style: bold;
+        color: $accent;
+    }
+    VoicePanel .voice-help {
+        color: $text-muted;
+        height: auto;
+        padding: 0 0 0 1;
+    }
+    VoicePanel #voice_status_banner {
+        height: auto;
+        padding: 0 1;
+        margin-bottom: 1;
+    }
+    VoicePanel .voice-req-row {
+        height: auto;
+        margin: 0 0 0 1;
+    }
+    VoicePanel .voice-req-label {
+        width: 22;
+    }
+    VoicePanel .voice-req-state {
+        width: 1fr;
+    }
+    VoicePanel .voice-command {
+        color: $text-muted;
+        height: auto;
+        padding: 0 0 0 3;
+    }
+    VoicePanel .voice-action-row {
+        height: auto;
+        margin: 0 0 1 3;
+    }
+    VoicePanel .voice-action-row Button {
+        margin-right: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Last resolved readiness, kept so button handlers do not re-probe
+        # (which would re-enumerate audio devices on every click).
+        self._readiness: Optional[Any] = None
+        # True while an install or download worker is in flight, so the
+        # action buttons cannot be double-fired.
+        self._busy = False
+
+    # ------------------------------------------------------------------
+    # Composition
+    # ------------------------------------------------------------------
+
+    def form_rows(self) -> ComposeResult:
+        """Yield the opt-in switch, the readiness card, and the tunables."""
+        yield Static("", id="voice_status_banner")
+
+        yield Horizontal(
+            Static("Enable voice input", classes="label"),
+            Switch(value=False, id="voice_enabled"),
+            classes="setting_row",
+        )
+        yield Static(
+            "Speech is transcribed on this machine — audio is never uploaded. "
+            "Turning this on adds a microphone button to the chat panel; it "
+            "downloads nothing by itself.",
+            classes="voice-help",
+        )
+
+        yield Static("Setup", classes="voice-section-header")
+        yield Static(
+            "These actions run immediately and are not part of Save.",
+            classes="voice-help",
+        )
+
+        yield Vertical(id="voice_requirements")
+
+        yield Horizontal(
+            Button("Re-check", id="voice_btn_recheck", variant="default"),
+            classes="voice-action-row",
+        )
+
+        yield Static("Transcription", classes="voice-section-header")
+        yield Horizontal(
+            Static("Model size", classes="label"),
+            Select(_MODEL_OPTIONS, id="voice_model_size", allow_blank=False),
+            classes="setting_row",
+        )
+        yield Horizontal(
+            Static("Language (ISO code, or 'auto')", classes="label"),
+            Input(placeholder="en", id="voice_language"),
+            classes="setting_row",
+        )
+        yield Static(
+            "Pin the language when you know it — 'auto' costs an extra "
+            "detection pass and misfires on short phrases.",
+            classes="voice-help",
+        )
+        yield Horizontal(
+            Static("Input device (blank = system default)", classes="label"),
+            Input(placeholder="default", id="voice_input_device"),
+            classes="setting_row",
+        )
+        yield Horizontal(
+            Static("Max seconds per recording", classes="label"),
+            Input(placeholder="60", id="voice_max_recording_seconds"),
+            classes="setting_row",
+        )
+
+    # ------------------------------------------------------------------
+    # Load / dirty / save
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """Populate widgets from config and render the readiness card."""
+        config = self.app.config_manager.get()
+        voice = config.voice
+
+        self.query_one("#voice_enabled", Switch).value = bool(voice.enabled)
+
+        size = voice.model_size
+        offered = {value for _label, value in _MODEL_OPTIONS}
+        # A size set by hand in config.json (or by a newer release) must not
+        # be clobbered just because the dropdown does not list it.
+        select = self.query_one("#voice_model_size", Select)
+        if size in offered:
+            select.value = size
+        else:
+            select.set_options([(f"{size} (from config)", size), *_MODEL_OPTIONS])
+            select.value = size
+
+        self.query_one("#voice_language", Input).value = voice.language or ""
+        self.query_one("#voice_input_device", Input).value = voice.input_device or ""
+        self.query_one("#voice_max_recording_seconds", Input).value = str(
+            voice.max_recording_seconds
+        )
+
+        self._refresh_readiness()
+        self._snapshot_now()
+
+    def current_values(self) -> Dict[str, Any]:
+        """Return current widget values for dirty comparison."""
+        return {
+            "enabled": self.query_one("#voice_enabled", Switch).value,
+            "model_size": str(self.query_one("#voice_model_size", Select).value),
+            "language": self.query_one("#voice_language", Input).value.strip(),
+            "input_device": self.query_one("#voice_input_device", Input).value.strip(),
+            "max_recording_seconds": self.query_one(
+                "#voice_max_recording_seconds", Input
+            ).value.strip(),
+        }
+
+    def collect(self) -> Dict[str, Any]:
+        """Validate widgets and return the fields to persist.
+
+        Raises:
+            ValidationError: On any invalid field value.
+        """
+        values = self.current_values()
+
+        language = values["language"] or "en"
+        # A stray sentence here would be passed straight to the model as a
+        # language code and rejected mid-dictation, so bound it to the
+        # shapes the backend accepts.
+        if language != "auto" and not (2 <= len(language) <= 5):
+            raise ValidationError(
+                "voice_language",
+                "Language must be an ISO code such as 'en', or 'auto'.",
+            )
+
+        seconds_raw = values["max_recording_seconds"] or "60"
+        try:
+            seconds = int(seconds_raw)
+        except ValueError:
+            raise ValidationError(
+                "voice_max_recording_seconds", "Max seconds must be a whole number."
+            ) from None
+        if not 1 <= seconds <= _MAX_RECORDING_CEILING:
+            raise ValidationError(
+                "voice_max_recording_seconds",
+                f"Max seconds must be between 1 and {_MAX_RECORDING_CEILING}.",
+            )
+
+        return {
+            "enabled": bool(values["enabled"]),
+            "model_size": values["model_size"],
+            "language": language,
+            "input_device": values["input_device"] or None,
+            "max_recording_seconds": seconds,
+        }
+
+    def persist(self) -> None:
+        """Validate, then replace the nested voice config.
+
+        Read-modify-write via :func:`dataclasses.replace` so a field added
+        to :class:`~servonaut.config.schema.VoiceConfig` by a later release
+        survives a save from this panel.
+        """
+        fields = self.collect()
+
+        config = self.app.config_manager.get()
+        updated = dataclasses.replace(
+            config.voice,
+            enabled=fields["enabled"],
+            model_size=fields["model_size"],
+            language=fields["language"],
+            input_device=fields["input_device"],
+            max_recording_seconds=fields["max_recording_seconds"],
+        )
+        self.app.config_manager.update(voice=updated)
+
+        # The running services hold the old config object and a cached
+        # availability verdict; both would otherwise describe the settings
+        # the user just replaced.
+        self._rebind_services(updated)
+        self._finish_save()
+        self._refresh_readiness()
+
+    def _rebind_services(self, updated: Any) -> None:
+        """Point the live voice services at the saved config."""
+        for attr in ("voice_input_service", "voice_setup_service"):
+            service = getattr(self.app, attr, None)
+            if service is None:
+                continue
+            try:
+                service._config = updated  # noqa: SLF001 — services are constructed with the config, not reloaded
+                reset = getattr(service, "reset_availability", None)
+                if callable(reset):
+                    reset()
+            except Exception:  # noqa: BLE001 — a stale service must not fail the save
+                logger.debug("Could not rebind %s to the new voice config", attr, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Readiness card
+    # ------------------------------------------------------------------
+
+    def _setup_service(self) -> Optional[Any]:
+        """The voice setup service, or None when it is not wired up."""
+        return getattr(self.app, "voice_setup_service", None)
+
+    def _selected_model_size(self) -> str:
+        """The size currently chosen in the dropdown, saved or not.
+
+        The readiness card tracks the dropdown rather than the saved value
+        so picking a different size immediately shows whether *that* one
+        needs downloading.
+        """
+        try:
+            return str(self.query_one("#voice_model_size", Select).value)
+        except Exception:  # noqa: BLE001 — called before compose finishes
+            return self.app.config_manager.get().voice.model_size
+
+    def _refresh_readiness(self, *, force: bool = False) -> None:
+        """Re-probe and repaint the banner and requirement rows."""
+        service = self._setup_service()
+        if service is None:
+            self._render_unavailable()
+            return
+
+        try:
+            self._readiness = service.probe(force=force)
+        except Exception as exc:  # noqa: BLE001 — a probe failure must not blank the panel
+            logger.error("Voice readiness probe failed: %s", exc)
+            self._render_unavailable(str(exc))
+            return
+
+        self._render_banner()
+        self._render_requirements()
+
+    def _render_unavailable(self, detail: str = "") -> None:
+        """Show that setup cannot be inspected on this build."""
+        try:
+            banner = self.query_one("#voice_status_banner", Static)
+        except Exception:
+            return
+        message = "Voice setup is unavailable in this build."
+        if detail:
+            message = f"{message} ({escape(detail)})"
+        banner.update(f"[yellow]{message}[/yellow]")
+
+    def _render_banner(self) -> None:
+        """Summarise readiness in one line at the top of the panel."""
+        readiness = self._readiness
+        try:
+            banner = self.query_one("#voice_status_banner", Static)
+        except Exception:
+            return
+
+        if readiness is None:
+            banner.update("")
+            return
+
+        enabled = self.query_one("#voice_enabled", Switch).value
+        if readiness.is_ready and enabled:
+            banner.update("[green]Ready — press the microphone in the chat panel, or ctrl+t.[/green]")
+        elif readiness.is_ready:
+            banner.update("[yellow]Set up, but switched off. Enable it above and save.[/yellow]")
+        else:
+            labels = {
+                "packages": "the Python packages are not installed",
+                "portaudio": "the PortAudio system library is missing",
+                "device": "no microphone was detected",
+                "model": "the speech model is not downloaded yet",
+            }
+            reason = labels.get(readiness.next_step, "setup is incomplete")
+            banner.update(f"[yellow]Not ready — {escape(reason)}.[/yellow]")
+
+    def _render_requirements(self) -> None:
+        """Rebuild the per-requirement rows and their action buttons."""
+        readiness = self._readiness
+        try:
+            container = self.query_one("#voice_requirements", Vertical)
+        except Exception:
+            return
+        if readiness is None:
+            return
+
+        service = self._setup_service()
+        container.remove_children()
+
+        # --- Python packages ---
+        container.mount(
+            self._requirement_row(
+                "Python packages",
+                readiness.packages_ok,
+                requirement_note("packages", readiness),
+            )
+        )
+        if not readiness.packages_ok and service is not None:
+            if service.install_command() is not None:
+                container.mount(
+                    Horizontal(
+                        Button(
+                            "Install packages (~200 MB)",
+                            id="voice_btn_install",
+                            variant="primary",
+                        ),
+                        classes="voice-action-row",
+                    )
+                )
+            else:
+                # Source checkout, or pipx we cannot locate: the install is
+                # the user's to run, so hand them the exact command.
+                container.mount(
+                    Static(
+                        escape(service.manual_install_command()),
+                        classes="voice-command",
+                    )
+                )
+                container.mount(
+                    Horizontal(
+                        Button("Copy command", id="voice_btn_copy_install"),
+                        classes="voice-action-row",
+                    )
+                )
+
+        # --- PortAudio (system library, cannot be pip-installed) ---
+        if readiness.packages_ok or not readiness.portaudio_ok:
+            container.mount(
+                self._requirement_row(
+                    "PortAudio library",
+                    readiness.portaudio_ok,
+                    requirement_note("portaudio", readiness),
+                )
+            )
+            if not readiness.portaudio_ok and service is not None:
+                container.mount(
+                    Static(escape(service.portaudio_command()), classes="voice-command")
+                )
+                container.mount(
+                    Horizontal(
+                        Button("Copy command", id="voice_btn_copy_portaudio"),
+                        classes="voice-action-row",
+                    )
+                )
+
+        # --- Microphone ---
+        container.mount(
+            self._requirement_row(
+                "Microphone", readiness.device_ok, requirement_note("device", readiness)
+            )
+        )
+
+        # --- Model weights ---
+        size = self._selected_model_size()
+        cached = bool(service and service.is_model_cached(size))
+        if cached and service is not None:
+            footprint = service.model_cache_bytes(size)
+            note = f"cached, {self._human_bytes(footprint)} on disk"
+        elif service is not None:
+            note = f"{service.download_size_hint(size)} download"
+        else:
+            note = ""
+        container.mount(self._requirement_row(f"Model ({size})", cached, note))
+
+        if service is not None and readiness.packages_ok:
+            buttons = []
+            if not cached:
+                buttons.append(
+                    Button(
+                        f"Download model ({service.download_size_hint(size)})",
+                        id="voice_btn_download",
+                        variant="primary",
+                    )
+                )
+            else:
+                buttons.append(Button("Remove model", id="voice_btn_remove_model", variant="error"))
+            container.mount(Horizontal(*buttons, classes="voice-action-row"))
+
+    def _requirement_row(self, label: str, ok: bool, note: str = "") -> Horizontal:
+        """Build one 'requirement — state — note' row."""
+        state = _OK if ok else _MISSING
+        suffix = f"  [dim]{escape(note)}[/dim]" if note else ""
+        return Horizontal(
+            Static(escape(label), classes="voice-req-label"),
+            Static(f"{state}{suffix}", classes="voice-req-state"),
+            classes="voice-req-row",
+        )
+
+    @staticmethod
+    def _human_bytes(size: int) -> str:
+        """Render a byte count as a short human-readable string."""
+        value = float(size)
+        for unit in ("B", "KB", "MB", "GB"):
+            if value < 1024 or unit == "GB":
+                return f"{value:.0f} {unit}" if unit != "GB" else f"{value:.1f} GB"
+            value /= 1024
+        return f"{value:.1f} GB"
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dispatch the setup action buttons.
+
+        The base class owns ``save_{PANEL_ID}``; every other button in this
+        panel is a setup action, so unrelated ids are left to bubble.
+        """
+        button_id = event.button.id or ""
+        if button_id == "voice_btn_recheck":
+            event.stop()
+            self._refresh_readiness(force=True)
+            self.app.notify("Re-checked voice setup.", severity="information", markup=False)
+        elif button_id == "voice_btn_install":
+            event.stop()
+            self._start_install()
+        elif button_id == "voice_btn_download":
+            event.stop()
+            self._start_download()
+        elif button_id == "voice_btn_remove_model":
+            event.stop()
+            self._remove_model()
+        elif button_id == "voice_btn_copy_install":
+            event.stop()
+            service = self._setup_service()
+            if service is not None:
+                self._copy(service.manual_install_command())
+        elif button_id == "voice_btn_copy_portaudio":
+            event.stop()
+            service = self._setup_service()
+            if service is not None:
+                self._copy(service.portaudio_command())
+
+    def _copy(self, text: str) -> None:
+        """Put *text* on the clipboard, reporting honestly when that fails."""
+        from servonaut.utils.platform_utils import copy_to_clipboard
+
+        if copy_to_clipboard(text):
+            self.app.notify("Command copied to the clipboard.", severity="information", markup=False)
+        else:
+            self.app.notify(
+                f"Could not reach the clipboard. Run: {text}",
+                severity="warning",
+                markup=False,
+            )
+
+    def _start_install(self) -> None:
+        """Install the voice packages in a worker."""
+        service = self._setup_service()
+        if service is None or self._busy:
+            return
+        self._busy = True
+        self._set_actions_enabled(False)
+        self.app.notify(
+            "Installing voice packages — this can take a few minutes.",
+            severity="information",
+            markup=False,
+        )
+        self.run_worker(
+            self._do_install(service),
+            name="voice_install",
+            group="voice_setup",
+            exclusive=False,
+        )
+
+    async def _do_install(self, service: Any) -> None:
+        """Worker: run the package install and repaint the card."""
+        try:
+            success, message = await service.install_packages()
+        except Exception as exc:  # noqa: BLE001 — the installer surface is broad
+            logger.error("Voice package install raised: %s", exc)
+            success, message = False, f"Install failed: {exc}"
+        finally:
+            self._busy = False
+
+        self.app.notify(
+            message,
+            severity="information" if success else "error",
+            markup=False,
+        )
+        self._refresh_readiness(force=True)
+        self._set_actions_enabled(True)
+
+    def _start_download(self) -> None:
+        """Download the selected model in a worker."""
+        service = self._setup_service()
+        if service is None or self._busy:
+            return
+        size = self._selected_model_size()
+        self._busy = True
+        self._set_actions_enabled(False)
+        self.app.notify(
+            f"Downloading the {size} model ({service.download_size_hint(size)}).",
+            severity="information",
+            markup=False,
+        )
+        self.run_worker(
+            self._do_download(service, size),
+            name="voice_download",
+            group="voice_setup",
+            exclusive=False,
+        )
+
+    async def _do_download(self, service: Any, size: str) -> None:
+        """Worker: fetch the model weights and repaint the card."""
+        try:
+            success, message = await service.download_model(size)
+        except Exception as exc:  # noqa: BLE001 — hub/network/disk errors
+            logger.error("Voice model download raised: %s", exc)
+            success, message = False, f"Download failed: {exc}"
+        finally:
+            self._busy = False
+
+        self.app.notify(
+            message,
+            severity="information" if success else "error",
+            markup=False,
+        )
+        self._refresh_readiness(force=True)
+        self._set_actions_enabled(True)
+
+    def _remove_model(self) -> None:
+        """Delete the cached weights for the selected size."""
+        service = self._setup_service()
+        if service is None or self._busy:
+            return
+        size = self._selected_model_size()
+        success, message = service.remove_model(size)
+        self.app.notify(
+            message,
+            severity="information" if success else "error",
+            markup=False,
+        )
+        self._refresh_readiness(force=True)
+
+    def _set_actions_enabled(self, enabled: bool) -> None:
+        """Enable or disable every setup button while an action runs."""
+        for button in self.query(".voice-action-row Button"):
+            button.disabled = not enabled
+
+    # ------------------------------------------------------------------
+    # Change handlers
+    # ------------------------------------------------------------------
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Refresh the dirty marker on any Input change."""
+        self._dirty_watch()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Refresh the dirty marker, and the model row for the new size."""
+        self._dirty_watch()
+        if event.select.id == "voice_model_size":
+            # The card tracks the dropdown, so switching size must repaint
+            # the model row even though nothing has been saved yet.
+            self._render_requirements()
+            self._render_banner()
+
+    def on_switch_changed(self, event: Switch.Changed) -> None:
+        """Refresh the dirty marker and the banner's enabled/disabled wording."""
+        self._dirty_watch()
+        if event.switch.id == "voice_enabled":
+            self._render_banner()

--- a/src/servonaut/screens/settings/panels/voice.py
+++ b/src/servonaut/screens/settings/panels/voice.py
@@ -85,6 +85,7 @@ class VoicePanel(SettingsPanel):
     - voice.language              — str, ISO 639-1 or "auto"
     - voice.input_device          — Optional[str], capture device name
     - voice.max_recording_seconds — int, hard cap per dictation
+    - voice.auto_submit           — bool switch, send without review
 
     Setup actions (immediate, not saved with the form): install the
     packages, download the model, remove the model, re-check readiness.
@@ -201,6 +202,17 @@ class VoicePanel(SettingsPanel):
             Input(placeholder="60", id="voice_max_recording_seconds"),
             classes="setting_row",
         )
+        yield Horizontal(
+            Static("Send dictation automatically", classes="label"),
+            Switch(value=False, id="voice_auto_submit"),
+            classes="setting_row",
+        )
+        yield Static(
+            "Off by default: the assistant can run commands, and with this on "
+            "a misheard word reaches it unedited. Leave it off to review each "
+            "transcript in the input box before sending.",
+            classes="voice-help",
+        )
 
     # ------------------------------------------------------------------
     # Load / dirty / save
@@ -229,6 +241,7 @@ class VoicePanel(SettingsPanel):
         self.query_one("#voice_max_recording_seconds", Input).value = str(
             voice.max_recording_seconds
         )
+        self.query_one("#voice_auto_submit", Switch).value = bool(voice.auto_submit)
 
         self._refresh_readiness()
         self._snapshot_now()
@@ -243,6 +256,7 @@ class VoicePanel(SettingsPanel):
             "max_recording_seconds": self.query_one(
                 "#voice_max_recording_seconds", Input
             ).value.strip(),
+            "auto_submit": self.query_one("#voice_auto_submit", Switch).value,
         }
 
     def collect(self) -> Dict[str, Any]:
@@ -282,6 +296,7 @@ class VoicePanel(SettingsPanel):
             "language": language,
             "input_device": values["input_device"] or None,
             "max_recording_seconds": seconds,
+            "auto_submit": bool(values["auto_submit"]),
         }
 
     def persist(self) -> None:
@@ -301,6 +316,7 @@ class VoicePanel(SettingsPanel):
             language=fields["language"],
             input_device=fields["input_device"],
             max_recording_seconds=fields["max_recording_seconds"],
+            auto_submit=fields["auto_submit"],
         )
         self.app.config_manager.update(voice=updated)
 

--- a/src/servonaut/screens/settings/panels/voice.py
+++ b/src/servonaut/screens/settings/panels/voice.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional
 from rich.markup import escape
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Input, Select, Static, Switch
+from textual.widgets import Button, Input, ProgressBar, Select, Static, Switch
 
 from servonaut.screens.settings.base import SettingsPanel, ValidationError
 from servonaut.services.voice_engines import (
@@ -155,6 +155,17 @@ class VoicePanel(SettingsPanel):
     VoicePanel .voice-action-row Button {
         margin-right: 1;
     }
+    VoicePanel #voice_download_row {
+        height: auto;
+        margin: 0 0 1 3;
+    }
+    VoicePanel #voice_download_row.hidden {
+        display: none;
+    }
+    VoicePanel #voice_download_label {
+        height: auto;
+        color: $text-muted;
+    }
     """
 
     def __init__(self) -> None:
@@ -198,6 +209,14 @@ class VoicePanel(SettingsPanel):
         )
 
         yield Vertical(id="voice_requirements")
+
+        # Hidden until a download starts. A model is hundreds of megabytes,
+        # so a silent multi-minute wait is indistinguishable from a hang.
+        with Vertical(id="voice_download_row", classes="hidden"):
+            yield Static("", id="voice_download_label")
+            yield ProgressBar(
+                total=None, show_eta=True, id="voice_download_bar"
+            )
 
         yield Horizontal(
             Button("Re-check", id="voice_btn_recheck", variant="default"),
@@ -298,6 +317,7 @@ class VoicePanel(SettingsPanel):
         self._loaded_latency = latency
 
         self._sync_engine_rows()
+        self._sync_setup_service_config()
         self._refresh_readiness()
         self._snapshot_now()
 
@@ -501,6 +521,33 @@ class VoicePanel(SettingsPanel):
     def _setup_service(self) -> Optional[Any]:
         """The voice setup service, or None when it is not wired up."""
         return getattr(self.app, "voice_setup_service", None)
+
+    def _sync_setup_service_config(self) -> None:
+        """Point the setup service at the engine/model the dropdowns show.
+
+        Setup actions run immediately and are explicitly not part of Save,
+        so they have to act on what is selected rather than what was last
+        saved. Without this the service keeps answering for the previous
+        engine — pressing Download after picking a different one re-checked
+        the old model, found it cached, and reported instant success.
+        """
+        service = self._setup_service()
+        if service is None:
+            return
+        try:
+            saved = self.app.config_manager.get().voice
+            pending = dataclasses.replace(
+                saved,
+                engine=self._selected_engine(),
+                model_size=self._selected_model_size(),
+                nemotron_latency_ms=self._selected_latency(),
+            )
+        except Exception:  # noqa: BLE001 — called before compose completes
+            return
+        service._config = pending  # noqa: SLF001 — services take config at construction
+        reset = getattr(service, "reset_availability", None)
+        if callable(reset):
+            reset()
 
     def _selected_engine(self) -> str:
         """Engine currently chosen in the dropdown, saved or not."""
@@ -849,11 +896,56 @@ class VoicePanel(SettingsPanel):
                 markup=False,
             )
 
+    def _show_download_progress(self, label: str, total: Optional[int] = None) -> None:
+        """Reveal the progress row and set its label."""
+        try:
+            row = self.query_one("#voice_download_row", Vertical)
+            text = self.query_one("#voice_download_label", Static)
+            bar = self.query_one("#voice_download_bar", ProgressBar)
+        except Exception:  # noqa: BLE001 — panel closed or not composed
+            return
+        row.remove_class("hidden")
+        text.update(escape(label))
+        # total=None renders an indeterminate bar, which is the honest
+        # display for the batch engine's downloader — it reports nothing.
+        bar.update(total=total, progress=0)
+
+    def _hide_download_progress(self) -> None:
+        """Hide the progress row once a download settles."""
+        try:
+            self.query_one("#voice_download_row", Vertical).add_class("hidden")
+        except Exception:  # noqa: BLE001 — nothing to hide
+            return
+
+    def _on_download_progress(self, label: str, done: int, total: int) -> None:
+        """Progress callback for the downloader.
+
+        Called directly rather than marshalled: the streaming download is a
+        coroutine awaited on the event loop, not a worker thread, so we are
+        already where widgets may be touched.
+        """
+        self._render_download_progress(label, done, total)
+
+    def _render_download_progress(self, label: str, done: int, total: int) -> None:
+        """Repaint the progress row."""
+        try:
+            text = self.query_one("#voice_download_label", Static)
+            bar = self.query_one("#voice_download_bar", ProgressBar)
+        except Exception:  # noqa: BLE001 — panel closed mid-download
+            return
+        if total:
+            text.update(escape(f"{label} — {human_bytes(done)} of {human_bytes(total)}"))
+            bar.update(total=total, progress=done)
+        else:
+            text.update(escape(f"{label} — {human_bytes(done)}" if done else label))
+            bar.update(total=None)
+
     def _start_install(self) -> None:
         """Install the voice packages in a worker."""
         service = self._setup_service()
         if service is None or self._busy:
             return
+        self._sync_setup_service_config()
         self._busy = True
         self._set_actions_enabled(False)
         self.app.notify(
@@ -891,11 +983,18 @@ class VoicePanel(SettingsPanel):
         service = self._setup_service()
         if service is None or self._busy:
             return
+        # The service must be looking at the dropdown selection before the
+        # download starts, or it fetches the previously saved engine's model.
+        self._sync_setup_service_config()
         size = self._selected_model_size()
+        engine_id = self._selected_engine()
+        label = self._pending_model_label()
+        hint = service.download_size_hint_for(engine_id, model_size=size)
         self._busy = True
         self._set_actions_enabled(False)
+        self._show_download_progress(f"Starting {label} ({hint})")
         self.app.notify(
-            f"Downloading the {size} model ({service.download_size_hint(size)}).",
+            f"Downloading {label} ({hint}).",
             severity="information",
             markup=False,
         )
@@ -909,13 +1008,16 @@ class VoicePanel(SettingsPanel):
     async def _do_download(self, service: Any, size: str) -> None:
         """Worker: fetch the model weights and repaint the card."""
         try:
-            success, message = await service.download_model(size)
+            success, message = await service.download_model(
+                size, progress=self._on_download_progress
+            )
         except Exception as exc:  # noqa: BLE001 — hub/network/disk errors
             logger.error("Voice model download raised: %s", exc)
             success, message = False, f"Download failed: {exc}"
         finally:
             self._busy = False
 
+        self._hide_download_progress()
         self.app.notify(
             message,
             severity="information" if success else "error",
@@ -958,8 +1060,10 @@ class VoicePanel(SettingsPanel):
             # A different engine means different packages and a different
             # model, so the whole card is re-derived, not just one row.
             self._sync_engine_rows()
+            self._sync_setup_service_config()
             self._refresh_readiness(force=True)
         elif event.select.id in ("voice_model_size", "voice_latency"):
+            self._sync_setup_service_config()
             # The card tracks the dropdowns, so switching must repaint the
             # model row even though nothing has been saved yet.
             self._render_requirements()

--- a/src/servonaut/screens/settings/registry.py
+++ b/src/servonaut/screens/settings/registry.py
@@ -200,6 +200,14 @@ PANELS: List[PanelSpec] = [
         keywords=["ai", "chat", "prompt", "tool", "iterations", "guard", "memory"],
         factory=_panel("ai_chat", "AiChatPanel"),
     ),
+    PanelSpec(
+        id="voice",
+        title="Voice Input",
+        group="AI",
+        keywords=["voice", "speech", "microphone", "mic", "dictation", "stt",
+                  "whisper", "transcribe", "audio"],
+        factory=_panel("voice", "VoicePanel"),
+    ),
     # ------------------------------------------------------- Memory & Sync
     PanelSpec(
         id="memory",

--- a/src/servonaut/screens/voice_model_cleanup_modal.py
+++ b/src/servonaut/screens/voice_model_cleanup_modal.py
@@ -1,0 +1,139 @@
+"""Offer to delete voice models the new configuration no longer uses.
+
+Switching engine or model size leaves the previous weights on disk —
+several hundred megabytes each, in a cache directory nobody thinks to
+check. Rather than let that accumulate silently, the settings panel shows
+this straight after a switch, naming what is now unused and what removing
+it would reclaim.
+
+Framed as an offer, not a warning: keeping both is legitimate (switching
+back and forth without re-downloading), so neither button is destructive
+by default and the modal dismisses to "keep" on escape.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from rich.markup import escape
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from servonaut.services.voice_engines import human_bytes
+
+
+class VoiceModelCleanupModal(ModalScreen[bool]):
+    """Asks whether to delete the now-unused voice models.
+
+    Dismisses True to remove them, False to keep. A brief yes/no decision,
+    so a modal rather than a screen.
+    """
+
+    BINDINGS = [
+        # Escape keeps the files: the safe outcome for an accidental
+        # dismissal is the one that does not delete anything.
+        Binding("escape", "keep", "Keep", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    VoiceModelCleanupModal {
+        align: center middle;
+    }
+    VoiceModelCleanupModal #vmc_container {
+        width: 68;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    VoiceModelCleanupModal #vmc_title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    VoiceModelCleanupModal #vmc_body {
+        margin-bottom: 1;
+    }
+    VoiceModelCleanupModal .vmc-model {
+        padding-left: 2;
+        color: $text-muted;
+    }
+    VoiceModelCleanupModal #vmc_total {
+        margin-top: 1;
+        text-style: bold;
+    }
+    VoiceModelCleanupModal #vmc_buttons {
+        height: auto;
+        align: right middle;
+        margin-top: 1;
+    }
+    VoiceModelCleanupModal #vmc_keep {
+        margin-right: 1;
+    }
+    """
+
+    def __init__(self, stale_models: List, active_label: str) -> None:
+        """Initialise the prompt.
+
+        Args:
+            stale_models: :class:`~servonaut.services.voice_setup_service.InstalledModel`
+                entries the new configuration does not use.
+            active_label: Name of the model now in use, so the user can see
+                what is being kept.
+        """
+        super().__init__()
+        self._stale = list(stale_models)
+        self._active_label = active_label
+
+    def compose(self) -> ComposeResult:
+        """Compose the offer, listing each unused model and its size."""
+        total = sum(model.size_bytes for model in self._stale)
+        rows = [
+            Static(
+                f"  • {escape(model.label)} — {escape(model.human_size)}",
+                classes="vmc-model",
+            )
+            for model in self._stale
+        ]
+
+        yield Container(
+            Static("Remove the unused speech model?", id="vmc_title"),
+            Static(
+                f"Voice input now uses [bold]{escape(self._active_label)}[/bold]. "
+                "These downloads are no longer used:",
+                id="vmc_body",
+            ),
+            *rows,
+            Static(
+                f"Removing them frees {escape(human_bytes(total))}. "
+                "Keep them to switch back without downloading again.",
+                id="vmc_total",
+            ),
+            Horizontal(
+                Button("Keep both", variant="default", id="vmc_keep"),
+                Button(
+                    f"Remove and free {human_bytes(total)}",
+                    variant="warning",
+                    id="vmc_remove",
+                ),
+                id="vmc_buttons",
+            ),
+            id="vmc_container",
+        )
+
+    def on_mount(self) -> None:
+        """Focus the keep button so a stray Enter does not delete anything."""
+        self.query_one("#vmc_keep", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Resolve the prompt."""
+        if event.button.id == "vmc_remove":
+            self.dismiss(True)
+        elif event.button.id == "vmc_keep":
+            self.dismiss(False)
+
+    def action_keep(self) -> None:
+        """Escape keeps the files."""
+        self.dismiss(False)

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -1494,3 +1494,71 @@ class ObjectStorageServiceInterface(ABC):
             ValueError: If any argument fails validation.
         """
         pass
+
+
+class VoiceInputServiceInterface(ABC):
+    """Interface for microphone capture and local speech-to-text."""
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if voice input can be used right now.
+
+        Returns:
+            True only when the optional audio/transcription libraries are
+            importable AND at least one input device is present.
+        """
+        pass
+
+    @abstractmethod
+    def unavailable_reason(self) -> str:
+        """Explain why voice input cannot be used.
+
+        Returns:
+            Short, actionable message for the UI, or an empty string when
+            voice input is available.
+        """
+        pass
+
+    @abstractmethod
+    def start_recording(self) -> None:
+        """Begin capturing microphone audio into an in-memory buffer.
+
+        Raises:
+            VoiceInputError: If a recording is already in progress, voice
+                input is unavailable, or the audio device cannot be opened.
+        """
+        pass
+
+    @abstractmethod
+    def stop_and_transcribe(self, initial_prompt: str = "") -> str:
+        """Stop capturing and transcribe the buffered audio.
+
+        Args:
+            initial_prompt: Optional vocabulary hint (e.g. server names)
+                used to bias recognition of proper nouns.
+
+        Returns:
+            Transcribed text, or an empty string when the recording was
+            too short to transcribe.
+
+        Raises:
+            VoiceInputError: If transcription fails.
+        """
+        pass
+
+    @abstractmethod
+    def cancel_recording(self) -> None:
+        """Stop capturing and discard the buffer without transcribing."""
+        pass
+
+    @property
+    @abstractmethod
+    def is_recording(self) -> bool:
+        """Whether a recording is currently in progress."""
+        pass
+
+    @property
+    @abstractmethod
+    def hit_recording_cap(self) -> bool:
+        """Whether the last transcription's audio was cut off by the cap."""
+        pass

--- a/src/servonaut/services/voice_engines.py
+++ b/src/servonaut/services/voice_engines.py
@@ -1,0 +1,207 @@
+"""Registry of the speech-to-text engines voice input can run on.
+
+Two engines, with genuinely different shapes rather than two names for the
+same thing:
+
+``whisper``
+    Batch. Records first, then decodes the whole utterance. Accurate and
+    the lighter download, but the text only appears once you stop talking.
+
+``nemotron``
+    Streaming. A cache-aware transducer that decodes as the audio arrives,
+    so words appear while you speak and the output only ever grows —
+    unlike re-running a batch model over a widening buffer, which revises
+    text that has already been shown. Costs a larger download.
+
+Everything engine-specific lives here — pip requirements, model identity,
+where the weights land, how big they are — so the setup service and the
+settings panel can stay engine-agnostic and a third engine means adding
+one entry rather than editing branches in five files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import VoiceConfig
+
+# Shared by both engines: capture and buffer handling.
+_AUDIO_PACKAGES: Tuple[str, ...] = ("sounddevice>=0.4", "numpy>=1.24")
+
+# Root for weights we manage ourselves. Whisper's are handled by the
+# transcription backend's own Hugging Face cache instead, so only the
+# streaming engine keeps files here.
+VOICE_MODEL_ROOT = Path("~/.servonaut/voice_models").expanduser()
+
+# Streaming latency variants published for the transducer model. Smaller
+# chunks show words sooner and cost slightly more accuracy; every variant
+# is the same download size, so this is a free choice.
+NEMOTRON_LATENCY_OPTIONS: Tuple[int, ...] = (80, 160, 320, 560, 1120)
+NEMOTRON_DEFAULT_LATENCY_MS = 320
+
+# Repository template for the int8 streaming exports. int8 rather than the
+# float build on purpose: the float encoder alone is ~2.4 GB against
+# ~660 MB quantised, for no benefit at dictation quality.
+_NEMOTRON_REPO_TEMPLATE = (
+    "csukuangfj2/sherpa-onnx-nemotron-3.5-asr-streaming-0.6b-{latency}ms-int8-2026-06-11"
+)
+
+# The four files the recognizer needs, mapped to the local names it is
+# handed. Keeping the local names stable means a repository reshuffle only
+# touches the left-hand side.
+NEMOTRON_FILES: Dict[str, str] = {
+    "encoder.int8.onnx": "encoder.int8.onnx",
+    "decoder.int8.onnx": "decoder.int8.onnx",
+    "joiner.int8.onnx": "joiner.int8.onnx",
+    "tokens.txt": "tokens.txt",
+}
+
+# Measured total of the int8 files, for the confirmation copy.
+NEMOTRON_DOWNLOAD_BYTES = 683 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class VoiceEngineSpec:
+    """Static description of one speech-to-text engine.
+
+    Attributes:
+        id: Stable identifier stored in config.
+        label: Human-readable name for the settings dropdown.
+        streaming: Whether it emits partial text while the user speaks.
+        packages: pip requirements this engine needs on top of the audio ones.
+        import_names: Modules that must import for the engine to be usable.
+        summary: One-line description shown under the dropdown.
+    """
+
+    id: str
+    label: str
+    streaming: bool
+    packages: Tuple[str, ...]
+    import_names: Tuple[str, ...]
+    summary: str
+
+
+ENGINES: Dict[str, VoiceEngineSpec] = {
+    "whisper": VoiceEngineSpec(
+        id="whisper",
+        label="Whisper (batch, smaller download)",
+        streaming=False,
+        packages=("faster-whisper>=1.0", *_AUDIO_PACKAGES),
+        import_names=("numpy", "faster_whisper"),
+        summary=(
+            "Transcribes after you stop speaking. Smaller download and very "
+            "accurate; the wait is visible on longer dictations."
+        ),
+    ),
+    "nemotron": VoiceEngineSpec(
+        id="nemotron",
+        label="Nemotron streaming (live text, larger download)",
+        streaming=True,
+        packages=("sherpa-onnx>=1.13.3", *_AUDIO_PACKAGES),
+        import_names=("numpy", "sherpa_onnx"),
+        summary=(
+            "Words appear as you speak and are never rewritten. Needs a "
+            "larger model download and more memory while running."
+        ),
+    ),
+}
+
+DEFAULT_ENGINE = "whisper"
+
+
+def engine_spec(engine_id: str) -> VoiceEngineSpec:
+    """Look up an engine, falling back to the default for unknown ids.
+
+    Falls back rather than raising so a config written by a newer release
+    (or edited by hand) degrades to a working engine instead of breaking
+    the settings panel and the chat dock together.
+    """
+    return ENGINES.get(engine_id) or ENGINES[DEFAULT_ENGINE]
+
+
+def nemotron_repo(latency_ms: int) -> str:
+    """Repository id holding the streaming weights for *latency_ms*."""
+    return _NEMOTRON_REPO_TEMPLATE.format(latency=_normalise_latency(latency_ms))
+
+
+def nemotron_model_dir(latency_ms: int) -> Path:
+    """Local directory the streaming weights for *latency_ms* live in."""
+    latency = _normalise_latency(latency_ms)
+    return VOICE_MODEL_ROOT / f"nemotron-3.5-{latency}ms-int8"
+
+
+def _normalise_latency(latency_ms: int) -> int:
+    """Snap *latency_ms* to a published variant.
+
+    An unpublished value would resolve to a repository that does not exist
+    and fail at download time, so it is snapped to the nearest offered
+    chunk size instead.
+    """
+    try:
+        value = int(latency_ms)
+    except (TypeError, ValueError):
+        return NEMOTRON_DEFAULT_LATENCY_MS
+    if value in NEMOTRON_LATENCY_OPTIONS:
+        return value
+    return min(NEMOTRON_LATENCY_OPTIONS, key=lambda option: abs(option - value))
+
+
+def model_label(engine_id: str, *, model_size: str, latency_ms: int) -> str:
+    """Human-readable name for the model an engine is configured to use."""
+    if engine_spec(engine_id).streaming:
+        return f"Nemotron streaming {_normalise_latency(latency_ms)}ms"
+    return f"Whisper {model_size}"
+
+
+def directory_bytes(path: Path) -> int:
+    """Total size of the files under *path*, or 0 when it does not exist.
+
+    Symlinks are skipped so a cache that hard-links or symlinks blobs is
+    not counted twice.
+    """
+    if not path.is_dir():
+        return 0
+    total = 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_file() and not entry.is_symlink():
+                total += entry.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def build_voice_input_service(config: 'VoiceConfig'):  # type: ignore[name-defined]
+    """Construct the input service for the engine *config* selects.
+
+    The two engines are different classes with different runtimes, so
+    switching engine means building a new service rather than reconfiguring
+    the existing one. Imports are function-local because the engine modules
+    import this one for their model paths.
+
+    Returns:
+        A :class:`~servonaut.services.interfaces.VoiceInputServiceInterface`
+        implementation.
+    """
+    if engine_spec(getattr(config, "engine", DEFAULT_ENGINE)).streaming:
+        from servonaut.services.voice_streaming_service import (
+            StreamingVoiceInputService,
+        )
+        return StreamingVoiceInputService(config)
+    from servonaut.services.voice_input_service import VoiceInputService
+    return VoiceInputService(config)
+
+
+def human_bytes(size: Optional[int]) -> str:
+    """Render a byte count as a short human-readable string."""
+    if not size:
+        return "0 MB"
+    value = float(size)
+    for unit in ("B", "KB", "MB"):
+        if value < 1024:
+            return f"{value:.0f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GB"

--- a/src/servonaut/services/voice_input_service.py
+++ b/src/servonaut/services/voice_input_service.py
@@ -1,0 +1,370 @@
+"""Microphone capture and local speech-to-text for the chat panel.
+
+Transcription runs entirely on the local machine via ``faster-whisper``
+so dictated text never leaves the operator's workstation — the same
+privacy stance the rest of the AI surface takes.
+
+Both dependencies are optional (``pip install 'servonaut[voice]'``) and
+the whole module degrades to a disabled feature when they are missing:
+importing this module never raises, and :meth:`VoiceInputService.is_available`
+reports the truth so callers can hide the mic affordance instead of
+failing at click time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from typing import Any, List, Optional, Tuple, TYPE_CHECKING
+
+from .interfaces import VoiceInputServiceInterface
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import VoiceConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    import numpy as np
+    import sounddevice as sd
+    from faster_whisper import WhisperModel
+    HAS_VOICE_DEPS = True
+except Exception:  # noqa: BLE001 — a broken PortAudio/ctranslate2 build raises OSError, not ImportError
+    np = None  # type: ignore[assignment]
+    sd = None  # type: ignore[assignment]
+    WhisperModel = None  # type: ignore[assignment]
+    HAS_VOICE_DEPS = False
+
+
+def reload_voice_deps() -> bool:
+    """Re-attempt the optional imports and rebind the module globals.
+
+    The flag above is resolved once at import time, so a successful
+    in-app install would otherwise keep reporting the feature as missing
+    until the user restarted. Calling this after an install promotes the
+    new packages without a restart; when the imports still fail the
+    module is left exactly as it was.
+
+    Returns:
+        True when the dependencies are importable afterwards.
+    """
+    global np, sd, WhisperModel, HAS_VOICE_DEPS  # noqa: PLW0603 — rebinding the cached import state is the point
+
+    importlib.invalidate_caches()
+    try:
+        import numpy as _np
+        import sounddevice as _sd
+        from faster_whisper import WhisperModel as _WhisperModel
+    except Exception as e:  # noqa: BLE001 — same failure surface as the initial import
+        logger.debug("Voice dependencies still unavailable after reload: %s", e)
+        return False
+
+    np = _np
+    sd = _sd
+    WhisperModel = _WhisperModel
+    HAS_VOICE_DEPS = True
+    logger.info("Voice dependencies loaded without a restart")
+    return True
+
+# Whisper models are trained on 16 kHz mono audio; feeding anything else
+# means resampling somewhere, so capture at the target rate directly.
+SAMPLE_RATE = 16000
+CHANNELS = 1
+
+# Below this, the buffer is a stray click or a mis-fired toggle — running
+# the model on it wastes seconds and reliably returns hallucinated text.
+MIN_AUDIO_SECONDS = 0.3
+
+# Whisper only conditions on a short window of prior text; a long prompt
+# crowds out the audio and degrades accuracy instead of biasing it.
+MAX_INITIAL_PROMPT_CHARS = 200
+
+_INSTALL_HINT = "Voice input needs: pip install 'servonaut[voice]'"
+_NO_DEVICE_HINT = "No microphone detected"
+
+
+class VoiceInputError(Exception):
+    """Raised when recording or transcription fails.
+
+    Wraps every backend failure (PortAudio, ctranslate2, model download)
+    so callers never have to catch library-specific exception types.
+    """
+
+
+class VoiceInputService(VoiceInputServiceInterface):
+    """Records microphone audio and transcribes it locally."""
+
+    def __init__(self, config: 'VoiceConfig') -> None:
+        self._config = config
+        # Guards ``_blocks`` against the PortAudio callback thread, which
+        # appends concurrently with the UI thread stopping the stream.
+        self._lock = threading.Lock()
+        self._blocks: List[Any] = []
+        self._stream: Optional[Any] = None
+        self._recording = False
+        self._frames_captured = 0
+        self._hit_cap = False
+        self._last_hit_cap = False
+        self._model: Optional[Any] = None
+        # Device enumeration costs a PortAudio init, so probe once and
+        # reuse the verdict for the lifetime of the service.
+        self._availability: Optional[Tuple[bool, str]] = None
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Check if voice input can be used right now.
+
+        Returns:
+            True only when the optional libraries imported cleanly AND at
+            least one input device is present.
+        """
+        available, _ = self._probe()
+        return available
+
+    def unavailable_reason(self) -> str:
+        """Explain why voice input cannot be used.
+
+        Returns:
+            Short, actionable message, or an empty string when available.
+            Never contains a traceback or a library-internal message.
+        """
+        _, reason = self._probe()
+        return reason
+
+    def reset_availability(self) -> None:
+        """Drop the cached availability verdict so the next check re-probes.
+
+        Call this after installing the dependencies or plugging in a
+        microphone: without it the service would keep serving the
+        "unavailable" answer it cached at startup for its whole lifetime.
+        """
+        self._availability = None
+
+    def _probe(self) -> Tuple[bool, str]:
+        """Resolve and cache the (available, reason) verdict."""
+        if self._availability is not None:
+            return self._availability
+
+        if not HAS_VOICE_DEPS:
+            self._availability = (False, _INSTALL_HINT)
+            return self._availability
+
+        try:
+            devices = sd.query_devices()
+            has_input = any(
+                int(device.get('max_input_channels', 0)) > 0 for device in devices
+            )
+        except Exception as e:  # noqa: BLE001 — headless hosts raise OSError from PortAudio
+            logger.debug("Audio device probe failed: %s", e)
+            self._availability = (False, _NO_DEVICE_HINT)
+            return self._availability
+
+        if not has_input:
+            self._availability = (False, _NO_DEVICE_HINT)
+        else:
+            self._availability = (True, "")
+        return self._availability
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    @property
+    def is_recording(self) -> bool:
+        """Whether a recording is currently in progress."""
+        return self._recording
+
+    @property
+    def hit_recording_cap(self) -> bool:
+        """Whether the last transcription's audio was cut off by the cap.
+
+        Set by :meth:`stop_and_transcribe` so callers can tell the user
+        that the tail of what they said was dropped instead of leaving
+        the truncation to a log line.
+        """
+        return self._last_hit_cap
+
+    def start_recording(self) -> None:
+        """Begin capturing microphone audio into an in-memory buffer.
+
+        Raises:
+            VoiceInputError: If a recording is already in progress, voice
+                input is unavailable, or the audio device cannot be opened.
+        """
+        if self._recording:
+            # One service instance backs every chat panel. Returning
+            # quietly here would hand the second caller the first one's
+            # buffer, which it would then drain as if it were its own.
+            raise VoiceInputError("A recording is already in progress")
+
+        available, reason = self._probe()
+        if not available:
+            raise VoiceInputError(reason)
+
+        with self._lock:
+            self._blocks = []
+            self._frames_captured = 0
+            self._hit_cap = False
+            self._last_hit_cap = False
+
+        try:
+            self._stream = sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=CHANNELS,
+                dtype='float32',
+                device=self._config.input_device or None,
+                callback=self._on_audio_block,
+            )
+            self._stream.start()
+        except Exception as e:  # noqa: BLE001 — PortAudio raises its own error hierarchy
+            self._stream = None
+            logger.error("Failed to open audio input stream: %s", e)
+            raise VoiceInputError(f"Could not open the microphone: {e}") from e
+
+        self._recording = True
+        logger.debug("Voice recording started (device=%s)", self._config.input_device or 'default')
+
+    def _on_audio_block(self, indata: Any, frames: int, time_info: Any, status: Any) -> None:
+        """PortAudio callback — runs on the audio thread, must not block."""
+        if status:
+            logger.debug("Audio input status: %s", status)
+
+        max_frames = max(1, int(self._config.max_recording_seconds)) * SAMPLE_RATE
+        with self._lock:
+            if self._frames_captured >= max_frames:
+                # Hard cap: keep the stream alive (stopping it from the
+                # callback thread is fragile) but stop growing the buffer.
+                self._hit_cap = True
+                return
+            self._blocks.append(indata.copy())
+            self._frames_captured += frames
+
+    def cancel_recording(self) -> None:
+        """Stop capturing and discard the buffer without transcribing.
+
+        Never raises — it is the cleanup path for every failure route.
+        """
+        self._close_stream()
+        with self._lock:
+            self._blocks = []
+            self._frames_captured = 0
+            self._hit_cap = False
+
+    def _close_stream(self) -> None:
+        """Stop and close the input stream, tolerating any backend error."""
+        self._recording = False
+        stream = self._stream
+        self._stream = None
+        if stream is None:
+            return
+        try:
+            stream.stop()
+            stream.close()
+        except Exception as e:  # noqa: BLE001 — teardown must never mask the caller's outcome
+            logger.debug("Error while closing audio stream: %s", e)
+
+    # ------------------------------------------------------------------
+    # Transcription
+    # ------------------------------------------------------------------
+
+    def stop_and_transcribe(self, initial_prompt: str = "") -> str:
+        """Stop capturing and transcribe the buffered audio.
+
+        This BLOCKS for the duration of the transcription (and, on the
+        very first call, for the model load). Call it from a worker
+        thread — never from the Textual event loop.
+
+        Args:
+            initial_prompt: Optional vocabulary hint (e.g. the names of
+                the servers on screen) used to bias proper nouns.
+                Truncated before it reaches the model.
+
+        Returns:
+            Transcribed text, or an empty string when the recording was
+            shorter than :data:`MIN_AUDIO_SECONDS`.
+
+        Raises:
+            VoiceInputError: If transcription fails.
+        """
+        self._close_stream()
+
+        with self._lock:
+            blocks = self._blocks
+            self._blocks = []
+            self._frames_captured = 0
+            hit_cap = self._hit_cap
+            self._hit_cap = False
+
+        self._last_hit_cap = hit_cap
+        if hit_cap:
+            logger.info(
+                "Recording reached the %ss cap; transcribing the captured portion",
+                self._config.max_recording_seconds,
+            )
+
+        if not blocks:
+            return ""
+
+        try:
+            audio = np.concatenate(blocks, axis=0).reshape(-1).astype('float32')
+        except Exception as e:  # noqa: BLE001 — a partial/ragged buffer must not crash the panel
+            logger.error("Failed to assemble the audio buffer: %s", e)
+            raise VoiceInputError("Recorded audio could not be read") from e
+
+        if audio.shape[0] < int(MIN_AUDIO_SECONDS * SAMPLE_RATE):
+            logger.debug("Discarding %d frames of audio (below the minimum)", audio.shape[0])
+            return ""
+
+        model = self._get_model()
+        prompt = (initial_prompt or "").strip()[:MAX_INITIAL_PROMPT_CHARS] or None
+        language = self._config.language
+        language = None if not language or language == "auto" else language
+
+        try:
+            segments, _info = model.transcribe(
+                audio,
+                language=language,
+                initial_prompt=prompt,
+            )
+            text = "".join(segment.text for segment in segments).strip()
+        except Exception as e:  # noqa: BLE001 — ctranslate2 raises its own error types
+            logger.error("Transcription failed: %s", e)
+            raise VoiceInputError(f"Transcription failed: {e}") from e
+
+        logger.debug("Transcribed %.1fs of audio into %d characters",
+                     audio.shape[0] / SAMPLE_RATE, len(text))
+        return text
+
+    def _get_model(self) -> Any:
+        """Load the transcription model, caching it on the instance.
+
+        Deferred until the first transcription: constructing the model
+        reads several hundred megabytes from disk (or downloads it), and
+        app startup must stay instant for users who never dictate.
+
+        Raises:
+            VoiceInputError: If the model cannot be loaded.
+        """
+        if self._model is not None:
+            return self._model
+
+        if not HAS_VOICE_DEPS:
+            raise VoiceInputError(_INSTALL_HINT)
+
+        model_size = self._config.model_size
+        try:
+            # int8 on CPU keeps a small model real-time on a laptop while
+            # leaving the GPU (if any) free for whatever else is running.
+            self._model = WhisperModel(model_size, device="cpu", compute_type="int8")
+        except Exception as e:  # noqa: BLE001 — model download/load failures vary by backend
+            logger.error("Failed to load the '%s' speech model: %s", model_size, e)
+            raise VoiceInputError(
+                f"Could not load the '{model_size}' speech model: {e}"
+            ) from e
+
+        logger.info("Loaded speech model '%s' (cpu/int8)", model_size)
+        return self._model

--- a/src/servonaut/services/voice_input_service.py
+++ b/src/servonaut/services/voice_input_service.py
@@ -149,9 +149,16 @@ class VoiceInputService(VoiceInputServiceInterface):
         if self._availability is not None:
             return self._availability
 
-        if not HAS_VOICE_DEPS:
-            self._availability = (False, _INSTALL_HINT)
-            return self._availability
+        # The import flag is resolved once when this module loads, so an
+        # install performed while the app was running would otherwise be
+        # invisible here — and the setup panel, which imports live, would
+        # report the feature ready while this kept asking for a pip
+        # install. Retry the import before trusting a negative flag, and
+        # do NOT cache this particular verdict: an install outside the app
+        # can flip it at any moment, and a cached negative would keep
+        # demanding an install that has already happened.
+        if not HAS_VOICE_DEPS and not reload_voice_deps():
+            return False, _INSTALL_HINT
 
         try:
             devices = sd.query_devices()
@@ -352,7 +359,7 @@ class VoiceInputService(VoiceInputServiceInterface):
         if self._model is not None:
             return self._model
 
-        if not HAS_VOICE_DEPS:
+        if not HAS_VOICE_DEPS and not reload_voice_deps():
             raise VoiceInputError(_INSTALL_HINT)
 
         model_size = self._config.model_size

--- a/src/servonaut/services/voice_setup_service.py
+++ b/src/servonaut/services/voice_setup_service.py
@@ -8,6 +8,16 @@ that silently half-succeeds, this service reports each requirement
 independently so the settings panel can name the one thing standing in
 the way and offer the matching action.
 
+Both engines are handled here. What differs between them — which packages,
+which weights, where they land, how big they are — comes from
+:mod:`servonaut.services.voice_engines`, so this module stays free of
+per-engine branching beyond the two places it genuinely matters: probing
+imports and fetching weights.
+
+The service also keeps an inventory of every model on disk across both
+engines. Switching engine or model size otherwise silently strands
+hundreds of megabytes, which the settings panel uses to offer a cleanup.
+
 Split from :mod:`servonaut.services.voice_input_service` on purpose: the
 recording hot path has no business carrying subprocess and download
 logic, and setup has no business holding an audio buffer.
@@ -23,27 +33,37 @@ import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import Callable, List, Optional, Tuple, TYPE_CHECKING
 
 from servonaut.utils.platform_utils import command_exists, get_os
+from servonaut.services.voice_engines import (
+    NEMOTRON_DOWNLOAD_BYTES,
+    NEMOTRON_FILES,
+    VOICE_MODEL_ROOT,
+    directory_bytes,
+    engine_spec,
+    human_bytes,
+    model_label,
+    nemotron_model_dir,
+    nemotron_repo,
+)
 
 if TYPE_CHECKING:
     from servonaut.config.schema import VoiceConfig
 
 logger = logging.getLogger(__name__)
 
-# The pip-installable half of the requirements. numpy is explicit because
-# the capture buffer uses it directly and neither of the other two
-# declares it as a dependency.
+# Kept for callers that predate per-engine package lists; the batch
+# engine's requirements. New code should ask :meth:`VoiceSetupService.packages`.
 VOICE_PACKAGES: Tuple[str, ...] = (
     "faster-whisper>=1.0",
     "sounddevice>=0.4",
     "numpy>=1.24",
 )
 
-# Rough download footprint per model size, for the confirmation copy. These
-# are the int8 CTranslate2 conversions faster-whisper actually pulls, not
-# the original OpenAI checkpoints.
+# Rough download footprint per Whisper model size, for the confirmation
+# copy. These are the int8 CTranslate2 conversions the batch engine pulls,
+# not the original checkpoints.
 MODEL_DOWNLOAD_SIZES: dict = {
     "tiny": "~75 MB",
     "tiny.en": "~75 MB",
@@ -73,14 +93,45 @@ _PORTAUDIO_COMMANDS: Tuple[Tuple[str, str], ...] = (
 
 _PORTAUDIO_MACOS = "brew install portaudio"
 
-# Ceiling for the package install subprocess. A cold install pulls
-# ctranslate2 and onnxruntime, which is slow on a thin connection but
+# Ceiling for the package install subprocess. A cold install pulls a
+# multi-hundred-megabyte runtime, which is slow on a thin connection but
 # should never take a quarter of an hour.
 _INSTALL_TIMEOUT_SECONDS = 900
 
-# Ceiling for the model download. Generous because the large models are
-# multi-gigabyte and Hugging Face throttles.
+# Ceiling for the model download. Generous because the larger models are
+# multi-gigabyte and the host throttles.
 _DOWNLOAD_TIMEOUT_SECONDS = 1800
+
+# Streamed download chunk size. Large enough to keep syscall overhead off
+# the profile, small enough that progress updates feel live.
+_DOWNLOAD_CHUNK_BYTES = 1 << 20
+
+
+@dataclass(frozen=True)
+class InstalledModel:
+    """One set of model weights present on disk.
+
+    Attributes:
+        engine: Engine the weights belong to.
+        label: Human-readable name, e.g. "Whisper small".
+        key: Identifier the removal call takes back — a Whisper model size
+            or a streaming latency, depending on the engine.
+        path: Directory holding the weights.
+        size_bytes: Total on-disk size.
+        in_use: Whether the current configuration points at these weights.
+    """
+
+    engine: str
+    label: str
+    key: str
+    path: Path
+    size_bytes: int
+    in_use: bool
+
+    @property
+    def human_size(self) -> str:
+        """On-disk size as a short string."""
+        return human_bytes(self.size_bytes)
 
 
 @dataclass(frozen=True)
@@ -88,19 +139,19 @@ class VoiceReadiness:
     """Which of the voice-input requirements are currently satisfied.
 
     Attributes:
-        packages_ok: ``faster-whisper`` and ``numpy`` are importable.
+        packages_ok: The engine's Python packages are importable.
         portaudio_ok: ``sounddevice`` imports, meaning the PortAudio shared
             library resolved. False specifically when the Python package is
             present but the system library is not — the one failure pip
             cannot fix.
         device_ok: At least one capture device is present. False on a
             headless host or over SSH.
-        model_ok: Weights for the configured model size are already in the
-            local cache, so the first dictation will not stall on a
-            download.
-        model_size: The size these verdicts were resolved against.
+        model_ok: Weights for the configured model are already on disk, so
+            the first dictation will not stall on a download.
+        model_size: The Whisper size these verdicts were resolved against.
         detail: Optional human-readable note about the first unmet
             requirement (an import error message, for instance).
+        engine: The engine these verdicts were resolved against.
     """
 
     packages_ok: bool
@@ -109,6 +160,7 @@ class VoiceReadiness:
     model_ok: bool
     model_size: str
     detail: str = ""
+    engine: str = "whisper"
 
     @property
     def is_ready(self) -> bool:
@@ -150,6 +202,35 @@ class VoiceSetupService:
         self._cached: Optional[VoiceReadiness] = None
 
     # ------------------------------------------------------------------
+    # Engine
+    # ------------------------------------------------------------------
+
+    @property
+    def engine_id(self) -> str:
+        """Configured engine id, normalised to one this release knows."""
+        return self._engine().id
+
+    def _engine(self):
+        """Spec for the currently configured engine."""
+        return engine_spec(getattr(self._config, "engine", "whisper"))
+
+    def _latency_ms(self) -> int:
+        """Configured streaming chunk size."""
+        return int(getattr(self._config, "nemotron_latency_ms", 320) or 320)
+
+    def packages(self) -> Tuple[str, ...]:
+        """pip requirements for the configured engine."""
+        return self._engine().packages
+
+    def current_model_label(self) -> str:
+        """Human-readable name of the model the configuration points at."""
+        return model_label(
+            self.engine_id,
+            model_size=self._config.model_size,
+            latency_ms=self._latency_ms(),
+        )
+
+    # ------------------------------------------------------------------
     # Readiness
     # ------------------------------------------------------------------
 
@@ -170,25 +251,24 @@ class VoiceSetupService:
             return self._cached
 
         packages_ok, portaudio_ok, device_ok, detail = self._probe_runtime()
-        model_size = self._config.model_size
-        # Only meaningful once the packages are in place: the cache layout
-        # is a Hugging Face implementation detail we can still inspect
-        # without them, but reporting "no model" to someone who has not
-        # installed anything yet buries the actual next step.
-        model_ok = self.is_model_cached(model_size) if packages_ok else False
+        # Only meaningful once the packages are in place: reporting "no
+        # model" to someone who has installed nothing buries the real
+        # next step.
+        model_ok = self.is_model_present() if packages_ok else False
 
         self._cached = VoiceReadiness(
             packages_ok=packages_ok,
             portaudio_ok=portaudio_ok,
             device_ok=device_ok,
             model_ok=model_ok,
-            model_size=model_size,
+            model_size=self._config.model_size,
             detail=detail,
+            engine=self.engine_id,
         )
         return self._cached
 
     def _probe_runtime(self) -> Tuple[bool, bool, bool, str]:
-        """Check the imports and the capture devices.
+        """Check the engine's imports and the capture devices.
 
         ``sounddevice`` is imported separately from the rest because its
         failure mode is the interesting one: an :exc:`OSError` naming
@@ -198,18 +278,18 @@ class VoiceSetupService:
         Returns:
             Tuple of (packages_ok, portaudio_ok, device_ok, detail).
         """
-        detail = ""
-        try:
-            import numpy  # noqa: F401
-            from faster_whisper import WhisperModel  # noqa: F401
-            packages_ok = True
-        except Exception as e:  # noqa: BLE001 — a broken ctranslate2 build raises OSError
-            logger.debug("Voice packages unavailable: %s", e)
-            return False, False, False, str(e)
+        import importlib
+
+        importlib.invalidate_caches()
+        for module in self._engine().import_names:
+            try:
+                importlib.import_module(module)
+            except Exception as e:  # noqa: BLE001 — a broken build raises OSError
+                logger.debug("Voice package %s unavailable: %s", module, e)
+                return False, False, False, str(e)
 
         try:
             import sounddevice as sd
-            portaudio_ok = True
         except OSError as e:
             # sounddevice raises OSError, not ImportError, when the shared
             # library is absent — that is the signal we branch on.
@@ -219,6 +299,7 @@ class VoiceSetupService:
             logger.debug("sounddevice unavailable: %s", e)
             return False, False, False, str(e)
 
+        detail = ""
         try:
             devices = sd.query_devices()
             device_ok = any(
@@ -231,14 +312,70 @@ class VoiceSetupService:
             device_ok = False
             detail = str(e)
 
-        return packages_ok, portaudio_ok, device_ok, detail
+        return True, True, device_ok, detail
 
     # ------------------------------------------------------------------
-    # Model cache
+    # Model presence
     # ------------------------------------------------------------------
+
+    def is_model_present(self) -> bool:
+        """Whether usable weights for the configured engine are on disk."""
+        return self.is_model_present_for(
+            self.engine_id,
+            model_size=self._config.model_size,
+            latency_ms=self._latency_ms(),
+        )
+
+    def is_model_present_for(
+        self, engine_id: str, *, model_size: str, latency_ms: int
+    ) -> bool:
+        """Whether weights for an arbitrary engine/model choice are on disk.
+
+        Takes the choice explicitly so the settings panel can describe what
+        the user is about to save rather than what is currently saved —
+        showing the old model's status next to a newly picked engine is how
+        a readiness card starts lying.
+        """
+        if engine_spec(engine_id).streaming:
+            return self.is_streaming_model_present(latency_ms)
+        return self.is_model_cached(model_size)
+
+    def model_bytes_for(
+        self, engine_id: str, *, model_size: str, latency_ms: int
+    ) -> int:
+        """On-disk size of the weights for an arbitrary engine/model choice."""
+        if engine_spec(engine_id).streaming:
+            return directory_bytes(nemotron_model_dir(latency_ms))
+        return self.model_cache_bytes(model_size)
+
+    def download_size_hint_for(self, engine_id: str, *, model_size: str) -> str:
+        """Approximate download size for an arbitrary engine/model choice."""
+        if engine_spec(engine_id).streaming:
+            return f"~{human_bytes(NEMOTRON_DOWNLOAD_BYTES)}"
+        return MODEL_DOWNLOAD_SIZES.get(model_size, "size unknown")
+
+    def packages_size_hint(self, engine_id: Optional[str] = None) -> str:
+        """Rough install footprint for an engine's packages.
+
+        Both runtimes are dominated by their inference library, so this is
+        a coarse figure rather than a resolved dependency total.
+        """
+        return "~90 MB" if engine_spec(engine_id or self.engine_id).streaming else "~200 MB"
+
+    def is_streaming_model_present(self, latency_ms: int) -> bool:
+        """Whether the streaming weights for *latency_ms* are complete.
+
+        Every file is checked, not just the directory: an interrupted
+        download leaves a partial set behind, and treating that as done
+        pushes the failure to the first dictation.
+        """
+        model_dir = nemotron_model_dir(latency_ms)
+        if not model_dir.is_dir():
+            return False
+        return all((model_dir / name).is_file() for name in NEMOTRON_FILES.values())
 
     def _model_cache_root(self) -> Path:
-        """Locate the Hugging Face hub cache the model lands in.
+        """Locate the Hugging Face hub cache the batch weights land in.
 
         Honours the same environment overrides the hub library does so a
         user who redirected their cache is not told the model is missing.
@@ -253,12 +390,11 @@ class VoiceSetupService:
         return Path.home() / ".cache" / "huggingface" / "hub"
 
     def _model_cache_dirs(self, model_size: str) -> List[Path]:
-        """Find cache directories that look like the requested model.
+        """Find cache directories that look like the requested Whisper model.
 
         Matched by glob rather than by an exact repository id because the
-        publishing org has moved before (``Systran/faster-whisper-*``,
-        ``Systran/faster-distil-whisper-*``) and a hard-coded id would
-        report a present model as missing after the next move.
+        publishing org has moved before, and a hard-coded id would report
+        a present model as missing after the next move.
         """
         root = self._model_cache_root()
         if not root.is_dir():
@@ -267,7 +403,7 @@ class VoiceSetupService:
         return [Path(p) for p in glob.glob(pattern) if Path(p).is_dir()]
 
     def is_model_cached(self, model_size: str) -> bool:
-        """Whether usable weights for *model_size* are already downloaded.
+        """Whether usable Whisper weights for *model_size* are downloaded.
 
         Checks for the weights file rather than just the directory: an
         interrupted download leaves the folder and its refs behind, and
@@ -285,47 +421,116 @@ class VoiceSetupService:
         return False
 
     def model_cache_bytes(self, model_size: str) -> int:
-        """Total on-disk size of the cached weights, or 0 when absent.
+        """Total on-disk size of the cached Whisper weights, or 0 if absent."""
+        return sum(directory_bytes(d) for d in self._model_cache_dirs(model_size))
 
-        Reported so the panel can tell the user what removing the model
-        would reclaim.
+    def download_size_hint(self, model_size: Optional[str] = None) -> str:
+        """Approximate download size for the configured model."""
+        if self._engine().streaming:
+            return f"~{human_bytes(NEMOTRON_DOWNLOAD_BYTES)}"
+        size = model_size or self._config.model_size
+        return MODEL_DOWNLOAD_SIZES.get(size, "size unknown")
+
+    # ------------------------------------------------------------------
+    # Model inventory + removal
+    # ------------------------------------------------------------------
+
+    def installed_models(
+        self,
+        *,
+        active_engine: Optional[str] = None,
+        active_model_size: Optional[str] = None,
+        active_latency_ms: Optional[int] = None,
+    ) -> List[InstalledModel]:
+        """Every set of weights on disk, across both engines.
+
+        Switching engine or model size strands the previous download, which
+        is hundreds of megabytes; this is what lets the settings panel show
+        what is taking up space and offer to reclaim it.
         """
-        total = 0
-        for cache_dir in self._model_cache_dirs(model_size):
-            for path in cache_dir.rglob("*"):
-                try:
-                    if path.is_file() and not path.is_symlink():
-                        total += path.stat().st_size
-                except OSError:
-                    continue
-        return total
+        found: List[InstalledModel] = []
+        engine_id = engine_spec(active_engine or self.engine_id).id
+        active_size = active_model_size or self._config.model_size
+        active_latency = active_latency_ms or self._latency_ms()
+        streaming_active = engine_spec(engine_id).streaming
 
-    def remove_model(self, model_size: str) -> Tuple[bool, str]:
-        """Delete the cached weights for *model_size*.
+        for size in MODEL_DOWNLOAD_SIZES:
+            if not self.is_model_cached(size):
+                continue
+            found.append(InstalledModel(
+                engine="whisper",
+                label=f"Whisper {size}",
+                key=size,
+                path=self._model_cache_dirs(size)[0],
+                size_bytes=self.model_cache_bytes(size),
+                in_use=(engine_id == "whisper" and size == active_size),
+            ))
+
+        if VOICE_MODEL_ROOT.is_dir():
+            for entry in sorted(VOICE_MODEL_ROOT.iterdir()):
+                if not entry.is_dir() or not entry.name.startswith("nemotron"):
+                    continue
+                latency = self._latency_from_dirname(entry.name)
+                found.append(InstalledModel(
+                    engine="nemotron",
+                    label=f"Nemotron streaming {latency}ms" if latency else entry.name,
+                    key=str(latency or ""),
+                    path=entry,
+                    size_bytes=directory_bytes(entry),
+                    in_use=streaming_active and latency == active_latency,
+                ))
+
+        return found
+
+    @staticmethod
+    def _latency_from_dirname(name: str) -> Optional[int]:
+        """Recover the chunk size from a streaming model directory name."""
+        for part in name.split("-"):
+            if part.endswith("ms") and part[:-2].isdigit():
+                return int(part[:-2])
+        return None
+
+    def stale_models(self, **active) -> List[InstalledModel]:
+        """Weights on disk that the given (or current) choice does not use."""
+        return [
+            model for model in self.installed_models(**active) if not model.in_use
+        ]
+
+    def remove_installed(self, model: InstalledModel) -> Tuple[bool, str]:
+        """Delete the weights *model* describes.
 
         Returns:
-            Tuple of (success, message). Removing an absent model is
-            reported as success — the requested end state already holds.
+            Tuple of (success, message).
+        """
+        try:
+            shutil.rmtree(model.path)
+        except FileNotFoundError:
+            return True, f"{model.label} was already gone"
+        except OSError as e:
+            logger.error("Could not remove %s: %s", model.path, e)
+            return False, f"Could not remove {model.label}: {e}"
+        self._cached = None
+        return True, f"Removed {model.label}, reclaiming {model.human_size}"
+
+    def remove_model(self, model_size: str) -> Tuple[bool, str]:
+        """Delete the cached Whisper weights for *model_size*.
+
+        Removing an absent model is reported as success — the requested end
+        state already holds.
         """
         cache_dirs = self._model_cache_dirs(model_size)
         if not cache_dirs:
             return True, f"No cached weights for {model_size}"
 
-        removed = 0
         for cache_dir in cache_dirs:
             try:
                 shutil.rmtree(cache_dir)
-                removed += 1
             except OSError as e:
                 logger.error("Could not remove %s: %s", cache_dir, e)
                 return False, f"Could not remove the cached model: {e}"
 
         self._cached = None
         return True, f"Removed the cached {model_size} model"
-
-    def download_size_hint(self, model_size: str) -> str:
-        """Approximate download size for *model_size*, for the UI copy."""
-        return MODEL_DOWNLOAD_SIZES.get(model_size, "size unknown")
 
     # ------------------------------------------------------------------
     # Package install
@@ -360,13 +565,14 @@ class VoiceSetupService:
             user (:meth:`manual_install_command` has the copy for them).
         """
         method = self.install_method()
+        packages = list(self.packages())
         if method == "pipx":
             pipx = shutil.which("pipx")
             if not pipx:
                 return None
-            return [pipx, "inject", "servonaut", *VOICE_PACKAGES]
+            return [pipx, "inject", "servonaut", *packages]
         if method == "pip":
-            return [sys.executable, "-m", "pip", "install", *VOICE_PACKAGES]
+            return [sys.executable, "-m", "pip", "install", *packages]
         return None
 
     def manual_install_command(self) -> str:
@@ -378,12 +584,12 @@ class VoiceSetupService:
         argv = self.install_command()
         if argv:
             return " ".join(argv)
-        packages = " ".join(VOICE_PACKAGES)
+        extra = "voice-streaming" if self._engine().streaming else "voice"
         if self.install_method() == "source":
             # An editable checkout installs extras through the project, so
             # point at the extra rather than the loose package list.
-            return "pip install -e '.[voice]'"
-        return f"pip install {packages}"
+            return f"pip install -e '.[{extra}]'"
+        return f"pip install {' '.join(self.packages())}"
 
     def portaudio_command(self) -> str:
         """The command that installs the PortAudio system library.
@@ -399,12 +605,10 @@ class VoiceSetupService:
         return "install the PortAudio library for your distribution"
 
     async def install_packages(self) -> Tuple[bool, str]:
-        """Install the voice packages into Servonaut's own environment.
+        """Install the engine's packages into Servonaut's own environment.
 
-        Runs the package manager as a subprocess and, on success, asks
-        :func:`~servonaut.services.voice_input_service.reload_voice_deps`
-        to pick the new modules up so the feature works without a
-        restart.
+        Runs the package manager as a subprocess and, on success, asks the
+        input service to re-import so the feature works without a restart.
 
         Returns:
             Tuple of (success, message) fit for display.
@@ -442,14 +646,20 @@ class VoiceSetupService:
             return False, self._installer_failure_message(output)
 
         self._cached = None
-        from servonaut.services.voice_input_service import reload_voice_deps
-        if not reload_voice_deps():
-            readiness = self.probe(force=True)
-            if not readiness.portaudio_ok:
-                return True, (
-                    "Packages installed. PortAudio is still missing — run: "
-                    f"{self.portaudio_command()}"
-                )
+        if not self._engine().streaming:
+            # Only the batch engine caches its imports in module globals;
+            # the streaming service re-imports on every probe, so it picks
+            # a fresh install up without help.
+            from servonaut.services.voice_input_service import reload_voice_deps
+            reload_voice_deps()
+
+        readiness = self.probe(force=True)
+        if not readiness.portaudio_ok:
+            return True, (
+                "Packages installed. PortAudio is still missing — run: "
+                f"{self.portaudio_command()}"
+            )
+        if not readiness.packages_ok:
             return True, "Packages installed. Restart Servonaut to finish enabling voice input."
         return True, "Voice packages installed."
 
@@ -468,28 +678,39 @@ class VoiceSetupService:
     # Model download
     # ------------------------------------------------------------------
 
-    async def download_model(self, model_size: Optional[str] = None) -> Tuple[bool, str]:
+    async def download_model(
+        self,
+        model_size: Optional[str] = None,
+        *,
+        progress: Optional[Callable[[str], None]] = None,
+    ) -> Tuple[bool, str]:
         """Fetch the model weights ahead of the first dictation.
 
-        The transcription backend would download these lazily anyway; doing
-        it here means the cost is paid against a button the user pressed
-        knowingly, with the size shown, instead of stalling their first
-        recording for minutes.
+        The engines would fetch these lazily anyway; doing it here means
+        the cost is paid against a button the user pressed knowingly, with
+        the size shown, instead of stalling their first recording.
 
         Args:
-            model_size: Size to fetch. Defaults to the configured size.
+            model_size: Whisper size to fetch. Ignored by the streaming
+                engine, whose model is selected by latency instead.
+            progress: Optional callback receiving human-readable progress
+                lines. Only the streaming download reports progress; the
+                batch engine's downloader gives us no hook.
 
         Returns:
             Tuple of (success, message).
         """
-        size = model_size or self._config.model_size
         readiness = self.probe()
         if not readiness.packages_ok:
             return False, "Install the voice packages first."
 
+        if self._engine().streaming:
+            return await self._download_streaming_model(progress)
+
+        size = model_size or self._config.model_size
         try:
             success, message = await asyncio.wait_for(
-                asyncio.to_thread(self._download_model_blocking, size),
+                asyncio.to_thread(self._download_whisper_blocking, size),
                 timeout=_DOWNLOAD_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
@@ -498,8 +719,8 @@ class VoiceSetupService:
         self._cached = None
         return success, message
 
-    def _download_model_blocking(self, model_size: str) -> Tuple[bool, str]:
-        """Construct the model once, which pulls the weights into the cache.
+    def _download_whisper_blocking(self, model_size: str) -> Tuple[bool, str]:
+        """Construct the batch model, which pulls its weights into the cache.
 
         Runs on a worker thread — it blocks for the whole download.
         """
@@ -511,11 +732,107 @@ class VoiceSetupService:
             return False, f"Download failed: {e}"
 
         if not self.is_model_cached(model_size):
-            # The model loaded from somewhere we do not recognise as the
-            # cache (a local conversion path, say). Not a failure, but the
-            # panel should not promise it is cached.
+            # Loaded from somewhere we do not recognise as the cache (a
+            # local conversion path, say). Not a failure, but the panel
+            # should not promise it is cached.
             return True, f"Loaded {model_size}, but it is not in the expected cache location."
         return True, f"Downloaded the {model_size} model."
+
+    async def _download_streaming_model(
+        self, progress: Optional[Callable[[str], None]]
+    ) -> Tuple[bool, str]:
+        """Fetch the four streaming model files.
+
+        Downloaded with the HTTP client already in Servonaut's core
+        dependencies rather than pulling in a hub library the streaming
+        engine does not otherwise need — and it gives us real progress,
+        which matters for a download this size.
+        """
+        latency = self._latency_ms()
+        model_dir = nemotron_model_dir(latency)
+        repo = nemotron_repo(latency)
+
+        try:
+            import httpx
+        except ImportError:  # pragma: no cover — httpx is a core dependency
+            return False, "The HTTP client is unavailable; cannot download the model."
+
+        # Staged in a sibling directory so an interrupted download can never
+        # be mistaken for a complete one by the presence check.
+        staging = model_dir.with_name(model_dir.name + ".partial")
+        try:
+            if staging.exists():
+                shutil.rmtree(staging)
+            staging.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            return False, f"Could not prepare the download directory: {e}"
+
+        try:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=60.0) as client:
+                for index, (remote, local) in enumerate(NEMOTRON_FILES.items(), start=1):
+                    url = f"https://huggingface.co/{repo}/resolve/main/{remote}"
+                    if progress is not None:
+                        progress(f"Downloading {local} ({index}/{len(NEMOTRON_FILES)})")
+                    ok, error = await self._download_file(
+                        client, url, staging / local, local, progress
+                    )
+                    if not ok:
+                        shutil.rmtree(staging, ignore_errors=True)
+                        return False, error
+        except asyncio.TimeoutError:
+            shutil.rmtree(staging, ignore_errors=True)
+            return False, "The model download timed out."
+        except Exception as e:  # noqa: BLE001 — network failures vary widely
+            shutil.rmtree(staging, ignore_errors=True)
+            logger.error("Streaming model download failed: %s", e)
+            return False, f"Download failed: {e}"
+
+        try:
+            if model_dir.exists():
+                shutil.rmtree(model_dir)
+            staging.rename(model_dir)
+        except OSError as e:
+            shutil.rmtree(staging, ignore_errors=True)
+            return False, f"Could not finalise the download: {e}"
+
+        self._cached = None
+        return True, f"Downloaded the streaming model ({latency}ms)."
+
+    async def _download_file(
+        self,
+        client,
+        url: str,
+        destination: Path,
+        label: str,
+        progress: Optional[Callable[[str], None]],
+    ) -> Tuple[bool, str]:
+        """Stream one file to disk, reporting progress as it goes."""
+        try:
+            async with client.stream("GET", url) as response:
+                if response.status_code != 200:
+                    return False, f"Download failed for {label}: HTTP {response.status_code}"
+                total = int(response.headers.get("content-length") or 0)
+                written = 0
+                last_reported = 0
+                with destination.open("wb") as handle:
+                    async for chunk in response.aiter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                        handle.write(chunk)
+                        written += len(chunk)
+                        # Report per 16 MB rather than per chunk: a 660 MB
+                        # file would otherwise push 660 notifications.
+                        if progress is not None and written - last_reported >= 16 << 20:
+                            last_reported = written
+                            if total:
+                                progress(
+                                    f"{label}: {human_bytes(written)} of "
+                                    f"{human_bytes(total)}"
+                                )
+                            else:
+                                progress(f"{label}: {human_bytes(written)}")
+        except Exception as e:  # noqa: BLE001 — network/disk failures vary
+            logger.error("Failed downloading %s: %s", url, e)
+            return False, f"Download failed for {label}: {e}"
+        return True, ""
 
 
 def build_voice_setup_service(config: 'VoiceConfig') -> VoiceSetupService:

--- a/src/servonaut/services/voice_setup_service.py
+++ b/src/servonaut/services/voice_setup_service.py
@@ -682,7 +682,7 @@ class VoiceSetupService:
         self,
         model_size: Optional[str] = None,
         *,
-        progress: Optional[Callable[[str], None]] = None,
+        progress: Optional[Callable[[str, int, int], None]] = None,
     ) -> Tuple[bool, str]:
         """Fetch the model weights ahead of the first dictation.
 
@@ -693,9 +693,12 @@ class VoiceSetupService:
         Args:
             model_size: Whisper size to fetch. Ignored by the streaming
                 engine, whose model is selected by latency instead.
-            progress: Optional callback receiving human-readable progress
-                lines. Only the streaming download reports progress; the
-                batch engine's downloader gives us no hook.
+            progress: Optional callback invoked as
+                ``(label, downloaded_bytes, total_bytes)``. ``total_bytes``
+                is 0 when the server sends no length. Only the streaming
+                download reports progress — the batch engine's downloader
+                exposes no hook, so its caller should show an indeterminate
+                indicator instead of a percentage.
 
         Returns:
             Tuple of (success, message).
@@ -739,7 +742,7 @@ class VoiceSetupService:
         return True, f"Downloaded the {model_size} model."
 
     async def _download_streaming_model(
-        self, progress: Optional[Callable[[str], None]]
+        self, progress: Optional[Callable[[str, int, int], None]]
     ) -> Tuple[bool, str]:
         """Fetch the four streaming model files.
 
@@ -772,7 +775,7 @@ class VoiceSetupService:
                 for index, (remote, local) in enumerate(NEMOTRON_FILES.items(), start=1):
                     url = f"https://huggingface.co/{repo}/resolve/main/{remote}"
                     if progress is not None:
-                        progress(f"Downloading {local} ({index}/{len(NEMOTRON_FILES)})")
+                        progress(f"{local} ({index}/{len(NEMOTRON_FILES)})", 0, 0)
                     ok, error = await self._download_file(
                         client, url, staging / local, local, progress
                     )
@@ -804,7 +807,7 @@ class VoiceSetupService:
         url: str,
         destination: Path,
         label: str,
-        progress: Optional[Callable[[str], None]],
+        progress: Optional[Callable[[str, int, int], None]],
     ) -> Tuple[bool, str]:
         """Stream one file to disk, reporting progress as it goes."""
         try:
@@ -818,17 +821,11 @@ class VoiceSetupService:
                     async for chunk in response.aiter_bytes(_DOWNLOAD_CHUNK_BYTES):
                         handle.write(chunk)
                         written += len(chunk)
-                        # Report per 16 MB rather than per chunk: a 660 MB
-                        # file would otherwise push 660 notifications.
-                        if progress is not None and written - last_reported >= 16 << 20:
+                        # Throttled to every 4 MB: a 660 MB file would
+                        # otherwise repaint the bar hundreds of times a second.
+                        if progress is not None and written - last_reported >= 4 << 20:
                             last_reported = written
-                            if total:
-                                progress(
-                                    f"{label}: {human_bytes(written)} of "
-                                    f"{human_bytes(total)}"
-                                )
-                            else:
-                                progress(f"{label}: {human_bytes(written)}")
+                            progress(label, written, total)
         except Exception as e:  # noqa: BLE001 — network/disk failures vary
             logger.error("Failed downloading %s: %s", url, e)
             return False, f"Download failed for {label}: {e}"

--- a/src/servonaut/services/voice_setup_service.py
+++ b/src/servonaut/services/voice_setup_service.py
@@ -1,0 +1,527 @@
+"""Readiness detection and guided setup for local voice input.
+
+Voice input is opt-in because it costs a few hundred megabytes across two
+separate downloads — the Python packages and the speech model weights —
+and one of its requirements (the PortAudio system library) cannot be
+installed by pip at all. Rather than hide that behind a single button
+that silently half-succeeds, this service reports each requirement
+independently so the settings panel can name the one thing standing in
+the way and offer the matching action.
+
+Split from :mod:`servonaut.services.voice_input_service` on purpose: the
+recording hot path has no business carrying subprocess and download
+logic, and setup has no business holding an audio buffer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
+from servonaut.utils.platform_utils import command_exists, get_os
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import VoiceConfig
+
+logger = logging.getLogger(__name__)
+
+# The pip-installable half of the requirements. numpy is explicit because
+# the capture buffer uses it directly and neither of the other two
+# declares it as a dependency.
+VOICE_PACKAGES: Tuple[str, ...] = (
+    "faster-whisper>=1.0",
+    "sounddevice>=0.4",
+    "numpy>=1.24",
+)
+
+# Rough download footprint per model size, for the confirmation copy. These
+# are the int8 CTranslate2 conversions faster-whisper actually pulls, not
+# the original OpenAI checkpoints.
+MODEL_DOWNLOAD_SIZES: dict = {
+    "tiny": "~75 MB",
+    "tiny.en": "~75 MB",
+    "base": "~145 MB",
+    "base.en": "~145 MB",
+    "small": "~490 MB",
+    "small.en": "~490 MB",
+    "medium": "~1.5 GB",
+    "medium.en": "~1.5 GB",
+    "large-v2": "~3 GB",
+    "large-v3": "~3 GB",
+    "distil-small.en": "~340 MB",
+    "distil-medium.en": "~790 MB",
+    "distil-large-v3": "~1.5 GB",
+}
+
+# Install hint for the PortAudio shared library, keyed by the package
+# manager we can actually find on the box. pip cannot provide this — it is
+# a system library — so every path here is a command for the user to run.
+_PORTAUDIO_COMMANDS: Tuple[Tuple[str, str], ...] = (
+    ("apt-get", "sudo apt install libportaudio2"),
+    ("dnf", "sudo dnf install portaudio"),
+    ("pacman", "sudo pacman -S portaudio"),
+    ("zypper", "sudo zypper install portaudio"),
+    ("apk", "sudo apk add portaudio"),
+)
+
+_PORTAUDIO_MACOS = "brew install portaudio"
+
+# Ceiling for the package install subprocess. A cold install pulls
+# ctranslate2 and onnxruntime, which is slow on a thin connection but
+# should never take a quarter of an hour.
+_INSTALL_TIMEOUT_SECONDS = 900
+
+# Ceiling for the model download. Generous because the large models are
+# multi-gigabyte and Hugging Face throttles.
+_DOWNLOAD_TIMEOUT_SECONDS = 1800
+
+
+@dataclass(frozen=True)
+class VoiceReadiness:
+    """Which of the voice-input requirements are currently satisfied.
+
+    Attributes:
+        packages_ok: ``faster-whisper`` and ``numpy`` are importable.
+        portaudio_ok: ``sounddevice`` imports, meaning the PortAudio shared
+            library resolved. False specifically when the Python package is
+            present but the system library is not — the one failure pip
+            cannot fix.
+        device_ok: At least one capture device is present. False on a
+            headless host or over SSH.
+        model_ok: Weights for the configured model size are already in the
+            local cache, so the first dictation will not stall on a
+            download.
+        model_size: The size these verdicts were resolved against.
+        detail: Optional human-readable note about the first unmet
+            requirement (an import error message, for instance).
+    """
+
+    packages_ok: bool
+    portaudio_ok: bool
+    device_ok: bool
+    model_ok: bool
+    model_size: str
+    detail: str = ""
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether a dictation started right now would work end to end."""
+        return (
+            self.packages_ok
+            and self.portaudio_ok
+            and self.device_ok
+            and self.model_ok
+        )
+
+    @property
+    def next_step(self) -> str:
+        """The first unmet requirement, as a stable identifier.
+
+        Ordered by dependency: there is no point reporting a missing model
+        to someone who has not installed the packages yet.
+
+        Returns:
+            One of ``packages``, ``portaudio``, ``device``, ``model``, or
+            an empty string when everything is satisfied.
+        """
+        if not self.packages_ok:
+            return "packages"
+        if not self.portaudio_ok:
+            return "portaudio"
+        if not self.device_ok:
+            return "device"
+        if not self.model_ok:
+            return "model"
+        return ""
+
+
+class VoiceSetupService:
+    """Detects what voice input still needs, and installs it on request."""
+
+    def __init__(self, config: 'VoiceConfig') -> None:
+        self._config = config
+        self._cached: Optional[VoiceReadiness] = None
+
+    # ------------------------------------------------------------------
+    # Readiness
+    # ------------------------------------------------------------------
+
+    def probe(self, *, force: bool = False) -> VoiceReadiness:
+        """Resolve which requirements are met.
+
+        Importing the audio stack and enumerating devices both cost real
+        time, so the verdict is cached until something might have changed.
+
+        Args:
+            force: Re-run every check instead of returning the cached
+                verdict. Pass this after an install or a download.
+
+        Returns:
+            The current :class:`VoiceReadiness`.
+        """
+        if self._cached is not None and not force:
+            return self._cached
+
+        packages_ok, portaudio_ok, device_ok, detail = self._probe_runtime()
+        model_size = self._config.model_size
+        # Only meaningful once the packages are in place: the cache layout
+        # is a Hugging Face implementation detail we can still inspect
+        # without them, but reporting "no model" to someone who has not
+        # installed anything yet buries the actual next step.
+        model_ok = self.is_model_cached(model_size) if packages_ok else False
+
+        self._cached = VoiceReadiness(
+            packages_ok=packages_ok,
+            portaudio_ok=portaudio_ok,
+            device_ok=device_ok,
+            model_ok=model_ok,
+            model_size=model_size,
+            detail=detail,
+        )
+        return self._cached
+
+    def _probe_runtime(self) -> Tuple[bool, bool, bool, str]:
+        """Check the imports and the capture devices.
+
+        ``sounddevice`` is imported separately from the rest because its
+        failure mode is the interesting one: an :exc:`OSError` naming
+        PortAudio means the pip package installed fine and the system
+        library is what is missing.
+
+        Returns:
+            Tuple of (packages_ok, portaudio_ok, device_ok, detail).
+        """
+        detail = ""
+        try:
+            import numpy  # noqa: F401
+            from faster_whisper import WhisperModel  # noqa: F401
+            packages_ok = True
+        except Exception as e:  # noqa: BLE001 — a broken ctranslate2 build raises OSError
+            logger.debug("Voice packages unavailable: %s", e)
+            return False, False, False, str(e)
+
+        try:
+            import sounddevice as sd
+            portaudio_ok = True
+        except OSError as e:
+            # sounddevice raises OSError, not ImportError, when the shared
+            # library is absent — that is the signal we branch on.
+            logger.debug("PortAudio unavailable: %s", e)
+            return True, False, False, str(e)
+        except Exception as e:  # noqa: BLE001 — the package itself is broken
+            logger.debug("sounddevice unavailable: %s", e)
+            return False, False, False, str(e)
+
+        try:
+            devices = sd.query_devices()
+            device_ok = any(
+                int(device.get('max_input_channels', 0)) > 0 for device in devices
+            )
+            if not device_ok:
+                detail = "No capture device reported by the audio system"
+        except Exception as e:  # noqa: BLE001 — headless hosts raise from PortAudio
+            logger.debug("Device enumeration failed: %s", e)
+            device_ok = False
+            detail = str(e)
+
+        return packages_ok, portaudio_ok, device_ok, detail
+
+    # ------------------------------------------------------------------
+    # Model cache
+    # ------------------------------------------------------------------
+
+    def _model_cache_root(self) -> Path:
+        """Locate the Hugging Face hub cache the model lands in.
+
+        Honours the same environment overrides the hub library does so a
+        user who redirected their cache is not told the model is missing.
+        """
+        for env_var in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"):
+            value = os.environ.get(env_var)
+            if value:
+                return Path(value).expanduser()
+        hf_home = os.environ.get("HF_HOME")
+        if hf_home:
+            return Path(hf_home).expanduser() / "hub"
+        return Path.home() / ".cache" / "huggingface" / "hub"
+
+    def _model_cache_dirs(self, model_size: str) -> List[Path]:
+        """Find cache directories that look like the requested model.
+
+        Matched by glob rather than by an exact repository id because the
+        publishing org has moved before (``Systran/faster-whisper-*``,
+        ``Systran/faster-distil-whisper-*``) and a hard-coded id would
+        report a present model as missing after the next move.
+        """
+        root = self._model_cache_root()
+        if not root.is_dir():
+            return []
+        pattern = str(root / f"models--*whisper*{model_size}")
+        return [Path(p) for p in glob.glob(pattern) if Path(p).is_dir()]
+
+    def is_model_cached(self, model_size: str) -> bool:
+        """Whether usable weights for *model_size* are already downloaded.
+
+        Checks for the weights file rather than just the directory: an
+        interrupted download leaves the folder and its refs behind, and
+        treating that as "done" would push the failure to the first
+        dictation instead of surfacing it here.
+        """
+        for cache_dir in self._model_cache_dirs(model_size):
+            snapshots = cache_dir / "snapshots"
+            if not snapshots.is_dir():
+                continue
+            for weights in snapshots.glob("*/model.bin"):
+                # A blob symlink that outlived its target reads as missing.
+                if weights.exists():
+                    return True
+        return False
+
+    def model_cache_bytes(self, model_size: str) -> int:
+        """Total on-disk size of the cached weights, or 0 when absent.
+
+        Reported so the panel can tell the user what removing the model
+        would reclaim.
+        """
+        total = 0
+        for cache_dir in self._model_cache_dirs(model_size):
+            for path in cache_dir.rglob("*"):
+                try:
+                    if path.is_file() and not path.is_symlink():
+                        total += path.stat().st_size
+                except OSError:
+                    continue
+        return total
+
+    def remove_model(self, model_size: str) -> Tuple[bool, str]:
+        """Delete the cached weights for *model_size*.
+
+        Returns:
+            Tuple of (success, message). Removing an absent model is
+            reported as success — the requested end state already holds.
+        """
+        cache_dirs = self._model_cache_dirs(model_size)
+        if not cache_dirs:
+            return True, f"No cached weights for {model_size}"
+
+        removed = 0
+        for cache_dir in cache_dirs:
+            try:
+                shutil.rmtree(cache_dir)
+                removed += 1
+            except OSError as e:
+                logger.error("Could not remove %s: %s", cache_dir, e)
+                return False, f"Could not remove the cached model: {e}"
+
+        self._cached = None
+        return True, f"Removed the cached {model_size} model"
+
+    def download_size_hint(self, model_size: str) -> str:
+        """Approximate download size for *model_size*, for the UI copy."""
+        return MODEL_DOWNLOAD_SIZES.get(model_size, "size unknown")
+
+    # ------------------------------------------------------------------
+    # Package install
+    # ------------------------------------------------------------------
+
+    def install_method(self) -> str:
+        """How Servonaut itself was installed.
+
+        Delegates to :class:`~servonaut.services.update_service.UpdateService`
+        so the extras install targets the same environment the in-app
+        upgrade does, instead of guessing separately.
+
+        Returns:
+            One of ``pipx``, ``pip``, ``source``, ``unknown``.
+        """
+        try:
+            from servonaut.services.update_service import UpdateService
+            return UpdateService().detect_install_method()
+        except Exception as e:  # noqa: BLE001 — detection must never block setup
+            logger.debug("Install-method detection failed: %s", e)
+            return "unknown"
+
+    def install_command(self) -> Optional[List[str]]:
+        """Build the argv that installs the packages, when it is safe to run.
+
+        A source or editable checkout is deliberately excluded: its
+        dependencies are owned by whoever manages that environment, and
+        quietly pip-installing into it is not ours to do.
+
+        Returns:
+            The argv list, or None when the install should be left to the
+            user (:meth:`manual_install_command` has the copy for them).
+        """
+        method = self.install_method()
+        if method == "pipx":
+            pipx = shutil.which("pipx")
+            if not pipx:
+                return None
+            return [pipx, "inject", "servonaut", *VOICE_PACKAGES]
+        if method == "pip":
+            return [sys.executable, "-m", "pip", "install", *VOICE_PACKAGES]
+        return None
+
+    def manual_install_command(self) -> str:
+        """The install command as a single copy-pasteable string.
+
+        Always available, including for the source installs
+        :meth:`install_command` refuses to run itself.
+        """
+        argv = self.install_command()
+        if argv:
+            return " ".join(argv)
+        packages = " ".join(VOICE_PACKAGES)
+        if self.install_method() == "source":
+            # An editable checkout installs extras through the project, so
+            # point at the extra rather than the loose package list.
+            return "pip install -e '.[voice]'"
+        return f"pip install {packages}"
+
+    def portaudio_command(self) -> str:
+        """The command that installs the PortAudio system library.
+
+        Resolved against the package manager actually present so the
+        instruction is runnable rather than a list of maybes.
+        """
+        if get_os() == "macos":
+            return _PORTAUDIO_MACOS
+        for binary, command in _PORTAUDIO_COMMANDS:
+            if command_exists(binary):
+                return command
+        return "install the PortAudio library for your distribution"
+
+    async def install_packages(self) -> Tuple[bool, str]:
+        """Install the voice packages into Servonaut's own environment.
+
+        Runs the package manager as a subprocess and, on success, asks
+        :func:`~servonaut.services.voice_input_service.reload_voice_deps`
+        to pick the new modules up so the feature works without a
+        restart.
+
+        Returns:
+            Tuple of (success, message) fit for display.
+        """
+        argv = self.install_command()
+        if argv is None:
+            return False, (
+                "This looks like a source checkout — install the extra "
+                f"yourself with: {self.manual_install_command()}"
+            )
+
+        logger.info("Installing voice packages via %s", argv[0])
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except OSError as e:
+            logger.error("Could not start the installer: %s", e)
+            return False, f"Could not start the installer: {e}"
+
+        try:
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(), timeout=_INSTALL_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            return False, "The install timed out. Try running it in a terminal."
+
+        output = (stdout or b"").decode(errors="replace")
+        if process.returncode != 0:
+            logger.error("Voice package install failed (rc=%s)", process.returncode)
+            return False, self._installer_failure_message(output)
+
+        self._cached = None
+        from servonaut.services.voice_input_service import reload_voice_deps
+        if not reload_voice_deps():
+            readiness = self.probe(force=True)
+            if not readiness.portaudio_ok:
+                return True, (
+                    "Packages installed. PortAudio is still missing — run: "
+                    f"{self.portaudio_command()}"
+                )
+            return True, "Packages installed. Restart Servonaut to finish enabling voice input."
+        return True, "Voice packages installed."
+
+    def _installer_failure_message(self, output: str) -> str:
+        """Turn installer output into one actionable line.
+
+        The tail of a pip failure is usually the useful part, but it can
+        run to hundreds of lines of resolver noise, so it is trimmed to
+        something a notification can hold.
+        """
+        lines = [line.strip() for line in output.splitlines() if line.strip()]
+        tail = lines[-1] if lines else "no output"
+        return f"Install failed: {tail[:200]}"
+
+    # ------------------------------------------------------------------
+    # Model download
+    # ------------------------------------------------------------------
+
+    async def download_model(self, model_size: Optional[str] = None) -> Tuple[bool, str]:
+        """Fetch the model weights ahead of the first dictation.
+
+        The transcription backend would download these lazily anyway; doing
+        it here means the cost is paid against a button the user pressed
+        knowingly, with the size shown, instead of stalling their first
+        recording for minutes.
+
+        Args:
+            model_size: Size to fetch. Defaults to the configured size.
+
+        Returns:
+            Tuple of (success, message).
+        """
+        size = model_size or self._config.model_size
+        readiness = self.probe()
+        if not readiness.packages_ok:
+            return False, "Install the voice packages first."
+
+        try:
+            success, message = await asyncio.wait_for(
+                asyncio.to_thread(self._download_model_blocking, size),
+                timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return False, "The model download timed out."
+
+        self._cached = None
+        return success, message
+
+    def _download_model_blocking(self, model_size: str) -> Tuple[bool, str]:
+        """Construct the model once, which pulls the weights into the cache.
+
+        Runs on a worker thread — it blocks for the whole download.
+        """
+        try:
+            from faster_whisper import WhisperModel
+            WhisperModel(model_size, device="cpu", compute_type="int8")
+        except Exception as e:  # noqa: BLE001 — hub errors, disk-full, bad size
+            logger.error("Model download failed for %s: %s", model_size, e)
+            return False, f"Download failed: {e}"
+
+        if not self.is_model_cached(model_size):
+            # The model loaded from somewhere we do not recognise as the
+            # cache (a local conversion path, say). Not a failure, but the
+            # panel should not promise it is cached.
+            return True, f"Loaded {model_size}, but it is not in the expected cache location."
+        return True, f"Downloaded the {model_size} model."
+
+
+def build_voice_setup_service(config: 'VoiceConfig') -> VoiceSetupService:
+    """Construct the setup service.
+
+    A factory for symmetry with the other optional-service builders, and so
+    call sites do not import the class directly.
+    """
+    return VoiceSetupService(config)

--- a/src/servonaut/services/voice_streaming_service.py
+++ b/src/servonaut/services/voice_streaming_service.py
@@ -1,0 +1,466 @@
+"""Streaming speech-to-text: text appears while the user is still talking.
+
+Wraps a cache-aware transducer running under ``sherpa-onnx``. Unlike the
+batch engine, decoding happens concurrently with capture, so partial text
+can be shown as it is recognised — and because the model decodes
+frame-synchronously rather than re-reading a widening buffer, the partial
+text only ever grows. Nothing already shown to the user gets rewritten,
+which is what makes it usable as live feedback in an input box.
+
+Threading, since three threads are involved:
+
+* The audio callback thread (owned by PortAudio) only enqueues blocks. It
+  must never decode — overrunning that callback drops audio.
+* A decoder thread drains the queue, advances the recognizer and reports
+  partial text through a callback.
+* The UI thread starts and stops the whole thing and receives partials via
+  that callback, which it is responsible for marshalling onto its own loop.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import queue
+import threading
+from typing import Any, Callable, List, Optional, Tuple, TYPE_CHECKING
+
+from .interfaces import VoiceInputServiceInterface
+from .voice_engines import nemotron_model_dir
+from .voice_input_service import (
+    MIN_AUDIO_SECONDS,
+    SAMPLE_RATE,
+    VoiceInputError,
+)
+
+if TYPE_CHECKING:
+    from servonaut.config.schema import VoiceConfig
+
+logger = logging.getLogger(__name__)
+
+CHANNELS = 1
+
+# Audio handed to the decoder in 100 ms blocks: long enough that the
+# decode loop is not woken thousands of times a second, short enough that
+# partial text keeps up with speech.
+_BLOCK_SECONDS = 0.1
+
+# Trailing silence (seconds) before the recognizer calls an utterance
+# finished. Only consulted when endpoint detection is enabled; a shorter
+# value clips people who pause mid-sentence.
+_ENDPOINT_SILENCE_SECONDS = 2.0
+
+# Sentinel pushed onto the queue to retire the decoder thread.
+_STOP = object()
+
+_INSTALL_HINT = "Streaming voice input needs: pip install 'servonaut[voice-streaming]'"
+_NO_DEVICE_HINT = "No microphone detected"
+_NO_MODEL_HINT = "The streaming model is not downloaded yet — see Settings > Voice Input"
+
+
+def _load_modules() -> Tuple[Optional[Any], Optional[Any]]:
+    """Import the streaming stack, returning ``(sounddevice, sherpa_onnx)``.
+
+    Imported on demand rather than at module scope so this module is safe
+    to import on an install that never enables streaming, and so an
+    install performed while the app is running is picked up without a
+    restart.
+    """
+    importlib.invalidate_caches()
+    try:
+        import numpy  # noqa: F401 — required by the capture buffer
+        import sounddevice
+        import sherpa_onnx
+    except Exception as e:  # noqa: BLE001 — a broken onnxruntime build raises OSError
+        logger.debug("Streaming voice dependencies unavailable: %s", e)
+        return None, None
+    return sounddevice, sherpa_onnx
+
+
+class StreamingVoiceInputService(VoiceInputServiceInterface):
+    """Records and transcribes concurrently, emitting partial text."""
+
+    #: Marks this implementation as able to report text mid-utterance, so
+    #: callers can register a partial-text callback without type-checking.
+    supports_streaming = True
+
+    def __init__(self, config: 'VoiceConfig') -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._queue: 'queue.Queue[Any]' = queue.Queue()
+        self._stream: Optional[Any] = None
+        self._decoder_thread: Optional[threading.Thread] = None
+        self._recognizer: Optional[Any] = None
+        self._online_stream: Optional[Any] = None
+        self._recording = False
+        self._frames_captured = 0
+        self._hit_cap = False
+        self._last_hit_cap = False
+        self._partial_text = ""
+        self._final_text = ""
+        self._decode_error: Optional[str] = None
+        self._on_partial: Optional[Callable[[str], None]] = None
+        self._on_endpoint: Optional[Callable[[], None]] = None
+        self._availability: Optional[Tuple[bool, str]] = None
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+
+    def set_partial_callback(self, callback: Optional[Callable[[str], None]]) -> None:
+        """Register a callback for partial transcripts.
+
+        The callback is invoked from the decoder thread, so a UI caller
+        must marshal onto its own event loop (``App.call_from_thread``).
+        """
+        self._on_partial = callback
+
+    def set_endpoint_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Register a callback fired when the speaker stops talking.
+
+        Also invoked from the decoder thread. Only fires when endpoint
+        detection is switched on, which this service ties to auto-submit:
+        detecting the end of an utterance is only actionable if something
+        is going to act on it.
+        """
+        self._on_endpoint = callback
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Whether a streaming dictation could start right now."""
+        return self._probe()[0]
+
+    def unavailable_reason(self) -> str:
+        """Short actionable reason, or "" when the engine is usable."""
+        return self._probe()[1]
+
+    def reset_availability(self) -> None:
+        """Drop the cached verdict so the next check re-probes."""
+        self._availability = None
+
+    def _probe(self) -> Tuple[bool, str]:
+        """Resolve (available, reason), caching only stable outcomes."""
+        sd, _sherpa = _load_modules()
+        if sd is None:
+            # Not cached: an install outside the app flips this at any time.
+            return False, _INSTALL_HINT
+
+        if not self._model_dir().is_dir():
+            # Also not cached — the download button changes this.
+            return False, _NO_MODEL_HINT
+
+        if self._availability is not None:
+            return self._availability
+
+        try:
+            devices = sd.query_devices()
+            has_input = any(
+                int(device.get('max_input_channels', 0)) > 0 for device in devices
+            )
+        except Exception as e:  # noqa: BLE001 — headless hosts raise from PortAudio
+            logger.debug("Audio device probe failed: %s", e)
+            self._availability = (False, _NO_DEVICE_HINT)
+            return self._availability
+
+        self._availability = (True, "") if has_input else (False, _NO_DEVICE_HINT)
+        return self._availability
+
+    def _model_dir(self):
+        """Directory holding the weights for the configured latency."""
+        return nemotron_model_dir(
+            getattr(self._config, "nemotron_latency_ms", 320)
+        )
+
+    # ------------------------------------------------------------------
+    # Recognizer
+    # ------------------------------------------------------------------
+
+    def _get_recognizer(self) -> Any:
+        """Build the recognizer once and reuse it.
+
+        Construction reads ~660 MB of quantised weights, so it is deferred
+        to the first dictation and then cached for the process lifetime.
+        """
+        if self._recognizer is not None:
+            return self._recognizer
+
+        _sd, sherpa = _load_modules()
+        if sherpa is None:
+            raise VoiceInputError(_INSTALL_HINT)
+
+        model_dir = self._model_dir()
+        paths = {
+            name: model_dir / name
+            for name in ("encoder.int8.onnx", "decoder.int8.onnx",
+                         "joiner.int8.onnx", "tokens.txt")
+        }
+        missing = [name for name, path in paths.items() if not path.is_file()]
+        if missing:
+            raise VoiceInputError(_NO_MODEL_HINT)
+
+        # Endpoint detection is only switched on when something will act on
+        # it; otherwise a mid-sentence pause would reset the decoder and
+        # silently drop the first half of what was said.
+        detect_endpoint = bool(getattr(self._config, "auto_submit", False))
+        try:
+            self._recognizer = sherpa.OnlineRecognizer.from_transducer(
+                tokens=str(paths["tokens.txt"]),
+                encoder=str(paths["encoder.int8.onnx"]),
+                decoder=str(paths["decoder.int8.onnx"]),
+                joiner=str(paths["joiner.int8.onnx"]),
+                num_threads=2,
+                sample_rate=SAMPLE_RATE,
+                enable_endpoint_detection=detect_endpoint,
+                rule1_min_trailing_silence=_ENDPOINT_SILENCE_SECONDS,
+                rule2_min_trailing_silence=_ENDPOINT_SILENCE_SECONDS,
+            )
+        except Exception as e:  # noqa: BLE001 — onnxruntime raises its own types
+            logger.error("Failed to load the streaming model: %s", e)
+            raise VoiceInputError(f"Could not load the streaming model: {e}") from e
+
+        logger.info("Loaded streaming model from %s", model_dir)
+        return self._recognizer
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    @property
+    def is_recording(self) -> bool:
+        """Whether a capture is currently running."""
+        return self._recording
+
+    @property
+    def hit_recording_cap(self) -> bool:
+        """Whether the last dictation was cut short by the length cap."""
+        return self._last_hit_cap
+
+    @property
+    def partial_text(self) -> str:
+        """The most recent partial transcript."""
+        with self._lock:
+            return self._partial_text
+
+    def start_recording(self) -> None:
+        """Open the microphone and begin decoding concurrently.
+
+        Blocks long enough to load the model on the first call, so callers
+        must run it off the UI thread.
+
+        Raises:
+            VoiceInputError: If a capture is already running, the engine is
+                unavailable, or the device cannot be opened.
+        """
+        if self._recording:
+            raise VoiceInputError("A recording is already in progress")
+
+        available, reason = self._probe()
+        if not available:
+            raise VoiceInputError(reason)
+
+        recognizer = self._get_recognizer()
+        sd, _sherpa = _load_modules()
+        if sd is None:
+            raise VoiceInputError(_INSTALL_HINT)
+
+        with self._lock:
+            self._partial_text = ""
+            self._final_text = ""
+            self._frames_captured = 0
+            self._hit_cap = False
+            self._last_hit_cap = False
+            self._decode_error = None
+        self._queue = queue.Queue()
+        self._online_stream = recognizer.create_stream()
+
+        # Started before the device opens: if the first blocks arrive
+        # before the consumer exists they would sit in the queue unread,
+        # and the first words of the dictation would surface late.
+        self._decoder_thread = threading.Thread(
+            target=self._decode_loop,
+            args=(recognizer, self._online_stream),
+            name="voice-stream-decoder",
+            daemon=True,
+        )
+        self._decoder_thread.start()
+
+        try:
+            self._stream = sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=CHANNELS,
+                dtype='float32',
+                blocksize=int(SAMPLE_RATE * _BLOCK_SECONDS),
+                device=self._config.input_device or None,
+                callback=self._on_audio_block,
+            )
+            self._stream.start()
+        except Exception as e:  # noqa: BLE001 — PortAudio has its own hierarchy
+            self._stream = None
+            self._queue.put(_STOP)
+            self._join_decoder()
+            logger.error("Failed to open audio input stream: %s", e)
+            raise VoiceInputError(f"Could not open the microphone: {e}") from e
+
+        self._recording = True
+        logger.debug("Streaming capture started (device=%s)",
+                     self._config.input_device or 'default')
+
+    def _on_audio_block(self, indata: Any, frames: int, time_info: Any, status: Any) -> None:
+        """PortAudio callback — enqueue only, never decode.
+
+        Runs on the audio thread. Anything slow here overruns the callback
+        and drops samples, so the work is handed to the decoder thread.
+        """
+        if status:
+            logger.debug("Audio input status: %s", status)
+
+        max_frames = max(1, int(self._config.max_recording_seconds)) * SAMPLE_RATE
+        with self._lock:
+            if self._frames_captured >= max_frames:
+                self._hit_cap = True
+                return
+            self._frames_captured += frames
+        self._queue.put(indata.copy())
+
+    def _decode_loop(self, recognizer: Any, online_stream: Any) -> None:
+        """Decoder thread: drain audio, advance the model, report partials."""
+        try:
+            while True:
+                block = self._queue.get()
+                if block is _STOP:
+                    break
+                online_stream.accept_waveform(SAMPLE_RATE, block.reshape(-1))
+                while recognizer.is_ready(online_stream):
+                    recognizer.decode_stream(online_stream)
+
+                text = (recognizer.get_result(online_stream) or "").strip()
+                if text:
+                    self._publish_partial(text)
+
+                if recognizer.is_endpoint(online_stream):
+                    # Commit what was said and start a fresh utterance, so a
+                    # long dictation is not capped by the model's context.
+                    if text:
+                        self._commit_utterance(text)
+                    recognizer.reset(online_stream)
+                    if self._on_endpoint is not None:
+                        self._safe_endpoint_callback()
+        except Exception as e:  # noqa: BLE001 — surfaced on stop, not swallowed
+            logger.error("Streaming decode failed: %s", e)
+            with self._lock:
+                self._decode_error = str(e)
+
+    def _publish_partial(self, text: str) -> None:
+        """Store a partial transcript and notify the listener."""
+        with self._lock:
+            combined = f"{self._final_text} {text}".strip() if self._final_text else text
+            if combined == self._partial_text:
+                return
+            self._partial_text = combined
+        callback = self._on_partial
+        if callback is None:
+            return
+        try:
+            callback(combined)
+        except Exception:  # noqa: BLE001 — a UI failure must not kill the decoder
+            logger.debug("Partial-text callback failed", exc_info=True)
+
+    def _commit_utterance(self, text: str) -> None:
+        """Fold a completed utterance into the running final transcript."""
+        with self._lock:
+            self._final_text = f"{self._final_text} {text}".strip() if self._final_text else text
+            self._partial_text = self._final_text
+
+    def _safe_endpoint_callback(self) -> None:
+        """Invoke the endpoint callback without letting it kill the decoder."""
+        try:
+            self._on_endpoint()  # type: ignore[misc]
+        except Exception:  # noqa: BLE001
+            logger.debug("Endpoint callback failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Stopping
+    # ------------------------------------------------------------------
+
+    def stop_and_transcribe(self, initial_prompt: str = "") -> str:
+        """Stop capturing and return the full transcript.
+
+        Most of the work already happened during capture, so this only
+        drains what is still queued. ``initial_prompt`` is accepted for
+        interface compatibility and ignored: a transducer has no prompt to
+        condition on.
+
+        Returns:
+            The transcript, or "" when nothing intelligible was captured.
+
+        Raises:
+            VoiceInputError: If decoding failed.
+        """
+        self._close_stream()
+        self._queue.put(_STOP)
+        self._join_decoder()
+
+        with self._lock:
+            hit_cap = self._hit_cap
+            self._last_hit_cap = hit_cap
+            self._hit_cap = False
+            error = self._decode_error
+            frames = self._frames_captured
+            text = self._partial_text.strip()
+
+        if error:
+            raise VoiceInputError(f"Transcription failed: {error}")
+
+        if frames < int(MIN_AUDIO_SECONDS * SAMPLE_RATE):
+            return ""
+
+        if hit_cap:
+            logger.info(
+                "Recording reached the %ss cap; returning the captured portion",
+                self._config.max_recording_seconds,
+            )
+        return text
+
+    def cancel_recording(self) -> None:
+        """Stop capturing and discard everything. Never raises."""
+        self._close_stream()
+        self._queue.put(_STOP)
+        self._join_decoder()
+        with self._lock:
+            self._partial_text = ""
+            self._final_text = ""
+            self._frames_captured = 0
+            self._hit_cap = False
+
+    def _close_stream(self) -> None:
+        """Stop and close the input stream, tolerating backend errors."""
+        self._recording = False
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        try:
+            stream.stop()
+            stream.close()
+        except Exception as e:  # noqa: BLE001 — teardown must not mask the outcome
+            logger.debug("Error while closing audio stream: %s", e)
+
+    def _join_decoder(self) -> None:
+        """Wait for the decoder thread to retire.
+
+        Bounded: a wedged decoder must not hang the UI thread that is
+        waiting to repaint the microphone button.
+        """
+        thread, self._decoder_thread = self._decoder_thread, None
+        if thread is None:
+            return
+        thread.join(timeout=10)
+        if thread.is_alive():
+            logger.warning("Streaming decoder did not stop within 10s")
+
+
+def build_streaming_voice_service(config: 'VoiceConfig') -> StreamingVoiceInputService:
+    """Construct the streaming service."""
+    return StreamingVoiceInputService(config)

--- a/src/servonaut/styles/screens/ai.tcss
+++ b/src/servonaut/styles/screens/ai.tcss
@@ -237,3 +237,16 @@
     max-width: 6;
 }
 
+/* Pinned width: the default Button min-width would crush the 1fr input
+   on a narrow panel. */
+#chat-input-row #btn-chat-mic {
+    min-width: 6;
+    max-width: 6;
+    margin-right: 1;
+}
+
+#chat-input-row #btn-chat-mic.recording {
+    background: $error;
+    color: $text;
+}
+

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -90,8 +90,17 @@ _PROVIDER_INDICATOR_DEFAULT = "▾ Provider"
 # Mic button labels. Plain ASCII only — emoji carrying the U+FE0F
 # variation selector (the microphone glyph is one) corrupt row rendering
 # in several terminals.
-_MIC_IDLE = "MIC"
-_MIC_RECORDING = "STOP"
+# Microphone affordance glyphs. U+1F3A4 is emoji-presentation by default,
+# so it needs no VS16 variant selector — the selector is what corrupts row
+# rendering in some terminals, so it must never be appended here.
+_MIC_IDLE = "\U0001F3A4"
+_MIC_RECORDING = "⏹"
+
+# Braille spinner shown on the mic button and in the stats bar while the
+# model decodes. Transcription is several seconds of silence otherwise, and
+# a frozen button reads as a hang.
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SPINNER_INTERVAL = 0.1
 
 # Cap on the speech-to-text vocabulary hint. Whisper-family models treat
 # the initial prompt as leading context and degrade once it dominates the
@@ -131,6 +140,11 @@ class ChatPanel(Widget):
     _transcribing: bool = False
     _starting: bool = False
     _mic_unavailable: bool = False
+    # Spinner animation state for the transcription wait. The timer handle is
+    # class-defaulted to None so ``_stop_spinner`` is safe on a panel that
+    # never started one.
+    _spinner_timer: Optional[Any] = None
+    _spinner_frame: int = 0
 
     def __init__(self, **kwargs) -> None:
         super().__init__(id="chat-panel", **kwargs)
@@ -248,6 +262,9 @@ class ChatPanel(Widget):
 
     def on_unmount(self) -> None:
         """Drop a live capture so closing the panel can't leave the mic open."""
+        # Unconditional: a panel closed while the model was still decoding
+        # has no capture to cancel but does have a timer to stop.
+        self._stop_spinner()
         if not self._recording and not self._starting:
             return
         self._recording = False
@@ -549,7 +566,8 @@ class ChatPanel(Widget):
         if self._recording:
             parts.insert(0, "[bold red]● REC[/bold red]")
         elif self._transcribing:
-            parts.insert(0, "[yellow]Transcribing…[/yellow]")
+            frame = _SPINNER_FRAMES[self._spinner_frame % len(_SPINNER_FRAMES)]
+            parts.insert(0, f"[yellow]{frame} Transcribing…[/yellow]")
 
         if self._total_tokens > 0:
             parts.append(f"[dim]Tokens:[/dim] {self._total_tokens:,}")
@@ -1690,22 +1708,88 @@ class ChatPanel(Widget):
             )
             return
         self._append_to_input(transcript)
+        self._maybe_auto_submit()
+
+    def _maybe_auto_submit(self) -> None:
+        """Send the dictated text when the user has opted into auto-submit.
+
+        Deliberately routed through the same :meth:`_send` the Enter key
+        uses, so an auto-submitted turn is indistinguishable downstream.
+        Skipped while a reply is streaming — the transcript stays in the box
+        rather than being dropped or queued.
+        """
+        voice_config = self._voice_config()
+        if voice_config is None or not getattr(voice_config, "auto_submit", False):
+            return
+        if self._thinking:
+            self.app.notify(
+                "Dictation saved to the input box — a reply is still streaming.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        self._send()
 
     def _set_mic_state(self, *, recording: bool, transcribing: bool) -> None:
         """Store the voice flags and repaint the mic button + stats bar."""
         self._recording = recording
         self._transcribing = transcribing
+        # The spinner has to start and stop with the transcribing flag, not
+        # with any one call site: several paths (success, error, cancel)
+        # clear the flag and every one of them must leave the timer stopped.
+        if transcribing:
+            self._start_spinner()
+        else:
+            self._stop_spinner()
         try:
             mic_btn = self.query_one("#btn-chat-mic", Button)
         except Exception:
             self._update_stats()
             return
-        mic_btn.label = _MIC_RECORDING if recording else _MIC_IDLE
+        mic_btn.label = self._mic_label()
         mic_btn.disabled = transcribing or self._starting
         if recording:
             mic_btn.add_class("recording")
         else:
             mic_btn.remove_class("recording")
+        self._update_stats()
+
+    def _mic_label(self) -> str:
+        """The glyph the mic button should currently show."""
+        if self._transcribing:
+            return _SPINNER_FRAMES[self._spinner_frame % len(_SPINNER_FRAMES)]
+        return _MIC_RECORDING if self._recording else _MIC_IDLE
+
+    def _start_spinner(self) -> None:
+        """Begin animating the transcription spinner, if not already running."""
+        if self._spinner_timer is not None:
+            return
+        self._spinner_frame = 0
+        try:
+            self._spinner_timer = self.set_interval(
+                _SPINNER_INTERVAL, self._advance_spinner
+            )
+        except Exception:  # noqa: BLE001 — no running app (unit tests / teardown)
+            self._spinner_timer = None
+
+    def _stop_spinner(self) -> None:
+        """Stop the spinner timer. Safe to call when it is not running."""
+        timer, self._spinner_timer = self._spinner_timer, None
+        if timer is None:
+            return
+        try:
+            timer.stop()
+        except Exception:  # noqa: BLE001 — already torn down
+            logger.debug("Spinner timer stop failed", exc_info=True)
+
+    def _advance_spinner(self) -> None:
+        """Advance one spinner frame on the button and the stats bar."""
+        self._spinner_frame += 1
+        try:
+            self.query_one("#btn-chat-mic", Button).label = self._mic_label()
+        except Exception:  # noqa: BLE001 — the panel closed mid-transcription
+            self._stop_spinner()
+            return
         self._update_stats()
 
     def _append_to_input(self, transcript: str) -> None:

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -1432,6 +1432,20 @@ class ChatPanel(Widget):
             logger.debug("voice config unavailable", exc_info=True)
             return None
 
+    def refresh_voice_affordance(self) -> None:
+        """Re-evaluate the mic button after voice setup may have changed.
+
+        Called by the Voice Input settings panel once an install, download
+        or re-check completes, so a panel that was mounted while the
+        feature was still unusable picks the change up instead of keeping
+        a greyed-out button until the app restarts.
+        """
+        service = getattr(self.app, "voice_input_service", None)
+        reset = getattr(service, "reset_availability", None)
+        if callable(reset):
+            reset()
+        self._sync_mic_affordance()
+
     def _sync_mic_affordance(self) -> None:
         """Match the mic button to what this install can actually do.
 
@@ -1440,11 +1454,20 @@ class ChatPanel(Widget):
         optional audio stack or a microphone is missing — otherwise it
         looks exactly like a working button and only tells the truth
         after the user has clicked it.
+
+        Every path resets the button to its usable state first, so this is
+        safe to re-run: setup completing has to be able to undo an earlier
+        "unavailable" verdict, not just add to it.
         """
         try:
             mic_btn = self.query_one("#btn-chat-mic", Button)
         except Exception:  # noqa: BLE001 — nothing to style before compose
             return
+
+        self._mic_unavailable = False
+        mic_btn.display = True
+        mic_btn.disabled = False
+        mic_btn.tooltip = None
 
         voice_config = self._voice_config()
         if voice_config is not None and not voice_config.enabled:

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -37,6 +37,7 @@ to ``_do_send_servonaut`` only when the resolver picks Servonaut.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -86,6 +87,18 @@ _PROVIDER_INDICATORS = {
 }
 _PROVIDER_INDICATOR_DEFAULT = "▾ Provider"
 
+# Mic button labels. Plain ASCII only — emoji carrying the U+FE0F
+# variation selector (the microphone glyph is one) corrupt row rendering
+# in several terminals.
+_MIC_IDLE = "MIC"
+_MIC_RECORDING = "STOP"
+
+# Cap on the speech-to-text vocabulary hint. Whisper-family models treat
+# the initial prompt as leading context and degrade once it dominates the
+# window, so the fleet's server names are truncated at whole-name
+# boundaries rather than padded to the limit.
+_VOICE_PROMPT_MAX_CHARS = 200
+
 
 class ChatPanel(Widget):
     """Right-docked sidebar for chatting with the Servonaut DevOps assistant."""
@@ -96,10 +109,28 @@ class ChatPanel(Widget):
         # check_action() scopes it to the chat input, so Enter on the
         # panel's buttons still activates them normally.
         Binding("enter", "send_from_input", "Send", show=False, priority=True),
+        # A terminal delivers key presses only — there is no key-up event,
+        # so this toggles capture rather than holding it. ctrl+t is free
+        # across the app and is not printable, so it survives TextArea's
+        # key capture while the chat input has focus.
+        Binding("ctrl+t", "toggle_mic", "Voice", show=False, priority=True),
     ]
 
     # Debounce: stale_modules results cached 2 seconds per (instance_id, provider) key.
     _STALE_CACHE_TTL = 2.0
+
+    # Voice capture flags. ``_recording`` gates the mic toggle;
+    # ``_transcribing`` keeps the button disabled while the blocking
+    # speech-to-text call runs on a worker thread; ``_starting`` covers the
+    # equally blocking device-open worker, which a key binding could
+    # otherwise re-enter before the capture is live. ``_mic_unavailable``
+    # remembers a failed availability probe so the button is not silently
+    # re-enabled by an unrelated repaint. Class-level defaults so the stats
+    # bar stays renderable on a panel built without ``__init__``.
+    _recording: bool = False
+    _transcribing: bool = False
+    _starting: bool = False
+    _mic_unavailable: bool = False
 
     def __init__(self, **kwargs) -> None:
         super().__init__(id="chat-panel", **kwargs)
@@ -200,6 +231,7 @@ class ChatPanel(Widget):
             # Input row
             with Horizontal(id="chat-input-row"):
                 yield TextArea("", id="chat-input", soft_wrap=True, tab_behavior="focus")
+                yield Button(_MIC_IDLE, id="btn-chat-mic")
                 yield Button("➤", id="btn-chat-send", variant="primary")
 
     def on_mount(self) -> None:
@@ -212,6 +244,21 @@ class ChatPanel(Widget):
         self._check_provider_decision_events()
         self._update_provider_indicator()
         self._update_quota_footer()
+        self._sync_mic_affordance()
+
+    def on_unmount(self) -> None:
+        """Drop a live capture so closing the panel can't leave the mic open."""
+        if not self._recording and not self._starting:
+            return
+        self._recording = False
+        self._transcribing = False
+        self._starting = False
+        try:
+            service = getattr(self.app, "voice_input_service", None)
+        except Exception:  # noqa: BLE001 — no active app during teardown
+            return
+        if service is not None:
+            service.cancel_recording()
 
     def focus_input(self) -> None:
         """Focus the chat input field."""
@@ -496,6 +543,14 @@ class ChatPanel(Widget):
         else:
             parts = [f"[dim]Model:[/dim] [dim italic]not configured[/dim italic]"]
 
+        # Voice status is derived from panel state on every repaint: this
+        # method rebuilds the whole one-row bar, so an imperatively pushed
+        # indicator would be wiped by the next caller.
+        if self._recording:
+            parts.insert(0, "[bold red]● REC[/bold red]")
+        elif self._transcribing:
+            parts.insert(0, "[yellow]Transcribing…[/yellow]")
+
         if self._total_tokens > 0:
             parts.append(f"[dim]Tokens:[/dim] {self._total_tokens:,}")
         if self._total_cost > 0:
@@ -718,16 +773,23 @@ class ChatPanel(Widget):
             banner = self.query_one("#chat-pinned-error-banner", Horizontal)
             chat_input = self.query_one("#chat-input", TextArea)
             send_btn = self.query_one("#btn-chat-send", Button)
+            mic_btn = self.query_one("#btn-chat-mic", Button)
         except Exception:
             return
         if active:
             banner.remove_class("hidden")
             chat_input.disabled = True
             send_btn.disabled = True
+            mic_btn.disabled = True
         else:
             banner.add_class("hidden")
             chat_input.disabled = False
             send_btn.disabled = False
+            # Re-enabling mid-transcription is cosmetic only: the toggle
+            # itself refuses while the decoder is running, and the worker
+            # repaints the button when it finishes. An install with no
+            # usable microphone stays greyed out, though.
+            mic_btn.disabled = self._mic_unavailable
 
     def _push_first_run_modal(self) -> None:
         """B2 — push :class:`AIProviderFirstRunModal` once per session."""
@@ -1108,6 +1170,8 @@ class ChatPanel(Widget):
             self._toggle_history()
         elif button_id == "btn-chat-provider":
             self._toggle_provider_override()
+        elif button_id == "btn-chat-mic":
+            self._toggle_recording()
         elif button_id == "btn-chat-send":
             self._send()
         elif button_id == "btn-chat-close":
@@ -1221,6 +1285,10 @@ class ChatPanel(Widget):
     def action_send_from_input(self) -> None:
         """Send the current input (Enter while the chat input is focused)."""
         self._send()
+
+    def action_toggle_mic(self) -> None:
+        """Start or stop voice capture (ctrl+t anywhere in the panel)."""
+        self._toggle_recording()
 
     def _toggle_history(self) -> None:
         """Open the unified Previous Chats screen with Cloud + Local tabs.
@@ -1351,6 +1419,318 @@ class ChatPanel(Widget):
         self._update_stats()
         self.query_one("#chat-history-list", VerticalScroll).add_class("hidden")
         self._do_focus_input()
+
+    # ------------------------------------------------------------------
+    # Voice input
+    # ------------------------------------------------------------------
+
+    def _voice_config(self) -> Optional[Any]:
+        """Read the voice settings, or None when they cannot be resolved."""
+        try:
+            return self.app.config_manager.get().voice
+        except Exception:  # noqa: BLE001 — a panel outside the app has no config
+            logger.debug("voice config unavailable", exc_info=True)
+            return None
+
+    def _sync_mic_affordance(self) -> None:
+        """Match the mic button to what this install can actually do.
+
+        The entry point disappears when voice is switched off in the
+        config, and greys out with the reason on its tooltip when the
+        optional audio stack or a microphone is missing — otherwise it
+        looks exactly like a working button and only tells the truth
+        after the user has clicked it.
+        """
+        try:
+            mic_btn = self.query_one("#btn-chat-mic", Button)
+        except Exception:  # noqa: BLE001 — nothing to style before compose
+            return
+
+        voice_config = self._voice_config()
+        if voice_config is not None and not voice_config.enabled:
+            mic_btn.display = False
+            return
+
+        service = getattr(self.app, "voice_input_service", None)
+        if service is None:
+            self._mic_unavailable = True
+            mic_btn.disabled = True
+            mic_btn.tooltip = "Voice input unavailable."
+            return
+
+        self.run_worker(
+            self._probe_mic_availability(service),
+            exclusive=False,
+            name="voice_probe",
+            group="voice",
+        )
+
+    async def _probe_mic_availability(self, service: Any) -> None:
+        """Worker: resolve availability without stalling the mount.
+
+        The first probe enumerates capture devices through the audio
+        backend, which is not a call the event loop should wait on.
+
+        Setup readiness is folded in here as well: the transcription
+        backend fetches missing weights on demand, so a mic that looks
+        live while the model is absent would turn the user's first
+        dictation into a silent multi-minute download.
+        """
+        try:
+            available = await asyncio.to_thread(service.is_available)
+        except Exception:  # noqa: BLE001 — a broken probe must not break the panel
+            logger.debug("voice availability probe failed", exc_info=True)
+            return
+
+        reason = ""
+        if not available:
+            reason = service.unavailable_reason() or "Voice input unavailable."
+        else:
+            reason = await self._model_missing_reason()
+            if not reason:
+                return
+
+        self._mic_unavailable = True
+        try:
+            mic_btn = self.query_one("#btn-chat-mic", Button)
+        except Exception:  # noqa: BLE001 — the panel was closed mid-probe
+            return
+        mic_btn.disabled = True
+        mic_btn.tooltip = reason
+
+    async def _model_missing_reason(self) -> str:
+        """Explain an absent speech model, or return "" when one is cached.
+
+        Returns an empty string whenever the answer cannot be established
+        (no setup service, probe error) so an inconclusive check never
+        disables a mic that would have worked.
+        """
+        setup = getattr(self.app, "voice_setup_service", None)
+        if setup is None:
+            return ""
+        try:
+            readiness = await asyncio.to_thread(setup.probe)
+        except Exception:  # noqa: BLE001 — never let a probe failure gate the mic
+            logger.debug("voice readiness probe failed", exc_info=True)
+            return ""
+        if readiness.model_ok:
+            return ""
+        return (
+            "The speech model is not downloaded yet — "
+            "download it in Settings > Voice Input."
+        )
+
+    def _toggle_recording(self) -> None:
+        """Start voice capture, or stop it and transcribe into the input box."""
+        voice_config = self._voice_config()
+        if voice_config is not None and not voice_config.enabled:
+            self.app.notify(
+                "Voice input is switched off in settings.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        service = getattr(self.app, "voice_input_service", None)
+        if service is None:
+            self.app.notify(
+                "Voice input unavailable.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        # A second toggle while the model is decoding would stop a stream
+        # that is already closed, and one while the device is still being
+        # opened would race the start worker, so swallow both.
+        if self._transcribing or self._starting:
+            return
+
+        # One service instance backs every mounted panel, so a panel can
+        # be left painting REC over a capture that another panel took over
+        # or cancelled. Stopping here would drain a buffer it never owned.
+        if self._recording and not service.is_recording:
+            self._set_mic_state(recording=False, transcribing=False)
+            self.app.notify(
+                "That recording was already stopped elsewhere.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        if self._recording:
+            self._set_mic_state(recording=False, transcribing=True)
+            self.run_worker(
+                self._do_transcribe(service),
+                exclusive=False,
+                name="voice_transcribe",
+                # Dedicated group: the ``ai_chat`` group runs exclusive
+                # workers that would cancel a capture mid-sentence.
+                group="voice",
+            )
+            return
+
+        # Recording during a streaming turn would drop the transcript into
+        # a box the user has already sent from, so refuse rather than queue.
+        if self._thinking:
+            self.app.notify(
+                "Wait for the current response to finish before recording.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        # Opening the capture device blocks until the audio backend hands
+        # it over — long enough to freeze the TUI when another application
+        # already holds the mic — so the start half runs off the event
+        # loop exactly like the transcribe half does.
+        self._starting = True
+        self._set_mic_state(recording=False, transcribing=False)
+        self.run_worker(
+            self._do_start_recording(service),
+            exclusive=False,
+            name="voice_start",
+            group="voice",
+        )
+
+    async def _do_start_recording(self, service: Any) -> None:
+        """Worker: probe the device and open the stream off the event loop."""
+        started = False
+        try:
+            if not await asyncio.to_thread(service.is_available):
+                self.app.notify(
+                    service.unavailable_reason() or "Voice input unavailable.",
+                    severity="warning",
+                    markup=False,
+                )
+            else:
+                await asyncio.to_thread(service.start_recording)
+                started = True
+        except Exception as exc:  # noqa: BLE001 — a dead mic must not kill the panel
+            logger.debug("voice start_recording failed", exc_info=True)
+            self.app.notify(
+                str(exc) or "Could not start recording.",
+                severity="error",
+                markup=False,
+            )
+        finally:
+            # Every exit path, cancellation included: a button left
+            # disabled would strand the user with no way back to an
+            # idle mic.
+            self._starting = False
+            self._set_mic_state(recording=started, transcribing=False)
+
+    async def _do_transcribe(self, service: Any) -> None:
+        """Worker: transcribe the captured audio and append it to the input.
+
+        ``stop_and_transcribe`` loads a local model and decodes audio;
+        awaiting it inline would freeze every widget in the TUI, so it
+        runs on a worker thread.
+        """
+        try:
+            transcript = await asyncio.to_thread(
+                service.stop_and_transcribe,
+                self._voice_prompt_hint(),
+            )
+        except Exception as exc:  # noqa: BLE001 — surface the engine error, stay alive
+            logger.debug("voice transcription failed", exc_info=True)
+            self.app.notify(
+                str(exc) or "Transcription failed.",
+                severity="error",
+                markup=False,
+            )
+            return
+        finally:
+            # Every exit path, cancellation included, leaves the mic idle —
+            # a stuck "STOP" button would strand the user.
+            self._set_mic_state(recording=False, transcribing=False)
+
+        # The cap drops the tail of a long dictation, which is the part a
+        # user scanning a small input box is least likely to notice.
+        if getattr(service, "hit_recording_cap", False):
+            voice_config = self._voice_config()
+            seconds = getattr(voice_config, "max_recording_seconds", None)
+            limit = f"{seconds}s" if seconds else "recording"
+            self.app.notify(
+                f"Recording hit the {limit} limit — only the audio up to "
+                "that point was transcribed.",
+                severity="warning",
+                markup=False,
+            )
+
+        transcript = transcript.strip()
+        if not transcript:
+            self.app.notify(
+                "No speech detected.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        self._append_to_input(transcript)
+
+    def _set_mic_state(self, *, recording: bool, transcribing: bool) -> None:
+        """Store the voice flags and repaint the mic button + stats bar."""
+        self._recording = recording
+        self._transcribing = transcribing
+        try:
+            mic_btn = self.query_one("#btn-chat-mic", Button)
+        except Exception:
+            self._update_stats()
+            return
+        mic_btn.label = _MIC_RECORDING if recording else _MIC_IDLE
+        mic_btn.disabled = transcribing or self._starting
+        if recording:
+            mic_btn.add_class("recording")
+        else:
+            mic_btn.remove_class("recording")
+        self._update_stats()
+
+    def _append_to_input(self, transcript: str) -> None:
+        """Append a transcript to the input box — never send it.
+
+        Speech recognition is not reliable enough to dispatch a turn
+        unreviewed, so the text always lands in the box for the user to
+        edit and send.
+        """
+        try:
+            inp = self.query_one("#chat-input", TextArea)
+        except Exception:
+            return
+        # Demo mode redacts every on-screen surface, and a transcript is
+        # on-screen content — an address spoken aloud must not survive
+        # into a recording.
+        if getattr(self.app, "demo_mode", False):
+            redactor = getattr(self.app, "redaction_service", None)
+            if redactor is not None:
+                transcript = redactor.scrub_stream(transcript)
+        existing = inp.text
+        if existing.strip():
+            inp.load_text(f"{existing.rstrip()} {transcript}")
+        else:
+            inp.load_text(transcript)
+        inp.move_cursor(inp.document.end)
+        self._do_focus_input()
+
+    def _voice_prompt_hint(self) -> str:
+        """Build a vocabulary hint from the fleet's server names.
+
+        Instance names are proper nouns no general speech model has seen;
+        passing them as leading context is what keeps ``web-1`` from being
+        transcribed as ``web one``. The panel can be mounted before the
+        instance list loads, so an empty fleet is normal.
+        """
+        hint = ""
+        for inst in (getattr(self.app, "instances", []) or []):
+            name = inst.get("name") or inst.get("id")
+            if not name:
+                continue
+            candidate = f"{hint}, {name}" if hint else str(name)
+            # Truncate on a whole-name boundary — a half-written hostname
+            # biases the model toward a word that does not exist.
+            if len(candidate) > _VOICE_PROMPT_MAX_CHARS:
+                break
+            hint = candidate
+        return hint
 
     def _send(self) -> None:
         """Read the input field and dispatch the message as a worker."""

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -145,6 +145,10 @@ class ChatPanel(Widget):
     # never started one.
     _spinner_timer: Optional[Any] = None
     _spinner_frame: int = 0
+    # Text already in the input box when a streaming dictation started.
+    # Partials replace each other, so they are rendered after this prefix
+    # rather than on top of whatever the user had typed.
+    _partial_prefix: str = ""
 
     def __init__(self, **kwargs) -> None:
         super().__init__(id="chat-panel", **kwargs)
@@ -1645,6 +1649,8 @@ class ChatPanel(Widget):
                     markup=False,
                 )
             else:
+                self._capture_partial_prefix()
+                self._attach_partial_listener(service)
                 await asyncio.to_thread(service.start_recording)
                 started = True
         except Exception as exc:  # noqa: BLE001 — a dead mic must not kill the panel
@@ -1660,6 +1666,60 @@ class ChatPanel(Widget):
             # idle mic.
             self._starting = False
             self._set_mic_state(recording=started, transcribing=False)
+
+    def _capture_partial_prefix(self) -> None:
+        """Remember what was typed before a dictation started."""
+        try:
+            self._partial_prefix = self.query_one("#chat-input", TextArea).text.strip()
+        except Exception:  # noqa: BLE001 — nothing typed if the box is not there
+            self._partial_prefix = ""
+
+    def _attach_partial_listener(self, service: Any) -> None:
+        """Subscribe to partial transcripts when the engine emits them.
+
+        Only the streaming engine does; the batch engine has nothing to
+        report until it finishes, so this is a no-op there.
+        """
+        register = getattr(service, "set_partial_callback", None)
+        if not callable(register):
+            return
+        # The decoder thread invokes this, so hop to the UI thread before
+        # touching a widget.
+        register(lambda text: self._post_partial(text))
+
+    def _post_partial(self, text: str) -> None:
+        """Marshal a partial transcript from the decoder thread to the UI."""
+        try:
+            self.app.call_from_thread(self._render_partial, text)
+        except Exception:  # noqa: BLE001 — app gone, or panel unmounted mid-decode
+            logger.debug("Could not deliver a partial transcript", exc_info=True)
+
+    def _render_partial(self, text: str) -> None:
+        """Show in-progress dictation in the input box.
+
+        The partial replaces the previous partial rather than appending, so
+        the box tracks what has been said instead of accumulating every
+        intermediate hypothesis. Anything the user had typed before starting
+        is preserved as a prefix.
+        """
+        if not self._recording:
+            return
+        try:
+            inp = self.query_one("#chat-input", TextArea)
+        except Exception:  # noqa: BLE001 — panel closed mid-dictation
+            return
+        if getattr(self.app, "demo_mode", False):
+            redactor = getattr(self.app, "redaction_service", None)
+            if redactor is not None:
+                text = redactor.scrub_stream(text)
+        prefix = self._partial_prefix
+        combined = f"{prefix} {text}".strip() if prefix else text
+        inp.load_text(combined)
+        # Keep the caret at the end so the newest words stay in view.
+        try:
+            inp.move_cursor(inp.document.end)
+        except Exception:  # noqa: BLE001 — cursor API is best-effort here
+            pass
 
     async def _do_transcribe(self, service: Any) -> None:
         """Worker: transcribe the captured audio and append it to the input.
@@ -1707,8 +1767,27 @@ class ChatPanel(Widget):
                 markup=False,
             )
             return
-        self._append_to_input(transcript)
+        if getattr(service, "supports_streaming", False):
+            # The box already shows this dictation from the partials, so
+            # appending would duplicate every word.
+            self._replace_dictation(transcript)
+        else:
+            self._append_to_input(transcript)
         self._maybe_auto_submit()
+
+    def _replace_dictation(self, transcript: str) -> None:
+        """Swap the live partial for the finished transcript."""
+        try:
+            inp = self.query_one("#chat-input", TextArea)
+        except Exception:  # noqa: BLE001 — panel closed mid-dictation
+            return
+        if getattr(self.app, "demo_mode", False):
+            redactor = getattr(self.app, "redaction_service", None)
+            if redactor is not None:
+                transcript = redactor.scrub_stream(transcript)
+        prefix = self._partial_prefix
+        inp.load_text(f"{prefix} {transcript}".strip() if prefix else transcript)
+        self._partial_prefix = ""
 
     def _maybe_auto_submit(self) -> None:
         """Send the dictated text when the user has opted into auto-submit.

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -1002,6 +1002,9 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'voice_auto_submit',
         'voice_btn_copy_install',
         'voice_btn_prune',
+        # Reason: ProgressBar; inherits global ProgressBar styling, laid out
+        # by the #voice_download_row rule in VoicePanel.DEFAULT_CSS.
+        'voice_download_bar',
         'voice_btn_copy_portaudio',
         'voice_btn_download',
         'voice_btn_install',

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -995,6 +995,7 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'ssh_keys_count',
         'ssh_keys_open',
         'voice',
+        'voice_auto_submit',
         'voice_btn_copy_install',
         'voice_btn_copy_portaudio',
         'voice_btn_download',

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -994,9 +994,14 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'ssh_keys',
         'ssh_keys_count',
         'ssh_keys_open',
+        # Reason: Buttons in the voice-model cleanup modal; inherit global
+        # Button styling, positioned by the #vmc_buttons row rule.
+        'vmc_keep',
+        'vmc_remove',
         'voice',
         'voice_auto_submit',
         'voice_btn_copy_install',
+        'voice_btn_prune',
         'voice_btn_copy_portaudio',
         'voice_btn_download',
         'voice_btn_install',
@@ -1006,6 +1011,9 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'voice_input_device',
         'voice_language',
         'voice_max_recording_seconds',
+        'voice_engine',
+        'voice_engine_summary',
+        'voice_latency',
         'voice_model_size',
         # Reason: readiness rows are mounted at runtime and styled by the
         # .voice-req-* / .voice-action-row classes in VoicePanel.DEFAULT_CSS.

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -994,6 +994,21 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         'ssh_keys',
         'ssh_keys_count',
         'ssh_keys_open',
+        'voice',
+        'voice_btn_copy_install',
+        'voice_btn_copy_portaudio',
+        'voice_btn_download',
+        'voice_btn_install',
+        'voice_btn_recheck',
+        'voice_btn_remove_model',
+        'voice_enabled',
+        'voice_input_device',
+        'voice_language',
+        'voice_max_recording_seconds',
+        'voice_model_size',
+        # Reason: readiness rows are mounted at runtime and styled by the
+        # .voice-req-* / .voice-action-row classes in VoicePanel.DEFAULT_CSS.
+        'voice_requirements',
         # ---- Bitwarden SSH picker / unlock modals ----
         # Buttons inherit global Button styling; Inputs inherit global Input
         # styling; the Checkboxes inherit global Checkbox styling; the dynamic

--- a/tests/test_settings_registry_coverage.py
+++ b/tests/test_settings_registry_coverage.py
@@ -75,6 +75,7 @@ _FIELD_TO_PANEL = {
     "ai_system_prompt": "ai_chat",
     "mcp": "mcp",
     "ssh": "_no_ui",  # advanced SSH transport tuning (keepalive/connect timeout); editable via config.json, not surfaced in the Settings TUI
+    "voice": "voice",
     "bw_vault_folder": "bw_ssh",  # local vault-folder scope for the Bitwarden SSH picker; surfaced by BwSshPanel
     "relay": "relay",
     "ovh": "ovh",

--- a/tests/test_voice_engines.py
+++ b/tests/test_voice_engines.py
@@ -1,0 +1,325 @@
+"""Tests for the voice engine registry and the streaming service.
+
+The streaming runtime (``sherpa-onnx``) is not installed in CI, so the
+recognizer is stubbed. What is tested here is the wiring that decides
+which engine runs, where its weights live, and that the decode loop
+publishes partials and folds completed utterances together — the parts
+that stay wrong silently if they are wrong.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.config.schema import VoiceConfig
+from servonaut.services.voice_engines import (
+    DEFAULT_ENGINE,
+    ENGINES,
+    NEMOTRON_LATENCY_OPTIONS,
+    VOICE_MODEL_ROOT,
+    build_voice_input_service,
+    directory_bytes,
+    engine_spec,
+    human_bytes,
+    model_label,
+    nemotron_model_dir,
+    nemotron_repo,
+)
+
+
+class TestEngineRegistry:
+
+    def test_both_engines_are_registered(self):
+        assert set(ENGINES) == {"whisper", "nemotron"}
+
+    def test_only_nemotron_is_streaming(self):
+        assert ENGINES["whisper"].streaming is False
+        assert ENGINES["nemotron"].streaming is True
+
+    def test_default_engine_is_the_lighter_download(self):
+        """The default must not commit a new user to the bigger model."""
+        assert DEFAULT_ENGINE == "whisper"
+
+    def test_unknown_engine_falls_back_rather_than_raising(self):
+        """A config from a newer release must not break the settings panel."""
+        assert engine_spec("some-future-engine").id == DEFAULT_ENGINE
+        assert engine_spec("").id == DEFAULT_ENGINE
+
+    def test_each_engine_declares_the_modules_it_needs(self):
+        assert "faster_whisper" in ENGINES["whisper"].import_names
+        assert "sherpa_onnx" in ENGINES["nemotron"].import_names
+
+    def test_each_engine_declares_numpy(self):
+        """Both capture into numpy buffers, and neither runtime declares it."""
+        for spec in ENGINES.values():
+            assert any("numpy" in pkg for pkg in spec.packages)
+
+    def test_engines_do_not_share_a_runtime_package(self):
+        whisper = {p for p in ENGINES["whisper"].packages if "whisper" in p}
+        nemotron = {p for p in ENGINES["nemotron"].packages if "sherpa" in p}
+        assert whisper and nemotron
+        assert not (whisper & nemotron)
+
+
+class TestLatencyNormalisation:
+
+    @pytest.mark.parametrize("latency", NEMOTRON_LATENCY_OPTIONS)
+    def test_published_variants_are_kept(self, latency):
+        assert f"{latency}ms" in nemotron_repo(latency)
+        assert f"{latency}ms" in nemotron_model_dir(latency).name
+
+    def test_unpublished_value_snaps_to_the_nearest(self):
+        """An unpublished value would resolve to a repository that is 404."""
+        assert "320ms" in nemotron_repo(300)
+        assert "1120ms" in nemotron_repo(99999)
+        assert "80ms" in nemotron_repo(1)
+
+    def test_garbage_falls_back_to_the_default(self):
+        assert "320ms" in nemotron_repo(None)  # type: ignore[arg-type]
+        assert "320ms" in nemotron_repo("nonsense")  # type: ignore[arg-type]
+
+    def test_model_dir_lives_under_the_managed_root(self):
+        assert VOICE_MODEL_ROOT in nemotron_model_dir(320).parents
+
+    def test_repo_targets_the_quantised_build(self):
+        """The float build is ~2.6 GB against ~683 MB for no real gain."""
+        assert "int8" in nemotron_repo(320)
+
+
+class TestModelLabels:
+
+    def test_whisper_label_names_the_size(self):
+        assert model_label("whisper", model_size="tiny", latency_ms=320) == "Whisper tiny"
+
+    def test_streaming_label_names_the_latency(self):
+        label = model_label("nemotron", model_size="small", latency_ms=160)
+        assert label == "Nemotron streaming 160ms"
+
+    def test_streaming_label_ignores_the_whisper_size(self):
+        """Size is meaningless for the streaming engine; it ships in one."""
+        a = model_label("nemotron", model_size="tiny", latency_ms=320)
+        b = model_label("nemotron", model_size="large-v3", latency_ms=320)
+        assert a == b
+
+
+class TestHumanBytes:
+
+    @pytest.mark.parametrize("size,expected", [
+        (0, "0 MB"),
+        (None, "0 MB"),
+        (2048, "2 KB"),
+        (5 * 1024 ** 2, "5 MB"),
+    ])
+    def test_scales_to_a_readable_unit(self, size, expected):
+        assert human_bytes(size) == expected
+
+    def test_gigabytes_get_a_decimal(self):
+        assert human_bytes(2 * 1024 ** 3) == "2.0 GB"
+
+
+class TestDirectoryBytes:
+
+    def test_absent_directory_is_zero(self, tmp_path):
+        assert directory_bytes(tmp_path / "nope") == 0
+
+    def test_sums_nested_files(self, tmp_path):
+        (tmp_path / "a").write_bytes(b"x" * 100)
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        (nested / "b").write_bytes(b"y" * 50)
+        assert directory_bytes(tmp_path) == 150
+
+    def test_symlinks_are_not_double_counted(self, tmp_path):
+        real = tmp_path / "real"
+        real.write_bytes(b"z" * 200)
+        (tmp_path / "link").symlink_to(real)
+        assert directory_bytes(tmp_path) == 200
+
+
+class TestServiceFactory:
+
+    def test_whisper_config_builds_the_batch_service(self):
+        service = build_voice_input_service(VoiceConfig(engine="whisper"))
+        assert type(service).__name__ == "VoiceInputService"
+        assert getattr(service, "supports_streaming", False) is False
+
+    def test_nemotron_config_builds_the_streaming_service(self):
+        service = build_voice_input_service(VoiceConfig(engine="nemotron"))
+        assert type(service).__name__ == "StreamingVoiceInputService"
+        assert service.supports_streaming is True
+
+    def test_unknown_engine_builds_the_batch_service(self):
+        service = build_voice_input_service(VoiceConfig(engine="nope"))
+        assert type(service).__name__ == "VoiceInputService"
+
+    def test_both_services_satisfy_the_interface(self):
+        from servonaut.services.interfaces import VoiceInputServiceInterface
+        for engine in ("whisper", "nemotron"):
+            service = build_voice_input_service(VoiceConfig(engine=engine))
+            assert isinstance(service, VoiceInputServiceInterface)
+
+
+# ---------------------------------------------------------------------------
+# Streaming service
+# ---------------------------------------------------------------------------
+
+def _fake_recognizer(results, *, endpoint_after=None):
+    """Build a recognizer stub returning *results* in sequence."""
+    rec = MagicMock()
+    state = {"index": 0}
+
+    def get_result(_stream):
+        index = min(state["index"], len(results) - 1)
+        return results[index]
+
+    def is_ready(_stream):
+        return False
+
+    def is_endpoint(_stream):
+        return endpoint_after is not None and state["index"] == endpoint_after
+
+    rec.get_result.side_effect = get_result
+    rec.is_ready.side_effect = is_ready
+    rec.is_endpoint.side_effect = is_endpoint
+    rec.create_stream.return_value = MagicMock()
+    return rec, state
+
+
+class TestStreamingService:
+
+    def _service(self, **kwargs):
+        import servonaut.services.voice_streaming_service as vss
+        return vss.StreamingVoiceInputService(VoiceConfig(engine="nemotron", **kwargs))
+
+    def test_declares_streaming_support(self):
+        assert self._service().supports_streaming is True
+
+    def test_missing_packages_report_the_streaming_extra(self):
+        import servonaut.services.voice_streaming_service as vss
+        with patch.object(vss, "_load_modules", return_value=(None, None)):
+            service = self._service()
+            assert service.is_available() is False
+            assert "voice-streaming" in service.unavailable_reason()
+
+    def test_missing_model_is_reported_separately_from_packages(self, tmp_path):
+        """"Install the packages" is the wrong advice once they are installed."""
+        import servonaut.services.voice_streaming_service as vss
+        with patch.object(vss, "_load_modules", return_value=(MagicMock(), MagicMock())):
+            with patch.object(vss, "nemotron_model_dir", return_value=tmp_path / "absent"):
+                service = self._service()
+                assert service.is_available() is False
+                assert "not downloaded" in service.unavailable_reason()
+
+    def test_incomplete_model_directory_refuses_to_load(self, tmp_path):
+        """A half-finished download must not surface as a decode failure."""
+        import servonaut.services.voice_streaming_service as vss
+        from servonaut.services.voice_input_service import VoiceInputError
+        model_dir = tmp_path / "nemotron"
+        model_dir.mkdir()
+        (model_dir / "tokens.txt").write_text("a\n")
+        with patch.object(vss, "_load_modules", return_value=(MagicMock(), MagicMock())):
+            with patch.object(vss, "nemotron_model_dir", return_value=model_dir):
+                with pytest.raises(VoiceInputError):
+                    self._service()._get_recognizer()
+
+    def test_partials_are_published_to_the_callback(self):
+        import servonaut.services.voice_streaming_service as vss
+        service = self._service()
+        seen = []
+        service.set_partial_callback(seen.append)
+        service._publish_partial("hello")
+        service._publish_partial("hello world")
+        assert seen == ["hello", "hello world"]
+
+    def test_an_unchanged_partial_is_not_republished(self):
+        """Repainting the input box on every identical frame is wasted work."""
+        service = self._service()
+        seen = []
+        service.set_partial_callback(seen.append)
+        service._publish_partial("same")
+        service._publish_partial("same")
+        assert seen == ["same"]
+
+    def test_a_failing_callback_does_not_kill_the_decoder(self):
+        service = self._service()
+        service.set_partial_callback(MagicMock(side_effect=RuntimeError("ui gone")))
+        service._publish_partial("text")
+        assert service.partial_text == "text"
+
+    def test_committed_utterances_accumulate(self):
+        """Endpointing resets the decoder; earlier words must not be lost."""
+        service = self._service()
+        service._commit_utterance("first sentence")
+        service._publish_partial("second")
+        assert service.partial_text == "first sentence second"
+
+    def test_endpoint_detection_follows_auto_submit(self, tmp_path):
+        """Endpointing mid-pause would truncate unless something acts on it."""
+        import servonaut.services.voice_streaming_service as vss
+        model_dir = tmp_path / "m"
+        model_dir.mkdir()
+        for name in ("encoder.int8.onnx", "decoder.int8.onnx",
+                     "joiner.int8.onnx", "tokens.txt"):
+            (model_dir / name).write_bytes(b"x")
+
+        for auto_submit, expected in ((True, True), (False, False)):
+            sherpa = MagicMock()
+            with patch.object(vss, "_load_modules", return_value=(MagicMock(), sherpa)):
+                with patch.object(vss, "nemotron_model_dir", return_value=model_dir):
+                    service = vss.StreamingVoiceInputService(
+                        VoiceConfig(engine="nemotron", auto_submit=auto_submit)
+                    )
+                    service._get_recognizer()
+            kwargs = sherpa.OnlineRecognizer.from_transducer.call_args.kwargs
+            assert kwargs["enable_endpoint_detection"] is expected
+
+    def test_second_start_raises_instead_of_sharing_state(self):
+        from servonaut.services.voice_input_service import VoiceInputError
+        service = self._service()
+        service._recording = True
+        with pytest.raises(VoiceInputError):
+            service.start_recording()
+
+    def test_cancel_clears_the_transcript(self):
+        service = self._service()
+        service._publish_partial("discard me")
+        service.cancel_recording()
+        assert service.partial_text == ""
+
+    def test_cancel_without_a_recording_is_silent(self):
+        self._service().cancel_recording()
+
+    def test_too_short_audio_returns_empty(self):
+        service = self._service()
+        service._publish_partial("noise")
+        service._frames_captured = 10
+        assert service.stop_and_transcribe() == ""
+
+    def test_decode_error_surfaces_on_stop(self):
+        from servonaut.services.voice_input_service import VoiceInputError
+        service = self._service()
+        service._decode_error = "onnx blew up"
+        service._frames_captured = 16000
+        with pytest.raises(VoiceInputError) as exc:
+            service.stop_and_transcribe()
+        assert "onnx blew up" in str(exc.value)
+
+    def test_initial_prompt_is_accepted_and_ignored(self):
+        """Interface compatibility: a transducer has no prompt to condition on."""
+        service = self._service()
+        service._publish_partial("hello there")
+        service._frames_captured = 16000 * 2
+        assert service.stop_and_transcribe("server-1, server-2") == "hello there"
+
+    def test_the_cap_is_reported(self):
+        service = self._service(max_recording_seconds=1)
+        service._publish_partial("cut off")
+        service._frames_captured = 16000 * 2
+        service._hit_cap = True
+        service.stop_and_transcribe()
+        assert service.hit_recording_cap is True

--- a/tests/test_voice_input_service.py
+++ b/tests/test_voice_input_service.py
@@ -538,3 +538,64 @@ class TestTranscription:
             _feed(doubles, _LONG_ENOUGH)
             with pytest.raises(VoiceInputError):
                 service.stop_and_transcribe()
+
+
+class TestInstallWhileRunning:
+    """Regression guard: an install done outside the app must take effect.
+
+    The import flag is resolved once when the module loads. Before this was
+    handled, a user who installed the extra while Servonaut was running saw
+    the settings panel (which imports live) report the feature ready while
+    the chat panel's microphone kept telling them to run pip install.
+    """
+
+    _FLAG = "servonaut.services.voice_input_service.HAS_VOICE_DEPS"
+    _RELOAD = "servonaut.services.voice_input_service.reload_voice_deps"
+
+    def test_probe_retries_the_import_before_reporting_missing_deps(self):
+        service = _make_service()
+        with patch(self._FLAG, False):
+            with patch(self._RELOAD, return_value=False) as reload:
+                assert service.is_available() is False
+        reload.assert_called_once()
+
+    def test_a_successful_reload_makes_the_service_available(self):
+        """The mic must start working without restarting the app."""
+        service = _make_service()
+        audio = MagicMock()
+        audio.query_devices.return_value = [{'max_input_channels': 2}]
+        with patch(self._FLAG, False):
+            with patch(self._RELOAD, return_value=True) as reload:
+                with patch("servonaut.services.voice_input_service.sd", audio):
+                    assert service.is_available() is True
+                    assert service.unavailable_reason() == ""
+        reload.assert_called_once()
+
+    def test_the_missing_deps_verdict_is_not_cached(self):
+        """A cached negative would outlive the install that fixed it."""
+        service = _make_service()
+        with patch(self._FLAG, False):
+            with patch(self._RELOAD, return_value=False) as reload:
+                service.is_available()
+                service.is_available()
+                service.is_available()
+        # Re-checked each time rather than answered from a stale cache.
+        assert reload.call_count == 3
+
+    def test_model_load_retries_the_import_too(self):
+        """_get_model has its own flag check, so it must self-heal as well."""
+        service = _make_service()
+        with patch(self._FLAG, False):
+            with patch(self._RELOAD, return_value=False) as reload:
+                with pytest.raises(VoiceInputError) as excinfo:
+                    service._get_model()
+        assert "servonaut[voice]" in str(excinfo.value)
+        reload.assert_called_once()
+
+    def test_a_device_verdict_is_still_cached(self):
+        """Only the deps verdict is retried; device enumeration is expensive."""
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.is_available()
+            service.is_available()
+        assert doubles.sd.query_devices.call_count == 1

--- a/tests/test_voice_input_service.py
+++ b/tests/test_voice_input_service.py
@@ -599,3 +599,31 @@ class TestInstallWhileRunning:
             service.is_available()
             service.is_available()
         assert doubles.sd.query_devices.call_count == 1
+
+
+class TestAutoSubmitConfig:
+    """The auto-submit flag has to survive a real config round-trip."""
+
+    @pytest.fixture
+    def config_manager(self, tmp_path):
+        manager = ConfigManager()
+        manager._config_path = tmp_path / 'config.json'
+        return manager
+
+    def test_default_is_off(self):
+        assert AppConfig().voice.auto_submit is False
+
+    def test_round_trip_preserves_auto_submit(self, config_manager):
+        config_manager.save(AppConfig(voice=VoiceConfig(auto_submit=True)))
+        config_manager._config = None
+        assert config_manager.load().voice.auto_submit is True
+
+    def test_a_config_predating_the_field_still_loads(self, config_manager):
+        """Existing users have no auto_submit key; it must default, not raise."""
+        config_manager.save(AppConfig())
+        raw = json.loads(config_manager._config_path.read_text())
+        del raw['voice']['auto_submit']
+        config_manager._config_path.write_text(json.dumps(raw))
+        config_manager._config = None
+        loaded = config_manager.load()
+        assert loaded.voice.auto_submit is False

--- a/tests/test_voice_input_service.py
+++ b/tests/test_voice_input_service.py
@@ -1,0 +1,540 @@
+"""Tests for the local speech-to-text service and its config plumbing.
+
+The audio dependencies (``sounddevice``, ``faster-whisper``, ``numpy``) are
+optional and are NOT installed in CI, so every test here has to run without
+them: the degradation cases exercise the real absent-dependency path, and the
+recording/transcription cases inject stand-in modules the same way the AI
+service tests inject a fake ``httpx``.
+
+The config round-trip case is the highest-value one — a nested dataclass that
+loads back as a plain dict does not raise at load time, it raises on the first
+attribute access, and only for users who already have the key on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.config.manager import ConfigManager
+from servonaut.config.schema import AppConfig, VoiceConfig, CONFIG_VERSION
+from servonaut.services.voice_input_service import (
+    MAX_INITIAL_PROMPT_CHARS,
+    MIN_AUDIO_SECONDS,
+    SAMPLE_RATE,
+    VoiceInputError,
+    VoiceInputService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the optional audio stack
+# ---------------------------------------------------------------------------
+
+class _FakeAudio:
+    """Stand-in for the numpy array the service captures and concatenates.
+
+    Only the operations the service actually performs are implemented
+    (``copy``/``reshape``/``astype``/``shape``), so a test failure points at
+    the service using a new numpy feature rather than at a silent MagicMock.
+    """
+
+    def __init__(self, samples) -> None:
+        self.samples = list(samples)
+
+    @property
+    def shape(self):
+        return (len(self.samples),)
+
+    def copy(self) -> '_FakeAudio':
+        return _FakeAudio(self.samples)
+
+    def reshape(self, *_args) -> '_FakeAudio':
+        return self
+
+    def astype(self, _dtype) -> '_FakeAudio':
+        return self
+
+
+def _fake_concatenate(blocks, axis=0):
+    """Flatten the captured blocks the way ``np.concatenate`` would."""
+    flattened = [sample for block in blocks for sample in block.samples]
+    return _FakeAudio(flattened)
+
+
+def _make_segment(text: str):
+    """Build a faster-whisper-style segment carrying only ``.text``."""
+    segment = MagicMock()
+    segment.text = text
+    return segment
+
+
+@contextmanager
+def _mock_voice_deps(devices=None, segments=None, transcribe_error=None):
+    """Inject stand-in audio modules and set HAS_VOICE_DEPS=True.
+
+    Yields a namespace of the injected doubles (``sd``, ``whisper_model``,
+    ``model``, ``stream``) so tests can assert on the calls the service made.
+    """
+    import servonaut.services.voice_input_service as svc_module
+
+    stream = MagicMock()
+
+    sd_mock = MagicMock()
+    sd_mock.query_devices.return_value = (
+        devices if devices is not None else [{'max_input_channels': 2}]
+    )
+    sd_mock.InputStream.return_value = stream
+
+    model = MagicMock()
+    if transcribe_error is not None:
+        model.transcribe.side_effect = transcribe_error
+    else:
+        seg_texts = segments if segments is not None else [" hello world"]
+        model.transcribe.return_value = (
+            [_make_segment(t) for t in seg_texts],
+            MagicMock(),
+        )
+
+    whisper_model = MagicMock(return_value=model)
+
+    np_mock = MagicMock()
+    np_mock.concatenate.side_effect = _fake_concatenate
+
+    numpy_module = np_mock
+    sounddevice_module = sd_mock
+    faster_whisper_module = MagicMock()
+    faster_whisper_module.WhisperModel = whisper_model
+
+    originals = {
+        name: sys.modules.get(name)
+        for name in ('numpy', 'sounddevice', 'faster_whisper')
+    }
+    original_flag = svc_module.HAS_VOICE_DEPS
+    original_np = svc_module.np
+    original_sd = svc_module.sd
+    original_whisper = svc_module.WhisperModel
+
+    sys.modules['numpy'] = numpy_module
+    sys.modules['sounddevice'] = sounddevice_module
+    sys.modules['faster_whisper'] = faster_whisper_module
+    svc_module.np = np_mock
+    svc_module.sd = sd_mock
+    svc_module.WhisperModel = whisper_model
+    svc_module.HAS_VOICE_DEPS = True
+
+    # A plain namespace rather than a MagicMock, so a mistyped attribute in a
+    # test raises instead of silently returning an always-passing mock.
+    doubles = SimpleNamespace(
+        sd=sd_mock,
+        np=np_mock,
+        whisper_model=whisper_model,
+        model=model,
+        stream=stream,
+    )
+
+    try:
+        yield doubles
+    finally:
+        svc_module.HAS_VOICE_DEPS = original_flag
+        svc_module.np = original_np
+        svc_module.sd = original_sd
+        svc_module.WhisperModel = original_whisper
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _feed(doubles, sample_count: int) -> None:
+    """Push one block of audio through the PortAudio callback."""
+    callback = doubles.sd.InputStream.call_args.kwargs['callback']
+    block = _FakeAudio([0.1] * sample_count)
+    callback(block, sample_count, None, None)
+
+
+def _make_service(**overrides) -> VoiceInputService:
+    """Build a service over a VoiceConfig with the given field overrides."""
+    return VoiceInputService(VoiceConfig(**overrides))
+
+
+# Comfortably above MIN_AUDIO_SECONDS so the model is actually invoked.
+_LONG_ENOUGH = int(MIN_AUDIO_SECONDS * SAMPLE_RATE) + SAMPLE_RATE
+
+
+# ---------------------------------------------------------------------------
+# Degradation — optional dependencies absent (the CI path)
+# ---------------------------------------------------------------------------
+
+class TestDegradesWithoutDeps:
+
+    def test_is_available_is_false(self):
+        with patch("servonaut.services.voice_input_service.HAS_VOICE_DEPS", False):
+            assert _make_service().is_available() is False
+
+    def test_unavailable_reason_names_the_install_extra(self):
+        with patch("servonaut.services.voice_input_service.HAS_VOICE_DEPS", False):
+            reason = _make_service().unavailable_reason()
+        assert reason
+        assert "servonaut[voice]" in reason
+        assert "pip install" in reason
+
+    def test_start_recording_raises_the_documented_error(self):
+        """The install hint must arrive as VoiceInputError, not NameError."""
+        with patch("servonaut.services.voice_input_service.HAS_VOICE_DEPS", False):
+            service = _make_service()
+            with pytest.raises(VoiceInputError) as excinfo:
+                service.start_recording()
+        assert "servonaut[voice]" in str(excinfo.value)
+        assert service.is_recording is False
+
+    def test_stop_and_transcribe_returns_empty_without_raising(self):
+        with patch("servonaut.services.voice_input_service.HAS_VOICE_DEPS", False):
+            assert _make_service().stop_and_transcribe() == ""
+
+    def test_cancel_recording_is_silent(self):
+        with patch("servonaut.services.voice_input_service.HAS_VOICE_DEPS", False):
+            _make_service().cancel_recording()
+
+    def test_no_input_device_reports_no_microphone(self):
+        with _mock_voice_deps(devices=[{'max_input_channels': 0}]):
+            service = _make_service()
+            assert service.is_available() is False
+            assert service.unavailable_reason() == "No microphone detected"
+
+    def test_device_probe_failure_degrades_instead_of_raising(self):
+        """A headless host raises OSError from PortAudio during enumeration."""
+        with _mock_voice_deps() as doubles:
+            doubles.sd.query_devices.side_effect = OSError("PortAudio not initialized")
+            service = _make_service()
+            assert service.is_available() is False
+            assert service.unavailable_reason() == "No microphone detected"
+
+    def test_availability_is_probed_once(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.is_available()
+            service.is_available()
+            service.unavailable_reason()
+            assert doubles.sd.query_devices.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Config plumbing — VoiceConfig on AppConfig and through ConfigManager
+# ---------------------------------------------------------------------------
+
+class TestVoiceConfigPersistence:
+
+    @pytest.fixture
+    def config_manager(self, tmp_path):
+        """Config manager writing to a temp path."""
+        manager = ConfigManager()
+        manager._config_path = tmp_path / 'config.json'
+        return manager
+
+    def test_voice_is_off_until_opted_into(self):
+        """The feature costs hundreds of MB, so it must never default to on."""
+        assert AppConfig().voice.enabled is False
+
+    def test_defaults_land_on_appconfig(self):
+        config = AppConfig()
+        assert isinstance(config.voice, VoiceConfig)
+        assert config.voice.model_size == "small"
+        assert config.voice.language == "en"
+        assert config.voice.input_device is None
+        assert config.voice.max_recording_seconds == 60
+
+    def test_round_trip_preserves_every_field(self, config_manager):
+        voice = VoiceConfig(
+            enabled=False,
+            model_size="distil-small.en",
+            language="auto",
+            input_device="USB Audio Device",
+            max_recording_seconds=15,
+        )
+        config_manager.save(AppConfig(voice=voice))
+        config_manager._config = None
+        loaded = config_manager.load()
+
+        assert isinstance(loaded.voice, VoiceConfig)
+        assert loaded.voice.enabled is False
+        assert loaded.voice.model_size == "distil-small.en"
+        assert loaded.voice.language == "auto"
+        assert loaded.voice.input_device == "USB Audio Device"
+        assert loaded.voice.max_recording_seconds == 15
+
+    def test_config_without_voice_key_still_loads(self, config_manager):
+        """Regression guard for the nested-config registration in _deserialize.
+
+        An on-disk config predating the feature must yield a real VoiceConfig,
+        not a missing attribute — and a config carrying the key must not come
+        back as a plain dict.
+        """
+        config_manager._config_path.write_text(json.dumps({
+            'version': CONFIG_VERSION,
+            'default_username': 'ubuntu',
+        }))
+        loaded = config_manager.load()
+
+        assert isinstance(loaded.voice, VoiceConfig)
+        assert loaded.voice.model_size == "small"
+
+    def test_unknown_voice_key_on_disk_does_not_break_the_load(self, config_manager):
+        """A field removed in a future release must not take the config down."""
+        config_manager._config_path.write_text(json.dumps({
+            'version': CONFIG_VERSION,
+            'voice': {'language': 'de', 'some_removed_field': True},
+        }))
+        loaded = config_manager.load()
+
+        assert isinstance(loaded.voice, VoiceConfig)
+        assert loaded.voice.language == "de"
+
+    def test_unfamiliar_model_size_survives_a_load_and_save(self, config_manager):
+        """The backend accepts sizes this release does not list (and local
+        model directories), while a save serialises the whole config — so
+        coercing the value would silently delete the user's choice."""
+        config_manager._config_path.write_text(json.dumps({
+            'version': CONFIG_VERSION,
+            'voice': {'model_size': '/opt/models/whisper-custom'},
+        }))
+        loaded = config_manager.load()
+        assert loaded.voice.model_size == "/opt/models/whisper-custom"
+
+        config_manager.save(loaded)
+        on_disk = json.loads(config_manager._config_path.read_text())
+        assert on_disk['voice']['model_size'] == "/opt/models/whisper-custom"
+
+    def test_service_reads_the_config_it_was_given(self, config_manager):
+        config_manager._config_path.write_text(json.dumps({
+            'version': CONFIG_VERSION,
+            'voice': {'input_device': 'Front Mic', 'language': 'fr'},
+        }))
+        config = config_manager.load()
+
+        with _mock_voice_deps() as doubles:
+            service = VoiceInputService(config.voice)
+            service.start_recording()
+
+        assert doubles.sd.InputStream.call_args.kwargs['device'] == 'Front Mic'
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+class TestRecording:
+
+    def test_start_recording_opens_and_starts_the_stream(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+
+            assert service.is_recording is True
+            doubles.stream.start.assert_called_once()
+            kwargs = doubles.sd.InputStream.call_args.kwargs
+            assert kwargs['samplerate'] == SAMPLE_RATE
+            assert kwargs['channels'] == 1
+            assert kwargs['dtype'] == 'float32'
+            # None means "system default"; an empty config value must not be
+            # forwarded as a device name.
+            assert kwargs['device'] is None
+
+    def test_backend_failure_becomes_voice_input_error(self):
+        with _mock_voice_deps() as doubles:
+            doubles.sd.InputStream.side_effect = OSError("Device unavailable")
+            service = _make_service()
+            with pytest.raises(VoiceInputError):
+                service.start_recording()
+            assert service.is_recording is False
+
+    def test_second_start_raises_instead_of_sharing_the_buffer(self):
+        """One service backs every panel, so a silent no-op would let a
+        second caller drain audio the first one is still recording."""
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+
+            with pytest.raises(VoiceInputError):
+                service.start_recording()
+
+            assert doubles.sd.InputStream.call_count == 1
+            assert service.is_recording is True
+
+            service.stop_and_transcribe()
+            audio = doubles.model.transcribe.call_args.args[0]
+            assert audio.shape[0] == _LONG_ENOUGH
+
+    def test_recording_is_capped_at_max_recording_seconds(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service(max_recording_seconds=1)
+            service.start_recording()
+            block = SAMPLE_RATE // 2
+            for _ in range(6):
+                _feed(doubles, block)
+            service.stop_and_transcribe()
+
+            audio = doubles.model.transcribe.call_args.args[0]
+            assert audio.shape[0] == SAMPLE_RATE
+
+    def test_hitting_the_cap_is_reported_to_the_caller(self):
+        """Truncation must be surfaceable, not just logged."""
+        with _mock_voice_deps() as doubles:
+            service = _make_service(max_recording_seconds=1)
+            service.start_recording()
+            for _ in range(6):
+                _feed(doubles, SAMPLE_RATE // 2)
+            service.stop_and_transcribe()
+
+            assert service.hit_recording_cap is True
+
+    def test_a_recording_within_the_cap_reports_no_truncation(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe()
+
+            assert service.hit_recording_cap is False
+
+    def test_cancel_discards_the_buffer(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.cancel_recording()
+
+            assert service.is_recording is False
+            doubles.stream.stop.assert_called_once()
+            doubles.stream.close.assert_called_once()
+            assert service.stop_and_transcribe() == ""
+            doubles.model.transcribe.assert_not_called()
+
+    def test_cancel_without_a_recording_is_silent(self):
+        with _mock_voice_deps():
+            _make_service().cancel_recording()
+
+    def test_cancel_survives_a_failing_teardown(self):
+        with _mock_voice_deps() as doubles:
+            doubles.stream.stop.side_effect = OSError("stream already dead")
+            service = _make_service()
+            service.start_recording()
+            service.cancel_recording()
+            assert service.is_recording is False
+
+
+# ---------------------------------------------------------------------------
+# Transcription
+# ---------------------------------------------------------------------------
+
+class TestTranscription:
+
+    def test_transcribes_the_buffered_audio(self):
+        with _mock_voice_deps(segments=[" restart ", "nginx on web-1"]) as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH // 2)
+            _feed(doubles, _LONG_ENOUGH // 2)
+            text = service.stop_and_transcribe()
+
+            assert text == "restart nginx on web-1"
+            assert service.is_recording is False
+            doubles.stream.close.assert_called_once()
+            audio = doubles.model.transcribe.call_args.args[0]
+            assert audio.shape[0] == (_LONG_ENOUGH // 2) * 2
+
+    def test_empty_buffer_returns_empty_without_loading_the_model(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            assert service.stop_and_transcribe() == ""
+            doubles.whisper_model.assert_not_called()
+            doubles.model.transcribe.assert_not_called()
+
+    def test_too_short_buffer_returns_empty_without_transcribing(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, int(MIN_AUDIO_SECONDS * SAMPLE_RATE) - 1)
+            assert service.stop_and_transcribe() == ""
+            doubles.model.transcribe.assert_not_called()
+
+    def test_initial_prompt_is_truncated(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe("web-1 " * 200)
+
+            prompt = doubles.model.transcribe.call_args.kwargs['initial_prompt']
+            assert len(prompt) == MAX_INITIAL_PROMPT_CHARS
+
+    def test_empty_initial_prompt_is_passed_as_none(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe("   ")
+
+            assert doubles.model.transcribe.call_args.kwargs['initial_prompt'] is None
+
+    def test_language_auto_maps_to_none(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service(language="auto")
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe()
+
+            assert doubles.model.transcribe.call_args.kwargs['language'] is None
+
+    def test_explicit_language_is_forwarded(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service(language="de")
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe()
+
+            assert doubles.model.transcribe.call_args.kwargs['language'] == "de"
+
+    def test_model_is_loaded_lazily_and_reused(self):
+        with _mock_voice_deps() as doubles:
+            service = _make_service(model_size="tiny")
+            doubles.whisper_model.assert_not_called()
+
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            doubles.whisper_model.assert_not_called()
+
+            service.stop_and_transcribe()
+            doubles.whisper_model.assert_called_once_with(
+                "tiny", device="cpu", compute_type="int8"
+            )
+
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            service.stop_and_transcribe()
+            assert doubles.whisper_model.call_count == 1
+
+    def test_model_load_failure_becomes_voice_input_error(self):
+        with _mock_voice_deps() as doubles:
+            doubles.whisper_model.side_effect = RuntimeError("no such model")
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            with pytest.raises(VoiceInputError):
+                service.stop_and_transcribe()
+
+    def test_transcription_failure_becomes_voice_input_error(self):
+        with _mock_voice_deps(transcribe_error=RuntimeError("backend failure")) as doubles:
+            service = _make_service()
+            service.start_recording()
+            _feed(doubles, _LONG_ENOUGH)
+            with pytest.raises(VoiceInputError):
+                service.stop_and_transcribe()

--- a/tests/test_voice_settings_panel.py
+++ b/tests/test_voice_settings_panel.py
@@ -63,6 +63,8 @@ _FORM = {
     "#voice_input_device": "",
     "#voice_max_recording_seconds": "60",
     "#voice_auto_submit": False,
+    "#voice_engine": "whisper",
+    "#voice_latency": 320,
 }
 
 
@@ -100,6 +102,8 @@ class TestValidation:
             "input_device": None,
             "max_recording_seconds": 60,
             "auto_submit": False,
+            "engine": "whisper",
+            "nemotron_latency_ms": 320,
         }
 
     def test_blank_language_falls_back_to_english(self):
@@ -176,6 +180,7 @@ class TestPersist:
             existing,
             enabled=True, model_size="small", language="en",
             input_device=None, max_recording_seconds=60, auto_submit=False,
+            engine="whisper", nemotron_latency_ms=320,
         )
 
     def test_persist_resets_the_service_availability_cache(self):
@@ -413,3 +418,122 @@ class TestAutoSubmitSetting:
 
     def test_auto_submit_is_part_of_dirty_tracking(self):
         assert _panel_with(_form(auto_submit=True)).current_values()["auto_submit"] is True
+
+
+class TestEngineSwitchCleanup:
+    """Switching model must offer to reclaim the previous download.
+
+    Each model is several hundred megabytes in a cache directory nobody
+    thinks to check, so a silent switch strands the disk.
+    """
+
+    def _panel(self, *, stale, loaded_engine="whisper", loaded_size="small",
+               loaded_latency=320):
+        panel = _panel_with(_form())
+        panel._loaded_engine = loaded_engine
+        panel._loaded_model_size = loaded_size
+        panel._loaded_latency = loaded_latency
+        setup = MagicMock()
+        setup.stale_models.return_value = stale
+        setup.current_model_label.return_value = "Whisper small"
+        panel._setup_service = lambda: setup  # type: ignore[method-assign]
+        return panel, setup
+
+    def _stale_model(self, label="Whisper medium", size=1500 * 1024 * 1024):
+        model = MagicMock()
+        model.label = label
+        model.size_bytes = size
+        model.human_size = "1.5 GB"
+        model.in_use = False
+        return model
+
+    def test_a_switch_offers_cleanup(self):
+        panel, _setup = self._panel(stale=[self._stale_model()])
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+        app.push_screen.assert_called_once()
+
+    def test_nothing_stale_means_no_prompt(self):
+        """Never interrupt a save that stranded nothing."""
+        panel, _setup = self._panel(stale=[])
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+        app.push_screen.assert_not_called()
+
+    def test_confirming_removes_every_stale_model(self):
+        first, second = self._stale_model("Whisper medium"), self._stale_model("Whisper tiny")
+        panel, setup = self._panel(stale=[first, second])
+        setup.remove_installed.return_value = (True, "removed")
+        app = MagicMock()
+        panel._refresh_readiness = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+            callback = app.push_screen.call_args[0][1]
+            callback(True)
+        assert setup.remove_installed.call_count == 2
+
+    def test_declining_removes_nothing(self):
+        panel, setup = self._panel(stale=[self._stale_model()])
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+            app.push_screen.call_args[0][1](False)
+        setup.remove_installed.assert_not_called()
+
+    def test_dismissing_without_choosing_removes_nothing(self):
+        """Escape resolves to None; the safe reading of that is 'keep'."""
+        panel, setup = self._panel(stale=[self._stale_model()])
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+            app.push_screen.call_args[0][1](None)
+        setup.remove_installed.assert_not_called()
+
+    def test_a_failed_removal_is_reported(self):
+        panel, setup = self._panel(stale=[self._stale_model()])
+        setup.remove_installed.return_value = (False, "permission denied")
+        app = MagicMock()
+        panel._refresh_readiness = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+            app.push_screen.call_args[0][1](True)
+        severities = [c.kwargs.get("severity") for c in app.notify.call_args_list]
+        assert "error" in severities
+
+    def test_an_inventory_failure_does_not_break_the_save(self):
+        panel, setup = self._panel(stale=[])
+        setup.stale_models.side_effect = OSError("cache unreadable")
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+        app.push_screen.assert_not_called()
+
+    def test_no_setup_service_means_no_prompt(self):
+        panel = _panel_with(_form())
+        panel._setup_service = lambda: None  # type: ignore[method-assign]
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._offer_model_cleanup()
+        app.push_screen.assert_not_called()
+
+
+class TestEngineFields:
+
+    def test_engine_is_collected_and_normalised(self):
+        fields = _panel_with(_form(engine="nemotron")).collect()
+        assert fields["engine"] == "nemotron"
+
+    def test_an_unknown_engine_is_normalised_on_save(self):
+        fields = _panel_with(_form(engine="not-an-engine")).collect()
+        assert fields["engine"] == "whisper"
+
+    def test_latency_is_collected(self):
+        fields = _panel_with(_form(latency=160)).collect()
+        assert fields["nemotron_latency_ms"] == 160
+
+    def test_engine_and_latency_are_part_of_dirty_tracking(self):
+        values = _panel_with(_form(engine="nemotron", latency=80)).current_values()
+        assert values["engine"] == "nemotron"
+        assert values["nemotron_latency_ms"] == 80

--- a/tests/test_voice_settings_panel.py
+++ b/tests/test_voice_settings_panel.py
@@ -1,0 +1,315 @@
+"""Tests for the Voice Input settings panel.
+
+Panel logic is exercised without mounting a Textual app: the widget-facing
+methods are driven against stubbed ``query_one`` results, which keeps the
+tests fast and focused on the decisions (validation bounds, what gets
+persisted, which requirement row is offered) rather than on layout.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.config.schema import AppConfig, VoiceConfig
+from servonaut.screens.settings.base import ValidationError
+from servonaut.screens.settings.panels.voice import VoicePanel, requirement_note
+from servonaut.screens.settings.registry import PANELS
+from servonaut.services.voice_setup_service import VoiceReadiness
+
+
+def _readiness(**overrides) -> VoiceReadiness:
+    base = dict(
+        packages_ok=True, portaudio_ok=True, device_ok=True,
+        model_ok=True, model_size="small",
+    )
+    base.update(overrides)
+    return VoiceReadiness(**base)
+
+
+class _StubWidgets:
+    """Serves stub widgets from ``query_one`` keyed by selector."""
+
+    def __init__(self, values: dict) -> None:
+        self._widgets = {}
+        for selector, value in values.items():
+            widget = MagicMock()
+            if isinstance(value, bool):
+                widget.value = value
+            else:
+                widget.value = value
+            self._widgets[selector] = widget
+
+    def query_one(self, selector, _type=None):
+        if selector in self._widgets:
+            return self._widgets[selector]
+        raise KeyError(selector)
+
+
+def _panel_with(values: dict) -> VoicePanel:
+    """Build a panel whose ``query_one`` returns stubs for *values*."""
+    panel = VoicePanel()
+    stub = _StubWidgets(values)
+    panel.query_one = stub.query_one  # type: ignore[method-assign]
+    return panel
+
+
+_FORM = {
+    "#voice_enabled": True,
+    "#voice_model_size": "small",
+    "#voice_language": "en",
+    "#voice_input_device": "",
+    "#voice_max_recording_seconds": "60",
+}
+
+
+def _form(**overrides) -> dict:
+    values = dict(_FORM)
+    values.update({f"#voice_{k}": v for k, v in overrides.items()})
+    return values
+
+
+class TestRegistration:
+
+    def test_panel_is_registered_under_ai(self):
+        spec = next((p for p in PANELS if p.id == "voice"), None)
+        assert spec is not None
+        assert spec.group == "AI"
+        assert spec.factory() is VoicePanel
+
+    def test_search_keywords_cover_the_obvious_terms(self):
+        spec = next(p for p in PANELS if p.id == "voice")
+        for term in ("voice", "microphone", "dictation", "whisper"):
+            assert term in spec.keywords
+
+    def test_panel_id_matches_the_spec(self):
+        assert VoicePanel.PANEL_ID == "voice"
+
+
+class TestValidation:
+
+    def test_valid_form_collects_cleanly(self):
+        fields = _panel_with(_form()).collect()
+        assert fields == {
+            "enabled": True,
+            "model_size": "small",
+            "language": "en",
+            "input_device": None,
+            "max_recording_seconds": 60,
+        }
+
+    def test_blank_language_falls_back_to_english(self):
+        assert _panel_with(_form(language="")).collect()["language"] == "en"
+
+    def test_auto_language_is_accepted(self):
+        assert _panel_with(_form(language="auto")).collect()["language"] == "auto"
+
+    def test_a_sentence_is_rejected_as_a_language(self):
+        """It would reach the model verbatim and fail mid-dictation."""
+        with pytest.raises(ValidationError) as exc:
+            _panel_with(_form(language="English please")).collect()
+        assert exc.value.field_id == "voice_language"
+
+    def test_non_numeric_cap_is_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            _panel_with(_form(max_recording_seconds="abc")).collect()
+        assert exc.value.field_id == "voice_max_recording_seconds"
+
+    def test_zero_cap_is_rejected(self):
+        with pytest.raises(ValidationError):
+            _panel_with(_form(max_recording_seconds="0")).collect()
+
+    def test_absurd_cap_is_rejected(self):
+        with pytest.raises(ValidationError):
+            _panel_with(_form(max_recording_seconds="99999")).collect()
+
+    def test_blank_cap_falls_back_to_the_default(self):
+        fields = _panel_with(_form(max_recording_seconds="")).collect()
+        assert fields["max_recording_seconds"] == 60
+
+    def test_blank_device_becomes_none_not_empty_string(self):
+        """The service treats None as 'system default'; '' is not a device."""
+        assert _panel_with(_form(input_device="")).collect()["input_device"] is None
+
+    def test_named_device_is_preserved(self):
+        fields = _panel_with(_form(input_device="USB Audio")).collect()
+        assert fields["input_device"] == "USB Audio"
+
+
+class TestPersist:
+
+    def _panel_with_app(self, values: dict, existing: VoiceConfig):
+        panel = _panel_with(values)
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig(voice=existing)
+        app.voice_input_service = MagicMock()
+        app.voice_setup_service = MagicMock()
+        # Patched away: they touch widgets the stub does not serve.
+        panel._finish_save = MagicMock()  # type: ignore[method-assign]
+        panel._refresh_readiness = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel.persist()
+        return app
+
+    def test_persist_writes_the_nested_voice_config(self):
+        app = self._panel_with_app(_form(enabled=True), VoiceConfig())
+        kwargs = app.config_manager.update.call_args.kwargs
+        assert isinstance(kwargs["voice"], VoiceConfig)
+        assert kwargs["voice"].enabled is True
+
+    def test_persist_replaces_rather_than_rebuilds_the_config(self):
+        """Read-modify-write is what lets a later release add an unexposed field.
+
+        VoiceConfig currently has no field the panel leaves alone, so this
+        asserts the mechanism (a copy of the existing object with the panel's
+        fields applied) instead of the preservation it buys.
+        """
+        existing = VoiceConfig(model_size="tiny")
+        app = self._panel_with_app(_form(), existing)
+        saved = app.config_manager.update.call_args.kwargs["voice"]
+        assert saved is not existing
+        assert saved == dataclasses.replace(
+            existing,
+            enabled=True, model_size="small", language="en",
+            input_device=None, max_recording_seconds=60,
+        )
+
+    def test_persist_resets_the_service_availability_cache(self):
+        """A stale verdict would describe the settings just replaced."""
+        app = self._panel_with_app(_form(), VoiceConfig())
+        app.voice_input_service.reset_availability.assert_called_once()
+
+    def test_persist_rebinds_both_services_to_the_new_config(self):
+        app = self._panel_with_app(_form(model_size="base"), VoiceConfig())
+        saved = app.config_manager.update.call_args.kwargs["voice"]
+        assert app.voice_input_service._config is saved
+        assert app.voice_setup_service._config is saved
+
+    def test_persist_survives_a_missing_service(self):
+        panel = _panel_with(_form())
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig()
+        app.voice_input_service = None
+        app.voice_setup_service = None
+        panel._finish_save = MagicMock()  # type: ignore[method-assign]
+        panel._refresh_readiness = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel.persist()
+        app.config_manager.update.assert_called_once()
+
+
+class TestDirtyTracking:
+
+    def test_current_values_reflect_the_widgets(self):
+        values = _panel_with(_form(language="auto")).current_values()
+        assert values["language"] == "auto"
+        assert values["enabled"] is True
+
+    def test_values_are_stripped(self):
+        panel = VoicePanel()
+        stub = _StubWidgets(_form())
+        stub._widgets["#voice_language"].value = "  en  "
+        panel.query_one = stub.query_one  # type: ignore[method-assign]
+        assert panel.current_values()["language"] == "en"
+
+
+class TestHumanBytes:
+
+    @pytest.mark.parametrize("size,expected", [
+        (0, "0 B"),
+        (2048, "2 KB"),
+        (5 * 1024 * 1024, "5 MB"),
+    ])
+    def test_scales_to_a_readable_unit(self, size, expected):
+        assert VoicePanel._human_bytes(size) == expected
+
+    def test_gigabytes_get_a_decimal(self):
+        assert VoicePanel._human_bytes(3 * 1024 ** 3) == "3.0 GB"
+
+
+class TestBannerCopy:
+
+    def _banner_for(self, readiness, *, enabled=True) -> str:
+        panel = _panel_with(_form(enabled=enabled))
+        banner = MagicMock()
+        panel._readiness = readiness
+        original = panel.query_one
+
+        def query_one(selector, _type=None):
+            if selector == "#voice_status_banner":
+                return banner
+            return original(selector, _type)
+
+        panel.query_one = query_one  # type: ignore[method-assign]
+        panel._render_banner()
+        return banner.update.call_args[0][0]
+
+    def test_ready_and_enabled_tells_the_user_how_to_start(self):
+        text = self._banner_for(_readiness(), enabled=True)
+        assert "Ready" in text
+        assert "ctrl+t" in text
+
+    def test_ready_but_disabled_points_at_the_switch(self):
+        text = self._banner_for(_readiness(), enabled=False)
+        assert "switched off" in text
+
+    @pytest.mark.parametrize("missing,phrase", [
+        ("packages_ok", "Python packages"),
+        ("portaudio_ok", "PortAudio"),
+        ("device_ok", "no microphone"),
+        ("model_ok", "not downloaded"),
+    ])
+    def test_each_unmet_requirement_gets_its_own_wording(self, missing, phrase):
+        text = self._banner_for(_readiness(**{missing: False}))
+        assert phrase in text
+
+    def test_a_missing_setup_service_is_reported_not_crashed(self):
+        panel = _panel_with(_form())
+        banner = MagicMock()
+        panel.query_one = lambda s, t=None: banner  # type: ignore[method-assign]
+        app = MagicMock()
+        app.voice_setup_service = None
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._refresh_readiness()
+        assert "unavailable" in banner.update.call_args[0][0]
+
+
+class TestRequirementNotes:
+    """Row notes must not assert a cause that was never established."""
+
+    def test_microphone_is_not_blamed_on_ssh_before_any_probe_ran(self):
+        """Without PortAudio there was no enumeration to conclude anything from."""
+        note = requirement_note(
+            "device",
+            _readiness(packages_ok=True, portaudio_ok=False, device_ok=False),
+        )
+        assert note == "not checked yet"
+
+    def test_a_real_device_miss_explains_the_likely_cause(self):
+        note = requirement_note(
+            "device",
+            _readiness(packages_ok=True, portaudio_ok=True, device_ok=False),
+        )
+        assert "SSH" in note
+
+    def test_a_present_device_is_reported_as_detected(self):
+        assert requirement_note("device", _readiness()) == "detected"
+
+    def test_installed_packages_are_not_labelled_with_a_download_size(self):
+        """A pending-download note beside OK reads as outstanding work."""
+        note = requirement_note("packages", _readiness())
+        assert note == "installed"
+        assert "MB" not in note
+
+    def test_missing_packages_do_show_the_download_size(self):
+        assert "200 MB" in requirement_note("packages", _readiness(packages_ok=False))
+
+    def test_missing_portaudio_flags_that_it_needs_sudo(self):
+        """pip cannot install it, so the note must not imply the button will."""
+        note = requirement_note("portaudio", _readiness(portaudio_ok=False))
+        assert "sudo" in note
+
+    def test_unknown_requirement_yields_no_note(self):
+        assert requirement_note("nonsense", _readiness()) == ""

--- a/tests/test_voice_settings_panel.py
+++ b/tests/test_voice_settings_panel.py
@@ -313,3 +313,74 @@ class TestRequirementNotes:
 
     def test_unknown_requirement_yields_no_note(self):
         assert requirement_note("nonsense", _readiness()) == ""
+
+
+class TestChatPanelNotification:
+    """The mic button has to recover without an app restart.
+
+    This path failed silently once already: ``app.query()`` does not
+    traverse into screens, so an app-level search returned nothing even
+    with a chat panel mounted, and the broad except around it meant no
+    error surfaced — the microphone simply stayed greyed out.
+    """
+
+    def _panel_with_screens(self, screens):
+        panel = _panel_with(_form())
+        app = MagicMock()
+        app.screen_stack = screens
+        return panel, app
+
+    def test_every_screen_in_the_stack_is_searched(self):
+        chat_a, chat_b = MagicMock(), MagicMock()
+        screen_with = MagicMock()
+        screen_with.query.return_value = [chat_a]
+        screen_under = MagicMock()
+        screen_under.query.return_value = [chat_b]
+        panel, app = self._panel_with_screens([screen_under, screen_with])
+
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._notify_chat_panels()
+
+        chat_a.refresh_voice_affordance.assert_called_once()
+        chat_b.refresh_voice_affordance.assert_called_once()
+
+    def test_no_chat_panel_mounted_is_not_an_error(self):
+        screen = MagicMock()
+        screen.query.return_value = []
+        panel, app = self._panel_with_screens([screen])
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._notify_chat_panels()
+
+    def test_a_failing_panel_does_not_break_the_settings_save(self):
+        chat = MagicMock()
+        chat.refresh_voice_affordance.side_effect = RuntimeError("panel is going away")
+        screen = MagicMock()
+        screen.query.return_value = [chat]
+        panel, app = self._panel_with_screens([screen])
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._notify_chat_panels()
+
+    def test_a_forced_refresh_notifies_the_chat_panels(self):
+        """Forced refresh follows a setup action — the moment staleness bites."""
+        panel = _panel_with(_form())
+        setup = MagicMock()
+        setup.probe.return_value = _readiness()
+        panel._setup_service = lambda: setup  # type: ignore[method-assign]
+        panel._render_banner = MagicMock()  # type: ignore[method-assign]
+        panel._render_requirements = MagicMock()  # type: ignore[method-assign]
+        panel._notify_chat_panels = MagicMock()  # type: ignore[method-assign]
+
+        panel._refresh_readiness(force=True)
+        panel._notify_chat_panels.assert_called_once()
+
+    def test_an_unforced_refresh_does_not_churn_the_chat_panels(self):
+        panel = _panel_with(_form())
+        setup = MagicMock()
+        setup.probe.return_value = _readiness()
+        panel._setup_service = lambda: setup  # type: ignore[method-assign]
+        panel._render_banner = MagicMock()  # type: ignore[method-assign]
+        panel._render_requirements = MagicMock()  # type: ignore[method-assign]
+        panel._notify_chat_panels = MagicMock()  # type: ignore[method-assign]
+
+        panel._refresh_readiness()
+        panel._notify_chat_panels.assert_not_called()

--- a/tests/test_voice_settings_panel.py
+++ b/tests/test_voice_settings_panel.py
@@ -62,6 +62,7 @@ _FORM = {
     "#voice_language": "en",
     "#voice_input_device": "",
     "#voice_max_recording_seconds": "60",
+    "#voice_auto_submit": False,
 }
 
 
@@ -98,6 +99,7 @@ class TestValidation:
             "language": "en",
             "input_device": None,
             "max_recording_seconds": 60,
+            "auto_submit": False,
         }
 
     def test_blank_language_falls_back_to_english(self):
@@ -173,7 +175,7 @@ class TestPersist:
         assert saved == dataclasses.replace(
             existing,
             enabled=True, model_size="small", language="en",
-            input_device=None, max_recording_seconds=60,
+            input_device=None, max_recording_seconds=60, auto_submit=False,
         )
 
     def test_persist_resets_the_service_availability_cache(self):
@@ -384,3 +386,30 @@ class TestChatPanelNotification:
 
         panel._refresh_readiness()
         panel._notify_chat_panels.assert_not_called()
+
+
+class TestAutoSubmitSetting:
+    """Auto-submit must be opt-in and must round-trip."""
+
+    def test_auto_submit_is_off_by_default(self):
+        """A misheard word would reach an assistant that can run commands."""
+        assert VoiceConfig().auto_submit is False
+
+    def test_auto_submit_is_collected(self):
+        fields = _panel_with(_form(auto_submit=True)).collect()
+        assert fields["auto_submit"] is True
+
+    def test_auto_submit_reaches_the_saved_config(self):
+        panel = _panel_with(_form(auto_submit=True))
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig()
+        app.voice_input_service = None
+        app.voice_setup_service = None
+        panel._finish_save = MagicMock()  # type: ignore[method-assign]
+        panel._refresh_readiness = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel.persist()
+        assert app.config_manager.update.call_args.kwargs["voice"].auto_submit is True
+
+    def test_auto_submit_is_part_of_dirty_tracking(self):
+        assert _panel_with(_form(auto_submit=True)).current_values()["auto_submit"] is True

--- a/tests/test_voice_settings_panel.py
+++ b/tests/test_voice_settings_panel.py
@@ -537,3 +537,147 @@ class TestEngineFields:
         values = _panel_with(_form(engine="nemotron", latency=80)).current_values()
         assert values["engine"] == "nemotron"
         assert values["nemotron_latency_ms"] == 80
+
+
+class TestPendingSelectionDrivesActions:
+    """Setup actions must act on the dropdown, not the last-saved config.
+
+    Regression guard: pressing Download after picking a different engine
+    used to re-check the *previous* engine's model, find it cached, and
+    report instant success without fetching anything.
+    """
+
+    def _panel_and_service(self, *, saved_engine="whisper", picked_engine="nemotron"):
+        panel = _panel_with(_form(engine=picked_engine))
+        service = MagicMock()
+        service.download_size_hint_for.return_value = "~683 MB"
+        service._config = VoiceConfig(engine=saved_engine)
+        panel._setup_service = lambda: service  # type: ignore[method-assign]
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig(
+            voice=VoiceConfig(engine=saved_engine)
+        )
+        return panel, service, app
+
+    def test_sync_repoints_the_service_at_the_picked_engine(self):
+        panel, service, app = self._panel_and_service()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._sync_setup_service_config()
+        assert service._config.engine == "nemotron"
+
+    def test_sync_carries_the_picked_latency(self):
+        panel = _panel_with(_form(engine="nemotron", latency=80))
+        service = MagicMock()
+        service._config = VoiceConfig()
+        panel._setup_service = lambda: service  # type: ignore[method-assign]
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._sync_setup_service_config()
+        assert service._config.nemotron_latency_ms == 80
+
+    def test_sync_drops_the_cached_availability_verdict(self):
+        """A verdict cached for the old engine would describe the wrong model."""
+        panel, service, app = self._panel_and_service()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._sync_setup_service_config()
+        service.reset_availability.assert_called_once()
+
+    def test_sync_preserves_unrelated_voice_settings(self):
+        panel = _panel_with(_form(engine="nemotron"))
+        service = MagicMock()
+        service._config = VoiceConfig()
+        panel._setup_service = lambda: service  # type: ignore[method-assign]
+        app = MagicMock()
+        app.config_manager.get.return_value = AppConfig(
+            voice=VoiceConfig(auto_submit=True, max_recording_seconds=45)
+        )
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._sync_setup_service_config()
+        assert service._config.auto_submit is True
+        assert service._config.max_recording_seconds == 45
+
+    def test_download_syncs_before_dispatching(self):
+        panel, service, app = self._panel_and_service()
+        panel._show_download_progress = MagicMock()  # type: ignore[method-assign]
+        panel.run_worker = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._start_download()
+        assert service._config.engine == "nemotron"
+        panel.run_worker.assert_called_once()
+
+    def test_download_announces_the_picked_model(self):
+        """"Downloading the small model" while Nemotron is picked is a lie."""
+        panel, service, app = self._panel_and_service()
+        panel._show_download_progress = MagicMock()  # type: ignore[method-assign]
+        panel.run_worker = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._start_download()
+        announced = app.notify.call_args[0][0]
+        assert "Nemotron" in announced
+        assert "small" not in announced
+
+    def test_install_syncs_before_dispatching(self):
+        """Otherwise it installs the extra for the engine you switched away from."""
+        panel, service, app = self._panel_and_service()
+        panel.run_worker = MagicMock()  # type: ignore[method-assign]
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._start_install()
+        assert service._config.engine == "nemotron"
+
+    def test_sync_survives_a_missing_service(self):
+        panel = _panel_with(_form())
+        panel._setup_service = lambda: None  # type: ignore[method-assign]
+        app = MagicMock()
+        with patch.object(type(panel), 'app', property(lambda _self: app)):
+            panel._sync_setup_service_config()
+
+
+class TestDownloadProgress:
+    """A multi-hundred-megabyte download must show that it is progressing."""
+
+    def _panel_with_progress_widgets(self):
+        panel = VoicePanel()
+        widgets = {
+            "#voice_download_row": MagicMock(),
+            "#voice_download_label": MagicMock(),
+            "#voice_download_bar": MagicMock(),
+        }
+        panel.query_one = lambda sel, _t=None: widgets[sel]  # type: ignore[method-assign]
+        return panel, widgets
+
+    def test_known_total_drives_a_determinate_bar(self):
+        panel, widgets = self._panel_with_progress_widgets()
+        panel._render_download_progress("encoder.int8.onnx", 200 * 1024 ** 2, 683 * 1024 ** 2)
+        kwargs = widgets["#voice_download_bar"].update.call_args.kwargs
+        assert kwargs["total"] == 683 * 1024 ** 2
+        assert kwargs["progress"] == 200 * 1024 ** 2
+
+    def test_the_label_reports_both_figures(self):
+        panel, widgets = self._panel_with_progress_widgets()
+        panel._render_download_progress("encoder.int8.onnx", 200 * 1024 ** 2, 683 * 1024 ** 2)
+        label = widgets["#voice_download_label"].update.call_args[0][0]
+        assert "200 MB" in label
+        assert "683 MB" in label
+
+    def test_unknown_total_stays_indeterminate(self):
+        """The batch downloader reports nothing; a fake percentage would lie."""
+        panel, widgets = self._panel_with_progress_widgets()
+        panel._render_download_progress("model", 0, 0)
+        assert widgets["#voice_download_bar"].update.call_args.kwargs["total"] is None
+
+    def test_showing_reveals_the_row(self):
+        panel, widgets = self._panel_with_progress_widgets()
+        panel._show_download_progress("Starting")
+        widgets["#voice_download_row"].remove_class.assert_called_with("hidden")
+
+    def test_hiding_conceals_the_row(self):
+        panel, widgets = self._panel_with_progress_widgets()
+        panel._hide_download_progress()
+        widgets["#voice_download_row"].add_class.assert_called_with("hidden")
+
+    def test_progress_after_the_panel_closed_is_ignored(self):
+        panel = VoicePanel()
+        panel.query_one = MagicMock(side_effect=Exception("gone"))  # type: ignore[method-assign]
+        panel._render_download_progress("x", 1, 2)
+        panel._hide_download_progress()

--- a/tests/test_voice_setup_service.py
+++ b/tests/test_voice_setup_service.py
@@ -1,0 +1,543 @@
+"""Tests for the voice-input setup service: readiness, install, model cache.
+
+The optional voice dependencies are absent in CI, so the import-dependent
+paths are driven by injecting fake modules into ``sys.modules`` (the same
+approach ``test_ai_analysis_service.py`` takes for httpx). The filesystem
+paths are exercised against a real temp cache directory rather than mocks,
+because the bug they guard against — treating an interrupted download as a
+complete one — lives in the directory layout itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from servonaut.config.schema import VoiceConfig
+from servonaut.services.voice_setup_service import (
+    VOICE_PACKAGES,
+    VoiceReadiness,
+    VoiceSetupService,
+    build_voice_setup_service,
+)
+
+
+def run_async(coro):
+    """Run a coroutine synchronously for testing."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+@contextmanager
+def _fake_voice_modules(*, portaudio_ok: bool = True, devices=None):
+    """Install importable stand-ins for numpy / faster_whisper / sounddevice.
+
+    Args:
+        portaudio_ok: When False, importing ``sounddevice`` raises OSError —
+            the real failure mode when the system library is absent.
+        devices: Device list ``query_devices`` returns.
+    """
+    if devices is None:
+        devices = [{'max_input_channels': 2, 'name': 'Fake Mic'}]
+
+    numpy_mod = types.ModuleType('numpy')
+    fw_mod = types.ModuleType('faster_whisper')
+    fw_mod.WhisperModel = MagicMock(name='WhisperModel')
+
+    sd_mod = types.ModuleType('sounddevice')
+    sd_mod.query_devices = MagicMock(return_value=devices)
+
+    saved = {name: sys.modules.get(name) for name in
+             ('numpy', 'faster_whisper', 'sounddevice')}
+    sys.modules['numpy'] = numpy_mod
+    sys.modules['faster_whisper'] = fw_mod
+    if portaudio_ok:
+        sys.modules['sounddevice'] = sd_mod
+    else:
+        # A module that raises on import: drop it and make the finder fail.
+        sys.modules.pop('sounddevice', None)
+
+    try:
+        if portaudio_ok:
+            yield fw_mod
+        else:
+            real_import = __builtins__['__import__'] if isinstance(__builtins__, dict) \
+                else __builtins__.__import__
+
+            def _raising_import(name, *args, **kwargs):
+                if name == 'sounddevice':
+                    raise OSError("PortAudio library not found")
+                return real_import(name, *args, **kwargs)
+
+            with patch('builtins.__import__', side_effect=_raising_import):
+                yield fw_mod
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _service(**config_kwargs) -> VoiceSetupService:
+    return VoiceSetupService(VoiceConfig(**config_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# VoiceReadiness — the state machine the panel renders
+# ---------------------------------------------------------------------------
+
+class TestReadinessStateMachine:
+
+    def _readiness(self, **overrides) -> VoiceReadiness:
+        base = dict(
+            packages_ok=True, portaudio_ok=True, device_ok=True,
+            model_ok=True, model_size="small",
+        )
+        base.update(overrides)
+        return VoiceReadiness(**base)
+
+    def test_everything_present_is_ready(self):
+        readiness = self._readiness()
+        assert readiness.is_ready is True
+        assert readiness.next_step == ""
+
+    @pytest.mark.parametrize("missing,expected", [
+        ("packages_ok", "packages"),
+        ("portaudio_ok", "portaudio"),
+        ("device_ok", "device"),
+        ("model_ok", "model"),
+    ])
+    def test_next_step_names_the_missing_requirement(self, missing, expected):
+        readiness = self._readiness(**{missing: False})
+        assert readiness.is_ready is False
+        assert readiness.next_step == expected
+
+    def test_next_step_reports_the_earliest_unmet_requirement(self):
+        """Reporting a missing model to someone with no packages buries the lede."""
+        readiness = self._readiness(packages_ok=False, model_ok=False)
+        assert readiness.next_step == "packages"
+
+
+# ---------------------------------------------------------------------------
+# Probing
+# ---------------------------------------------------------------------------
+
+class TestProbe:
+
+    def test_missing_packages_report_packages_as_the_next_step(self):
+        readiness = _service().probe()
+        assert readiness.packages_ok is False
+        assert readiness.next_step == "packages"
+        assert readiness.is_ready is False
+
+    def test_probe_is_cached_until_forced(self):
+        service = _service()
+        with patch.object(service, '_probe_runtime',
+                          return_value=(False, False, False, "")) as probe:
+            service.probe()
+            service.probe()
+            assert probe.call_count == 1
+            service.probe(force=True)
+            assert probe.call_count == 2
+
+    def test_model_is_not_reported_missing_before_the_packages_are_there(self):
+        """model_ok stays False without a cache hit, but packages come first."""
+        service = _service()
+        with patch.object(service, 'is_model_cached') as cached:
+            readiness = service.probe()
+        cached.assert_not_called()
+        assert readiness.model_ok is False
+        assert readiness.next_step == "packages"
+
+    def test_present_packages_and_device_are_ready_when_the_model_is_cached(self):
+        service = _service()
+        with _fake_voice_modules():
+            with patch.object(service, 'is_model_cached', return_value=True):
+                readiness = service.probe(force=True)
+        assert readiness.packages_ok is True
+        assert readiness.portaudio_ok is True
+        assert readiness.device_ok is True
+        assert readiness.is_ready is True
+
+    def test_no_capture_device_is_reported_separately(self):
+        service = _service()
+        with _fake_voice_modules(devices=[{'max_input_channels': 0, 'name': 'Speakers'}]):
+            with patch.object(service, 'is_model_cached', return_value=True):
+                readiness = service.probe(force=True)
+        assert readiness.packages_ok is True
+        assert readiness.portaudio_ok is True
+        assert readiness.device_ok is False
+        assert readiness.next_step == "device"
+
+    def test_missing_portaudio_is_distinguished_from_missing_packages(self):
+        """The distinction matters: pip fixes one and cannot fix the other."""
+        service = _service()
+        with _fake_voice_modules(portaudio_ok=False):
+            readiness = service.probe(force=True)
+        assert readiness.packages_ok is True
+        assert readiness.portaudio_ok is False
+        assert readiness.next_step == "portaudio"
+
+
+# ---------------------------------------------------------------------------
+# Model cache inspection
+# ---------------------------------------------------------------------------
+
+class TestModelCache:
+
+    @pytest.fixture
+    def cache(self, tmp_path, monkeypatch):
+        """Point the hub cache at a temp dir via the documented env var."""
+        root = tmp_path / 'hub'
+        root.mkdir()
+        monkeypatch.setenv('HF_HUB_CACHE', str(root))
+        return root
+
+    def _make_model(self, root, size, *, with_weights=True, org="Systran"):
+        repo = root / f"models--{org}--faster-whisper-{size}"
+        snapshot = repo / 'snapshots' / 'abc123'
+        snapshot.mkdir(parents=True)
+        if with_weights:
+            (snapshot / 'model.bin').write_bytes(b'x' * 2048)
+        return repo
+
+    def test_absent_model_is_not_cached(self, cache):
+        assert _service().is_model_cached('small') is False
+
+    def test_downloaded_model_is_cached(self, cache):
+        self._make_model(cache, 'small')
+        assert _service().is_model_cached('small') is True
+
+    def test_interrupted_download_is_not_treated_as_cached(self, cache):
+        """The directory survives a cancelled download; the weights do not."""
+        self._make_model(cache, 'small', with_weights=False)
+        assert _service().is_model_cached('small') is False
+
+    def test_a_different_size_does_not_satisfy_the_check(self, cache):
+        self._make_model(cache, 'tiny')
+        assert _service().is_model_cached('small') is False
+
+    def test_cache_hit_survives_a_change_of_publishing_org(self, cache):
+        """Matched by glob so a repo rename does not read as a missing model."""
+        self._make_model(cache, 'small', org='SomeNewOrg')
+        assert _service().is_model_cached('small') is True
+
+    def test_cache_bytes_sums_the_weights(self, cache):
+        self._make_model(cache, 'small')
+        assert _service().model_cache_bytes('small') == 2048
+
+    def test_cache_bytes_is_zero_when_absent(self, cache):
+        assert _service().model_cache_bytes('small') == 0
+
+    def test_remove_model_deletes_the_cache_entry(self, cache):
+        repo = self._make_model(cache, 'small')
+        service = _service()
+        success, message = service.remove_model('small')
+        assert success is True
+        assert not repo.exists()
+        assert 'small' in message
+
+    def test_removing_an_absent_model_succeeds(self, cache):
+        """The requested end state already holds, so this is not a failure."""
+        success, _ = _service().remove_model('small')
+        assert success is True
+
+    def test_hf_home_is_honoured(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('HF_HUB_CACHE', raising=False)
+        monkeypatch.delenv('HUGGINGFACE_HUB_CACHE', raising=False)
+        monkeypatch.setenv('HF_HOME', str(tmp_path))
+        root = tmp_path / 'hub'
+        root.mkdir()
+        self._make_model(root, 'base')
+        assert _service(model_size='base').is_model_cached('base') is True
+
+    def test_download_size_hint_is_offered_for_every_dropdown_size(self):
+        service = _service()
+        for size in ('tiny', 'base', 'small', 'distil-small.en', 'medium'):
+            assert 'MB' in service.download_size_hint(size) or \
+                   'GB' in service.download_size_hint(size)
+
+    def test_unknown_size_hint_does_not_invent_a_number(self):
+        assert _service().download_size_hint('not-a-model') == 'size unknown'
+
+
+# ---------------------------------------------------------------------------
+# Install command construction
+# ---------------------------------------------------------------------------
+
+class TestInstallCommand:
+
+    def test_pipx_installs_use_inject(self):
+        """pip install into a pipx venv would land in the wrong environment."""
+        service = _service()
+        with patch.object(service, 'install_method', return_value='pipx'):
+            with patch('shutil.which', return_value='/usr/bin/pipx'):
+                argv = service.install_command()
+        assert argv[:3] == ['/usr/bin/pipx', 'inject', 'servonaut']
+        assert all(pkg in argv for pkg in VOICE_PACKAGES)
+
+    def test_pip_installs_target_the_running_interpreter(self):
+        service = _service()
+        with patch.object(service, 'install_method', return_value='pip'):
+            argv = service.install_command()
+        assert argv[0] == sys.executable
+        assert argv[1:3] == ['-m', 'pip']
+        assert all(pkg in argv for pkg in VOICE_PACKAGES)
+
+    def test_source_checkouts_are_not_auto_installed(self):
+        """Someone else owns that environment's dependencies."""
+        service = _service()
+        with patch.object(service, 'install_method', return_value='source'):
+            assert service.install_command() is None
+
+    def test_source_checkouts_get_the_extra_as_a_manual_command(self):
+        service = _service()
+        with patch.object(service, 'install_method', return_value='source'):
+            assert service.manual_install_command() == "pip install -e '.[voice]'"
+
+    def test_unknown_install_method_is_not_auto_installed(self):
+        service = _service()
+        with patch.object(service, 'install_method', return_value='unknown'):
+            assert service.install_command() is None
+            assert 'faster-whisper' in service.manual_install_command()
+
+    def test_pipx_without_a_pipx_binary_falls_back_to_manual(self):
+        service = _service()
+        with patch.object(service, 'install_method', return_value='pipx'):
+            with patch('shutil.which', return_value=None):
+                assert service.install_command() is None
+
+    def test_manual_command_is_the_runnable_argv_when_there_is_one(self):
+        service = _service()
+        with patch.object(service, 'install_method', return_value='pip'):
+            assert service.manual_install_command().startswith(sys.executable)
+
+
+class TestPortAudioCommand:
+
+    def test_macos_uses_brew(self):
+        service = _service()
+        with patch('servonaut.services.voice_setup_service.get_os', return_value='macos'):
+            assert service.portaudio_command() == 'brew install portaudio'
+
+    def test_debian_uses_apt(self):
+        service = _service()
+        with patch('servonaut.services.voice_setup_service.get_os', return_value='linux'):
+            with patch('servonaut.services.voice_setup_service.command_exists',
+                       side_effect=lambda c: c == 'apt-get'):
+                assert service.portaudio_command() == 'sudo apt install libportaudio2'
+
+    def test_fedora_uses_dnf(self):
+        service = _service()
+        with patch('servonaut.services.voice_setup_service.get_os', return_value='linux'):
+            with patch('servonaut.services.voice_setup_service.command_exists',
+                       side_effect=lambda c: c == 'dnf'):
+                assert service.portaudio_command() == 'sudo dnf install portaudio'
+
+    def test_unknown_distro_still_says_something_useful(self):
+        service = _service()
+        with patch('servonaut.services.voice_setup_service.get_os', return_value='linux'):
+            with patch('servonaut.services.voice_setup_service.command_exists',
+                       return_value=False):
+                assert 'PortAudio' in service.portaudio_command()
+
+
+# ---------------------------------------------------------------------------
+# Install execution
+# ---------------------------------------------------------------------------
+
+class _FakeProcess:
+    def __init__(self, returncode=0, output=b''):
+        self.returncode = returncode
+        self._output = output
+        self.killed = False
+
+    async def communicate(self):
+        return self._output, b''
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        return self.returncode
+
+
+class TestInstallPackages:
+
+    def test_source_checkout_refuses_and_explains(self):
+        service = _service()
+        with patch.object(service, 'install_command', return_value=None):
+            with patch.object(service, 'install_method', return_value='source'):
+                success, message = run_async(service.install_packages())
+        assert success is False
+        assert 'source checkout' in message
+
+    def test_successful_install_reloads_the_deps(self):
+        service = _service()
+        proc = _FakeProcess(returncode=0)
+        with patch.object(service, 'install_command', return_value=['pip', 'install']):
+            with patch('asyncio.create_subprocess_exec', return_value=proc):
+                with patch('servonaut.services.voice_input_service.reload_voice_deps',
+                           return_value=True) as reload:
+                    success, message = run_async(service.install_packages())
+        reload.assert_called_once()
+        assert success is True
+        assert 'installed' in message.lower()
+
+    def test_install_that_needs_a_restart_says_so(self):
+        """Packages on disk but not importable in this process is not a failure."""
+        service = _service()
+        proc = _FakeProcess(returncode=0)
+        with patch.object(service, 'install_command', return_value=['pip', 'install']):
+            with patch('asyncio.create_subprocess_exec', return_value=proc):
+                with patch('servonaut.services.voice_input_service.reload_voice_deps',
+                           return_value=False):
+                    with patch.object(service, 'probe') as probe:
+                        probe.return_value = VoiceReadiness(
+                            packages_ok=True, portaudio_ok=True, device_ok=True,
+                            model_ok=False, model_size='small',
+                        )
+                        success, message = run_async(service.install_packages())
+        assert success is True
+        assert 'Restart' in message
+
+    def test_missing_portaudio_after_install_names_the_system_command(self):
+        service = _service()
+        proc = _FakeProcess(returncode=0)
+        with patch.object(service, 'install_command', return_value=['pip', 'install']):
+            with patch('asyncio.create_subprocess_exec', return_value=proc):
+                with patch('servonaut.services.voice_input_service.reload_voice_deps',
+                           return_value=False):
+                    with patch.object(service, 'probe') as probe:
+                        probe.return_value = VoiceReadiness(
+                            packages_ok=True, portaudio_ok=False, device_ok=False,
+                            model_ok=False, model_size='small',
+                        )
+                        with patch.object(service, 'portaudio_command',
+                                          return_value='sudo apt install libportaudio2'):
+                            success, message = run_async(service.install_packages())
+        assert success is True
+        assert 'libportaudio2' in message
+
+    def test_failed_install_surfaces_the_tail_of_the_output(self):
+        service = _service()
+        proc = _FakeProcess(returncode=1, output=b'lots of noise\nERROR: no matching dist\n')
+        with patch.object(service, 'install_command', return_value=['pip', 'install']):
+            with patch('asyncio.create_subprocess_exec', return_value=proc):
+                success, message = run_async(service.install_packages())
+        assert success is False
+        assert 'no matching dist' in message
+
+    def test_unstartable_installer_is_reported_not_raised(self):
+        service = _service()
+        with patch.object(service, 'install_command', return_value=['nope']):
+            with patch('asyncio.create_subprocess_exec', side_effect=OSError('no such file')):
+                success, message = run_async(service.install_packages())
+        assert success is False
+        assert 'no such file' in message
+
+    def test_install_output_is_truncated(self):
+        service = _service()
+        proc = _FakeProcess(returncode=1, output=b'x' * 5000)
+        with patch.object(service, 'install_command', return_value=['pip', 'install']):
+            with patch('asyncio.create_subprocess_exec', return_value=proc):
+                _success, message = run_async(service.install_packages())
+        assert len(message) < 300
+
+
+# ---------------------------------------------------------------------------
+# Model download
+# ---------------------------------------------------------------------------
+
+class TestDownloadModel:
+
+    def test_download_requires_the_packages_first(self):
+        service = _service()
+        success, message = run_async(service.download_model('small'))
+        assert success is False
+        assert 'packages' in message.lower()
+
+    def test_successful_download_reports_the_size(self):
+        service = _service()
+        with patch.object(service, 'probe') as probe:
+            probe.return_value = VoiceReadiness(
+                packages_ok=True, portaudio_ok=True, device_ok=True,
+                model_ok=False, model_size='small',
+            )
+            with patch.object(service, '_download_model_blocking',
+                              return_value=(True, 'Downloaded the small model.')):
+                success, message = run_async(service.download_model('small'))
+        assert success is True
+        assert 'small' in message
+
+    def test_download_defaults_to_the_configured_size(self):
+        service = _service(model_size='tiny')
+        with patch.object(service, 'probe') as probe:
+            probe.return_value = VoiceReadiness(
+                packages_ok=True, portaudio_ok=True, device_ok=True,
+                model_ok=False, model_size='tiny',
+            )
+            with patch.object(service, '_download_model_blocking',
+                              return_value=(True, 'ok')) as blocking:
+                run_async(service.download_model())
+        blocking.assert_called_once_with('tiny')
+
+    def test_download_failure_is_reported_not_raised(self):
+        service = _service()
+        with patch.object(service, 'probe') as probe:
+            probe.return_value = VoiceReadiness(
+                packages_ok=True, portaudio_ok=True, device_ok=True,
+                model_ok=False, model_size='small',
+            )
+            with patch.object(service, '_download_model_blocking',
+                              return_value=(False, 'Download failed: disk full')):
+                success, message = run_async(service.download_model('small'))
+        assert success is False
+        assert 'disk full' in message
+
+    def test_download_invalidates_the_cached_readiness(self):
+        """A stale verdict would keep showing 'not downloaded' afterwards."""
+        service = _service()
+        with patch.object(service, 'probe') as probe:
+            probe.return_value = VoiceReadiness(
+                packages_ok=True, portaudio_ok=True, device_ok=True,
+                model_ok=False, model_size='small',
+            )
+            with patch.object(service, '_download_model_blocking',
+                              return_value=(True, 'ok')):
+                run_async(service.download_model('small'))
+        assert service._cached is None
+
+    def test_blocking_download_wraps_backend_errors(self):
+        service = _service()
+        fw = types.ModuleType('faster_whisper')
+        fw.WhisperModel = MagicMock(side_effect=RuntimeError('hub unreachable'))
+        saved = sys.modules.get('faster_whisper')
+        sys.modules['faster_whisper'] = fw
+        try:
+            success, message = service._download_model_blocking('small')
+        finally:
+            if saved is None:
+                sys.modules.pop('faster_whisper', None)
+            else:
+                sys.modules['faster_whisper'] = saved
+        assert success is False
+        assert 'hub unreachable' in message
+
+
+class TestFactory:
+
+    def test_factory_returns_a_configured_service(self):
+        config = VoiceConfig(model_size='base')
+        service = build_voice_setup_service(config)
+        assert isinstance(service, VoiceSetupService)
+        assert service._config is config

--- a/tests/test_voice_setup_service.py
+++ b/tests/test_voice_setup_service.py
@@ -403,7 +403,7 @@ class TestInstallPackages:
                            return_value=False):
                     with patch.object(service, 'probe') as probe:
                         probe.return_value = VoiceReadiness(
-                            packages_ok=True, portaudio_ok=True, device_ok=True,
+                            packages_ok=False, portaudio_ok=True, device_ok=True,
                             model_ok=False, model_size='small',
                         )
                         success, message = run_async(service.install_packages())
@@ -473,7 +473,7 @@ class TestDownloadModel:
                 packages_ok=True, portaudio_ok=True, device_ok=True,
                 model_ok=False, model_size='small',
             )
-            with patch.object(service, '_download_model_blocking',
+            with patch.object(service, '_download_whisper_blocking',
                               return_value=(True, 'Downloaded the small model.')):
                 success, message = run_async(service.download_model('small'))
         assert success is True
@@ -486,7 +486,7 @@ class TestDownloadModel:
                 packages_ok=True, portaudio_ok=True, device_ok=True,
                 model_ok=False, model_size='tiny',
             )
-            with patch.object(service, '_download_model_blocking',
+            with patch.object(service, '_download_whisper_blocking',
                               return_value=(True, 'ok')) as blocking:
                 run_async(service.download_model())
         blocking.assert_called_once_with('tiny')
@@ -498,7 +498,7 @@ class TestDownloadModel:
                 packages_ok=True, portaudio_ok=True, device_ok=True,
                 model_ok=False, model_size='small',
             )
-            with patch.object(service, '_download_model_blocking',
+            with patch.object(service, '_download_whisper_blocking',
                               return_value=(False, 'Download failed: disk full')):
                 success, message = run_async(service.download_model('small'))
         assert success is False
@@ -512,7 +512,7 @@ class TestDownloadModel:
                 packages_ok=True, portaudio_ok=True, device_ok=True,
                 model_ok=False, model_size='small',
             )
-            with patch.object(service, '_download_model_blocking',
+            with patch.object(service, '_download_whisper_blocking',
                               return_value=(True, 'ok')):
                 run_async(service.download_model('small'))
         assert service._cached is None
@@ -524,7 +524,7 @@ class TestDownloadModel:
         saved = sys.modules.get('faster_whisper')
         sys.modules['faster_whisper'] = fw
         try:
-            success, message = service._download_model_blocking('small')
+            success, message = service._download_whisper_blocking('small')
         finally:
             if saved is None:
                 sys.modules.pop('faster_whisper', None)


### PR DESCRIPTION
Adds voice dictation to the AI chat panel. Speech is transcribed entirely on
the local machine — audio never leaves the workstation and no transcription
service is contacted.

The feature is opt-in and downloads nothing by default: its dependencies live
behind optional extras, `voice.enabled` defaults to off, and neither the
packages nor the model weights are fetched without an explicit click.

## Using it

Enable it in **Settings → AI → Voice Input**, then press the microphone button
in the chat input row or `ctrl+t` while the input is focused. Press again to
stop.

The transcript lands in the input box to review and send. It is never sent
automatically unless **Send dictation automatically** is switched on, which is
off by default — the assistant can run commands, and with auto-submit on a
misheard word would reach it unedited.

Recordings are capped (60 seconds by default) so a control left on cannot fill
memory, and a dictation that hits the cap says so rather than silently
truncating. Dictated text is redacted in demo mode like every other on-screen
surface.

## Two engines

Selectable in the settings panel.

**Whisper** (default, `pip install 'servonaut[voice]'`) records and then
transcribes. Smaller download, very accurate; a spinner runs on the microphone
button while it decodes. Sizes from `tiny` (~75 MB) to `medium` (~1.5 GB),
defaulting to `small` (~490 MB).

**Nemotron streaming** (`pip install 'servonaut[voice-streaming]'`) decodes as
the audio arrives, so words appear in the input box while you are still
speaking. It decodes frame-synchronously rather than re-reading a widening
buffer, so the text only ever grows — nothing already shown gets rewritten.
Larger download (~683 MB), and a configurable chunk size (80–1120 ms) trading
a little accuracy for how soon words appear.

## Guided setup

Voice input has four independent requirements — Python packages, the PortAudio
system library, a capture device, and model weights — and PortAudio cannot be
installed by pip at all, being a system library.

The settings panel therefore reports each requirement separately and offers the
action for whichever is unmet, rather than one button that could half-succeed:

- an install that targets the environment Servonaut was installed into
  (`pipx inject` or `pip`, detected automatically)
- a copyable, distribution-specific command for PortAudio
- a model download that states its size in the button label and shows progress

## Managing disk space

Each model is several hundred megabytes, and switching engine or size would
otherwise strand the previous download in a cache directory that is easy to
forget.

The panel lists every model present with its size and marks which is in use,
with a button to remove the rest. Switching also prompts directly after
saving, naming what is now unused and how much removing it would reclaim.
Nothing is deleted without confirmation — keeping both models is reasonable if
you switch back and forth.

## Notes

Capture and decoding run off the UI thread, so a dictation neither stalls the
interface nor interrupts a streaming reply. Small speech models fumble
hostnames and instance IDs; transcription is biased with the names of the
instances currently on screen, which helps with proper nouns, but identifiers
are still better typed than spoken.

Documentation: [`docs/voice-input.md`](docs/voice-input.md).

Tests accompany each part — the engine registry, both input services, setup
and download, and the settings panel.
