### PR TITLE
fix(ai-tools): tolerate unknown tool arguments; add hours_back to web_traffic_summary

### DIFF
--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -2048,6 +2048,13 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
                     "description": "How many top IPs/URLs to report (1–100, default 15).",
                     "default": 15,
                 },
+                "hours_back": {
+                    "type": "integer",
+                    "description": "Only count entries from the last N hours "
+                                   "(1–168). Omit for no time filter; the window "
+                                   "can never reach further back than the tailed "
+                                   "lines cover.",
+                },
             },
             "required": ["instance_id"],
         },

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -4227,6 +4227,7 @@ class ServonautTools:
     async def web_traffic_summary(
         self, instance_id: str, log_path: str = "",
         lines: int = 10000, top_n: int = 15,
+        hours_back: Optional[int] = None,
     ) -> str:
         """Summarize a box's OWN web access logs (XFF / mod_remoteip aware).
 
@@ -4234,16 +4235,29 @@ class ServonautTools:
         volume, approx req/s, status-code mix, top client IPs and top URLs.
         Unlike ``cloudwatch_top_ips`` (which only sees WAF logs), this reads
         the decisive data that lives on the box. When ``log_path`` is empty
-        it auto-discovers nginx/apache/httpd access logs.
+        it auto-discovers nginx/apache/httpd access logs. ``hours_back``
+        narrows the count to recent entries — within whatever the tailed
+        ``lines`` cover, since only those ever leave the box.
         """
         args = {
             'instance_id': instance_id, 'log_path': log_path,
-            'lines': lines, 'top_n': top_n,
+            'lines': lines, 'top_n': top_n, 'hours_back': hours_back,
         }
         allowed, reason = self._guard.check_tool('web_traffic_summary')
         if not allowed:
             self._audit.log('web_traffic_summary', args, '', False, reason)
             return f"Blocked: {reason}"
+
+        hours: Optional[int] = None
+        if hours_back is not None:
+            try:
+                hours = max(1, min(int(hours_back), 168))
+            except (TypeError, ValueError):
+                self._audit.log(
+                    'web_traffic_summary', args, '', False,
+                    'validation: hours_back must be an integer',
+                )
+                return "validation: hours_back must be an integer (1-168)"
 
         instance = await self._find_instance(instance_id)
         if not instance:
@@ -4286,7 +4300,9 @@ class ServonautTools:
         from servonaut.utils.log_analysis import (
             summarize_web_traffic, format_web_traffic,
         )
-        summary = summarize_web_traffic(stdout, top)
+        if hours is not None:
+            hint = f"{hint}, last {hours}h only"
+        summary = summarize_web_traffic(stdout, top, hours_back=hours)
         result = format_web_traffic(summary, log_hint=hint)
         if not summary.get("vhosts") and stderr.strip():
             result += f"\n\n(stderr: {stderr.strip()[:300]})"

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -28,6 +28,7 @@ collaborators mocked.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 from collections import OrderedDict
@@ -38,8 +39,10 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    List,
     Literal,
     Optional,
+    Tuple,
     TYPE_CHECKING,
 )
 
@@ -1022,11 +1025,24 @@ class AIToolBridge(_FloorDangerousMixin):
                 ),
             )
 
+        # The argument shape is authored server-side (the catalog the
+        # model sees) and can run ahead of the installed CLI: a knob the
+        # server knows about that this version's handler does not. Drop
+        # the unknown keys and say so in the result, instead of failing a
+        # call whose supported arguments were perfectly serviceable.
+        accepted_args, dropped_args = _split_supported_args(handler, call.args)
+        if dropped_args:
+            logger.warning(
+                "Local tool %r: ignoring unsupported argument(s) %s",
+                call.tool, dropped_args,
+            )
+
         try:
-            output = await handler(**call.args)
+            output = await handler(**accepted_args)
         except TypeError as exc:
-            # Argument shape mismatch — model emitted args the handler
-            # doesn't accept. Surface as error so the model can retry.
+            # Still reachable: a missing required argument, or a value of
+            # a shape the handler body rejects. Surface it so the model
+            # can retry with corrected arguments.
             logger.warning(
                 "Local tool %r argument mismatch: %s", call.tool, exc,
             )
@@ -1046,6 +1062,13 @@ class AIToolBridge(_FloorDangerousMixin):
             )
 
         text = output if isinstance(output, str) else str(output)
