### PR TITLE
feat(mcp): add codex and agy install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install and configure Servonaut, a TUI for managing servers (AWS EC2, OVHcloud, 
 8. For AI log analysis or chat with my own model (instead of Servonaut AI), help me configure `ai_provider` (openai/anthropic/gemini/ollama)
    - Each provider has its own key field (`openai_api_key`, `anthropic_api_key`, `gemini_api_key`, `ollama_api_key`); local Ollama needs none
    - Key fields support `$ENV_VAR` and `file:~/.secrets/key` syntax so secrets stay out of the config file
-9. Install the MCP server into my coding agent: `servonaut --mcp-install claude` (or `cursor`, `windsurf`, `opencode`, `vscode`, `all`)
+9. Install the MCP server into my coding agent: `servonaut --mcp-install claude` (or `cursor`, `windsurf`, `opencode`, `vscode`, `codex`, `agy`, `all`)
 10. (Optional) To let AI agents/teammates reach this machine over the relay — and to run proactive Findings scans — start it with `servonaut connect`
 
 After setup, launch with `servonaut` and walk me through the key features, including the Findings inbox if I enabled the hosted features.
@@ -330,6 +330,8 @@ servonaut --mcp-install cursor     # Cursor
 servonaut --mcp-install windsurf   # Windsurf
 servonaut --mcp-install opencode   # OpenCode
 servonaut --mcp-install vscode     # VS Code Copilot
+servonaut --mcp-install codex      # Codex CLI
+servonaut --mcp-install agy        # Antigravity CLI
 servonaut --mcp-install all        # All of the above
 
 # Run MCP server manually (stdio transport)
@@ -345,7 +347,7 @@ purely as an MCP backend for your coding agent:
 
 ```bash
 pipx install 'servonaut[mcp]'
-servonaut --mcp-install claude   # or cursor, windsurf, opencode, vscode, all
+servonaut --mcp-install claude   # or cursor, windsurf, opencode, vscode, codex, agy, all
 ```
 
 Configure credentials and servers the same way as a TUI install (

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -410,6 +410,6 @@ servonaut logout
 | `servonaut --install-desktop` | Create a desktop shortcut (Linux/macOS) |
 | `servonaut --setup-ovh` | Guided OVHcloud credential setup |
 | `servonaut --mcp` | Start as an MCP server (stdio transport) |
-| `servonaut --mcp-install <agent>` | Auto-install MCP into `claude`, `opencode`, `cursor`, `windsurf`, `vscode`, or `all` |
+| `servonaut --mcp-install <agent>` | Auto-install MCP into `claude`, `opencode`, `cursor`, `windsurf`, `vscode`, `codex`, `agy`, or `all` |
 
 See [MCP Tools reference](mcp-tools.md) for the full list of MCP tools.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -9,7 +9,7 @@ servonaut --mcp
 Or auto-install into a coding agent:
 
 ```bash
-servonaut --mcp-install claude       # or: cursor, windsurf, vscode, opencode, all
+servonaut --mcp-install claude       # or: cursor, windsurf, vscode, opencode, codex, agy, all
 ```
 
 This document lists every exposed tool.  The full canonical list (with JSON Schemas) lives in `src/servonaut/mcp/tool_schemas.py`.  When adding a tool, put the schema there — both the MCP server and the built-in chat adapter pick it up automatically.

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -775,7 +775,8 @@ def _main() -> None:
     parser.add_argument('--mcp-install', type=str, nargs='?', const='claude',
                         metavar='TARGET',
                         help='Install MCP server into a coding agent '
-                             '(claude, opencode, cursor, windsurf, vscode, all)')
+                             '(claude, opencode, cursor, windsurf, vscode, '
+                             'codex, agy, all)')
     parser.add_argument('--list-backups', action='store_true',
                         help='List local config backups and exit')
     parser.add_argument('--restore-backup', type=int, metavar='N', nargs='?', const=-1,

--- a/src/servonaut/mcp/installer.py
+++ b/src/servonaut/mcp/installer.py
@@ -7,7 +7,9 @@ import shutil
 import sys
 from pathlib import Path
 
-SUPPORTED_TARGETS = ['claude', 'opencode', 'cursor', 'windsurf', 'vscode']
+SUPPORTED_TARGETS = [
+    'claude', 'opencode', 'cursor', 'windsurf', 'vscode', 'codex', 'agy',
+]
 
 
 def _resolve_mcp_command() -> tuple[str, list[str]]:
@@ -48,8 +50,11 @@ def _appdata() -> Path:
 def _load_json(path: Path) -> dict:
     """Load a JSON config file, returning empty dict on missing or invalid."""
     if path.exists():
+        text = path.read_text()
+        if not text.strip():
+            return {}
         try:
-            return json.loads(path.read_text())
+            return json.loads(text)
         except json.JSONDecodeError:
             print(f"Warning: Could not parse {path}, will create fresh entry")
     return {}
@@ -198,12 +203,159 @@ def _install_vscode() -> None:
     print("Restart VS Code to use the new MCP server.")
 
 
+def _install_agy() -> None:
+    """Install into the Antigravity CLI global config.
+
+    Path: ~/.gemini/config/mcp_config.json
+
+    Antigravity uses the standard `mcpServers` map (command/args/env for stdio
+    transport), so the JSON shape matches Claude Code and Cursor. The `agy`
+    binary ships no `mcp` subcommand, so the file is written directly.
+    """
+    config_path = Path.home() / '.gemini' / 'config' / 'mcp_config.json'
+    config = _load_json(config_path)
+
+    if 'mcpServers' not in config:
+        config['mcpServers'] = {}
+
+    command, args = _resolve_mcp_command()
+    config['mcpServers']['servonaut'] = {
+        'command': command,
+        'args': args,
+        'env': {},
+    }
+
+    _save_json(config_path, config)
+    print(f"Installed servonaut MCP server in {config_path}")
+    print(f"  command: {command} {' '.join(args)}")
+    print("Restart Antigravity (agy) to use the new MCP server.")
+
+
+_CODEX_TABLE = 'mcp_servers.servonaut'
+_CODEX_HEADERS = (f'[{_CODEX_TABLE}]', '[mcp_servers."servonaut"]')
+
+# Keys this installer owns. Everything else in an existing block (timeouts,
+# approval mode, env) belongs to the user and is preserved verbatim.
+_CODEX_MANAGED_KEYS = ('command', 'args')
+
+
+def _codex_home() -> Path:
+    """Return the Codex CLI home directory (honours $CODEX_HOME)."""
+    return Path(os.environ.get('CODEX_HOME') or Path.home() / '.codex')
+
+
+def _toml_str(value: str) -> str:
+    """Render a Python string as a quoted TOML basic string."""
+    escaped = (
+        value.replace('\\', '\\\\')
+        .replace('"', '\\"')
+        .replace('\n', '\\n')
+        .replace('\r', '\\r')
+        .replace('\t', '\\t')
+    )
+    return f'"{escaped}"'
+
+
+def _split_codex_block(text: str) -> tuple[list[str], list[str], list[str]]:
+    """Split config text into (before, servonaut_block, after) line lists.
+
+    The block runs from its table header to the next top-level table header
+    (a line starting with '[' at column 0) or end of file.
+    """
+    lines = text.splitlines()
+
+    start = next(
+        (i for i, line in enumerate(lines) if line.strip() in _CODEX_HEADERS),
+        None,
+    )
+    if start is None:
+        return lines, [], []
+
+    end = next(
+        (j for j in range(start + 1, len(lines)) if lines[j].startswith('[')),
+        len(lines),
+    )
+    return lines[:start], lines[start:end], lines[end:]
+
+
+def _preserved_codex_lines(block: list[str]) -> list[str]:
+    """Return the block's lines minus the header and the keys we manage.
+
+    Multi-line values for a managed key are skipped in full by tracking
+    bracket depth, so a `args = [\\n  "--mcp",\\n]` form leaves no orphans.
+    """
+    kept: list[str] = []
+    depth = 0
+    skipping = False
+
+    for line in block[1:]:
+        if skipping:
+            depth += line.count('[') - line.count(']')
+            skipping = depth > 0
+            continue
+
+        key, sep, value = line.partition('=')
+        if sep and key.strip().strip('"') in _CODEX_MANAGED_KEYS:
+            depth = value.count('[') - value.count(']')
+            skipping = depth > 0
+            continue
+
+        kept.append(line)
+
+    while kept and not kept[-1].strip():
+        kept.pop()
+    return kept
+
+
+def _install_codex() -> None:
+    """Install into the Codex CLI global config ($CODEX_HOME or ~/.codex).
+
+    Codex uses TOML, and the Python stdlib can read TOML (3.11+) but never
+    write it. The server's block is therefore rewritten textually: only
+    `command` and `args` are managed here, and any other keys already set on
+    the block are preserved so hand-tuned timeouts survive a re-install.
+
+    See https://github.com/openai/codex/blob/main/docs/config.md
+    """
+    config_path = _codex_home() / 'config.toml'
+    command, args = _resolve_mcp_command()
+
+    text = config_path.read_text() if config_path.exists() else ''
+    before, block, after = _split_codex_block(text)
+    preserved = _preserved_codex_lines(block)
+
+    new_block = [
+        f'[{_CODEX_TABLE}]',
+        f'command = {_toml_str(command)}',
+        'args = [' + ', '.join(_toml_str(arg) for arg in args) + ']',
+        *preserved,
+    ]
+
+    while before and not before[-1].strip():
+        before.pop()
+    if before:
+        before.append('')
+    if after:
+        new_block.append('')
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('\n'.join(before + new_block + after) + '\n')
+
+    print(f"Installed servonaut MCP server in {config_path}")
+    print(f"  command: {command} {' '.join(args)}")
+    if preserved:
+        print(f"  preserved existing settings: {len(preserved)} line(s)")
+    print("Restart Codex to use the new MCP server.")
+
+
 _INSTALLERS = {
     'claude': _install_claude,
     'opencode': _install_opencode,
     'cursor': _install_cursor,
     'windsurf': _install_windsurf,
     'vscode': _install_vscode,
+    'codex': _install_codex,
+    'agy': _install_agy,
 }
 
 
@@ -212,7 +364,8 @@ def install_mcp_server(target: str) -> None:
 
     Args:
         target: One of 'claude', 'opencode', 'cursor', 'windsurf', 'vscode',
-                or 'all' to install into every supported client.
+                'codex', 'agy', or 'all' to install into every supported
+                client.
     """
     if target == 'all':
         for name, installer in _INSTALLERS.items():

--- a/src/servonaut/screens/help.py
+++ b/src/servonaut/screens/help.py
@@ -157,7 +157,8 @@ Expose Servonaut tools to AI agents like Claude Code.
 
 ```
 servonaut --mcp           # Start MCP server (stdio)
-servonaut --mcp-install [TARGET]  # Auto-install (claude, opencode, cursor, windsurf, vscode, all)
+servonaut --mcp-install [TARGET]  # Auto-install (claude, opencode, cursor,
+                                  #   windsurf, vscode, codex, agy, all)
 ```
 
 **Tools:** `list_instances`, `run_command`, `get_logs`, `check_status`, `get_server_info`, `transfer_file`

--- a/tests/test_mcp_installer.py
+++ b/tests/test_mcp_installer.py
@@ -1,0 +1,218 @@
+"""Tests for the MCP auto-installer (per-agent config writers)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from servonaut.mcp import installer
+from servonaut.mcp.installer import SUPPORTED_TARGETS, install_mcp_server
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect Path.home() and $CODEX_HOME into a throwaway directory."""
+    home = tmp_path / 'home'
+    home.mkdir()
+    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: home))
+    monkeypatch.delenv('CODEX_HOME', raising=False)
+    return home
+
+
+@pytest.fixture(autouse=True)
+def stub_command(monkeypatch):
+    """Pin the resolved MCP command so assertions are deterministic."""
+    monkeypatch.setattr(
+        installer, '_resolve_mcp_command', lambda: ('/usr/bin/servonaut', ['--mcp'])
+    )
+
+
+def test_every_supported_target_has_an_installer():
+    assert set(SUPPORTED_TARGETS) == set(installer._INSTALLERS)
+
+
+def test_unknown_target_exits_nonzero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        install_mcp_server('emacs')
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Unknown target 'emacs'" in out
+    # The error must advertise every target we actually support.
+    for target in SUPPORTED_TARGETS:
+        assert target in out
+
+
+# --- agy (Antigravity CLI) -------------------------------------------------
+
+
+def test_agy_writes_mcp_servers_entry(fake_home):
+    install_mcp_server('agy')
+
+    config = json.loads((fake_home / '.gemini' / 'config' / 'mcp_config.json').read_text())
+    assert config['mcpServers']['servonaut'] == {
+        'command': '/usr/bin/servonaut',
+        'args': ['--mcp'],
+        'env': {},
+    }
+
+
+def test_agy_preserves_other_servers(fake_home):
+    config_path = fake_home / '.gemini' / 'config' / 'mcp_config.json'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({'mcpServers': {'other': {'command': 'x'}}}))
+
+    install_mcp_server('agy')
+
+    config = json.loads(config_path.read_text())
+    assert config['mcpServers']['other'] == {'command': 'x'}
+    assert 'servonaut' in config['mcpServers']
+
+
+def test_agy_handles_zero_byte_config(fake_home, capsys):
+    """Antigravity ships an empty mcp_config.json — it must not warn or crash."""
+    config_path = fake_home / '.gemini' / 'config' / 'mcp_config.json'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text('')
+
+    install_mcp_server('agy')
+
+    assert 'Could not parse' not in capsys.readouterr().out
+    config = json.loads(config_path.read_text())
+    assert config['mcpServers']['servonaut']['command'] == '/usr/bin/servonaut'
+
+
+# --- codex (TOML) ----------------------------------------------------------
+
+
+def test_codex_creates_config(fake_home):
+    install_mcp_server('codex')
+
+    text = (fake_home / '.codex' / 'config.toml').read_text()
+    assert '[mcp_servers.servonaut]' in text
+    assert 'command = "/usr/bin/servonaut"' in text
+    assert 'args = ["--mcp"]' in text
+
+
+def test_codex_honours_codex_home(fake_home, tmp_path, monkeypatch):
+    codex_home = tmp_path / 'alt-codex'
+    monkeypatch.setenv('CODEX_HOME', str(codex_home))
+
+    install_mcp_server('codex')
+
+    assert (codex_home / 'config.toml').exists()
+    assert not (fake_home / '.codex').exists()
+
+
+def test_codex_preserves_sibling_tables_and_leading_config(fake_home):
+    config_path = fake_home / '.codex' / 'config.toml'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        'model = "gpt-5"\n'
+        '\n'
+        '[mcp_servers.github]\n'
+        'command = "gh-mcp"\n'
+        '\n'
+        '[mcp_servers.playwright]\n'
+        'command = "npx"\n'
+    )
+
+    install_mcp_server('codex')
+
+    text = config_path.read_text()
+    assert 'model = "gpt-5"' in text
+    assert '[mcp_servers.github]\ncommand = "gh-mcp"' in text
+    assert '[mcp_servers.playwright]\ncommand = "npx"' in text
+    assert '[mcp_servers.servonaut]' in text
+
+
+def test_codex_reinstall_preserves_user_tuning(fake_home):
+    """Re-installing must not wipe hand-set timeouts on our own block."""
+    config_path = fake_home / '.codex' / 'config.toml'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[mcp_servers.servonaut]\n'
+        'command = "/old/path/servonaut"\n'
+        'args = ["--mcp"]\n'
+        'startup_timeout_sec = 30\n'
+        'tool_timeout_sec = 180\n'
+        'default_tools_approval_mode = "prompt"\n'
+        '\n'
+        '[mcp_servers.github]\n'
+        'command = "gh-mcp"\n'
+    )
+
+    install_mcp_server('codex')
+
+    text = config_path.read_text()
+    assert 'command = "/usr/bin/servonaut"' in text
+    assert '/old/path/servonaut' not in text
+    assert 'startup_timeout_sec = 30' in text
+    assert 'tool_timeout_sec = 180' in text
+    assert 'default_tools_approval_mode = "prompt"' in text
+    # The managed keys must appear exactly once — no duplicate TOML keys.
+    assert text.count('command = "/usr/bin/servonaut"') == 1
+    assert text.count('args = ') == 1
+    assert text.count('[mcp_servers.servonaut]') == 1
+
+
+def test_codex_replaces_multiline_args_without_orphans(fake_home):
+    config_path = fake_home / '.codex' / 'config.toml'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[mcp_servers.servonaut]\n'
+        'command = "/old/servonaut"\n'
+        'args = [\n'
+        '  "--mcp",\n'
+        '  "--verbose",\n'
+        ']\n'
+        'tool_timeout_sec = 180\n'
+    )
+
+    install_mcp_server('codex')
+
+    lines = config_path.read_text().splitlines()
+    assert 'args = ["--mcp"]' in lines
+    # No orphaned continuation lines from the replaced multi-line array.
+    assert '  "--verbose",' not in lines
+    assert ']' not in lines
+    assert 'tool_timeout_sec = 180' in lines
+
+
+def test_codex_matches_quoted_table_header(fake_home):
+    config_path = fake_home / '.codex' / 'config.toml'
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[mcp_servers."servonaut"]\n'
+        'command = "/old/servonaut"\n'
+        'tool_timeout_sec = 99\n'
+    )
+
+    install_mcp_server('codex')
+
+    text = config_path.read_text()
+    assert '/old/servonaut' not in text
+    assert 'tool_timeout_sec = 99' in text
+    # Rewritten under the canonical bare-key header, and only once.
+    assert text.count('servonaut]') == 1
+
+
+def test_toml_str_escapes_quotes_and_backslashes():
+    assert installer._toml_str(r'C:\bin\servonaut.exe') == r'"C:\\bin\\servonaut.exe"'
+    assert installer._toml_str('say "hi"') == '"say \\"hi\\""'
+
+
+# --- all -------------------------------------------------------------------
+
+
+def test_all_runs_every_installer(fake_home):
+    calls: list[str] = []
+    stubs = {name: (lambda n=name: calls.append(n)) for name in SUPPORTED_TARGETS}
+
+    with patch.dict(installer._INSTALLERS, stubs, clear=True):
+        install_mcp_server('all')
+
+    assert set(calls) == set(SUPPORTED_TARGETS)


### PR DESCRIPTION
Adds two new `--mcp-install` targets, bringing the supported set to seven:

```bash
servonaut --mcp-install codex   # Codex CLI
servonaut --mcp-install agy     # Antigravity CLI
```

## Antigravity (`agy`)

Writes `~/.gemini/config/mcp_config.json`. Antigravity uses the same `mcpServers` map as Claude Code and Cursor, so this reuses the existing JSON writers.

Antigravity ships that file zero-byte, so `_load_json` now treats an empty file as an empty config rather than printing a parse warning on every first install.

## Codex

Writes `$CODEX_HOME`/`~/.codex/config.toml`. Codex uses TOML, which the standard library can read (3.11+) but never write, so the server's block is rewritten textually.

Only `command` and `args` are managed. Any other key already set on the block — `startup_timeout_sec`, `tool_timeout_sec`, `default_tools_approval_mode`, `env` — is preserved, so a re-install doesn't discard per-server tuning. Sibling tables and leading top-level config are left untouched, and a multi-line `args` array is replaced in full rather than leaving orphan lines behind.

## Tests

`tests/test_mcp_installer.py` is new — the installer had no direct coverage before. It covers both new writers, the zero-byte config case, re-install key preservation, multi-line array replacement, TOML string escaping, `$CODEX_HOME` handling, and that every entry in `SUPPORTED_TARGETS` has a registered installer.

Docs updated: `README.md`, `docs/cli-reference.md`, `docs/mcp-tools.md`, `--help`, and the in-app help screen.
