### PR TITLE
fix(s3): honour the target region for bucket and object operations

### DIFF
--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -1684,6 +1684,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "description": "Delimiter for virtual folder grouping (default: '/').",
                     "default": "/",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
+                },
             },
             "required": ["provider", "bucket"],
         },
@@ -1716,6 +1725,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "string",
                     "description": "Local file path to write the downloaded object to.",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
+                },
             },
             "required": ["provider", "bucket", "key", "local_path"],
         },
@@ -1739,6 +1757,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "string",
                     "description": "Bucket name to create.",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region to create the bucket in (e.g. 'eu-central-1'). "
+                        "Omit to use the configured region for the provider. "
+                        "AWS only — for Hetzner/OVH the region is fixed by the "
+                        "configured endpoint URL and an override is rejected."
+                    ),
+                },
             },
             "required": ["provider", "bucket"],
         },
@@ -1761,6 +1788,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 "bucket": {
                     "type": "string",
                     "description": "Bucket name to delete (must be empty).",
+                },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
                 },
             },
             "required": ["provider", "bucket"],
@@ -1793,6 +1829,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "string",
                     "description": "Local file path to upload.",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
+                },
             },
             "required": ["provider", "bucket", "key", "local_path"],
         },
@@ -1819,6 +1864,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                 "key": {
                     "type": "string",
                     "description": "Object key to delete.",
+                },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
                 },
             },
             "required": ["provider", "bucket", "key"],
@@ -1855,6 +1909,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "string",
                     "description": "Destination object key.",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the DESTINATION bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
+                },
             },
             "required": ["provider", "src_bucket", "src_key", "dst_bucket", "dst_key"],
         },
@@ -1890,6 +1953,22 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "string",
                     "description": "Destination object key.",
                 },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the DESTINATION bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
+                },
+                "src_region": {
+                    "type": "string",
+                    "description": (
+                        "Region the SOURCE bucket lives in. Only needed when the "
+                        "source and destination are in different regions."
+                    ),
+                },
             },
             "required": ["provider", "src_bucket", "src_key", "dst_bucket", "dst_key"],
         },
@@ -1922,6 +2001,15 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "type": "integer",
                     "description": "URL expiry in seconds (1–604800, default 3600).",
                     "default": 3600,
+                },
+                "region": {
+                    "type": "string",
+                    "description": (
+                        "Region the bucket lives in (e.g. 'eu-central-1'). "
+                        "Omit unless you know it — it is resolved automatically. "
+                        "AWS only; rejected for Hetzner/OVH, whose region is fixed "
+                        "by the configured endpoint URL."
+                    ),
                 },
             },
             "required": ["provider", "bucket", "key"],

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -3811,11 +3811,12 @@ class ServonautTools:
         bucket: str,
         prefix: str = '',
         delimiter: str = '/',