+        if dropped_args:
+            text = (
+                "note: this CLI version does not support the argument(s) "
+                f"{', '.join(dropped_args)} — they were ignored and the "
+                "result below reflects the remaining arguments only.\n\n"
+                + text
+            )
         result = ToolResult(
             tool_call_id=call.tool_call_id,
             conversation_id=call.conversation_id,
@@ -1053,7 +1076,10 @@ class AIToolBridge(_FloorDangerousMixin):
             result=text,
             bytes=_utf8_len(text),
         )
-        self._audit_tool_call(call, result, allowed=True, reason="ok_local")
+        self._audit_tool_call(
+            call, result, allowed=True,
+            reason="ok_local_dropped_args" if dropped_args else "ok_local",
+        )
         return result
 
     async def _execute_ip_ban_status(self, call: ToolCall) -> ToolResult:
@@ -1319,6 +1345,27 @@ class AIToolBridge(_FloorDangerousMixin):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _split_supported_args(handler: Any, args: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    """Split call arguments into (supported by *handler*, unknown names).
+
+    The unknown list is sorted for stable log/audit output. When the
+    handler's signature cannot be inspected, or it takes ``**kwargs``,
+    everything passes through untouched — filtering is only safe when the
+    signature actually enumerates what is accepted.
+    """
+    try:
+        parameters = inspect.signature(handler).parameters
+    except (TypeError, ValueError):
+        return dict(args), []
+    if any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    ):
+        return dict(args), []
+    accepted = {k: v for k, v in args.items() if k in parameters}
+    dropped = sorted(k for k in args if k not in parameters)
+    return accepted, dropped
 
 
 def _utf8_len(value: Any) -> int:

--- a/src/servonaut/services/relay_tool_executor.py
+++ b/src/servonaut/services/relay_tool_executor.py
@@ -132,8 +132,9 @@ def parse_mercure_tool_call(raw: Dict[str, Any]) -> Optional[ToolCall]:
     # Args: SSE shape puts them in ``args``; CommandRequest shape in
     # ``payload``. A payload that only wrapped metadata (tool_call_id,
     # conversation_id) still passes through — the bridge's per-tool arg
-    # handling tolerates extras for relay tools and TypeErrors cleanly
-    # (reason="bad_args") for local handlers.
+    # handling tolerates extras for relay tools, and for local handlers
+    # drops unsupported argument names with a note in the result
+    # (genuinely malformed calls still fail as reason="bad_args").
     raw_args = raw.get("args")
     if isinstance(raw_args, dict):
         args = dict(raw_args)
@@ -157,8 +158,8 @@ def parse_mercure_tool_call(raw: Dict[str, Any]) -> Optional[ToolCall]:
 
     # CommandRequest-style target: fold into args for relay-bound tools so
     # the bridge's target resolution finds it. Local ServonautTools
-    # handlers get their args untouched (an unexpected kwarg would
-    # TypeError as reason="bad_args").
+    # handlers get their args untouched (the bridge drops any argument
+    # name the handler doesn't support, noting it in the result).
     target = raw.get("target_server_id")
     if (
         tool in _RELAY_TOOL_TO_TYPE

--- a/src/servonaut/utils/log_analysis.py
+++ b/src/servonaut/utils/log_analysis.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import ipaddress
 import re
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 # Marker the remote one-liner prints before each vhost's log tail so we can
@@ -120,9 +120,12 @@ def _split_vhosts(raw: str) -> Dict[str, List[str]]:
     return sections
 
 
-def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
+def _summarize_section(
+    lines: List[str], top_n: int, cutoff: Optional[datetime] = None,
+) -> Dict[str, Any]:
     total = 0
     parsed = 0
+    filtered = 0
     statuses: Counter = Counter()
     ips: Counter = Counter()
     urls: Counter = Counter()
@@ -135,6 +138,18 @@ def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
         m = _LOG_RE.match(line)
         if not m:
             continue
+        ts: Optional[datetime] = None
+        try:
+            ts = datetime.strptime(m.group("ts"), _TS_FMT)
+        except ValueError:
+            pass
+        if cutoff is not None and ts is not None and ts < cutoff:
+            # Older than the requested window. Lines whose timestamp does
+            # not parse are counted rather than filtered — a log format
+            # without readable timestamps must degrade to the unfiltered
+            # summary, not silently to an empty one.
+            filtered += 1
+            continue
         parsed += 1
         statuses[m.group("status")] += 1
         client = extract_client_ip(line, m.group("host"))
@@ -142,10 +157,8 @@ def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
         # Strip the query string so /search?q=a and /search?q=b group together.
         url = m.group("url").split("?", 1)[0]
         urls[url] += 1
-        try:
-            timestamps.append(datetime.strptime(m.group("ts"), _TS_FMT))
-        except ValueError:
-            pass
+        if ts is not None:
+            timestamps.append(ts)
 
     window_seconds = 0.0
     if len(timestamps) >= 2:
@@ -154,7 +167,8 @@ def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
 
     return {
         "requests": parsed,
-        "unparsed": total - parsed,
+        "unparsed": total - parsed - filtered,
+        "filtered_out": filtered,
         "window_seconds": round(window_seconds, 1),
         "req_per_sec": round(req_per_sec, 2),
         "status_mix": dict(statuses.most_common()),
@@ -163,20 +177,37 @@ def _summarize_section(lines: List[str], top_n: int) -> Dict[str, Any]:
     }
 
 
-def summarize_web_traffic(raw: str, top_n: int = 15) -> Dict[str, Any]:
+def summarize_web_traffic(
+    raw: str, top_n: int = 15, hours_back: Optional[float] = None,
+) -> Dict[str, Any]:
     """Summarize access-log output into a per-vhost structure.
 
     Returns ``{"vhosts": {label: {...}}, "total_requests": int}``. Each
     vhost summary carries ``requests``, ``req_per_sec``, ``window_seconds``,
     ``status_mix``, ``top_ips`` and ``top_urls``.
+
+    Args:
+        raw: The tailed log output (with vhost markers).
+        top_n: How many top IPs/URLs to keep per vhost.
+        hours_back: When set, only entries newer than this many hours ago
+            count; older ones are reported in ``filtered_total``. Entries
+            without a parseable timestamp are always counted, so a log in
+            an unexpected format degrades to the unfiltered summary
+            instead of an empty one. The window can never see further
+            back than the lines that were tailed.
     """
+    cutoff: Optional[datetime] = None
+    if hours_back is not None and hours_back > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=hours_back)
     sections = _split_vhosts(raw)
     vhosts: Dict[str, Any] = {}
     total = 0
     unparsed_total = 0
