### PR TITLE
test(mcp): make the SDK guard fail only on real incompatibilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,31 @@ test = [
     "pytest-asyncio>=0.21",
     "pytest-timeout>=2.3",
 ]
-# Upper-bounded on purpose. The 2.x SDK replaced the low-level Server's
-# decorator registration (@server.list_tools()) with constructor-based
-# on_list_tools= / on_call_tool= handlers, changed the handler signature,
-# and moved the types into a separate mcp_types package. Installing it
-# against this codebase fails at start-up with
-# "'Server' object has no attribute 'list_tools'". Lift the cap in the
-# same change that ports mcp/server.py to the new API.
+# Upper-bounded on purpose, and on the SDK maintainers' own advice to
+# library publishers. The 2.x SDK replaced the low-level Server's decorator
+# registration (@server.list_tools()) with constructor-based on_list_tools= /
+# on_call_tool= handlers, and removed automatic wrapping of handler return
+# values. Installing it against this codebase fails at start-up with
+# "'Server' object has no attribute 'list_tools'".
+#
+# Deferred rather than blocked: 2.x exists to carry the stateless
+# per-request-envelope protocol, which targets horizontal scaling behind a
+# load balancer. This is a local stdio server, and that protocol revision
+# cannot be reached through the initialize handshake anyway, so porting
+# would buy no capability we can currently use. 1.x keeps receiving
+# critical bug fixes and security patches.
+#
+# Lift the cap and port mcp/server.py when any of these becomes true:
+#   1. We add an HTTP / remote transport, making stateless scaling relevant.
+#   2. A client we support requires the 2026-07-28 protocol revision.
+#   3. 1.x reaches end of life, or a security issue lands unpatched there.
+#   4. We want a 2.x-only feature (Multi Round-Trip Requests, standard
+#      error codes, deprecation annotations).
+#
+# The port itself is contained: handler registration plus wrapping the
+# dispatch return in CallToolResult / ListToolsResult. Imports, Tool
+# construction, stdio and run() are unaffected — see
+# tests/test_mcp_sdk_contract.py, which pins that surface.
 mcp = ["mcp>=1.0.0,<2"]
 ovh = ["ovh"]
 hetzner = ["hcloud>=2.0"]

--- a/tests/test_mcp_sdk_contract.py
+++ b/tests/test_mcp_sdk_contract.py
@@ -99,4 +99,15 @@ class TestToolTypes:
             have_memory=False,
         )
         assert len(tools) > 0
-        assert all(t.name and t.inputSchema is not None for t in tools)
+        for tool in tools:
+            assert tool.name
+            # Assert through the serialised wire form rather than attribute
+            # access. 1.x names the field ``inputSchema``; 2.x renames it
+            # ``input_schema`` behind that alias, so ``tool.inputSchema``
+            # raises there — for a rename that does not actually break us,
+            # since construction takes the alias and the wire output is
+            # unchanged. A false failure here would drown out the real
+            # incompatibility this file exists to catch. ``by_alias=True``
+            # emits ``inputSchema`` identically on both lines.
+            dumped = tool.model_dump(by_alias=True)
+            assert dumped.get("inputSchema") is not None


### PR DESCRIPTION
## What

Follow-up to the MCP SDK dependency cap. Two refinements, no behaviour change.

### The SDK guard was failing on a non-break

`tests/test_mcp_sdk_contract.py` asserted `tool.inputSchema`, which raises on
the 2.x SDK. That rename does not actually break this codebase: 2.x renames the
field to `input_schema` behind an `inputSchema` alias, so construction still
accepts the camelCase keyword and the serialised wire form is unchanged.
`tool_schemas.py` needs no edit.

A guard that fails on a non-break is worse than no guard — the false signal sits
next to the genuine one (decorator registration is gone) and makes the
incompatibility look broader than it is. The assertion now goes through
`model_dump(by_alias=True)`, which emits `inputSchema` identically on both SDK
lines, so the test tracks the wire contract rather than an internal attribute
name.

Verified: 6/6 pass on 1.x. Under 2.0.0 the file now fails exactly once, on the
decorator test — previously twice.

### The dependency cap now explains itself

The `mcp<2` comment in `pyproject.toml` gains the conditions that should lift it
and the reason the port is deferred rather than blocked: the 2.x SDK carries the
stateless per-request-envelope protocol, which targets horizontal scaling behind
a load balancer and cannot be negotiated through the initialize handshake. For a
local stdio server it buys no reachable capability, and the 1.x line continues to
receive critical bug fixes and security patches.

The comment also records what the port would involve, so the scope does not have
to be rediscovered: handler registration plus wrapping the dispatch return.
Imports, `Tool` construction, stdio and `run()` are unaffected.

## Impact

None at runtime. Test-only change plus a comment.
