### PR TITLE
fix(mcp): name the secret-store backend in DB tool messages

### DIFF
--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -201,6 +201,19 @@ class ServonautTools:
         """
         self._secret_provider = provider
 
+    def _describe_secret_store(self) -> str:
+        """Human-readable name of the backend the DB tools read/write.
+
+        The provider is resolved at boot from the user's secrets config, so
+        the same tool call lands in Bitwarden Secrets Manager for one
+        operator and in a local file for another. Every message that
+        mentions "the secret store" names which one it means — an agent
+        cannot otherwise tell, and has previously reported a credential as
+        never having reached Bitwarden when it had.
+        """
+        from servonaut.services.secrets_status import describe_secret_store
+        return describe_secret_store(self._secret_provider)
+
     def set_bw_ssh_config_service(self, service) -> None:
         """Bind/rebind the Bitwarden SSH-ref client after construction.
 
@@ -4508,8 +4521,8 @@ class ServonautTools:
             if password is None:
                 self._audit.log(tool_name, args, '', False, 'secret_not_found')
                 return None, None, None, (
-                    f"Secret {profile.password_secret!r} not found in the "
-                    "active secret store."
+                    f"Secret {profile.password_secret!r} not found in "
+                    f"{self._describe_secret_store()}."
                 )
 
         return instance, profile, (password or ""), ""
