### PR TITLE
fix(findings): card titles, confirm-modal labelling, undo plan, and non-AWS IP blocking

### DIFF
--- a/src/servonaut/screens/findings.py
+++ b/src/servonaut/screens/findings.py
@@ -1119,6 +1119,15 @@ class FindingDetailScreen(Screen[bool]):
     #: server-side from the finding, never sent by us.
     _ACTIONS_REQUIRING_METHOD = frozenset({"block_ip"})
 
+    #: Flags a provider service stamps on its instance dicts. AWS stamps
+    #: none of them, so any one of these means "not an EC2 instance".
+    _NON_AWS_INSTANCE_FLAGS = ("is_custom", "is_ovh", "is_hetzner")
+
+    #: ``provider`` values that still mean EC2. AWS instances carry no
+    #: ``provider`` key at all; the others are belt-and-braces for
+    #: hand-written or future entries.
+    _AWS_PROVIDER_NAMES = frozenset({"", "aws", "ec2", "amazon"})
+
     def _find_finding_instance(self) -> Optional[Dict[str, Any]]:
         """Locate the finding's instance in the merged fleet list."""
         instance_id = str(self._finding.get("instance_id") or "")
@@ -1127,23 +1136,43 @@ class FindingDetailScreen(Screen[bool]):
                 return inst
         return None
 
+    @classmethod
+    def _is_aws_instance(cls, instance: Optional[Dict[str, Any]]) -> bool:
+        """Whether AWS control-plane banning can shield this instance.
+
+        A provider flag wins over ``provider``: a custom server the user
+        happened to label "aws" is still a box we hold no EC2 handle on
+        (no instance id or region to resolve a WAF/SG/NACL against), so
+        it belongs on the on-box path.
+        """
+        if not isinstance(instance, dict):
+            return False
+        if any(instance.get(flag) for flag in cls._NON_AWS_INSTANCE_FLAGS):
+            return False
+        provider = str(instance.get("provider") or "").strip().lower()
+        return provider in cls._AWS_PROVIDER_NAMES
+
     async def _resolve_block_ip_method(self) -> tuple:
         """Return ``(method, error)`` for a block_ip remediation.
 
         AWS instances ban at the control plane — the method comes from a
-        configured IP-ban plane (WAF/SG/NACL). Non-AWS/custom instances
-        (OVH, bare metal) can't be shielded by AWS WAF, so we SSH-detect
-        the box's active firewall and ban ON the box (nftables/ufw/
-        firewalld). Either way the confirm modal renders the server's
-        ``ban <ip> via <method>`` string and gates on a typed
-        confirmation, so the chosen plane is always visible and
+        configured IP-ban plane (WAF/SG/NACL). Every other provider
+        (custom, OVH, Hetzner, bare metal) can't be shielded by AWS WAF,
+        so we SSH-detect the box's active firewall and ban ON the box
+        (nftables/ufw/firewalld). Either way the confirm modal renders
+        the server's ``ban <ip> via <method>`` string and gates on a
+        typed confirmation, so the chosen plane is always visible and
         cancellable. A resolution failure returns a slug-style error the
         caller surfaces instead of calling preview.
+
+        An instance missing from the fleet list keeps the control-plane
+        path: it is the only branch that needs nothing but the user's
+        IP-ban config, so an AWS finding raised before the fleet list
+        loads still resolves.
         """
         instance = self._find_finding_instance()
-        is_custom = bool(instance and instance.get("is_custom"))
 
