### PR TITLE
fix(ai): keep the soft-cap badge from naming the downgraded model

### DIFF
--- a/src/servonaut/utils/formatting.py
+++ b/src/servonaut/utils/formatting.py
@@ -225,32 +225,28 @@ def format_resets_at(iso_str: str) -> str:
 def format_soft_cap_badge(
     soft_capped: bool,
     hard_capped: bool,
-    model: Optional[str] = None,
 ) -> Optional[str]:
     """Pick the right cap badge string for the chat panel.
 
     Hard cap takes precedence — if a user is hard-capped the soft-cap state is
     irrelevant to the user-facing badge.
 
+    The downgrade wording is deliberately generic. Which model the hosted
+    service swapped to is not disclosed, so the badge must not name it — an
+    earlier version interpolated the model id from the ``usage`` event.
+
     Args:
         soft_capped: True iff server force-downgraded to a faster model.
         hard_capped: True iff token quota is fully exhausted.
-        model: Optional model name from the latest ``usage`` event. When
-            present and only ``soft_capped`` is true the badge reads
-            ``"downgraded to <model>"``; absent → generic
-            ``"downgraded to faster model"`` (D3 — never hardcode "Flash").
 
     Returns:
         ``"out of tokens"`` when ``hard_capped`` is true (regardless of soft).
-        ``"downgraded to <model>"`` or ``"downgraded to faster model"`` when
-        only ``soft_capped`` is true.
+        ``"downgraded to faster model"`` when only ``soft_capped`` is true.
         ``None`` otherwise — caller hides the badge widget.
     """
     if hard_capped:
         return "out of tokens"
     if soft_capped:
-        if model:
-            return f"downgraded to {model}"
         return "downgraded to faster model"
     return None
 

--- a/src/servonaut/widgets/chat_panel.py
+++ b/src/servonaut/widgets/chat_panel.py
@@ -593,12 +593,9 @@ class ChatPanel(Widget):
         # who never authenticate.
         try:
             from servonaut.utils.formatting import format_soft_cap_badge
-            # D3 — pass the latest usage.model so the badge reads
-            # "downgraded to <actual-model>" rather than hardcoding "Flash".
             badge = format_soft_cap_badge(
                 self._last_soft_capped,
                 self._last_hard_capped,
-                model=self._model or None,
             )
             if badge:
                 colour = "red" if self._last_hard_capped else "yellow"

--- a/tests/test_ai_quota_formatters.py
+++ b/tests/test_ai_quota_formatters.py
@@ -124,22 +124,13 @@ class TestFormatSoftCapBadge:
             "out of tokens"
         )
 
-    def test_soft_cap_badge_soft_only_with_model(self):
-        """Soft-only with explicit model renders the dynamic downgrade label.
+    def test_soft_cap_badge_never_names_the_model(self):
+        """Soft-only renders a generic label that does not name a model.
 
-        D3 — "downgraded to Flash" was hardcoded; now the badge uses the
-        model name from the latest ``usage`` event when available so the
-        UX reflects whatever model the server actually swapped to.
-        """
-        assert format_soft_cap_badge(
-            soft_capped=True, hard_capped=False, model="gemini-2-flash-002"
-        ) == "downgraded to gemini-2-flash-002"
-
-    def test_soft_cap_badge_soft_only_without_model(self):
-        """Soft-only without a model renders a generic faster-model label.
-
-        D3 — when ``model`` is omitted the badge falls back to the generic
-        "downgraded to faster model" text rather than hardcoding "Flash".
+        Which model the hosted service downgraded to is not disclosed, so
+        the badge stays generic. An earlier version accepted a ``model``
+        argument and rendered "downgraded to <model>"; the parameter is
+        gone and the wording must not regress to naming anything.
         """
         assert format_soft_cap_badge(
             soft_capped=True, hard_capped=False

--- a/tests/test_aws3_coverage_gaps.py
+++ b/tests/test_aws3_coverage_gaps.py
@@ -1520,13 +1520,10 @@ class TestFormatSoftCapBadge:
     def test_hard_capped_returns_out_of_tokens(self) -> None:
         assert format_soft_cap_badge(False, True) == "out of tokens"
 
-    def test_soft_capped_with_model(self) -> None:
-        result = format_soft_cap_badge(True, False, model="gemini-flash")
-        assert result == "downgraded to gemini-flash"
-
-    def test_soft_capped_without_model(self) -> None:
+    def test_soft_capped_stays_generic(self) -> None:
+        # The badge deliberately does not name the model it downgraded to.
         result = format_soft_cap_badge(True, False)
-        assert "faster model" in result
+        assert result == "downgraded to faster model"
 
     def test_neither_returns_none(self) -> None:
         assert format_soft_cap_badge(False, False) is None


### PR DESCRIPTION
## What

When a Servonaut AI user hits the soft token cap, the chat panel's stats bar
shows a badge explaining why responses changed. That badge named the model the
service had switched to:

```
downgraded to <model id>
```

It now reads:

```
downgraded to faster model
```

Which model the hosted service falls back to is not part of the product
surface, and this badge was the only place it appeared.

## Changes

- `widgets/chat_panel.py` — no longer passes the latest usage event's model
  into `format_soft_cap_badge`.
- `utils/formatting.py` — removes the now-unused `model` parameter. After the
  call-site change no caller supplied it (`cli/ai.py` already called it with
  two positional arguments), and leaving the parameter in place would let the
  wording regress. The generic branch it now always takes already existed.
- Tests — the two cases that asserted the model-naming behaviour now assert
  the opposite invariant, so the rule stays covered.

## Impact

No configuration change and no user action required. Behaviour is identical
unless you are soft-capped, where only the badge wording differs. The
`Model:` field in the same stats bar is unaffected.