@@ -5499,7 +5512,8 @@ class ServonautTools:
         result = (
             f"Saved db_profile for {target_instance}{_label_note}: {eff_engine} "
             f"{eff_user}@{eff_host}:{eff_port}/{eff_db or '?'} "
-            f"(password in secret store as {secret_name!r})."
+            f"(password stored in {self._describe_secret_store()} as "
+            f"{secret_name!r})."
             + _select_hint + "\n"
             f"  tip: {eff_user!r} looks like the app user — for routine "
             "diagnostics prefer a dedicated read-only DB user (SELECT + "
@@ -5581,8 +5595,12 @@ class ServonautTools:
         if delete_secret and match.password_secret and self._secret_provider is not None:
             try:
                 deleted = await self._secret_provider.delete_secret(match.password_secret)
-                secret_note = (f" Secret {match.password_secret!r} "
-                               + ("deleted." if deleted else "was not present."))
+                _store = self._describe_secret_store()
+                secret_note = (
+                    f" Secret {match.password_secret!r} "
+                    + (f"deleted from {_store}." if deleted
+                       else f"was not present in {_store}.")
+                )
             except Exception as e:  # noqa: BLE001
                 secret_note = (f" (could not delete secret "
                                f"{match.password_secret!r}: {e})")

--- a/src/servonaut/services/secrets_status.py
+++ b/src/servonaut/services/secrets_status.py
@@ -44,6 +44,45 @@ def is_valid_project_id(project_id: Optional[str]) -> bool:
     return bool(project_id) and _UUID_RE.match(project_id.strip()) is not None
 
 
+def describe_secret_store(provider: object) -> str:
+    """Name the backend a secret physically lands in, for user-facing text.
+
+    Callers that only hold a resolved :class:`SecretProviderInterface`
+    (the MCP tools) have no view of the auth/entitlement state
+    :func:`compute_secrets_status` needs, but still owe the operator an
+    answer to "where did that password actually go?". Saying only
+    "the secret store" reads as a Servonaut-proprietary vault and has
+    misled agents into reporting that a credential never reached
+    Bitwarden when it did.
+
+    Duck-typed on ``provider_name`` rather than isinstance so test
+    doubles and any future provider degrade to the generic phrasing
+    instead of raising. Only the two names the resolver can produce are
+    recognised; anything else (including a bare mock) falls through.
+
+    The Bitwarden project id and the local file path are pointers, not
+    secrets — both are already shown by ``servonaut secrets status``.
+    """
+    if provider is None:
+        return "no active secret store"
+
+    name = getattr(provider, "provider_name", None)
+
+    if name == "bitwarden":
+        project_id = getattr(provider, "project_id", None)
+        if isinstance(project_id, str) and project_id:
+            return f"Bitwarden Secrets Manager (project {project_id})"
+        return "Bitwarden Secrets Manager"
+
+    if name == "local":
+        path = getattr(provider, "path", None)
+        if path is not None:
+            return f"the local secret store ({path})"
+        return "the local secret store"
+
+    return "your active secret store"
+
+
 @dataclass(frozen=True)
 class SecretsStatusSummary:
     """Point-in-time snapshot of the user's secrets-management state.

--- a/tests/test_secret_store_description.py
+++ b/tests/test_secret_store_description.py
@@ -1,0 +1,155 @@
+"""Naming the secret-store backend in user- and agent-facing messages.
+
+The active provider is resolved at boot from the operator's secrets config,
+so an identical ``db_setup_save`` call lands in Bitwarden Secrets Manager for
+one operator and in a local file for another. Messages that said only "the
+secret store" left agents unable to tell which — and one reported that a
+credential had never reached Bitwarden when it had.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from servonaut.config.schema import AppConfig, DBProfile
+from servonaut.mcp.guards import CommandGuard
+from servonaut.mcp.tools import ServonautTools
+from servonaut.services.bitwarden_provider import BitwardenProvider
+from servonaut.services.db_credential_scanner import DBCandidate
+from servonaut.services.secret_provider import LocalProvider
+from servonaut.services.secrets_status import describe_secret_store
+
+_PW = "s3cr3t-store-naming-pw"
+_PROJECT_ID = "11111111-2222-4333-8444-555555555555"
+
+
+def _tools(cfg: AppConfig, secret_provider):
+    """ServonautTools whose config_manager.update mutates the config."""
+    cm = MagicMock()
+    cm.get.return_value = cfg
+
+    def _update(**kwargs):
+        for k, v in kwargs.items():
+            setattr(cfg, k, v)
+    cm.update.side_effect = _update
+
+    return ServonautTools(
+        config_manager=cm, aws_service=MagicMock(),
+        custom_server_service=MagicMock(), cache_service=MagicMock(),
+        ssh_service=MagicMock(), connection_service=MagicMock(),
+        scp_service=MagicMock(), guard=CommandGuard(cfg.mcp),
+        audit=MagicMock(), secret_provider=secret_provider,
+    )
+
+
+def _bitwarden_provider(project_id: str = _PROJECT_ID) -> BitwardenProvider:
+    """A real BitwardenProvider — constructing it touches no network/bws."""
+    return BitwardenProvider(project_id=project_id)
+
+
+# ---------------------------------------------------------------------------
+# describe_secret_store — the pure describer
+# ---------------------------------------------------------------------------
+
+
+def test_describes_bitwarden_with_project_id():
+    out = describe_secret_store(_bitwarden_provider())
+    assert out == f"Bitwarden Secrets Manager (project {_PROJECT_ID})"
+
+
+def test_describes_local_provider_with_path(tmp_path: Path):
+    provider = LocalProvider(tmp_path / "secrets.json", _allow_any_path=True)
+    out = describe_secret_store(provider)
+    assert "local secret store" in out
+    assert str(tmp_path / "secrets.json") in out
+
+
+def test_describes_absent_provider():
+    assert describe_secret_store(None) == "no active secret store"
+
+
+def test_unknown_provider_degrades_to_generic_phrasing():
+    """Duck-typed, so a test double or a future provider never raises."""
+    assert describe_secret_store(MagicMock()) == "your active secret store"
+
+    class _FutureProvider:
+        provider_name = "vault"
+
+    assert describe_secret_store(_FutureProvider()) == "your active secret store"
+
+
+def test_bitwarden_without_readable_project_id_still_names_the_product():
+    """Defensive: a provider-shaped object with no usable id is still Bitwarden."""
+    stub = MagicMock()
+    stub.provider_name = "bitwarden"
+    stub.project_id = None
+    assert describe_secret_store(stub) == "Bitwarden Secrets Manager"
+
+
+# ---------------------------------------------------------------------------
+# Tool surface — the three messages that mention the store
+# ---------------------------------------------------------------------------
+
+
+def test_db_setup_save_names_the_backend_it_wrote_to():
+    cfg = AppConfig()
+    provider = _bitwarden_provider()
+    provider.set_secret = AsyncMock()  # don't shell out to bws
+    t = _tools(cfg, provider)
+    t._db_staging["tok"] = DBCandidate(
+        "mysql", "127.0.0.1", 3306, "app", _PW, "appdb", "/var/www/html/.env")
+
+    out = asyncio.run(t.db_setup_save("tok", instance_id="web"))
+
+    assert "Bitwarden Secrets Manager" in out
+    assert _PROJECT_ID in out
+    assert "'db/web'" in out          # the key name is still reported
+    assert _PW not in out             # ...but never the password
+
+
+def test_db_setup_save_names_the_local_file_when_local_is_active(tmp_path: Path):
+    cfg = AppConfig()
+    provider = LocalProvider(tmp_path / "secrets.json", _allow_any_path=True)
+    t = _tools(cfg, provider)
+    t._db_staging["tok"] = DBCandidate(
+        "mysql", "127.0.0.1", 3306, "app", _PW, "appdb", "/var/www/html/.env")
+
+    out = asyncio.run(t.db_setup_save("tok", instance_id="web"))
+
+    assert str(tmp_path / "secrets.json") in out
+    assert "Bitwarden" not in out
+    assert _PW not in out
+
+
+def test_secret_not_found_error_names_the_store_it_searched():
+    cfg = AppConfig()
+    cfg.db_profiles = [DBProfile(
+        instance="web", engine="mysql", host="127.0.0.1", port=3306,
+        user="app", password_secret="db/web", database="appdb",
+    )]
+    provider = _bitwarden_provider()
+    provider.get_secret = AsyncMock(return_value=None)  # absent from the vault
+    t = _tools(cfg, provider)
+    t._find_instance = AsyncMock(return_value={"id": "web", "name": "web"})
+
+    _, _, _, err = asyncio.run(t._resolve_db("web", "db_processlist", {}))
+
+    assert "not found in Bitwarden Secrets Manager" in err
+    assert _PROJECT_ID in err
+
+
+def test_db_setup_remove_names_the_store_it_deleted_from():
+    cfg = AppConfig()
+    cfg.db_profiles = [DBProfile(
+        instance="web", engine="mysql", host="127.0.0.1", port=3306,
+        user="app", password_secret="db/web", database="appdb",
+    )]
+    provider = _bitwarden_provider()
+    provider.delete_secret = AsyncMock(return_value=True)
+    t = _tools(cfg, provider)
+
+    out = asyncio.run(t.db_setup_remove("web"))
+
+    assert "deleted from Bitwarden Secrets Manager" in out
+    assert _PROJECT_ID in out

--- a/tests/test_secret_store_description.py
+++ b/tests/test_secret_store_description.py
@@ -21,7 +21,9 @@ from servonaut.services.secret_provider import LocalProvider
 from servonaut.services.secrets_status import describe_secret_store
 
 _PW = "s3cr3t-store-naming-pw"
-_PROJECT_ID = "11111111-2222-4333-8444-555555555555"
+# Synthetic project id: shape-valid so is_valid_project_id accepts it, but
+# patterned rather than random so it cannot be mistaken for a real vault.
+_PROJECT_ID = "11111111-2222-4333-8444-555555555555"  # leak-guard:allow
 
 
 def _tools(cfg: AppConfig, secret_provider):


### PR DESCRIPTION
## Problem

The DB tools store and read credentials through whichever secret provider is resolved at boot from the operator's secrets config — Bitwarden Secrets Manager for one operator, a local file for another. The messages reporting that work named neither:

```
(password in secret store as 'db/web')
Secret 'db/web' not found in the active secret store.
```

From the caller's side the two backends are indistinguishable, and "the secret store" reads as a Servonaut-proprietary vault rather than the operator's own Bitwarden. That is enough for a credential successfully written to Bitwarden to be reported back as never having reached it — and, on the read path, for a lookup failure to give no clue which store was searched.

## Change

`describe_secret_store(provider)` in `services/secrets_status.py` — the module that already owns the secrets-state view — renders the active backend:

| provider | rendering |
| --- | --- |
| Bitwarden | `Bitwarden Secrets Manager (project <id>)` |
| Local | `the local secret store (<path>)` |
| none active | `no active secret store` |

It is used in the three messages that mention the store:

| | before | after |
| --- | --- | --- |
| `db_setup_save` | `(password in secret store as 'db/web')` | `(password stored in Bitwarden Secrets Manager (project …) as 'db/web')` |
| `_resolve_db` | `Secret 'db/web' not found in the active secret store.` | `Secret 'db/web' not found in Bitwarden Secrets Manager (project …).` |
| `db_setup_remove` | `Secret 'db/web' deleted.` | `Secret 'db/web' deleted from Bitwarden Secrets Manager (project …).` |

The describer is duck-typed on `provider_name` rather than `isinstance`, so a provider added later degrades to generic phrasing instead of raising inside an error message.

The Bitwarden project id and the local file path are pointers, not secrets; `servonaut secrets status` already displays both. Passwords are unaffected — the tools continue to report only the key name.

## Tests

`tests/test_secret_store_description.py` covers the describer across every provider state, including the unknown-provider fallthrough, and asserts each of the three tool messages names its backend without leaking the stored password.
