### PR TITLE
fix(mcp): cap the MCP SDK below 2.x and guard the API it uses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,14 @@ test = [
     "pytest-asyncio>=0.21",
     "pytest-timeout>=2.3",
 ]
-mcp = ["mcp>=1.0.0"]
+# Upper-bounded on purpose. The 2.x SDK replaced the low-level Server's
+# decorator registration (@server.list_tools()) with constructor-based
+# on_list_tools= / on_call_tool= handlers, changed the handler signature,
+# and moved the types into a separate mcp_types package. Installing it
+# against this codebase fails at start-up with
+# "'Server' object has no attribute 'list_tools'". Lift the cap in the
+# same change that ports mcp/server.py to the new API.
+mcp = ["mcp>=1.0.0,<2"]
 ovh = ["ovh"]
 hetzner = ["hcloud>=2.0"]
 # Local speech-to-text for voice input. sounddevice needs the PortAudio
@@ -64,7 +71,8 @@ ai = []
 sync = []
 keyring = []
 all = [
-    "mcp>=1.0.0",
+    # Upper bound mirrors the `mcp` extra above — see the note there.
+    "mcp>=1.0.0,<2",
     "ovh",
     "hcloud>=2.0",
     "keyring>=24",

--- a/tests/test_mcp_sdk_contract.py
+++ b/tests/test_mcp_sdk_contract.py
@@ -1,0 +1,102 @@
+"""Guard the MCP SDK surface that :pymod:`servonaut.mcp.server` builds on.
+
+``create_mcp_server`` registers its handlers with the low-level SDK's
+decorator API::
+
+    server = Server("servonaut", instructions=...)
+
+    @server.list_tools()
+    async def list_tools(): ...
+
+    @server.call_tool()
+    async def call_tool(name, arguments): ...
+
+Nothing else in the suite executes that registration — the other MCP tests
+import ``_dispatch_tool`` and the tools module directly, so the decorators
+are never touched. That left a gap: SDK 2.x replaced this API with
+constructor-based ``on_list_tools=`` / ``on_call_tool=`` handlers, and the
+only symptom was ``'Server' object has no attribute 'list_tools'`` when a
+user actually started the server. The suite stayed green throughout.
+
+These tests are deliberately about the *SDK contract*, not our logic. They
+run the same construction and registration a real start-up performs, without
+initialising any services, so an incompatible SDK fails here instead of in
+someone's terminal. When the port to 2.x happens, this file changes with it.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+class TestServerConstruction:
+    def test_server_accepts_name_and_instructions(self):
+        """``Server(name, instructions=...)`` is the constructor we call."""
+        from mcp.server import Server
+
+        server = Server("servonaut-test", instructions="test instructions")
+        assert server is not None
+
+    def test_decorator_registration_is_available(self):
+        """The decorator API must exist and accept our handler signatures.
+
+        Mirrors ``create_mcp_server`` exactly: a nullary ``list_tools`` and a
+        ``call_tool`` taking ``(name, arguments)``. A signature change on
+        either one breaks dispatch just as surely as a missing attribute.
+        """
+        from mcp.server import Server
+
+        server = Server("servonaut-test")
+
+        @server.list_tools()
+        async def list_tools():
+            return []
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict):
+            return []
+
+        assert callable(list_tools)
+        assert callable(call_tool)
+
+    def test_initialization_options_are_buildable(self):
+        """``run_server`` passes this into ``server.run`` on every start-up."""
+        from mcp.server import Server
+
+        server = Server("servonaut-test")
+        assert server.create_initialization_options() is not None
+
+
+class TestStdioTransport:
+    def test_stdio_server_is_importable(self):
+        """``run_server`` imports this lazily, so a move would surface late."""
+        from mcp.server.stdio import stdio_server
+
+        assert stdio_server is not None
+
+
+class TestToolTypes:
+    def test_tool_and_text_content_are_importable(self):
+        """``tool_schemas`` builds ``Tool``; dispatch wraps results in ``TextContent``."""
+        from mcp.types import TextContent, Tool
+
+        assert Tool is not None
+        assert TextContent is not None
+
+    def test_tool_list_builds_against_the_installed_sdk(self):
+        """The real schema registry must instantiate under this SDK.
+
+        ``mcp_tool_list`` constructs one ``Tool`` per entry, so a change to
+        that model's required fields shows up here rather than at start-up.
+        """
+        from servonaut.mcp.tool_schemas import mcp_tool_list
+
+        tools = mcp_tool_list(
+            have_ovh=False,
+            have_hetzner=False,
+            have_ip_ban=False,
+            have_memory=False,
+        )
+        assert len(tools) > 0
+        assert all(t.name and t.inputSchema is not None for t in tools)


### PR DESCRIPTION
## What

The `mcp` extra declared an unbounded `mcp>=1.0.0`, so a fresh
`pip install 'servonaut[mcp]'` (or `[all]`) now resolves the 2.x SDK, which
removed the low-level server API this codebase builds on. `servonaut --mcp`
then fails at start-up:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

Anyone who installed or upgraded since the 2.x release has a non-starting MCP
server. This caps the constraint at `<2` so installs resolve a working SDK
again.

## Why not port to 2.x here

Two separate breaking changes, both confirmed by running the suite against
the 2.x SDK:

1. Decorator registration (`@server.list_tools()` / `@server.call_tool()`) is
   replaced by constructor-based `on_list_tools=` / `on_call_tool=` handlers,
   with different signatures and `Result`-typed returns.
2. `mcp.types.Tool.inputSchema` is renamed `input_schema`, which affects every
   entry `mcp_tool_list` builds.

That is a real port with its own testing, not a drive-by. Capping restores
working installs now; the cap comment names the condition for lifting it.

## Why CI did not catch this

CI installs the `mcp` extra, so it was already resolving the 2.x SDK and
still reporting green. No test calls `create_mcp_server` — the existing MCP
tests import `_dispatch_tool` and the tools module directly, so the handler
registration that breaks was never executed. The failure only appeared when
a user started the server.

`tests/test_mcp_sdk_contract.py` closes that gap. It performs the same
construction and handler registration a real start-up does, without
initialising any services, and builds the real tool list. Both breaking
changes above fail it under the 2.x SDK; all six tests pass under 1.x.

## Impact

Users on a working install see no change. Users whose MCP server stopped
starting get a working resolution on their next install or upgrade. To
recover an existing environment without waiting for a release:

```
pipx runpip servonaut install 'mcp<2'
```