+        region: str = '',
     ) -> str:
         """List objects and virtual-folder prefixes in an S3 bucket."""
         payload: Dict[str, Any] = {
             'provider': provider, 'bucket': bucket,
-            'prefix': prefix, 'delimiter': delimiter,
+            'prefix': prefix, 'delimiter': delimiter, 'region': region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_list_objects', payload)
         if err is not None:
@@ -3827,7 +3828,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            data = await svc.list_objects(bucket, prefix, delimiter)
+            data = await svc.list_objects(bucket, prefix, delimiter, region)
         except ValueError as exc:
             self._audit.log('s3_list_objects', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3847,11 +3848,12 @@ class ServonautTools:
 
     async def s3_download_object(
         self, provider: str, bucket: str, key: str, local_path: str,
+        region: str = '',
     ) -> str:
         """Download an S3 object to a local file."""
         payload: Dict[str, Any] = {
             'provider': provider, 'bucket': bucket,
-            'key': key, 'local_path': local_path,
+            'key': key, 'local_path': local_path, 'region': region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_download_object', payload)
         if err is not None:
@@ -3863,7 +3865,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.download_object(bucket, key, local_path)
+            await svc.download_object(bucket, key, local_path, region)
         except ValueError as exc:
             self._audit.log('s3_download_object', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3877,9 +3879,13 @@ class ServonautTools:
         self._audit.log('s3_download_object', payload, result, True)
         return result
 
-    async def s3_create_bucket(self, provider: str, bucket: str) -> str:
+    async def s3_create_bucket(
+        self, provider: str, bucket: str, region: str = "",
+    ) -> str:
         """Create a new S3 bucket on the given provider."""
-        payload: Dict[str, Any] = {'provider': provider, 'bucket': bucket}
+        payload: Dict[str, Any] = {
+            'provider': provider, 'bucket': bucket, 'region': region,
+        }
         svc, err = self._validate_s3_provider(provider, 's3_create_bucket', payload)
         if err is not None:
             return err
@@ -3890,7 +3896,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.create_bucket(bucket)
+            await svc.create_bucket(bucket, region)
         except ValueError as exc:
             self._audit.log('s3_create_bucket', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3898,13 +3904,25 @@ class ServonautTools:
             self._audit.log('s3_create_bucket', payload, '', False, f"api_error: {exc}")
             return f"Error creating {provider} S3 bucket {bucket!r}: {exc}"
 
-        result = f"Created {provider} S3 bucket {bucket!r}."
+        # Report where it actually landed: the explicit override, else the
+        # provider's configured region, else the credential chain's default.
+        configured = getattr(svc, 'region', '')
+        where = region or (configured if isinstance(configured, str) else '')
+        result = (
+            f"Created {provider} S3 bucket {bucket!r} in region {where}."
+            if where
+            else f"Created {provider} S3 bucket {bucket!r} in the account default region."
+        )
         self._audit.log('s3_create_bucket', payload, result, True)
         return result
 
-    async def s3_delete_bucket(self, provider: str, bucket: str) -> str:
+    async def s3_delete_bucket(
+        self, provider: str, bucket: str, region: str = '',
+    ) -> str:
         """Delete an empty S3 bucket."""
-        payload: Dict[str, Any] = {'provider': provider, 'bucket': bucket}
+        payload: Dict[str, Any] = {
+            'provider': provider, 'bucket': bucket, 'region': region,
+        }
         svc, err = self._validate_s3_provider(provider, 's3_delete_bucket', payload)
         if err is not None:
             return err
@@ -3915,7 +3933,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.delete_bucket(bucket)
+            await svc.delete_bucket(bucket, region)
         except ValueError as exc:
             self._audit.log('s3_delete_bucket', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3929,11 +3947,12 @@ class ServonautTools:
 
     async def s3_upload_object(
         self, provider: str, bucket: str, key: str, local_path: str,
+        region: str = '',
     ) -> str:
         """Upload a local file to an S3 bucket."""
         payload: Dict[str, Any] = {
             'provider': provider, 'bucket': bucket,
-            'key': key, 'local_path': local_path,
+            'key': key, 'local_path': local_path, 'region': region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_upload_object', payload)
         if err is not None:
@@ -3945,7 +3964,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.upload_object(bucket, key, local_path)
+            await svc.upload_object(bucket, key, local_path, region)
         except ValueError as exc:
             self._audit.log('s3_upload_object', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3965,10 +3984,12 @@ class ServonautTools:
         return result
 
     async def s3_delete_object(
-        self, provider: str, bucket: str, key: str,
+        self, provider: str, bucket: str, key: str, region: str = '',
     ) -> str:
         """Delete a single object from S3."""
-        payload: Dict[str, Any] = {'provider': provider, 'bucket': bucket, 'key': key}
+        payload: Dict[str, Any] = {
+            'provider': provider, 'bucket': bucket, 'key': key, 'region': region,
+        }
         svc, err = self._validate_s3_provider(provider, 's3_delete_object', payload)
         if err is not None:
             return err
@@ -3979,7 +4000,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.delete_object(bucket, key)
+            await svc.delete_object(bucket, key, region)
         except ValueError as exc:
             self._audit.log('s3_delete_object', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -3998,11 +4019,12 @@ class ServonautTools:
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = '',
     ) -> str:
         """Server-side copy of an S3 object within the same provider."""
         payload: Dict[str, Any] = {
             'provider': provider, 'src_bucket': src_bucket, 'src_key': src_key,
-            'dst_bucket': dst_bucket, 'dst_key': dst_key,
+            'dst_bucket': dst_bucket, 'dst_key': dst_key, 'region': region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_copy_object', payload)
         if err is not None:
@@ -4014,7 +4036,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.copy_object(src_bucket, src_key, dst_bucket, dst_key)
+            await svc.copy_object(src_bucket, src_key, dst_bucket, dst_key, region)
         except ValueError as exc:
             self._audit.log('s3_copy_object', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -4039,11 +4061,14 @@ class ServonautTools:
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = '',
+        src_region: str = '',
     ) -> str:
         """Move an S3 object (server-side copy then delete source)."""
         payload: Dict[str, Any] = {
             'provider': provider, 'src_bucket': src_bucket, 'src_key': src_key,
             'dst_bucket': dst_bucket, 'dst_key': dst_key,
+            'region': region, 'src_region': src_region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_move_object', payload)
         if err is not None:
@@ -4055,7 +4080,9 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            await svc.move_object(src_bucket, src_key, dst_bucket, dst_key)
+            await svc.move_object(
+                src_bucket, src_key, dst_bucket, dst_key, region, src_region,
+            )
         except ValueError as exc:
             self._audit.log('s3_move_object', payload, '', False, f"validation: {exc}")
             return f"Error: {exc}"
@@ -4079,6 +4106,7 @@ class ServonautTools:
         bucket: str,
         key: str,
         expires_in: int = 3600,
+        region: str = '',
     ) -> str:
         """Generate a time-limited pre-signed URL granting read access to an S3 object.
 
@@ -4090,7 +4118,7 @@ class ServonautTools:
         # expires_in included because it determines how dangerous the URL is.
         payload: Dict[str, Any] = {
             'provider': provider, 'bucket': bucket,
-            'key': key, 'expires_in': expires_in,
+            'key': key, 'expires_in': expires_in, 'region': region,
         }
         svc, err = self._validate_s3_provider(provider, 's3_generate_presigned_url', payload)
         if err is not None:
@@ -4102,7 +4130,7 @@ class ServonautTools:
             return f"Blocked: {reason}"
 
         try:
-            url = await svc.generate_presigned_url(bucket, key, expires_in)
+            url = await svc.generate_presigned_url(bucket, key, expires_in, region)
         except ValueError as exc:
             self._audit.log(
                 's3_generate_presigned_url', payload, '', False, f"validation: {exc}",

--- a/src/servonaut/screens/object_storage.py
+++ b/src/servonaut/screens/object_storage.py
@@ -36,7 +36,9 @@ from servonaut.utils.formatting import escape_cell
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, ScrollableContainer
 from textual.screen import Screen
-from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Static
+from textual.widgets import (
+    Button, DataTable, Footer, Header, Input, Label, Select, Static,
+)
 
 from servonaut.screens._binding_guard import check_action_passthrough
 from servonaut.screens.confirm_action import ConfirmActionScreen
@@ -103,6 +105,9 @@ class ObjectStorageScreen(Screen):
         self._buckets: List[Dict] = []
         self._folders: List[str] = []
         self._objects: List[Dict] = []
+        # Region picker state (AWS only — other providers are endpoint-pinned).
+        self._regions: List[str] = []
+        self._regions_loaded: bool = False
 
     # ------------------------------------------------------------------
     # Compose
@@ -140,6 +145,18 @@ class ObjectStorageScreen(Screen):
                     Static("[bold]Create Bucket[/bold]", classes="section_header"),
                     Label("Bucket name:"),
                     Input(placeholder="my-bucket", id="s3_input_bucket_name"),
+                    # Region row is AWS-only: Hetzner/OVH derive the region
+                    # from the configured endpoint URL, so offering a choice
+                    # there would be a control that cannot do anything.
+                    Container(
+                        Label("Region:"),
+                        Select(
+                            [],
+                            prompt="Default (configured region)",
+                            id="s3_select_bucket_region",
+                        ),
+                        id="s3_bucket_region_row",
+                    ),
                     Horizontal(
                         Button("Create", id="btn_s3_save_bucket",   variant="primary"),
                         Button("Cancel", id="btn_s3_cancel_bucket", variant="default"),
@@ -624,8 +641,64 @@ class ObjectStorageScreen(Screen):
     def _show_new_bucket_form(self) -> None:
         self._hide_all_forms()
         self.query_one("#s3_input_bucket_name", Input).value = ""
+        is_aws = self._provider == "aws"
+        self.query_one("#s3_bucket_region_row").display = is_aws
         self.query_one("#s3_new_bucket_form").display = True
         self.query_one("#s3_input_bucket_name", Input).focus()
+        # Fetch the region list once per screen, on first use rather than at
+        # mount — opening the browser should not pay for a describe_regions
+        # call that most sessions never need.
+        if is_aws and not self._regions_loaded:
+            self._regions_loaded = True
+            self.run_worker(
+                self._load_regions(),
+                group="s3_regions",
+                exclusive=True,
+                name="s3_load_regions",
+            )
+
+    async def _load_regions(self) -> None:
+        """Populate the region picker from the live EC2 region list."""
+        select = self.query_one("#s3_select_bucket_region", Select)
+        svc = getattr(self.app, "aws_service", None)
+        if svc is None:
+            return
+        # The configured default doubles as the bootstrap region for the
+        # describe_regions client, so listing works with no ambient
+        # AWS_DEFAULT_REGION set.
+        default_region = ""
+        try:
+            default_region = self.app.config_manager.get().aws.default_region or ""
+        except Exception:
+            pass
+        try:
+            self._regions = await svc.list_regions(
+                bootstrap_region=default_region or "us-east-1"
+            )
+        except Exception as exc:
+            logger.error("Failed to load S3 regions: %s", exc)
+            # Leaving the picker blank is not a dead end — blank means
+            # "configured region", which is what the old behaviour did.
+            self._regions_loaded = False
+            self.app.notify(
+                f"Could not load region list: {self.scrub(str(exc))}. "
+                "Leave the picker blank to use the configured region.",
+                severity="warning",
+                markup=False,
+            )
+            return
+        select.set_options((r, r) for r in self._regions)
+
+    def _selected_bucket_region(self) -> str:
+        """Return the picked region, or "" for the provider's configured one."""
+        if self._provider != "aws":
+            return ""
+        value = self.query_one("#s3_select_bucket_region", Select).value
+        # An unmade selection is a sentinel object, not a string — and which
+        # sentinel it is has moved between Textual releases (Select.BLANK vs
+        # Select.NULL). A real region is always a non-empty str, so test for
+        # that instead of naming the sentinel.
+        return value if isinstance(value, str) and value else ""
 
     def _show_upload_form(self) -> None:
         if self._view != _VIEW_OBJECTS:
@@ -697,21 +770,24 @@ class ObjectStorageScreen(Screen):
             self.app.notify("Bucket name is required", severity="error", markup=False)
             self.query_one("#s3_input_bucket_name", Input).focus()
             return
+        region = self._selected_bucket_region()
         self._hide_all_forms()
         self.run_worker(
-            self._create_bucket(name),
+            self._create_bucket(name, region),
             exclusive=False,
             name="s3_create_bucket",
         )
 
-    async def _create_bucket(self, name: str) -> None:
+    async def _create_bucket(self, name: str, region: str = "") -> None:
         svc = self._get_storage_service()
         if svc is None:
             return
         try:
-            await svc.create_bucket(name)
+            await svc.create_bucket(name, region)
+            where = region or getattr(svc, "region", "") or ""
             self.app.notify(
-                f"Bucket '{name}' created",
+                f"Bucket '{name}' created in {where}" if where
+                else f"Bucket '{name}' created",
                 severity="information",
                 markup=False,
             )

--- a/src/servonaut/services/interfaces.py
+++ b/src/servonaut/services/interfaces.py
@@ -1330,23 +1330,28 @@ class ObjectStorageServiceInterface(ABC):
         pass
 
     @abstractmethod
-    async def create_bucket(self, bucket: str) -> None:
+    async def create_bucket(self, bucket: str, region: str = "") -> None:
         """Create a new bucket.
 
         Args:
             bucket: Bucket name to create.
+            region: Region to create the bucket in.  Empty → the region the
+                service was configured with.  Providers whose region is pinned
+                by a configured endpoint URL reject a differing override.
 
         Raises:
-            ValueError: If *bucket* fails validation.
+            ValueError: If *bucket* or *region* fails validation.
         """
         pass
 
     @abstractmethod
-    async def delete_bucket(self, bucket: str) -> None:
+    async def delete_bucket(self, bucket: str, region: str = "") -> None:
         """Delete a bucket.  The bucket must be empty.
 
         Args:
             bucket: Name of the bucket to delete.
+            region: Region the bucket lives in.  Empty → the configured
+                region, with a redirect when it is wrong.
 
         Raises:
             ValueError: If *bucket* fails validation.
@@ -1359,6 +1364,7 @@ class ObjectStorageServiceInterface(ABC):
         bucket: str,
         prefix: str = "",
         delimiter: str = "/",
+        region: str = "",
     ) -> Dict[str, Any]:
         """List objects and common-prefix "folders" inside *bucket*.
 
@@ -1366,6 +1372,8 @@ class ObjectStorageServiceInterface(ABC):
             bucket: Target bucket name.
             prefix: Key prefix to filter results (e.g. ``"images/"``).
             delimiter: Hierarchy delimiter (default ``"/"``).
+            region: Region the bucket lives in.  Empty → the configured
+                region, with a redirect when it is wrong.
 
         Returns:
             Dict with keys:
@@ -1386,6 +1394,7 @@ class ObjectStorageServiceInterface(ABC):
         bucket: str,
         key: str,
         local_path: str,
+        region: str = "",
     ) -> None:
         """Upload a local file to *bucket* at *key*.
 
@@ -1393,6 +1402,8 @@ class ObjectStorageServiceInterface(ABC):
             bucket: Target bucket name.
             key: Destination object key.
             local_path: Absolute path to the local file.
+            region: Region the bucket lives in.  Empty → the configured
+                region, with a redirect when it is wrong.
 
         Raises:
             ValueError: If any argument fails validation.
@@ -1405,6 +1416,7 @@ class ObjectStorageServiceInterface(ABC):
         bucket: str,
         key: str,
         local_path: str,
+        region: str = "",
     ) -> None:
         """Download an object from *bucket*/*key* to *local_path*.
 
@@ -1412,6 +1424,8 @@ class ObjectStorageServiceInterface(ABC):
             bucket: Source bucket name.
             key: Object key to download.
             local_path: Absolute path where the file will be written.
+            region: Region the bucket lives in.  Empty → the configured
+                region, with a redirect when it is wrong.
 
         Raises:
             ValueError: If any argument fails validation.
@@ -1419,12 +1433,14 @@ class ObjectStorageServiceInterface(ABC):
         pass
 
     @abstractmethod
-    async def delete_object(self, bucket: str, key: str) -> None:
+    async def delete_object(self, bucket: str, key: str, region: str = "") -> None:
         """Delete a single object.
 
         Args:
             bucket: Bucket containing the object.
             key: Object key to delete.
+            region: Region the bucket lives in.  Empty → the configured
+                region, with a redirect when it is wrong.
 
         Raises:
             ValueError: If *bucket* or *key* fails validation.
@@ -1438,6 +1454,7 @@ class ObjectStorageServiceInterface(ABC):
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = "",
     ) -> None:
         """Server-side copy of an object.
 
@@ -1446,6 +1463,8 @@ class ObjectStorageServiceInterface(ABC):
             src_key: Source object key.
             dst_bucket: Destination bucket name.
             dst_key: Destination object key.
+            region: Region *dst_bucket* lives in — a cross-region copy is
+                driven from the destination side.
 
         Raises:
             ValueError: If any argument fails validation.
@@ -1459,6 +1478,8 @@ class ObjectStorageServiceInterface(ABC):
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = "",
+        src_region: str = "",
     ) -> None:
         """Move an object (server-side copy then delete source).
 
@@ -1467,6 +1488,8 @@ class ObjectStorageServiceInterface(ABC):
             src_key: Source object key.
             dst_bucket: Destination bucket name.
             dst_key: Destination object key.
+            region: Region *dst_bucket* lives in (drives the copy leg).
+            src_region: Region *src_bucket* lives in (drives the delete leg).
 
         Raises:
             ValueError: If any argument fails validation.
@@ -1479,6 +1502,7 @@ class ObjectStorageServiceInterface(ABC):
         bucket: str,
         key: str,
         expires_in: int = 3600,
+        region: str = "",
     ) -> str:
         """Generate a pre-signed URL for temporary public access to an object.
 
@@ -1486,6 +1510,9 @@ class ObjectStorageServiceInterface(ABC):
             bucket: Bucket containing the object.
             key: Object key.
             expires_in: Expiry in seconds (1–604800, default 3600).
+            region: Region the bucket lives in.  Empty → resolved for the
+                caller, since SigV4 binds the region into the signature and a
+                mismatch produces a URL that fails when opened.
 
         Returns:
             Pre-signed URL string.

--- a/src/servonaut/services/object_storage_service.py
+++ b/src/servonaut/services/object_storage_service.py
@@ -163,16 +163,15 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         if endpoint_url:
             _validate_endpoint_url(endpoint_url)
         # Validate region format to prevent injection into derived URLs.
-        if region and not S3_REGION_RE.match(region):
-            raise ValueError(
-                f"Invalid region {region!r}. Must match ^[a-z0-9-]{{1,32}}$."
-            )
+        self._validate_region(region)
         self._provider = provider
         self._access_key = access_key
         self._secret_key = secret_key
         self._region = region
         self._endpoint_url = endpoint_url
         self._client: Optional[Any] = None
+        # bucket name → home region, populated lazily by _discover_bucket_region.
+        self._bucket_regions: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Lazy client
@@ -200,9 +199,177 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         self._client = boto3.client("s3", **kwargs)
         return self._client
 
+    def _region_for_bucket(
+        self, bucket: str, override: str = "", *, discover: bool = False,
+    ) -> str:
+        """Resolve which region a request for *bucket* should target.
+
+        Resolution order: explicit *override* → endpoint-pinned region →
+        cached discovery → live discovery (only when *discover*) → the
+        configured region.
+
+        Discovery is off by default on purpose.  botocore's
+        ``S3RegionRedirectorv2`` already retries a misdirected request against
+        the correct region and caches the result, so paying for a HeadBucket
+        up front would just move that cost rather than remove it.  It is worth
+        paying only where no redirect can happen — see
+        :meth:`generate_presigned_url`.
+
+        Args:
+            bucket: Bucket the request targets.
+            override: Caller-supplied region (already validated).
+            discover: Issue a HeadBucket when the region is not yet known.
+
+        Returns:
+            Region string, possibly empty (→ credential-chain default).
+        """
+        if override:
+            return override
+        # For Hetzner/OVH the endpoint URL encodes the region; there is no
+        # cross-region redirect to discover and no other endpoint to reach.
+        if self._endpoint_url:
+            return self._region
+        cached = self._bucket_regions.get(bucket)
+        if cached:
+            return cached
+        if not discover:
+            return self._region
+        discovered = self._discover_bucket_region(bucket)
+        if discovered:
+            self._bucket_regions[bucket] = discovered
+            return discovered
+        return self._region
+
+    def _discover_bucket_region(self, bucket: str) -> str:
+        """Return the region *bucket* lives in, or "" if it cannot be found.
+
+        S3 reports the bucket's home region in the ``x-amz-bucket-region``
+        response header, and does so on the 301/403 error responses too — so
+        a HeadBucket answers the question even without ``s3:GetBucketLocation``
+        or read access to the bucket.
+
+        Never raises: a failed lookup degrades to the configured region.
+
+        Args:
+            bucket: Bucket to look up.
+
+        Returns:
+            Region string, or "" when undetermined.
+        """
+        def _header_region(payload: Any) -> str:
+            if not isinstance(payload, dict):
+                return ""
+            headers = payload.get("ResponseMetadata", {}).get("HTTPHeaders", {})
+            value = headers.get("x-amz-bucket-region", "") if headers else ""
+            return value if isinstance(value, str) else ""
+
+        try:
+            region = _header_region(self._get_client().head_bucket(Bucket=bucket))
+        except Exception as exc:  # noqa: BLE001 — best-effort lookup
+            region = _header_region(getattr(exc, "response", None))
+            if not region:
+                logger.debug("Bucket region lookup failed for %r: %s", bucket, exc)
+                return ""
+
+        # The value arrives off the wire and is fed straight into a boto3
+        # client config, so it gets the same format check as configured input.
+        if region and not S3_REGION_RE.match(region):
+            logger.warning(
+                "Ignoring malformed x-amz-bucket-region %r for bucket %r",
+                region, bucket,
+            )
+            return ""
+        return region
+
+    def _client_for_bucket(
+        self, bucket: str, override: str = "", *, discover: bool = False,
+    ) -> Any:
+        """Return an S3 client pointed at the region *bucket* lives in."""
+        return self._client_for_region(
+            self._region_for_bucket(bucket, override, discover=discover)
+        )
+
+    def _client_for_region(self, region: str) -> Any:
+        """Return an S3 client bound to *region*.
+
+        ``CreateBucket`` must be sent to the endpoint of the region the bucket
+        should live in, so a one-off region override needs its own client
+        rather than the cached default one.  Falls back to the cached client
+        when *region* is empty or already matches the configured region.
+
+        The ad-hoc client is deliberately NOT cached — an override is a
+        per-call concern and must not change the region of later calls.
+
+        Args:
+            region: Target region.  Empty → cached default client.
+
+        Returns:
+            A boto3 S3 client.
+        """
+        if not region or region == self._region:
+            return self._get_client()
+
+        kwargs: Dict[str, Any] = {"region_name": region}
+        if self._endpoint_url:
+            kwargs["endpoint_url"] = self._endpoint_url
+        if self._access_key and self._secret_key:
+            kwargs["aws_access_key_id"] = self._access_key
+            kwargs["aws_secret_access_key"] = self._secret_key
+        return boto3.client("s3", **kwargs)
+
+    @property
+    def region(self) -> str:
+        """Configured region for this provider (empty when unset)."""
+        return self._region
+
     # ------------------------------------------------------------------
     # Validation helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_region(region: str) -> None:
+        """Raise ValueError if *region* is set and malformed.
+
+        Region strings are interpolated into derived endpoint URLs and boto3
+        client config, so anything outside the expected shape is rejected.
+
+        Args:
+            region: Region string ("" is allowed and means "unset").
+
+        Raises:
+            ValueError: If the region is non-empty and malformed.
+        """
+        if region and not S3_REGION_RE.match(region):
+            raise ValueError(
+                f"Invalid region {region!r}. Must match ^[a-z0-9-]{{1,32}}$."
+            )
+
+    def _reject_pinned_region(self, region: str) -> None:
+        """Reject a region override that the configured endpoint cannot honour.
+
+        For Hetzner/OVH the endpoint URL encodes the region, so accepting an
+        override would send the request to the endpoint's region while
+        reporting the requested one back to the caller.  Failing loudly is the
+        honest outcome.
+
+        Args:
+            region: Requested region ("" is always allowed).
+
+        Raises:
+            ValueError: If an override disagrees with the pinned endpoint.
+        """
+        if region and self._endpoint_url and region != self._region:
+            raise ValueError(
+                f"Cannot target region {region!r}: provider {self._provider!r} "
+                f"is pinned to endpoint {self._endpoint_url} "
+                f"(region {self._region or 'unset'!r}). Configure a separate "
+                "endpoint URL for that region instead."
+            )
+
+    def _check_region_arg(self, region: str) -> None:
+        """Validate a caller-supplied region override for this provider."""
+        self._validate_region(region)
+        self._reject_pinned_region(region)
 
     @staticmethod
     def _validate_bucket(bucket: str) -> None:
@@ -371,45 +538,73 @@ class ObjectStorageService(ObjectStorageServiceInterface):
 
         return await asyncio.to_thread(_sync)
 
-    async def create_bucket(self, bucket: str) -> None:
+    async def create_bucket(self, bucket: str, region: str = "") -> None:
         """Create a new S3 bucket.
 
         Args:
             bucket: Bucket name to create.
+            region: Region to create the bucket in.  Empty → the region this
+                service was configured with (or the credential chain's default
+                when that is also unset).  Only meaningful for AWS: for
+                Hetzner/OVH the region is pinned by the configured endpoint
+                URL, so an override that disagrees with it is rejected rather
+                than silently creating the bucket somewhere else.
 
         Raises:
-            ValueError: If *bucket* fails validation.
+            ValueError: If *bucket* or *region* fails validation, or a region
+                override is given for an endpoint-pinned provider.
         """
         self._validate_bucket(bucket)
+        self._check_region_arg(region)
 
         def _sync() -> None:
-            client = self._get_client()
-            # AWS requires CreateBucketConfiguration for regions other than
-            # us-east-1; for other providers it is typically ignored.
-            if self._region and self._region != "us-east-1" and not self._endpoint_url:
+            client = self._client_for_region(region)
+            # Resolve the region the request will actually reach: an explicit
+            # override wins, then the configured region, then whatever boto3
+            # worked out from the credential chain (env, ~/.aws/config).  The
+            # last case matters — without it a client that boto3 pointed at
+            # eu-west-1 would send a CreateBucket with no LocationConstraint
+            # and get IllegalLocationConstraintException back.
+            effective = region or self._region
+            if not effective:
+                resolved = getattr(getattr(client, "meta", None), "region_name", None)
+                if isinstance(resolved, str):
+                    effective = resolved
+            # AWS requires CreateBucketConfiguration for every region except
+            # us-east-1, where it must be omitted.  Endpoint-based providers
+            # derive the region from the endpoint, so we send the plain call.
+            if effective and effective != "us-east-1" and not self._endpoint_url:
                 client.create_bucket(
                     Bucket=bucket,
-                    CreateBucketConfiguration={"LocationConstraint": self._region},
+                    CreateBucketConfiguration={"LocationConstraint": effective},
                 )
             else:
                 client.create_bucket(Bucket=bucket)
+            # We know exactly where it landed — seed the cache so later ops on
+            # this bucket skip both discovery and a redirect round-trip.
+            if effective:
+                self._bucket_regions[bucket] = effective
 
         await asyncio.to_thread(_sync)
 
-    async def delete_bucket(self, bucket: str) -> None:
+    async def delete_bucket(self, bucket: str, region: str = "") -> None:
         """Delete a bucket.  The bucket must be empty.
 
         Args:
             bucket: Name of the bucket to delete.
+            region: Region the bucket lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Raises:
-            ValueError: If *bucket* fails validation.
+            ValueError: If *bucket* or *region* fails validation.
         """
         self._validate_bucket(bucket)
+        self._check_region_arg(region)
 
         def _sync() -> None:
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region)
             client.delete_bucket(Bucket=bucket)
+            self._bucket_regions.pop(bucket, None)
 
         await asyncio.to_thread(_sync)
 
@@ -418,6 +613,7 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         bucket: str,
         prefix: str = "",
         delimiter: str = "/",
+        region: str = "",
     ) -> Dict[str, Any]:
         """List objects and virtual-folder prefixes in *bucket*.
 
@@ -429,6 +625,8 @@ class ObjectStorageService(ObjectStorageServiceInterface):
             bucket: Target bucket name.
             prefix: Key prefix filter (e.g. ``"images/"``).
             delimiter: Hierarchy delimiter (default ``"/"``).
+            region: Region the bucket lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Returns:
             Dict with keys:
@@ -439,12 +637,13 @@ class ObjectStorageService(ObjectStorageServiceInterface):
             - ``"is_truncated"`` — ``bool``.
 
         Raises:
-            ValueError: If *bucket* fails validation.
+            ValueError: If *bucket* or *region* fails validation.
         """
         self._validate_bucket(bucket)
+        self._check_region_arg(region)
 
         def _sync() -> Dict[str, Any]:
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region)
             kwargs: Dict[str, Any] = {"Bucket": bucket}
             if prefix:
                 kwargs["Prefix"] = prefix
@@ -481,6 +680,7 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         bucket: str,
         key: str,
         local_path: str,
+        region: str = "",
     ) -> None:
         """Upload a local file to *bucket* at *key*.
 
@@ -488,16 +688,19 @@ class ObjectStorageService(ObjectStorageServiceInterface):
             bucket: Target bucket name.
             key: Destination object key.
             local_path: Absolute path to the local file.
+            region: Region the bucket lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Raises:
             ValueError: If any argument fails validation.
         """
         self._validate_bucket(bucket)
         self._validate_object_key(key)
+        self._check_region_arg(region)
         resolved = self._validate_local_path(local_path, must_exist=True)
 
         def _sync() -> None:
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region)
             client.upload_file(str(resolved), bucket, key)
 
         await asyncio.to_thread(_sync)
@@ -507,6 +710,7 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         bucket: str,
         key: str,
         local_path: str,
+        region: str = "",
     ) -> None:
         """Download an object from *bucket*/*key* to *local_path*.
 
@@ -514,12 +718,15 @@ class ObjectStorageService(ObjectStorageServiceInterface):
             bucket: Source bucket name.
             key: Object key to download.
             local_path: Absolute path where the file will be written.
+            region: Region the bucket lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Raises:
             ValueError: If any argument fails validation.
         """
         self._validate_bucket(bucket)
         self._validate_object_key(key)
+        self._check_region_arg(region)
         resolved = self._validate_local_path(local_path, must_exist=False)
 
         def _sync() -> None:
@@ -528,26 +735,29 @@ class ObjectStorageService(ObjectStorageServiceInterface):
             # (defence against TOCTOU: a symlink swap between the outer check
             # and the actual download).
             self._validate_local_path(local_path, must_exist=False)
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region)
             client.download_file(bucket, key, str(resolved))
 
         await asyncio.to_thread(_sync)
 
-    async def delete_object(self, bucket: str, key: str) -> None:
+    async def delete_object(self, bucket: str, key: str, region: str = "") -> None:
         """Delete a single object from *bucket*.
 
         Args:
             bucket: Bucket containing the object.
             key: Object key to delete.
+            region: Region the bucket lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Raises:
-            ValueError: If *bucket* or *key* fails validation.
+            ValueError: If *bucket*, *key*, or *region* fails validation.
         """
         self._validate_bucket(bucket)
         self._validate_object_key(key)
+        self._check_region_arg(region)
 
         def _sync() -> None:
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region)
             client.delete_object(Bucket=bucket, Key=key)
 
         await asyncio.to_thread(_sync)
@@ -558,14 +768,21 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = "",
     ) -> None:
         """Server-side copy of an object.
+
+        A cross-region copy is driven from the DESTINATION region — S3 resolves
+        ``CopySource`` globally and pulls the source itself — so *region*
+        describes where *dst_bucket* lives, not the source.
 
         Args:
             src_bucket: Source bucket name.
             src_key: Source object key.
             dst_bucket: Destination bucket name.
             dst_key: Destination object key.
+            region: Region *dst_bucket* lives in.  Empty → resolved from the
+                configured region, with botocore redirecting if it is wrong.
 
         Raises:
             ValueError: If any argument fails validation.
@@ -574,9 +791,10 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         self._validate_object_key(src_key)
         self._validate_bucket(dst_bucket)
         self._validate_object_key(dst_key)
+        self._check_region_arg(region)
 
         def _sync() -> None:
-            client = self._get_client()
+            client = self._client_for_bucket(dst_bucket, region)
             client.copy_object(
                 CopySource={"Bucket": src_bucket, "Key": src_key},
                 Bucket=dst_bucket,
@@ -591,14 +809,23 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         src_key: str,
         dst_bucket: str,
         dst_key: str,
+        region: str = "",
+        src_region: str = "",
     ) -> None:
         """Move an object: server-side copy then delete source.
+
+        The two legs can target different regions: the copy is driven from the
+        destination region, the delete from the source one.  Hence the two
+        parameters — passing only *region* still works, the delete leg just
+        falls back to a redirect when the source lives elsewhere.
 
         Args:
             src_bucket: Source bucket name.
             src_key: Source object key.
             dst_bucket: Destination bucket name.
             dst_key: Destination object key.
+            region: Region *dst_bucket* lives in (drives the copy).
+            src_region: Region *src_bucket* lives in (drives the delete).
 
         Raises:
             ValueError: If any argument fails validation.
@@ -609,22 +836,33 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         self._validate_object_key(src_key)
         self._validate_bucket(dst_bucket)
         self._validate_object_key(dst_key)
+        self._check_region_arg(region)
+        self._check_region_arg(src_region)
 
-        await self.copy_object(src_bucket, src_key, dst_bucket, dst_key)
-        await self.delete_object(src_bucket, src_key)
+        await self.copy_object(src_bucket, src_key, dst_bucket, dst_key, region)
+        await self.delete_object(src_bucket, src_key, src_region)
 
     async def generate_presigned_url(
         self,
         bucket: str,
         key: str,
         expires_in: int = 3600,
+        region: str = "",
     ) -> str:
         """Generate a pre-signed URL for temporary public access to an object.
+
+        This is the one operation that resolves the bucket's region up front
+        (a single cached HeadBucket) rather than letting botocore redirect.
+        Signing happens locally with no request to redirect, and SigV4 binds
+        the region into the credential scope — so a URL signed for the wrong
+        region is not slow, it is silently unusable, failing with
+        ``SignatureDoesNotMatch`` only once somebody opens it.
 
         Args:
             bucket: Bucket containing the object.
             key: Object key.
             expires_in: Expiry in seconds (1–604800, default 3600).
+            region: Region the bucket lives in.  Empty → discovered and cached.
 
         Returns:
             Pre-signed URL string.
@@ -635,9 +873,10 @@ class ObjectStorageService(ObjectStorageServiceInterface):
         self._validate_bucket(bucket)
         self._validate_object_key(key)
         self._validate_expires_in(expires_in)
+        self._check_region_arg(region)
 
         def _sync() -> str:
-            client = self._get_client()
+            client = self._client_for_bucket(bucket, region, discover=True)
             return client.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": bucket, "Key": key},

--- a/src/servonaut/styles/providers/_shared.tcss
+++ b/src/servonaut/styles/providers/_shared.tcss
@@ -268,6 +268,18 @@
     width: 1fr;
 }
 
+/* Region picker row on the New Bucket form. Container defaults to 1fr,
+   which would stretch the inline form — pin it to its content. */
+#s3_bucket_region_row {
+    height: auto;
+    width: 1fr;
+}
+
+#s3_select_bucket_region {
+    margin: 0 0 1 0;
+    width: 1fr;
+}
+
 #hetzner_ssh_add_form_actions,
 #add_key_form_actions {
     layout: horizontal;

--- a/tests/test_aws3_coverage_gaps.py
+++ b/tests/test_aws3_coverage_gaps.py
@@ -1234,8 +1234,22 @@ class TestObjectStorageCreateBucket:
              patch.object(screen, "_set_status"):
             asyncio.run(screen._create_bucket("new-bucket"))
 
-        svc.create_bucket.assert_called_once_with("new-bucket")
+        # No region picked → "", meaning "the provider's configured region".
+        svc.create_bucket.assert_called_once_with("new-bucket", "")
         app.notify.assert_called()
+
+    def test_create_bucket_passes_selected_region(self) -> None:
+        svc = _s3_mock_storage_service()
+        app = _s3_app(provider="aws", storage_service=svc)
+        screen = ObjectStorageScreen("aws")
+        screen._view = _VIEW_BUCKETS
+
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=MagicMock()), \
+             patch.object(screen, "_set_status"):
+            asyncio.run(screen._create_bucket("new-bucket", "eu-central-1"))
+
+        svc.create_bucket.assert_called_once_with("new-bucket", "eu-central-1")
 
     def test_create_bucket_invalid_name_notifies_error(self) -> None:
         svc = _s3_mock_storage_service()
@@ -4267,3 +4281,126 @@ class TestAWSCreateLoaderEmptyRegionPaths:
             asyncio.run(screen._load_subnets(""))
 
         svc.list_subnets.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Object storage: region picker on the New Bucket form
+# ---------------------------------------------------------------------------
+
+class TestObjectStorageRegionPicker:
+    """The region is chosen from a live list, never typed."""
+
+    @staticmethod
+    def _screen_with_select(provider="aws", regions=None, list_regions=None):
+        from servonaut.screens.object_storage import ObjectStorageScreen
+
+        screen = ObjectStorageScreen(provider)
+        select = MagicMock()
+        app = _s3_app(provider=provider, storage_service=_s3_mock_storage_service())
+        app.aws_service = MagicMock()
+        app.aws_service.list_regions = list_regions or AsyncMock(
+            return_value=regions if regions is not None else ["us-east-1", "eu-central-1"]
+        )
+        cfg = MagicMock()
+        cfg.aws.default_region = "us-east-1"
+        app.config_manager.get.return_value = cfg
+        return screen, select, app
+
+    def test_populates_options_from_live_region_list(self) -> None:
+        screen, select, app = self._screen_with_select(
+            regions=["us-east-1", "eu-central-1", "ap-south-1"]
+        )
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=select):
+            asyncio.run(screen._load_regions())
+
+        app.aws_service.list_regions.assert_awaited_once_with(bootstrap_region="us-east-1")
+        options = list(select.set_options.call_args[0][0])
+        assert options == [
+            ("us-east-1", "us-east-1"),
+            ("eu-central-1", "eu-central-1"),
+            ("ap-south-1", "ap-south-1"),
+        ]
+
+    def test_region_list_failure_notifies_and_allows_retry(self) -> None:
+        """A failed lookup must not strand the user — blank still works."""
+        screen, select, app = self._screen_with_select(
+            list_regions=AsyncMock(side_effect=Exception("no credentials"))
+        )
+        screen._regions_loaded = True
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=select):
+            asyncio.run(screen._load_regions())
+
+        select.set_options.assert_not_called()
+        app.notify.assert_called()
+        assert screen._regions_loaded is False  # next open retries
+
+    @pytest.mark.parametrize("blank", ["Select.BLANK", "Select.NULL", ""])
+    def test_blank_selection_means_configured_region(self, blank) -> None:
+        """No pick → "" (the configured region), whichever sentinel Textual
+        uses. Returning the sentinel's str() would send a bogus region."""
+        from servonaut.screens.object_storage import ObjectStorageScreen
+        from textual.widgets import Select
+
+        screen = ObjectStorageScreen("aws")
+        select = MagicMock()
+        select.value = getattr(Select, blank.split(".")[-1]) if blank else ""
+        with patch.object(screen, "query_one", return_value=select):
+            assert screen._selected_bucket_region() == ""
+
+    def test_picked_region_is_returned(self) -> None:
+        from servonaut.screens.object_storage import ObjectStorageScreen
+
+        screen = ObjectStorageScreen("aws")
+        select = MagicMock()
+        select.value = "eu-central-1"
+        with patch.object(screen, "query_one", return_value=select):
+            assert screen._selected_bucket_region() == "eu-central-1"
+
+    @pytest.mark.parametrize("provider", ["hetzner", "ovh"])
+    def test_endpoint_pinned_providers_report_no_region(self, provider) -> None:
+        """Their region comes from the endpoint — never send an override."""
+        from servonaut.screens.object_storage import ObjectStorageScreen
+
+        screen = ObjectStorageScreen(provider)
+        select = MagicMock()
+        select.value = "eu-central-1"  # stale widget state must be ignored
+        with patch.object(screen, "query_one", return_value=select):
+            assert screen._selected_bucket_region() == ""
+
+    def test_region_row_hidden_for_endpoint_pinned_provider(self) -> None:
+        from servonaut.screens.object_storage import ObjectStorageScreen
+
+        screen = ObjectStorageScreen("hetzner")
+        widgets = {}
+
+        def query_side(sel, *a, **kw):
+            return widgets.setdefault(sel, MagicMock())
+
+        app = _s3_app(provider="hetzner")
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", side_effect=query_side), \
+             patch.object(screen, "_hide_all_forms"), \
+             patch.object(screen, "run_worker") as worker:
+            screen._show_new_bucket_form()
+
+        assert widgets["#s3_bucket_region_row"].display is False
+        worker.assert_not_called()  # no describe_regions for a pinned provider
+
+    def test_region_list_loaded_once_per_screen(self) -> None:
+        from servonaut.screens.object_storage import ObjectStorageScreen
+
+        screen = ObjectStorageScreen("aws")
+        app = _s3_app(provider="aws")
+
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=MagicMock()), \
+             patch.object(screen, "_hide_all_forms"), \
+             patch.object(screen, "run_worker") as worker, \
+             patch.object(screen, "_load_regions") as loader:
+            screen._show_new_bucket_form()
+            screen._show_new_bucket_form()
+
+        assert worker.call_count == 1
+        assert loader.call_count == 1

--- a/tests/test_mcp_s3_tools.py
+++ b/tests/test_mcp_s3_tools.py
@@ -415,6 +415,123 @@ class TestS3CreateBucket:
         assert tools._audit.log.call_args[0][0] == "s3_create_bucket"
         assert tools._audit.log.call_args[0][3] is True
 
+    def test_region_forwarded_to_service(self):
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        result = run(tools.s3_create_bucket(
+            provider="aws", bucket="new-bucket", region="eu-central-1",
+        ))
+        svc.create_bucket.assert_awaited_once_with("new-bucket", "eu-central-1")
+        assert "eu-central-1" in result
+
+    def test_region_recorded_in_audit_payload(self):
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        run(tools.s3_create_bucket(
+            provider="aws", bucket="new-bucket", region="eu-central-1",
+        ))
+        assert tools._audit.log.call_args[0][1]["region"] == "eu-central-1"
+
+    def test_omitted_region_falls_back_to_configured(self):
+        svc = _make_s3_svc()
+        svc.region = "ap-south-1"
+        tools = make_tools(aws_os_service=svc)
+        result = run(tools.s3_create_bucket(provider="aws", bucket="new-bucket"))
+        svc.create_bucket.assert_awaited_once_with("new-bucket", "")
+        assert "ap-south-1" in result
+
+    def test_region_rejection_uses_validation_channel(self):
+        """An endpoint-pinned provider's refusal is a validation error, not api_error."""
+        svc = _make_s3_svc()
+        svc.create_bucket = AsyncMock(side_effect=ValueError("pinned to endpoint"))
+        tools = make_tools(hetzner_os_service=svc)
+        result = run(tools.s3_create_bucket(
+            provider="hetzner", bucket="new-bucket", region="fsn1",
+        ))
+        assert result.startswith("Error:")
+        assert tools._audit.log.call_args[0][4].startswith("validation:")
+
+
+# ---------------------------------------------------------------------------
+# Cross-region: region reaches the service and the audit trail on every tool
+# ---------------------------------------------------------------------------
+
+class TestS3RegionPassThrough:
+    """Each bucket-scoped tool must forward `region` and record it.
+
+    The audit assertion is the point: an operator reading the trail has to be
+    able to tell which region a call actually targeted.
+    """
+
+    CASES = [
+        ("s3_list_objects", {"bucket": "b"}, "list_objects"),
+        ("s3_delete_bucket", {"bucket": "b"}, "delete_bucket"),
+        ("s3_delete_object", {"bucket": "b", "key": "k"}, "delete_object"),
+        ("s3_upload_object",
+         {"bucket": "b", "key": "k", "local_path": "/tmp/x"}, "upload_object"),
+        ("s3_download_object",
+         {"bucket": "b", "key": "k", "local_path": "/tmp/x"}, "download_object"),
+        ("s3_generate_presigned_url",
+         {"bucket": "b", "key": "k"}, "generate_presigned_url"),
+        ("s3_copy_object",
+         {"src_bucket": "a", "src_key": "k", "dst_bucket": "b", "dst_key": "k2"},
+         "copy_object"),
+        ("s3_move_object",
+         {"src_bucket": "a", "src_key": "k", "dst_bucket": "b", "dst_key": "k2"},
+         "move_object"),
+    ]
+
+    @pytest.mark.parametrize("tool_name,kwargs,svc_method", CASES)
+    def test_region_forwarded(self, tool_name, kwargs, svc_method):
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        run(getattr(tools, tool_name)(
+            provider="aws", region="eu-central-1", **kwargs,
+        ))
+        assert "eu-central-1" in getattr(svc, svc_method).await_args.args
+
+    @pytest.mark.parametrize("tool_name,kwargs,svc_method", CASES)
+    def test_region_in_audit_payload(self, tool_name, kwargs, svc_method):
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        run(getattr(tools, tool_name)(
+            provider="aws", region="eu-central-1", **kwargs,
+        ))
+        assert tools._audit.log.call_args[0][1]["region"] == "eu-central-1"
+
+    @pytest.mark.parametrize("tool_name,kwargs,svc_method", CASES)
+    def test_region_optional(self, tool_name, kwargs, svc_method):
+        """Omitting region must keep every existing caller working."""
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        result = run(getattr(tools, tool_name)(provider="aws", **kwargs))
+        assert not result.startswith(("Error", "Blocked"))
+        assert "" in getattr(svc, svc_method).await_args.args
+
+    def test_move_routes_source_region_separately(self):
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        run(tools.s3_move_object(
+            provider="aws", src_bucket="a", src_key="k",
+            dst_bucket="b", dst_key="k2",
+            region="eu-central-1", src_region="ap-south-1",
+        ))
+        svc.move_object.assert_awaited_once_with(
+            "a", "k", "b", "k2", "eu-central-1", "ap-south-1",
+        )
+        assert tools._audit.log.call_args[0][1]["src_region"] == "ap-south-1"
+
+    def test_presigned_url_still_masked_with_region(self):
+        """Adding region must not leak the URL into the audit trail."""
+        svc = _make_s3_svc()
+        tools = make_tools(aws_os_service=svc)
+        result = run(tools.s3_generate_presigned_url(
+            provider="aws", bucket="b", key="k", region="eu-central-1",
+        ))
+        assert "X-Amz-Signature" in result
+        audited = str(tools._audit.log.call_args)
+        assert "X-Amz-Signature" not in audited
+
 
 # ---------------------------------------------------------------------------
 # s3_delete_bucket

--- a/tests/test_object_storage_screen.py
+++ b/tests/test_object_storage_screen.py
@@ -15,6 +15,8 @@ from servonaut.screens.object_storage import (
     _VIEW_OBJECTS,
     _format_size,
 )
+from textual.widgets import Input
+
 from servonaut.services.redaction_service import RedactionService
 
 
@@ -456,3 +458,85 @@ async def test_object_storage_screen_objects_pilot() -> None:
         await pilot.pause(0.2)
         assert svc.list_objects.called
         assert pilot.app is not None
+
+
+# ---------------------------------------------------------------------------
+# Region picker — real mount, real widget
+# ---------------------------------------------------------------------------
+
+def _region_harness(provider: str, list_regions):
+    """Build a pilot App hosting an ObjectStorageScreen for *provider*."""
+    from textual.app import App, ComposeResult
+    from servonaut.config.schema import AppConfig
+
+    svc = _mock_storage_service()
+
+    class _Harness(App):
+        def __init__(self):
+            super().__init__()
+            for p in ("aws", "hetzner", "ovh"):
+                setattr(self, f"{p}_object_storage_service", svc if p == provider else None)
+            self.demo_mode = False
+            self.redaction_service = None
+            aws = MagicMock()
+            aws.list_regions = list_regions
+            self.aws_service = aws
+            cfg_mgr = MagicMock()
+            cfg_mgr.get.return_value = AppConfig()
+            self.config_manager = cfg_mgr
+
+        def compose(self) -> ComposeResult:
+            yield ObjectStorageScreen(provider)
+
+    return _Harness(), svc
+
+
+@pytest.mark.asyncio
+async def test_new_bucket_form_region_select_renders_and_populates() -> None:
+    """Mount for real: the picker must exist, fill from the live list, and
+    hand the chosen region to create_bucket."""
+    from textual.widgets import Select
+
+    app, svc = _region_harness(
+        "aws", AsyncMock(return_value=["us-east-1", "eu-central-1", "ap-south-1"]),
+    )
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        screen = pilot.app.query_one(ObjectStorageScreen)
+        screen._show_new_bucket_form()
+        await pilot.pause(0.3)
+
+        assert screen.query_one("#s3_bucket_region_row").display is True
+        select = screen.query_one("#s3_select_bucket_region", Select)
+        # Blank until the user picks — blank means "configured region".
+        # The sentinel is not a str; that, not its name, is what we rely on.
+        assert not isinstance(select.value, str)
+        assert screen._selected_bucket_region() == ""
+
+        select.value = "eu-central-1"
+        assert screen._selected_bucket_region() == "eu-central-1"
+
+        screen.query_one("#s3_input_bucket_name", Input).value = "new-bucket"
+        screen._submit_new_bucket()
+        await pilot.pause(0.3)
+        svc.create_bucket.assert_awaited_once_with("new-bucket", "eu-central-1")
+
+
+@pytest.mark.asyncio
+async def test_new_bucket_form_hides_region_for_endpoint_pinned_provider() -> None:
+    """Hetzner's region is fixed by its endpoint — no picker, no probe."""
+    list_regions = AsyncMock(return_value=["us-east-1"])
+    app, svc = _region_harness("hetzner", list_regions)
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        screen = pilot.app.query_one(ObjectStorageScreen)
+        screen._show_new_bucket_form()
+        await pilot.pause(0.3)
+
+        assert screen.query_one("#s3_bucket_region_row").display is False
+        list_regions.assert_not_awaited()
+
+        screen.query_one("#s3_input_bucket_name", Input).value = "new-bucket"
+        screen._submit_new_bucket()
+        await pilot.pause(0.3)
+        svc.create_bucket.assert_awaited_once_with("new-bucket", "")

--- a/tests/test_object_storage_service.py
+++ b/tests/test_object_storage_service.py
@@ -362,6 +362,290 @@ class TestCreateBucket:
         with pytest.raises(ValueError):
             asyncio.run(aws_svc.create_bucket("AB"))
 
+    # --- region override ---
+
+    def test_region_override_builds_client_for_that_region(self) -> None:
+        """An explicit region must reach boto3 as the client's region_name.
+
+        CreateBucket has to be sent to the target region's endpoint, so the
+        cached default client cannot be reused for an override.
+        """
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        svc._client = MagicMock()  # cached default — must NOT be used
+        override_client = MagicMock()
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=override_client,
+        ) as mock_boto:
+            asyncio.run(svc.create_bucket("my-bucket", "eu-central-1"))
+
+        assert mock_boto.call_args.kwargs["region_name"] == "eu-central-1"
+        override_client.create_bucket.assert_called_once_with(
+            Bucket="my-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "eu-central-1"},
+        )
+        svc._client.create_bucket.assert_not_called()
+
+    def test_region_override_is_not_cached(self) -> None:
+        """A per-call override must not change the region of later calls."""
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        default_client = MagicMock()
+        svc._client = default_client
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=MagicMock(),
+        ):
+            asyncio.run(svc.create_bucket("elsewhere", "eu-central-1"))
+
+        assert svc._client is default_client
+        asyncio.run(svc.create_bucket("back-home"))
+        default_client.create_bucket.assert_called_once_with(Bucket="back-home")
+
+    def test_us_east_1_override_omits_location_constraint(self) -> None:
+        """us-east-1 must be sent WITHOUT CreateBucketConfiguration."""
+        svc = ObjectStorageService(provider="aws", region="eu-central-1")
+        override_client = MagicMock()
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=override_client,
+        ):
+            asyncio.run(svc.create_bucket("my-bucket", "us-east-1"))
+        override_client.create_bucket.assert_called_once_with(Bucket="my-bucket")
+
+    def test_configured_region_used_when_no_override(self) -> None:
+        svc = ObjectStorageService(provider="aws", region="eu-west-2")
+        mock_client = MagicMock()
+        svc._client = mock_client
+        asyncio.run(svc.create_bucket("my-bucket"))
+        mock_client.create_bucket.assert_called_once_with(
+            Bucket="my-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-2"},
+        )
+
+    def test_falls_back_to_boto_resolved_region(self, aws_svc) -> None:
+        """No configured region → use the region boto3 resolved for the client.
+
+        Without this the call would go out with no LocationConstraint against
+        a non-us-east-1 endpoint and fail with IllegalLocationConstraintException.
+        """
+        mock_client = MagicMock()
+        mock_client.meta.region_name = "ap-southeast-2"
+        aws_svc._client = mock_client
+        asyncio.run(aws_svc.create_bucket("my-bucket"))
+        mock_client.create_bucket.assert_called_once_with(
+            Bucket="my-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "ap-southeast-2"},
+        )
+
+    def test_rejects_malformed_region(self, aws_svc) -> None:
+        aws_svc._client = MagicMock()
+        with pytest.raises(ValueError, match="region"):
+            asyncio.run(aws_svc.create_bucket("my-bucket", "EU_Central 1"))
+
+    def test_endpoint_pinned_provider_rejects_mismatched_region(
+        self, hetzner_svc,
+    ) -> None:
+        """Hetzner/OVH regions come from the endpoint URL — refuse to pretend."""
+        hetzner_svc._client = MagicMock()
+        with pytest.raises(ValueError, match="pinned to endpoint"):
+            asyncio.run(hetzner_svc.create_bucket("my-bucket", "fsn1"))
+
+    def test_endpoint_pinned_provider_accepts_matching_region(
+        self, hetzner_svc,
+    ) -> None:
+        mock_client = MagicMock()
+        hetzner_svc._client = mock_client
+        asyncio.run(hetzner_svc.create_bucket("my-bucket", "nbg1"))
+        mock_client.create_bucket.assert_called_once_with(Bucket="my-bucket")
+
+    def test_created_bucket_region_is_cached(self) -> None:
+        """A bucket we just made needs neither discovery nor a redirect."""
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=MagicMock(),
+        ):
+            asyncio.run(svc.create_bucket("fresh-bucket", "eu-west-3"))
+        assert svc._bucket_regions["fresh-bucket"] == "eu-west-3"
+
+
+# ---------------------------------------------------------------------------
+# Cross-region resolution shared by the bucket-scoped operations
+# ---------------------------------------------------------------------------
+
+class TestBucketRegionResolution:
+
+    def test_explicit_region_wins(self, aws_svc) -> None:
+        aws_svc._client = MagicMock()
+        assert aws_svc._region_for_bucket("b", "eu-west-1") == "eu-west-1"
+
+    def test_endpoint_pinned_provider_ignores_discovery(self, hetzner_svc) -> None:
+        """No cross-region redirect exists for a fixed endpoint — never probe."""
+        client = MagicMock()
+        hetzner_svc._client = client
+        assert hetzner_svc._region_for_bucket("b", discover=True) == "nbg1"
+        client.head_bucket.assert_not_called()
+
+    def test_no_discovery_by_default(self) -> None:
+        """Ordinary ops must not pay for a HeadBucket — botocore redirects."""
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        client = MagicMock()
+        svc._client = client
+        assert svc._region_for_bucket("b") == "us-east-1"
+        client.head_bucket.assert_not_called()
+
+    def test_discovery_reads_bucket_region_header(self, aws_svc) -> None:
+        client = MagicMock()
+        client.head_bucket.return_value = {
+            "ResponseMetadata": {"HTTPHeaders": {"x-amz-bucket-region": "eu-north-1"}}
+        }
+        aws_svc._client = client
+        assert aws_svc._region_for_bucket("b", discover=True) == "eu-north-1"
+
+    def test_discovery_reads_header_from_error_response(self, aws_svc) -> None:
+        """S3 returns the region on 301/403 too — no read access needed."""
+        exc = Exception("AccessDenied")
+        exc.response = {
+            "ResponseMetadata": {"HTTPHeaders": {"x-amz-bucket-region": "sa-east-1"}}
+        }
+        client = MagicMock()
+        client.head_bucket.side_effect = exc
+        aws_svc._client = client
+        assert aws_svc._region_for_bucket("b", discover=True) == "sa-east-1"
+
+    def test_discovery_result_is_cached(self, aws_svc) -> None:
+        client = MagicMock()
+        client.head_bucket.return_value = {
+            "ResponseMetadata": {"HTTPHeaders": {"x-amz-bucket-region": "eu-north-1"}}
+        }
+        aws_svc._client = client
+        aws_svc._region_for_bucket("b", discover=True)
+        aws_svc._region_for_bucket("b", discover=True)
+        client.head_bucket.assert_called_once()
+
+    def test_discovery_failure_degrades_to_configured_region(self) -> None:
+        """A failed lookup must not break the operation it was serving."""
+        svc = ObjectStorageService(provider="aws", region="us-west-1")
+        client = MagicMock()
+        client.head_bucket.side_effect = Exception("boom")
+        svc._client = client
+        assert svc._region_for_bucket("b", discover=True) == "us-west-1"
+        assert "b" not in svc._bucket_regions
+
+    def test_malformed_header_region_is_rejected(self, aws_svc) -> None:
+        """The header is off-the-wire input feeding a client config."""
+        client = MagicMock()
+        client.head_bucket.return_value = {
+            "ResponseMetadata": {
+                "HTTPHeaders": {"x-amz-bucket-region": "../../evil region"}
+            }
+        }
+        aws_svc._client = client
+        assert aws_svc._region_for_bucket("b", discover=True) == ""
+
+    @pytest.mark.parametrize("op,args", [
+        ("list_objects", ("my-bucket",)),
+        ("delete_object", ("my-bucket", "k")),
+        ("delete_bucket", ("my-bucket",)),
+    ])
+    def test_ops_honour_region_override(self, op, args) -> None:
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        svc._client = MagicMock()
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=MagicMock(),
+        ) as boto:
+            asyncio.run(getattr(svc, op)(*args, region="ap-northeast-1"))
+        assert boto.call_args.kwargs["region_name"] == "ap-northeast-1"
+
+    def test_ops_reject_malformed_region(self, aws_svc) -> None:
+        aws_svc._client = MagicMock()
+        with pytest.raises(ValueError, match="region"):
+            asyncio.run(aws_svc.list_objects("my-bucket", region="Bad Region"))
+
+    def test_copy_uses_destination_region(self) -> None:
+        """A cross-region copy is driven from the destination side."""
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        svc._client = MagicMock()
+        dst_client = MagicMock()
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=dst_client,
+        ) as boto:
+            asyncio.run(svc.copy_object("src-b", "k", "dst-b", "k2", "eu-west-1"))
+        assert boto.call_args.kwargs["region_name"] == "eu-west-1"
+        dst_client.copy_object.assert_called_once_with(
+            CopySource={"Bucket": "src-b", "Key": "k"},
+            Bucket="dst-b",
+            Key="k2",
+        )
+
+    def test_move_routes_each_leg_to_its_own_region(self) -> None:
+        """Copy goes to the destination region, delete to the source one."""
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        svc._client = MagicMock()
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=MagicMock(),
+        ) as boto:
+            asyncio.run(svc.move_object(
+                "src-b", "k", "dst-b", "k2", "eu-west-1", "ap-south-1",
+            ))
+        used = [c.kwargs["region_name"] for c in boto.call_args_list]
+        assert used == ["eu-west-1", "ap-south-1"]
+
+    def test_delete_bucket_evicts_cached_region(self) -> None:
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        svc._bucket_regions["gone"] = "us-east-1"
+        svc._client = MagicMock()
+        asyncio.run(svc.delete_bucket("gone"))
+        assert "gone" not in svc._bucket_regions
+
+
+# ---------------------------------------------------------------------------
+# Presigned URLs — the one op that cannot be redirected after the fact
+# ---------------------------------------------------------------------------
+
+class TestPresignedUrlRegion:
+
+    def test_discovers_bucket_region_before_signing(self, aws_svc) -> None:
+        """SigV4 binds the region into the signature; getting it wrong yields
+        a URL that fails only when somebody opens it."""
+        default_client = MagicMock()
+        default_client.head_bucket.return_value = {
+            "ResponseMetadata": {"HTTPHeaders": {"x-amz-bucket-region": "eu-central-1"}}
+        }
+        aws_svc._client = default_client
+        signer = MagicMock()
+        signer.generate_presigned_url.return_value = "https://signed"
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=signer,
+        ) as boto:
+            url = asyncio.run(aws_svc.generate_presigned_url("my-bucket", "k"))
+        assert url == "https://signed"
+        assert boto.call_args.kwargs["region_name"] == "eu-central-1"
+
+    def test_explicit_region_skips_discovery(self, aws_svc) -> None:
+        client = MagicMock()
+        aws_svc._client = client
+        with patch(
+            "servonaut.services.object_storage_service.boto3.client",
+            return_value=MagicMock(),
+        ) as boto:
+            asyncio.run(aws_svc.generate_presigned_url("my-bucket", "k", 60, "us-west-2"))
+        client.head_bucket.assert_not_called()
+        assert boto.call_args.kwargs["region_name"] == "us-west-2"
+
+    def test_signs_with_configured_region_when_discovery_fails(self) -> None:
+        svc = ObjectStorageService(provider="aws", region="us-east-1")
+        client = MagicMock()
+        client.head_bucket.side_effect = Exception("no permission")
+        client.generate_presigned_url.return_value = "https://signed"
+        svc._client = client
+        url = asyncio.run(svc.generate_presigned_url("my-bucket", "k"))
+        assert url == "https://signed"
+
 
 # ---------------------------------------------------------------------------
 # delete_bucket