+    filtered_total = 0
     for label, lines in sections.items():
-        summary = _summarize_section(lines, top_n)
+        summary = _summarize_section(lines, top_n, cutoff)
         unparsed_total += summary["unparsed"]
+        filtered_total += summary["filtered_out"]
         # Drop sections with nothing parseable — they'd only show empty
         # tables. The unparsed count is preserved at the top level so the
         # formatter can still tell the user "we saw lines but couldn't read
@@ -189,6 +220,7 @@ def summarize_web_traffic(raw: str, top_n: int = 15) -> Dict[str, Any]:
         "vhosts": vhosts,
         "total_requests": total,
         "unparsed_total": unparsed_total,
+        "filtered_total": filtered_total,
     }
 
 

--- a/tests/fixtures/server_catalog_v1.json
+++ b/tests/fixtures/server_catalog_v1.json
@@ -96,6 +96,7 @@
       "timeout"
     ],
     "web_traffic_summary": [
+      "hours_back",
       "instance_id",
       "lines",
       "log_path",

--- a/tests/test_ai_tool_bridge.py
+++ b/tests/test_ai_tool_bridge.py
@@ -1250,9 +1250,11 @@ def test_local_tool_with_no_servonaut_tools_returns_clear_error():
     assert "ServonautTools" in (result.error or "")
 
 
-def test_local_tool_argument_mismatch_returns_bad_args_error():
-    """If the model sends args the local handler can't accept, surface a
-    bad_args error instead of letting the TypeError bubble up."""
+def test_local_tool_unknown_argument_is_dropped_not_fatal():
+    """If the model sends an argument name the local handler can't accept
+    (hallucinated, or from a newer server-side catalog), the call still
+    runs on its supported arguments — with a note naming what was ignored
+    — instead of dead-ending as a bad_args error."""
     fake_tools = MagicMock()
     # Handler doesn't accept ``foo`` — simulates a model that hallucinated
     # an argument name.
@@ -1265,6 +1267,27 @@ def test_local_tool_argument_mismatch_returns_bad_args_error():
         tool="describe_instance",
         guard_level="readonly",
         args={"instance_id": "i-abc", "foo": "bar"},
+    )
+    result = run(bridge.handle_tool_call(call))
+
+    relay.execute.assert_not_awaited()
+    assert result.status == "ok"
+    assert "ok i-abc" in result.result
+    assert "foo" in result.result  # the note names the ignored argument
+
+
+def test_local_tool_missing_required_argument_is_still_bad_args():
+    """Dropping unknown names must not mask a genuinely malformed call."""
+    fake_tools = MagicMock()
+    async def _handler(instance_id):
+        return f"ok {instance_id}"
+    fake_tools.get_server_info = _handler
+    bridge, _, relay, _, _ = _make_bridge(servonaut_tools=fake_tools)
+
+    call = _call(
+        tool="describe_instance",
+        guard_level="readonly",
+        args={"foo": "bar"},
     )
     result = run(bridge.handle_tool_call(call))
 