-        if not is_custom:
+        if instance is None or self._is_aws_instance(instance):
             svc = getattr(self.app, "ip_ban_service", None)
             configs = svc.get_configs() if svc is not None else []
             methods = sorted({

--- a/src/servonaut/screens/findings.py
+++ b/src/servonaut/screens/findings.py
@@ -1285,8 +1285,14 @@ class FindingDetailScreen(Screen[bool]):
             elif decision == "dry_run":
                 self._launch_remediation(remediation, dry_run=True)
 
+        # The preview envelope carries the raw verb, never a label, so the
+        # header would read "block_ip". We already hold the playbook
+        # option's wording — hand it to the modal.
         self.app.push_screen(
-            RemediationConfirmModal(preview, dry_run=dry_run),
+            RemediationConfirmModal(
+                preview, dry_run=dry_run,
+                label=str(remediation.get("label") or "") or None,
+            ),
             _on_decision,
         )
 
@@ -1510,13 +1516,13 @@ class FindingDetailScreen(Screen[bool]):
             elif decision == "dry_run":
                 self._launch_revert(dry_run=True)
 
-        # The shared confirm modal titles itself from ``label``/``action``;
-        # the revert preview has neither (its key is ``verb``), so inject a
-        # label so the header reads "Undo…" rather than the generic
-        # "Remediation" fallback. command.human is still rendered verbatim.
-        modal_preview = {**preview, "label": "Undo remediation"}
+        # The revert preview has no label (its verb key is ``verb``), so
+        # title the modal explicitly rather than letting the header fall
+        # back to the raw verb. command.human still renders verbatim.
         self.app.push_screen(
-            RemediationConfirmModal(modal_preview, dry_run=dry_run),
+            RemediationConfirmModal(
+                preview, dry_run=dry_run, label="Undo remediation",
+            ),
             _on_decision,
         )
 

--- a/src/servonaut/screens/remediation_confirm.py
+++ b/src/servonaut/screens/remediation_confirm.py
@@ -28,6 +28,10 @@ from textual.widgets import Button, Input, Static
 #: The literal the user must type to arm the Execute button.
 CONFIRM_PHRASE = "RUN"
 
+#: Shown when the preview carries no usable undo plan. Silence would
+#: read as "reversible" — say so explicitly instead.
+NO_REVERT_TEXT = "no clean revert — this cannot be undone automatically"
+
 
 def preview_command_lines(preview: Dict[str, Any]) -> list:
     """Render the preview's command deterministically.
@@ -49,6 +53,23 @@ def preview_command_lines(preview: Dict[str, Any]) -> list:
         for key in sorted(args):
             lines.append(f"  {key}: {json.dumps(args[key], sort_keys=True)}")
     return lines
+
+
+def revert_plan_summary(preview: Dict[str, Any]) -> str:
+    """Return the human "what undoes this" line for the confirm modal.
+
+    Contract §6.4: the preview carries ``revert_plan`` so the operator
+    sees the undo path at the moment of confirmation, not after the
+    fact. ``human`` is the server-authored sentence; anything missing,
+    non-dict or blank falls back to :data:`NO_REVERT_TEXT` so the modal
+    always answers the question one way or the other.
+    """
+    plan = preview.get("revert_plan")
+    if isinstance(plan, dict):
+        human = plan.get("human")
+        if isinstance(human, str) and human.strip():
+            return human.strip()
+    return NO_REVERT_TEXT
 
 
 class RemediationConfirmModal(ModalScreen[Optional[str]]):
@@ -91,6 +112,7 @@ class RemediationConfirmModal(ModalScreen[Optional[str]]):
             escape(line) for line in preview_command_lines(p)
         )
         expires = escape(str(p.get("expires_at") or ""))
+        revert_line = escape(revert_plan_summary(p))
 
         yield Container(
             Static(
@@ -107,6 +129,12 @@ class RemediationConfirmModal(ModalScreen[Optional[str]]):
                     id="remediation_confirm_command",
                 ),
                 id="remediation_confirm_scroll",
+            ),
+            # Outside the scroll on purpose: a long command must not
+            # push the undo path out of view at confirm time.
+            Static(
+                f"[dim]Undo, if needed: {revert_line}[/dim]",
+                id="remediation_confirm_revert",
             ),
             Input(
                 placeholder=f"Type {CONFIRM_PHRASE} to arm Execute",

--- a/src/servonaut/screens/remediation_confirm.py
+++ b/src/servonaut/screens/remediation_confirm.py
@@ -58,14 +58,28 @@ class RemediationConfirmModal(ModalScreen[Optional[str]]):
         Binding("escape", "cancel", "Cancel", show=True),
     ]
 
-    def __init__(self, preview: Dict[str, Any], *, dry_run: bool) -> None:
+    def __init__(
+        self, preview: Dict[str, Any], *, dry_run: bool,
+        label: Optional[str] = None,
+    ) -> None:
+        """``label`` is the human title for the header.
+
+        The server's preview envelope has no ``label`` field — it
+        carries the raw verb in ``action``/``verb`` — so a caller that
+        knows the playbook option's wording ("Block 198.51.100.23")
+        passes it here rather than letting the header read "block_ip".
+        """
         super().__init__()
         self._preview = dict(preview)
         self._dry_run = dry_run
+        self._label = label
 
     def compose(self) -> ComposeResult:
         p = self._preview
-        label = escape(str(p.get("label") or p.get("action") or "Remediation"))
+        label = escape(str(
+            self._label or p.get("label") or p.get("action")
+            or p.get("verb") or "Remediation",
+        ))
         risk = escape(str(
             p.get("exec_risk") or p.get("risk_tier") or "unknown",
         ))

--- a/src/servonaut/styles/screens/findings.tcss
+++ b/src/servonaut/styles/screens/findings.tcss
@@ -86,7 +86,9 @@
     color: $accent;
     text-style: bold;
     padding: 0 0 1 0;
-    height: 1;
+    /* auto, not 1: Textual heights include padding, so height 1 with a
+       line of bottom padding leaves zero lines for the title text. */
+    height: auto;
 }
 
 .findings_card_body {

--- a/src/servonaut/styles/screens/findings.tcss
+++ b/src/servonaut/styles/screens/findings.tcss
@@ -242,6 +242,11 @@ RemediationConfirmModal {
     height: auto;
 }
 
+#remediation_confirm_revert {
+    height: auto;
+    padding: 1 0 0 0;
+}
+
 #remediation_confirm_input {
     margin: 1 0;
 }

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -1445,3 +1445,79 @@ class TestConfirmModalPresentation:
         assert revert_plan_summary(
             {"revert_plan": {"executable": False, "human": "   "}},
         ) == NO_REVERT_TEXT
+
+
+class TestBlockIPProviderRouting:
+    @pytest.mark.parametrize("instance", [
+        {"id": "i-0000test01", "name": "web-1"},
+        {"id": "i-0000test01", "name": "web-1", "provider": "AWS"},
+    ])
+    def test_aws_instances_use_the_control_plane(self, instance):
+        assert FindingDetailScreen._is_aws_instance(instance) is True
+
+    @pytest.mark.parametrize("instance", [
+        {"id": "srv-1", "is_custom": True},
+        {"id": "srv-1", "is_ovh": True, "provider": "OVH"},
+        {"id": "srv-1", "is_hetzner": True, "provider": "hetzner"},
+        # A provider flag outranks a `provider` string: we hold no EC2
+        # handle on a hand-added box regardless of what it is labelled.
+        {"id": "srv-1", "is_custom": True, "provider": "aws"},
+        {"id": "srv-1", "provider": "digitalocean"},
+    ])
+    def test_non_aws_instances_take_the_onbox_path(self, instance):
+        assert FindingDetailScreen._is_aws_instance(instance) is False
+
+    @pytest.mark.parametrize("flag,provider", [
+        ("is_hetzner", "hetzner"),
+        ("is_ovh", "OVH"),
+    ])
+    @pytest.mark.asyncio
+    async def test_hetzner_and_ovh_detect_the_onbox_firewall(
+        self, flag, provider,
+    ):
+        # Regression: routing on `is_custom` alone stranded every other
+        # non-AWS provider on the control-plane branch, which offered
+        # WAF/SG/NACL planes that cannot shield a non-AWS box.
+        finding = _finding(
+            instance_id="web-1",
+            remediations=[{
+                "label": "Block the source IP", "description": "Block it.",
+                "action": "block_ip", "risk_tier": "medium",
+                "reversible": True, "automatable": True,
+            }],
+        )
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock(return_value={
+            "finding_id": "fnd_01abc", "action": "block_ip",
+            "exec_risk": "low", "reversible": True, "dry_run": False,
+            "command": {"verb": "block_ip", "human": "ban 9.9.9.9 via ufw"},
+            "confirm_token": "tok-signed",
+            "expires_at": "2026-07-04T14:00:00Z",
+        })
+        tools = MagicMock()
+        tools.detect_onbox_firewall = AsyncMock(return_value="ufw")
+        ip_ban = MagicMock()
+        ip_ban.get_configs = MagicMock(return_value=[
+            MagicMock(method="waf"),
+        ])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            ip_ban_service=ip_ban,
+            servonaut_tools=tools,
+            instances=[{"id": "web-1", "name": "web-1",
+                        flag: True, "provider": provider}],
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            tools.detect_onbox_firewall.assert_awaited_once_with("web-1")
+            # The configured AWS plane must NOT win for a non-AWS box.
+            svc.remediate_preview.assert_awaited_once_with(
+                "fnd_01abc", "block_ip", dry_run=False, method="ufw",
+            )

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -15,6 +15,7 @@ hosts, IPs, or customer identifiers may appear here.
 """
 from __future__ import annotations
 
+import pathlib
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1300,3 +1301,46 @@ class TestFindingRevertFlow:
             # A dry run never flips _changed (nothing mutated).
             assert screen._changed is False
             assert screen._reverting is False
+
+
+# ---------------------------------------------------------------------------
+# Confirm-modal presentation + provider routing
+# ---------------------------------------------------------------------------
+
+
+class TestCardTitleVisibility:
+    """Guards the card-title layout against the padding-vs-height trap.
+
+    The screen tests above host the screens in a bare ``App`` that never
+    loads ``findings.tcss``, so they cannot see a stylesheet bug. This
+    one applies the real stylesheet to the real class name.
+    """
+
+    @pytest.mark.asyncio
+    async def test_card_title_has_a_content_line_under_real_css(self):
+        # Regression: .findings_card_title paired `height: 1` with a line
+        # of bottom padding. Textual heights include padding, so the
+        # title was allotted zero content lines and every card heading on
+        # the findings + detail screens rendered blank.
+        from servonaut.screens import findings as findings_module
+
+        css = (
+            pathlib.Path(findings_module.__file__).resolve().parents[1]
+            / "styles" / "screens" / "findings.tcss"
+        )
+
+        class _StyledApp(App):
+            CSS_PATH = str(css)
+
+            def compose(self):
+                yield Static("Details", classes="findings_card_title")
+
+        app = _StyledApp()
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            title = app.screen.query_one(".findings_card_title")
+            assert title.size.height >= 1, (
+                "card title is allotted no content line — check that "
+                ".findings_card_title does not pair a fixed height with "
+                "vertical padding"
+            )

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -1399,3 +1399,49 @@ class TestConfirmModalPresentation:
             text = _rendered_text(app)
             assert "Block 198.51.100.23" in text
             assert "block_ip" not in text.split("Exact command")[0]
+
+    @pytest.mark.asyncio
+    async def test_revert_plan_rendered_at_confirm_time(self):
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock(return_value=self._preview())
+        ip_ban = MagicMock()
+        ip_ban.get_configs = MagicMock(return_value=[
+            MagicMock(method="security_group"),
+        ])
+        finding = _finding(remediations=[{
+            "label": "Block the source IP", "description": "Block it.",
+            "action": "block_ip", "risk_tier": "medium",
+            "reversible": True, "automatable": True,
+        }])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            ip_ban_service=ip_ban,
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            text = _rendered_text(app)
+            # The operator sees the undo path BEFORE typing RUN.
+            assert "Undo, if needed: unblock 9.9.9.9 via nftables" in text
+
+    def test_revert_plan_summary_fallbacks(self):
+        from servonaut.screens.remediation_confirm import (
+            NO_REVERT_TEXT, revert_plan_summary,
+        )
+        assert revert_plan_summary(
+            {"revert_plan": {"human": "  unblock via ufw  "}},
+        ) == "unblock via ufw"
+        # Missing, wrong-typed or blank plans must still say something —
+        # silence would read as "reversible".
+        assert revert_plan_summary({}) == NO_REVERT_TEXT
+        assert revert_plan_summary({"revert_plan": None}) == NO_REVERT_TEXT
+        assert revert_plan_summary({"revert_plan": "none"}) == NO_REVERT_TEXT
+        assert revert_plan_summary(
+            {"revert_plan": {"executable": False, "human": "   "}},
+        ) == NO_REVERT_TEXT

--- a/tests/test_findings_screen.py
+++ b/tests/test_findings_screen.py
@@ -1344,3 +1344,58 @@ class TestCardTitleVisibility:
                 ".findings_card_title does not pair a fixed height with "
                 "vertical padding"
             )
+
+
+class TestConfirmModalPresentation:
+    def _preview(self, **overrides) -> dict:
+        p = {
+            "finding_id": "fnd_01abc",
+            "action": "block_ip",
+            "exec_risk": "medium",
+            "reversible": True,
+            "dry_run": False,
+            "command": {"verb": "block_ip",
+                        "human": "ban 9.9.9.9 via nftables"},
+            "revert_plan": {
+                "tier": 2, "strategy": "unblock_ip", "executable": True,
+                "human": "unblock 9.9.9.9 via nftables", "handle": "h1",
+            },
+            "confirm_token": "tok-signed",
+            "expires_at": "2026-07-04T14:00:00Z",
+        }
+        p.update(overrides)
+        return p
+
+    @pytest.mark.asyncio
+    async def test_header_uses_playbook_label_not_raw_verb(self):
+        # The server's preview envelope has no `label` field, so a header
+        # sourced from the preview alone reads "block_ip". The caller holds
+        # the playbook option's wording and must pass it through.
+        finding = _finding(remediations=[{
+            "label": "Block 198.51.100.23",
+            "description": "Block the offending ip at the firewall.",
+            "action": "block_ip", "risk_tier": "medium",
+            "reversible": True, "automatable": True,
+        }])
+        svc = _mock_findings_service()
+        svc.remediate_preview = AsyncMock(return_value=self._preview())
+        ip_ban = MagicMock()
+        ip_ban.get_configs = MagicMock(return_value=[
+            MagicMock(method="security_group"),
+        ])
+        app = _WrapperApp(
+            screen=FindingDetailScreen(finding),
+            auth=_mock_auth(),
+            findings_service=svc,
+            ip_ban_service=ip_ban,
+        )
+        async with app.run_test(headless=True) as pilot:
+            await pilot.pause()
+            await pilot.pause(0.05)
+            screen = app.screen_stack[-1]
+            (button_id, _rem), = screen._remediation_buttons.items()
+            screen.query_one(f"#{button_id}").press()
+            await pilot.pause(0.1)
+            text = _rendered_text(app)
+            assert "Block 198.51.100.23" in text
+            assert "block_ip" not in text.split("Exact command")[0]


### PR DESCRIPTION
Four fixes to the findings UI, all on the gated-remediation path.

### Card titles rendered blank

`.findings_card_title` paired `height: 1` with a line of bottom padding. Textual heights include padding, so the title was allotted zero content lines and every card heading on the findings and finding-detail screens ("Details", "Evidence", "Suggested remediations", "Undo") rendered empty. Now `height: auto`.

### Confirm modal showed the raw verb

The remediation preview envelope has no `label` field — its verb lives in `action`/`verb` — so the confirm header read `block_ip` rather than `Block 198.51.100.23`. The caller already holds the playbook option's wording, so it is now passed to the modal as an explicit constructor argument. The revert path drops its preview-merge workaround for the same argument, which keeps the server-signed envelope free of client-authored keys.

### The undo plan was never shown at confirm time

The preview carries `revert_plan` so the operator can see what undoes a change at the moment they confirm it, but the modal ignored the field. It now renders `revert_plan.human` as a dim line beneath the command block — outside the scroll container, so a long command cannot push it out of view. A missing or blank plan falls back to an explicit "no clean revert" rather than staying silent, since silence would read as "reversible".

### Non-AWS instances were offered AWS-only ban planes

`block_ip` resolved its ban plane by checking `is_custom` alone. Only the custom-server service sets that flag, so Hetzner and OVH instances fell through to the AWS control-plane branch and were either offered WAF/SG/NACL planes that cannot shield a non-AWS box, or told to add an IP-ban config — an AWS-only remedy.

The branch now matches the intent the method already documented: any instance that is not EC2 takes the on-box firewall-detection path, keyed on the provider flags each service stamps (`is_custom`/`is_ovh`/`is_hetzner`) with a provider-name check behind them. A provider flag outranks the provider string, since a hand-added box labelled "aws" still has no EC2 handle to resolve a WAF against. An instance missing from the fleet list keeps the control-plane path — it is the only branch that needs nothing but the user's IP-ban config, so a finding raised before the fleet list loads still resolves.

### Tests

Each fix ships a guard that was confirmed to fail against the unfixed code and pass against the fix. The card-title guard applies the real stylesheet to the real class name, because the existing screen tests host their screens in a bare `App` that never loads it and so cannot see a stylesheet bug at all.

Full suite: 7500 passed, 6 skipped.