### PR DESCRIPTION
## Problem

`s3_create_bucket` took no region, so buckets were always created in the provider's configured region with no way to choose another one.

Two related defects sat underneath it:

- With no region configured, `CreateBucket` was sent without a `LocationConstraint` while boto3 still resolved a region from the ambient AWS config. AWS rejects that combination with `IllegalLocationConstraintException`, so bucket creation failed outright for anyone relying on ambient AWS config rather than app settings.
- Presigned URLs were signed with the configured region regardless of where the bucket actually lived. SigV4 binds the region into the credential scope, so a mismatch produced a URL that failed with `SignatureDoesNotMatch` once opened.

## Region handling

Bucket-scoped operations now take an optional `region`.

`CreateBucket` builds a client bound to the target region — the request has to reach that region's endpoint — and resolves the `LocationConstraint` from the explicit override, then the configured region, then whatever region boto3 resolved for the client. `us-east-1` correctly omits the constraint.

`generate_presigned_url` resolves the bucket's home region up front via a cached `HeadBucket`. It is the only operation that cannot self-correct: signing happens locally, so there is no request for botocore's region redirector to retry. Every other operation leans on that redirector instead and skips the probe, which keeps the common path at one round-trip. A failed lookup degrades to the configured region rather than failing the call, and reads the region from the `x-amz-bucket-region` response header, which S3 returns on 301/403 responses too — so no extra IAM permission is required.

`copy_object` is driven from the destination region, since S3 resolves `CopySource` globally and pulls the source itself. `move_object` takes separate destination and source regions because its two legs can target different ones.

Providers whose endpoint URL encodes the region (Hetzner, OVH) reject a differing override instead of sending the request to the endpoint's region while reporting back the region that was asked for.

Regions arriving from response headers get the same format validation as configured ones before they reach a client config.

## Object storage screen

The Create Bucket form gains a region picker, populated from the live region list so it cannot go stale. It loads on first use rather than at mount, defaults to the configured region, and is hidden for providers whose region is fixed by their endpoint.

## Compatibility

`region` is optional everywhere and omitting it preserves the previous behaviour, so existing callers and tool invocations are unaffected. The MCP tool schemas advertise it as optional and describe when it applies.