--- a/tests/test_ai_tool_bridge_dispatch.py
+++ b/tests/test_ai_tool_bridge_dispatch.py
@@ -226,3 +226,82 @@ def test_unknown_tool_returns_error():
     result = run(bridge.handle_tool_call(call))
     assert result.status == "error"
     assert result.skipped is True
+
+
+# ---------------------------------------------------------------------------
+# Unsupported-argument tolerance (catalog drift)
+# ---------------------------------------------------------------------------
+
+class TestUnsupportedArgumentTolerance:
+    """The argument shape the model sees is authored server-side and can
+    run ahead of the installed CLI. Unknown argument names must be dropped
+    with a note, not fail a call whose supported arguments were fine."""
+
+    def _bridge_with_real_signature(self):
+        bridge, tools = _make_bridge_with_tools({})
+
+        async def web_traffic_summary(
+            instance_id: str, log_path: str = "",
+            lines: int = 10000, top_n: int = 15,
+        ) -> str:
+            return f"summary for {instance_id} top_n={top_n}"
+
+        # A plain async function (not an AsyncMock) so the real signature
+        # drives the filtering.
+        tools.web_traffic_summary = web_traffic_summary
+        return bridge, tools
+
+    def _call(self, args):
+        return ToolCall(
+            tool_call_id="tc-drift",
+            tool="web_traffic_summary",
+            args=args,
+            guard_level="dangerous",
+            conversation_id="conv-1",
+        )
+
+    def test_unknown_argument_is_dropped_with_a_note(self):
+        bridge, _ = self._bridge_with_real_signature()
+        result = run(bridge.handle_tool_call(
+            self._call({"instance_id": "web-1", "hours_ahead": 24})
+        ))
+        assert result.status == "ok"
+        assert "summary for web-1" in result.result
+        assert "hours_ahead" in result.result  # the note names what was ignored
+
+    def test_supported_arguments_still_reach_the_handler(self):
+        bridge, _ = self._bridge_with_real_signature()
+        result = run(bridge.handle_tool_call(
+            self._call({"instance_id": "web-1", "top_n": 3, "bogus_knob": 1})
+        ))
+        assert result.status == "ok"
+        assert "top_n=3" in result.result
+
+    def test_no_note_when_every_argument_is_supported(self):
+        bridge, _ = self._bridge_with_real_signature()
+        result = run(bridge.handle_tool_call(
+            self._call({"instance_id": "web-1"})
+        ))
+        assert result.status == "ok"
+        assert "ignored" not in result.result
+
+    def test_missing_required_argument_still_fails_as_bad_args(self):
+        bridge, _ = self._bridge_with_real_signature()
+        result = run(bridge.handle_tool_call(
+            self._call({"hours_ahead": 24})
+        ))
+        assert result.status == "error"
+        assert "Invalid arguments" in (result.error or result.result or "")
+
+    def test_mock_handlers_keep_receiving_everything(self):
+        """A **kwargs-shaped handler (mocks included) is never filtered."""
+        bridge, tools = _make_bridge_with_tools({"list_instances": "rows"})
+        result = run(bridge.handle_tool_call(ToolCall(
+            tool_call_id="tc-mock",
+            tool="list_instances",
+            args={"anything": "goes"},
+            guard_level="dangerous",
+            conversation_id="conv-1",
+        )))
+        assert result.status == "ok"
+        tools.list_instances.assert_called_once_with(anything="goes")

--- a/tests/test_incident_response_tools.py
+++ b/tests/test_incident_response_tools.py
@@ -1398,3 +1398,93 @@ def test_fleet_probe_detects_fpm_via_master():
     assert "pm.max_children" in cmd
     assert "s+=$1" in cmd                        # summed capacity, not single max
     assert "sudo -n" in cmd
+
+
+# ---------------------------------------------------------------------------
+# web_traffic_summary hours_back window
+# ---------------------------------------------------------------------------
+
+def _ts(hours_ago: float) -> str:
+    from datetime import datetime, timedelta, timezone
+    stamp = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    return stamp.strftime("%d/%b/%Y:%H:%M:%S %z")
+
+
+def test_hours_back_filters_entries_older_than_the_window():
+    raw = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [{_ts(1)}] "GET / HTTP/1.1" 200 12\n'
+        f'{_PUB_A} - - [{_ts(2)}] "GET /recent HTTP/1.1" 200 12\n'
+        f'{_PUB_B} - - [{_ts(30)}] "GET /old HTTP/1.1" 200 12\n'
+    )
+    s = summarize_web_traffic(raw, top_n=5, hours_back=24)
+    assert s["total_requests"] == 2
+    assert s["filtered_total"] == 1
+    urls = dict(s["vhosts"]["shop"]["top_urls"])
+    assert "/old" not in urls and "/recent" in urls
+
+
+def test_hours_back_none_counts_everything():
+    raw = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [{_ts(1)}] "GET / HTTP/1.1" 200 12\n'
+        f'{_PUB_B} - - [{_ts(30)}] "GET /old HTTP/1.1" 200 12\n'
+    )
+    s = summarize_web_traffic(raw, top_n=5)
+    assert s["total_requests"] == 2
+    assert s["filtered_total"] == 0
+
+
+def test_hours_back_keeps_lines_with_unreadable_timestamps():
+    """A format without readable timestamps degrades to unfiltered, not empty."""
+    raw = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [not-a-real-date] "GET /odd HTTP/1.1" 200 12\n'
+        f'{_PUB_B} - - [{_ts(30)}] "GET /old HTTP/1.1" 200 12\n'
+    )
+    s = summarize_web_traffic(raw, top_n=5, hours_back=24)
+    assert s["total_requests"] == 1
+    assert dict(s["vhosts"]["shop"]["top_urls"]) == {"/odd": 1}
+
+
+def test_hours_back_filtering_everything_reports_no_vhosts():
+    raw = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [{_ts(48)}] "GET /old HTTP/1.1" 200 12\n'
+    )
+    s = summarize_web_traffic(raw, top_n=5, hours_back=24)
+    assert s["vhosts"] == {}
+    assert s["filtered_total"] == 1
+
+
+def test_web_traffic_summary_tool_applies_the_hours_window():
+    t = _tools()
+    t._find_instance = _async_return({"id": "i-1", "name": "web-1"})  # type: ignore
+    dump = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [{_ts(1)}] "GET /recent HTTP/1.1" 200 12\n'
+        f'{_PUB_B} - - [{_ts(30)}] "GET /old HTTP/1.1" 200 12\n'
+    )
+    t._exec_ssh = _async_return((dump, ""))  # type: ignore
+    out = asyncio.run(t.web_traffic_summary("web-1", hours_back=24))
+    assert "/recent" in out
+    assert "/old" not in out
+    assert "last 24h only" in out
+
+
+def test_web_traffic_summary_tool_clamps_the_hours_window():
+    t = _tools()
+    t._find_instance = _async_return({"id": "i-1", "name": "web-1"})  # type: ignore
+    dump = (
+        "===VHOST:/var/log/nginx/shop.access.log===\n"
+        f'{_PUB_A} - - [{_ts(1)}] "GET / HTTP/1.1" 200 12\n'
+    )
+    t._exec_ssh = _async_return((dump, ""))  # type: ignore
+    out = asyncio.run(t.web_traffic_summary("web-1", hours_back=99999))
+    assert "last 168h only" in out
+
+
+def test_web_traffic_summary_tool_rejects_a_non_integer_window():
+    t = _tools()
+    out = asyncio.run(t.web_traffic_summary("web-1", hours_back="soon"))
+    assert out.startswith("validation:")


### PR DESCRIPTION
**Description of Changes:**

Fixes a dead-end failure mode in AI-chat tool calls, observed live: a call to `web_traffic_summary` with an `hours_back` argument failed outright (`bad_args`) because the installed CLI's handler didn't know that argument name — even though every supported argument in the call was fine.

Two changes:

**Unknown tool arguments are now tolerated.** The chat tool bridge inspects the local handler's signature and drops argument names it doesn't support, prefixing the tool result with a note naming exactly what was ignored so the model can account for it. The tool-argument vocabulary is authored remotely and can run ahead of an installed CLI (and models also invent plausible knobs) — an unknown *optional* argument shouldn't discard an otherwise valid call. Genuinely malformed calls (missing required arguments) still fail as `bad_args`, and handlers taking `**kwargs` are never filtered. Audited under a distinct reason (`ok_local_dropped_args`) so drift stays visible.

**`web_traffic_summary` gains `hours_back`** (integer, 1–168) — the argument that surfaced the issue, implemented for real: the summary is restricted to entries newer than N hours using the access-log timestamps already parsed for the req/s figure. Entries without readable timestamps stay counted (unusual formats degrade to the unfiltered summary, never an empty one), the window can never reach past the tailed `lines`, filtered volume is reported, and the result header names the window ("last 24h only").

**Related Issues:**

None.
