### PR TITLE
fix(mcp): harden cross-client reliability

### DIFF
--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -32,7 +32,11 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          # Keep the base commit's ancestry available for the three-dot diff.
+          # A depth-1 re-fetch can mark an updated base as shallow even after
+          # checkout fetched full history, leaving Git unable to find the
+          # genuine merge base with an older feature branch.
+          git fetch --no-tags origin "$BASE_REF"
           mkdir -p "$RUNNER_TEMP/guard"
           # Prefer base-branch versions so a PR can't weaken its own guard; fall
           # back to the PR copy only when base lacks them (first introduction).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install and configure Servonaut, a TUI for managing servers (AWS EC2, OVHcloud, 
 8. For AI log analysis or chat with my own model (instead of Servonaut AI), help me configure `ai_provider` (openai/anthropic/gemini/ollama)
    - Each provider has its own key field (`openai_api_key`, `anthropic_api_key`, `gemini_api_key`, `ollama_api_key`); local Ollama needs none
    - Key fields support `$ENV_VAR` and `file:~/.secrets/key` syntax so secrets stay out of the config file
-9. Install the MCP server into my coding agent: `servonaut --mcp-install claude` (or `cursor`, `windsurf`, `opencode`, `vscode`, `codex`, `agy`, `all`)
+9. Install the MCP server into my coding agent: `servonaut --mcp-install claude` (or `cursor`, `windsurf`, `opencode`, `vscode`, `codex`, `agy`, `gemini`, `all`)
 10. (Optional) To let AI agents/teammates reach this machine over the relay — and to run proactive Findings scans — start it with `servonaut connect`
 
 After setup, launch with `servonaut` and walk me through the key features, including the Findings inbox if I enabled the hosted features.
@@ -333,11 +333,27 @@ servonaut --mcp-install opencode   # OpenCode
 servonaut --mcp-install vscode     # VS Code Copilot
 servonaut --mcp-install codex      # Codex CLI
 servonaut --mcp-install agy        # Antigravity CLI
+servonaut --mcp-install gemini     # Gemini CLI
 servonaut --mcp-install all        # All of the above
 
 # Run MCP server manually (stdio transport)
 servonaut --mcp
 ```
+
+Re-running an installer updates only Servonaut's launch command and required
+environment forwarding. Other MCP servers and user-owned settings such as
+timeouts, trust, tool filters, and custom environment entries are preserved.
+Secret values are never copied into agent configuration: supported clients use
+references, variable-name allowlists, or inherited environment to supply
+SSH/Bitwarden state, AWS credentials, Servonaut endpoints, and `$ENV_VAR`
+references found in the local Servonaut config. Invalid agent JSON is refused
+instead of overwritten, and config writes are atomic without replacing
+symlinked dotfiles.
+
+SSH-backed MCP tools first use the configured local or vault key. If that key
+cannot authenticate and `SSH_AUTH_SOCK` was forwarded, Servonaut retries once
+using the agent without forcing the configured identity. Authentication
+failures are returned and audited as failures, never as successful tool calls.
 
 #### Agent-only / headless install
 
@@ -348,7 +364,7 @@ purely as an MCP backend for your coding agent:
 
 ```bash
 pipx install 'servonaut[mcp]'
-servonaut --mcp-install claude   # or cursor, windsurf, opencode, vscode, codex, agy, all
+servonaut --mcp-install claude   # or cursor, windsurf, opencode, vscode, codex, agy, gemini, all
 ```
 
 Configure credentials and servers the same way as a TUI install (

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -410,6 +410,6 @@ servonaut logout
 | `servonaut --install-desktop` | Create a desktop shortcut (Linux/macOS) |
 | `servonaut --setup-ovh` | Guided OVHcloud credential setup |
 | `servonaut --mcp` | Start as an MCP server (stdio transport) |
-| `servonaut --mcp-install <agent>` | Auto-install MCP into `claude`, `opencode`, `cursor`, `windsurf`, `vscode`, `codex`, `agy`, or `all` |
+| `servonaut --mcp-install <agent>` | Auto-install MCP into `claude`, `opencode`, `cursor`, `windsurf`, `vscode`, `codex`, `agy`, `gemini`, or `all` |
 
 See [MCP Tools reference](mcp-tools.md) for the full list of MCP tools.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -9,7 +9,7 @@ servonaut --mcp
 Or auto-install into a coding agent:
 
 ```bash
-servonaut --mcp-install claude       # or: cursor, windsurf, vscode, opencode, codex, agy, all
+servonaut --mcp-install claude       # or: cursor, windsurf, vscode, opencode, codex, agy, gemini, all
 ```
 
 This document lists every exposed tool.  The full canonical list (with JSON Schemas) lives in `src/servonaut/mcp/tool_schemas.py`.  When adding a tool, put the schema there — both the MCP server and the built-in chat adapter pick it up automatically.

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -776,7 +776,7 @@ def _main() -> None:
                         metavar='TARGET',
                         help='Install MCP server into a coding agent '
                              '(claude, opencode, cursor, windsurf, vscode, '
-                             'codex, agy, all)')
+                             'codex, agy, gemini, all)')
     parser.add_argument('--list-backups', action='store_true',
                         help='List local config backups and exit')
     parser.add_argument('--restore-backup', type=int, metavar='N', nargs='?', const=-1,

--- a/src/servonaut/mcp/installer.py
+++ b/src/servonaut/mcp/installer.py
@@ -1,15 +1,74 @@
 """Auto-installer for Servonaut MCP server into coding agents."""
+
 from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
+import subprocess
 import sys
+import tempfile
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import Any
 
 SUPPORTED_TARGETS = [
-    'claude', 'opencode', 'cursor', 'windsurf', 'vscode', 'codex', 'agy',
+    "claude",
+    "opencode",
+    "cursor",
+    "windsurf",
+    "vscode",
+    "codex",
+    "agy",
+    "gemini",
 ]
+
+
+class MCPInstallerError(RuntimeError):
+    """Raised when an existing client config cannot be updated safely."""
+
+
+# Environment names are forwarded by reference, never by value. Provider SDK
+# names are stable public contracts; additional $ENV_VAR references are
+# discovered from the operator's Servonaut config at install time.
+_BASE_FORWARD_ENV_VARS = (
+    "SSH_AUTH_SOCK",
+    "BW_SESSION",
+    "BWS_ACCESS_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "SERVONAUT_API_URL",
+    "SERVONAUT_MCP_URL",
+)
+_ENV_REFERENCE_RE = re.compile(
+    r"^\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}"
+    r"|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))$"
+)
+
+
+def _version_probe_timeout() -> float:
+    """Return the configured bounded client-version probe timeout."""
+    try:
+        timeout = float(
+            os.environ.get("SERVONAUT_MCP_INSTALL_VERSION_TIMEOUT_SECONDS", "5")
+        )
+    except ValueError as exc:
+        raise MCPInstallerError(
+            "MCP installer version timeout must be numeric"
+        ) from exc
+    if timeout <= 0:
+        raise MCPInstallerError("MCP installer version timeout must be positive")
+    return timeout
 
 
 def _resolve_mcp_command() -> tuple[str, list[str]]:
@@ -35,57 +94,236 @@ def _resolve_mcp_command() -> tuple[str, list[str]]:
 
 def _get_os() -> str:
     """Return 'linux', 'darwin', or 'windows'."""
-    if sys.platform.startswith('linux'):
-        return 'linux'
-    if sys.platform == 'darwin':
-        return 'darwin'
-    return 'windows'
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "windows"
 
 
 def _appdata() -> Path:
     """Return the Windows %APPDATA% directory (or equivalent)."""
-    return Path(os.environ.get('APPDATA', Path.home() / 'AppData' / 'Roaming'))
+    return Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
 
 
-def _load_json(path: Path) -> dict:
-    """Load a JSON config file, returning empty dict on missing or invalid."""
-    if path.exists():
-        text = path.read_text()
-        if not text.strip():
-            return {}
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load an agent config without risking replacement of invalid content."""
+    if not path.exists():
+        return {}
+
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return {}
+
+    try:
+        config = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise MCPInstallerError(
+            f"Refusing to overwrite invalid JSON in {path}: "
+            f"line {exc.lineno}, column {exc.colno}"
+        ) from exc
+
+    if not isinstance(config, dict):
+        raise MCPInstallerError(
+            f"Refusing to overwrite {path}: the JSON root must be an object"
+        )
+    return config
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Atomically write config text without replacing a dotfile symlink."""
+    target_path = path.resolve(strict=False) if path.is_symlink() else path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    mode = (
+        target_path.stat().st_mode & 0o777 if target_path.exists() else 0o600
+    )
+    temp_path: Path | None = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=target_path.parent,
+            prefix=f".{target_path.name}.",
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_path, mode)
+        os.replace(temp_path, target_path)
+    except Exception:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _save_json(path: Path, config: Mapping[str, Any]) -> None:
+    """Serialize and atomically write a JSON agent config."""
+    _atomic_write_text(path, json.dumps(config, indent=2) + "\n")
+
+
+def _mapping_at(
+    parent: dict[str, Any],
+    key: str,
+    *,
+    context: str,
+) -> dict[str, Any]:
+    """Return a nested mapping, creating it but never replacing a wrong type."""
+    value = parent.get(key)
+    if value is None:
+        value = {}
+        parent[key] = value
+    if not isinstance(value, dict):
+        raise MCPInstallerError(f"{context}.{key} must be a JSON object")
+    return value
+
+
+def _collect_env_references(value: Any, found: set[str]) -> None:
+    """Collect exact $NAME/${NAME} references without retaining their values."""
+    if isinstance(value, str):
+        match = _ENV_REFERENCE_RE.fullmatch(value)
+        if match:
+            found.add(match.group("braced") or match.group("plain"))
+        return
+    if isinstance(value, Mapping):
+        for nested in value.values():
+            _collect_env_references(nested, found)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            _collect_env_references(nested, found)
+
+
+def _required_forward_env_vars() -> tuple[str, ...]:
+    """Return runtime variables required by built-ins and local config refs."""
+    found = set(_BASE_FORWARD_ENV_VARS)
+    config_path = Path.home() / ".servonaut" / "config.json"
+    if config_path.exists():
         try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            print(f"Warning: Could not parse {path}, will create fresh entry")
-    return {}
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            config = None
+        _collect_env_references(config, found)
+    return tuple(
+        [*_BASE_FORWARD_ENV_VARS] + sorted(found.difference(_BASE_FORWARD_ENV_VARS))
+    )
 
 
-def _save_json(path: Path, config: dict) -> None:
-    """Write config dict as formatted JSON, creating parent dirs as needed."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(config, indent=2) + '\n')
+def _env_references(style: str) -> dict[str, str]:
+    """Render client-native references without persisting environment values."""
+    names = _required_forward_env_vars()
+    if style == "claude":
+        return {name: f"${{{name}:-}}" for name in names}
+    if style == "env-colon":
+        return {name: f"${{env:{name}}}" for name in names}
+    if style == "opencode":
+        return {name: f"{{env:{name}}}" for name in names}
+    if style == "dollar":
+        return {name: f"${name}" for name in names}
+    raise ValueError(f"Unknown environment-reference style: {style}")
+
+
+def _merge_server_entry(
+    existing: Any,
+    managed: Mapping[str, Any],
+    *,
+    env_references: Mapping[str, str] | None = None,
+    env_key: str = "env",
+) -> dict[str, Any]:
+    """Update owned launch fields while retaining every user-owned setting."""
+    if existing is None:
+        entry: dict[str, Any] = {}
+    elif isinstance(existing, dict):
+        entry = dict(existing)
+    else:
+        raise MCPInstallerError("The existing servonaut server entry must be an object")
+
+    entry.update(managed)
+    if env_references is None:
+        return entry
+
+    existing_env = entry.get(env_key)
+    if existing_env is not None and not isinstance(existing_env, dict):
+        raise MCPInstallerError(
+            f"The existing servonaut {env_key} setting must be an object"
+        )
+    merged_env = dict(env_references)
+    merged_env.update(existing_env or {})
+    entry[env_key] = merged_env
+    return entry
 
 
 def _install_claude() -> None:
     """Install into Claude Code (~/.claude.json)."""
-    config_path = Path.home() / '.claude.json'
+    config_path = Path.home() / ".claude.json"
     config = _load_json(config_path)
 
-    if 'mcpServers' not in config:
-        config['mcpServers'] = {}
+    servers = _mapping_at(config, "mcpServers", context="Claude config")
 
     command, args = _resolve_mcp_command()
-    config['mcpServers']['servonaut'] = {
-        'type': 'stdio',
-        'command': command,
-        'args': args,
-        'env': {},
-    }
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "type": "stdio",
+            "command": command,
+            "args": args,
+        },
+        env_references=_env_references("claude"),
+    )
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
     print(f"  command: {command} {' '.join(args)}")
     print("Restart Claude Code to use the new MCP server.")
+
+
+def _installed_major_version(command: str) -> int | None:
+    """Return an installed client's major version without invoking a shell."""
+    command_path = shutil.which(command)
+    if command_path is None:
+        return None
+    try:
+        result = subprocess.run(
+            [command_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_version_probe_timeout(),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    output = result.stdout or result.stderr or ""
+    match = re.search(r"\b(\d+)\.\d+", output)
+    return int(match.group(1)) if match else None
+
+
+def _opencode_server_map(
+    config: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Select classic or V2 OpenCode layout without corrupting either."""
+    mcp = _mapping_at(config, "mcp", context="OpenCode config")
+    existing_servers = mcp.get("servers")
+    if existing_servers is not None:
+        if not isinstance(existing_servers, dict):
+            raise MCPInstallerError("OpenCode config.mcp.servers must be an object")
+        return existing_servers, "v2"
+    if "servonaut" in mcp:
+        return mcp, "classic"
+
+    classic_entries = any(
+        isinstance(value, dict) and value.get("type") in {"local", "remote"}
+        for key, value in mcp.items()
+        if key != "timeout"
+    )
+    if classic_entries:
+        return mcp, "classic"
+    if (_installed_major_version("opencode") or 1) >= 2:
+        servers: dict[str, Any] = {}
+        mcp["servers"] = servers
+        return servers, "v2"
+    return mcp, "classic"
 
 
 def _install_opencode() -> None:
@@ -97,26 +335,31 @@ def _install_opencode() -> None:
     See https://opencode.ai/docs/mcp-servers/
     """
     os_type = _get_os()
-    if os_type == 'windows':
-        config_path = _appdata() / 'opencode' / 'opencode.json'
+    if os_type == "windows":
+        config_path = _appdata() / "opencode" / "opencode.json"
     else:
-        config_path = Path.home() / '.config' / 'opencode' / 'opencode.json'
+        config_path = Path.home() / ".config" / "opencode" / "opencode.json"
 
     config = _load_json(config_path)
-
-    if 'mcp' not in config:
-        config['mcp'] = {}
+    servers, layout = _opencode_server_map(config)
 
     command, args = _resolve_mcp_command()
-    config['mcp']['servonaut'] = {
-        'type': 'local',
-        'command': [command] + args,
-        'enabled': True,
-    }
+    entry = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "type": "local",
+            "command": [command, *args],
+        },
+        env_references=_env_references("opencode"),
+        env_key="environment",
+    )
+    if layout == "classic":
+        entry.setdefault("enabled", True)
+    servers["servonaut"] = entry
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
-    print(f"  command: {[command] + args}")
+    print(f"  command: {[command, *args]}")
     print("Restart OpenCode to use the new MCP server.")
 
 
@@ -125,19 +368,23 @@ def _install_cursor() -> None:
 
     See https://cursor.com/docs/mcp
     """
-    config_path = Path.home() / '.cursor' / 'mcp.json'
+    config_path = Path.home() / ".cursor" / "mcp.json"
     config = _load_json(config_path)
 
-    if 'mcpServers' not in config:
-        config['mcpServers'] = {}
+    servers = _mapping_at(config, "mcpServers", context="Cursor config")
 
     command, args = _resolve_mcp_command()
-    config['mcpServers']['servonaut'] = {
-        'type': 'stdio',
-        'command': command,
-        'args': args,
-        'env': {},
-    }
+    # Cursor IDE and CLI releases have differed on environment interpolation.
+    # Preserve explicit user env entries and rely on inherited environment
+    # instead of injecting a token that some builds pass through literally.
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "type": "stdio",
+            "command": command,
+            "args": args,
+        },
+    )
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
@@ -150,18 +397,20 @@ def _install_windsurf() -> None:
 
     See https://docs.windsurf.com/windsurf/cascade/mcp
     """
-    config_path = Path.home() / '.codeium' / 'windsurf' / 'mcp_config.json'
+    config_path = Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
     config = _load_json(config_path)
 
-    if 'mcpServers' not in config:
-        config['mcpServers'] = {}
+    servers = _mapping_at(config, "mcpServers", context="Windsurf config")
 
     command, args = _resolve_mcp_command()
-    config['mcpServers']['servonaut'] = {
-        'command': command,
-        'args': args,
-        'env': {},
-    }
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "command": command,
+            "args": args,
+        },
+        env_references=_env_references("env-colon"),
+    )
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
@@ -179,23 +428,33 @@ def _install_vscode() -> None:
     See https://code.visualstudio.com/docs/copilot/chat/mcp-servers
     """
     os_type = _get_os()
-    if os_type == 'darwin':
-        config_path = Path.home() / 'Library' / 'Application Support' / 'Code' / 'User' / 'mcp.json'
-    elif os_type == 'windows':
-        config_path = _appdata() / 'Code' / 'User' / 'mcp.json'
+    if os_type == "darwin":
+        config_path = (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Code"
+            / "User"
+            / "mcp.json"
+        )
+    elif os_type == "windows":
+        config_path = _appdata() / "Code" / "User" / "mcp.json"
     else:
-        config_path = Path.home() / '.config' / 'Code' / 'User' / 'mcp.json'
+        config_path = Path.home() / ".config" / "Code" / "User" / "mcp.json"
 
     config = _load_json(config_path)
-
-    if 'servers' not in config:
-        config['servers'] = {}
+    servers = _mapping_at(config, "servers", context="VS Code config")
 
     command, args = _resolve_mcp_command()
-    config['servers']['servonaut'] = {
-        'command': command,
-        'args': args,
-    }
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "type": "stdio",
+            "command": command,
+            "args": args,
+        },
+        env_references=_env_references("env-colon"),
+    )
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
@@ -212,18 +471,21 @@ def _install_agy() -> None:
     transport), so the JSON shape matches Claude Code and Cursor. The `agy`
     binary ships no `mcp` subcommand, so the file is written directly.
     """
-    config_path = Path.home() / '.gemini' / 'config' / 'mcp_config.json'
+    config_path = Path.home() / ".gemini" / "config" / "mcp_config.json"
     config = _load_json(config_path)
 
-    if 'mcpServers' not in config:
-        config['mcpServers'] = {}
+    servers = _mapping_at(config, "mcpServers", context="Antigravity config")
 
     command, args = _resolve_mcp_command()
-    config['mcpServers']['servonaut'] = {
-        'command': command,
-        'args': args,
-        'env': {},
-    }
+    # Antigravity documents this config shape but no interpolation grammar;
+    # inherited environment is safer than a potentially literal placeholder.
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "command": command,
+            "args": args,
+        },
+    )
 
     _save_json(config_path, config)
     print(f"Installed servonaut MCP server in {config_path}")
@@ -231,27 +493,73 @@ def _install_agy() -> None:
     print("Restart Antigravity (agy) to use the new MCP server.")
 
 
-_CODEX_TABLE = 'mcp_servers.servonaut'
-_CODEX_HEADERS = (f'[{_CODEX_TABLE}]', '[mcp_servers."servonaut"]')
+def _enable_gemini_policy(config: dict[str, Any]) -> None:
+    """Keep an explicitly installed server enabled by user-level MCP policy."""
+    policy = config.get("mcp")
+    if policy is None:
+        return
+    if not isinstance(policy, dict):
+        raise MCPInstallerError("Gemini config.mcp must be an object")
 
-# Keys this installer owns. Everything else in an existing block (timeouts,
-# approval mode, env) belongs to the user and is preserved verbatim.
-_CODEX_MANAGED_KEYS = ('command', 'args')
+    for key in ("allowed", "excluded"):
+        values = policy.get(key)
+        if values is None:
+            continue
+        if not isinstance(values, list) or not all(
+            isinstance(value, str) for value in values
+        ):
+            raise MCPInstallerError(f"Gemini config.mcp.{key} must be a string list")
+        if key == "allowed" and "servonaut" not in values:
+            values.append("servonaut")
+        elif key == "excluded" and "servonaut" in values:
+            policy[key] = [value for value in values if value != "servonaut"]
+
+
+def _install_gemini() -> None:
+    """Install into Gemini CLI user settings (~/.gemini/settings.json)."""
+    config_path = Path.home() / ".gemini" / "settings.json"
+    config = _load_json(config_path)
+
+    servers = _mapping_at(config, "mcpServers", context="Gemini config")
+    _enable_gemini_policy(config)
+
+    command, args = _resolve_mcp_command()
+    servers["servonaut"] = _merge_server_entry(
+        servers.get("servonaut"),
+        {
+            "command": command,
+            "args": args,
+        },
+        env_references=_env_references("dollar"),
+    )
+
+    _save_json(config_path, config)
+    print(f"Installed servonaut MCP server in {config_path}")
+    print(f"  command: {command} {' '.join(args)}")
+    print("Restart Gemini CLI to use the new MCP server.")
+
+
+_CODEX_TABLE = "mcp_servers.servonaut"
+_CODEX_HEADERS = (f"[{_CODEX_TABLE}]", '[mcp_servers."servonaut"]')
+
+# Managed values are rewritten safely; every other user-owned line survives.
+# Existing env_vars entries are merged with Servonaut's required variable names.
+_CODEX_MANAGED_KEYS = ("command", "args", "env_vars")
 
 
 def _codex_home() -> Path:
     """Return the Codex CLI home directory (honours $CODEX_HOME)."""
-    return Path(os.environ.get('CODEX_HOME') or Path.home() / '.codex')
+    return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
 
 
 def _toml_str(value: str) -> str:
     """Render a Python string as a quoted TOML basic string."""
     escaped = (
-        value.replace('\\', '\\\\')
+        value.replace("\\", "\\\\")
         .replace('"', '\\"')
-        .replace('\n', '\\n')
-        .replace('\r', '\\r')
-        .replace('\t', '\\t')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
     )
     return f'"{escaped}"'
 
@@ -272,7 +580,7 @@ def _split_codex_block(text: str) -> tuple[list[str], list[str], list[str]]:
         return lines, [], []
 
     end = next(
-        (j for j in range(start + 1, len(lines)) if lines[j].startswith('[')),
+        (j for j in range(start + 1, len(lines)) if lines[j].lstrip().startswith("[")),
         len(lines),
     )
     return lines[:start], lines[start:end], lines[end:]
@@ -290,13 +598,13 @@ def _preserved_codex_lines(block: list[str]) -> list[str]:
 
     for line in block[1:]:
         if skipping:
-            depth += line.count('[') - line.count(']')
+            depth += _toml_bracket_delta(line)
             skipping = depth > 0
             continue
 
-        key, sep, value = line.partition('=')
+        key, sep, value = line.partition("=")
         if sep and key.strip().strip('"') in _CODEX_MANAGED_KEYS:
-            depth = value.count('[') - value.count(']')
+            depth = _toml_bracket_delta(value)
             skipping = depth > 0
             continue
 
@@ -307,56 +615,166 @@ def _preserved_codex_lines(block: list[str]) -> list[str]:
     return kept
 
 
+def _toml_bracket_delta(value: str) -> int:
+    """Count array brackets outside quoted strings and comments."""
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for character in value:
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\" and quote == '"':
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character == "#":
+            break
+        elif character == "[":
+            depth += 1
+        elif character == "]":
+            depth -= 1
+    return depth
+
+
+def _codex_value_lines(
+    block: list[str],
+    wanted_key: str,
+) -> list[str]:
+    """Return one complete top-level TOML assignment from a server block."""
+    for index, line in enumerate(block[1:], start=1):
+        key, separator, value = line.partition("=")
+        if not separator or key.strip().strip('"') != wanted_key:
+            continue
+        lines = [line]
+        depth = _toml_bracket_delta(value)
+        cursor = index + 1
+        while depth > 0 and cursor < len(block):
+            lines.append(block[cursor])
+            depth += _toml_bracket_delta(block[cursor])
+            cursor += 1
+        if depth != 0:
+            raise MCPInstallerError(f"Unclosed Codex {wanted_key} value")
+        return lines
+    return []
+
+
+def _merged_codex_env_vars_lines(block: list[str]) -> list[str]:
+    """Merge required local names into Codex env_vars without losing entries."""
+    existing = _codex_value_lines(block, "env_vars")
+    required = _required_forward_env_vars()
+    if not existing:
+        rendered = ", ".join(_toml_str(name) for name in required)
+        return [f"env_vars = [{rendered}]"]
+
+    text = "\n".join(existing)
+    missing = [
+        name
+        for name in required
+        if not re.search(
+            rf"""(["']){re.escape(name)}\1""",
+            text,
+        )
+    ]
+    if not missing:
+        return existing
+    rendered = ", ".join(_toml_str(name) for name in missing)
+
+    if len(existing) == 1:
+        line = existing[0]
+        closing = line.rfind("]")
+        if closing < 0:
+            raise MCPInstallerError("Codex env_vars must be a TOML array")
+        prefix = line[:closing]
+        opening = prefix.find("[")
+        has_items = opening >= 0 and bool(prefix[opening + 1 :].strip())
+        separator = ", " if has_items and not prefix.rstrip().endswith(",") else ""
+        if has_items and not separator:
+            separator = " "
+        return [f"{prefix}{separator}{rendered}{line[closing:]}"]
+
+    closing_index = next(
+        (index for index in range(len(existing) - 1, -1, -1) if "]" in existing[index]),
+        None,
+    )
+    if closing_index is None:
+        raise MCPInstallerError("Codex env_vars must be a TOML array")
+    prefix = existing[:closing_index]
+    closing_line = existing[closing_index]
+    if prefix and not prefix[-1].rstrip().endswith(("[", ",")):
+        prefix[-1] = f"{prefix[-1]},"
+    indent = re.match(r"^\s*", closing_line).group(0) + "  "
+    inserted = [f"{indent}{_toml_str(name)}," for name in missing]
+    return [*prefix, *inserted, closing_line]
+
+
 def _install_codex() -> None:
     """Install into the Codex CLI global config ($CODEX_HOME or ~/.codex).
 
-    Codex uses TOML, and the Python stdlib can read TOML (3.11+) but never
-    write it. The server's block is therefore rewritten textually: only
-    `command` and `args` are managed here, and any other keys already set on
-    the block are preserved so hand-tuned timeouts survive a re-install.
+    Codex uses TOML, so the server block is rewritten textually. Command,
+    arguments, and the merged environment allowlist are managed; all other
+    settings are retained so hand-tuned timeouts survive a re-install.
 
     See https://github.com/openai/codex/blob/main/docs/config.md
     """
-    config_path = _codex_home() / 'config.toml'
+    config_path = _codex_home() / "config.toml"
     command, args = _resolve_mcp_command()
 
-    text = config_path.read_text() if config_path.exists() else ''
+    text = config_path.read_text() if config_path.exists() else ""
     before, block, after = _split_codex_block(text)
     preserved = _preserved_codex_lines(block)
 
+    forwarded_env = _merged_codex_env_vars_lines(block)
+
     new_block = [
-        f'[{_CODEX_TABLE}]',
-        f'command = {_toml_str(command)}',
-        'args = [' + ', '.join(_toml_str(arg) for arg in args) + ']',
+        f"[{_CODEX_TABLE}]",
+        f"command = {_toml_str(command)}",
+        "args = [" + ", ".join(_toml_str(arg) for arg in args) + "]",
+        *forwarded_env,
         *preserved,
     ]
 
     while before and not before[-1].strip():
         before.pop()
     if before:
-        before.append('')
+        before.append("")
     if after:
-        new_block.append('')
+        new_block.append("")
 
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text('\n'.join(before + new_block + after) + '\n')
+    rendered_config = "\n".join(before + new_block + after) + "\n"
+    _atomic_write_text(config_path, rendered_config)
 
     print(f"Installed servonaut MCP server in {config_path}")
     print(f"  command: {command} {' '.join(args)}")
+    forwarded_count = len(_required_forward_env_vars())
+    print(f"  forwards {forwarded_count} runtime variables by name")
     if preserved:
         print(f"  preserved existing settings: {len(preserved)} line(s)")
     print("Restart Codex to use the new MCP server.")
 
 
 _INSTALLERS = {
-    'claude': _install_claude,
-    'opencode': _install_opencode,
-    'cursor': _install_cursor,
-    'windsurf': _install_windsurf,
-    'vscode': _install_vscode,
-    'codex': _install_codex,
-    'agy': _install_agy,
+    "claude": _install_claude,
+    "opencode": _install_opencode,
+    "cursor": _install_cursor,
+    "windsurf": _install_windsurf,
+    "vscode": _install_vscode,
+    "codex": _install_codex,
+    "agy": _install_agy,
+    "gemini": _install_gemini,
 }
+
+
+def _run_installer(name: str, installer: Callable[[], None]) -> None:
+    """Run one installer with a concise, non-destructive failure surface."""
+    try:
+        installer()
+    except (MCPInstallerError, OSError) as exc:
+        print(f"Error: Could not install Servonaut for {name}: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 def install_mcp_server(target: str) -> None:
@@ -364,20 +782,31 @@ def install_mcp_server(target: str) -> None:
 
     Args:
         target: One of 'claude', 'opencode', 'cursor', 'windsurf', 'vscode',
-                'codex', 'agy', or 'all' to install into every supported
-                client.
+                'codex', 'agy', 'gemini', or 'all' to install into every
+                supported client.
     """
-    if target == 'all':
+    if target == "all":
+        failures: list[str] = []
         for name, installer in _INSTALLERS.items():
             print(f"\n--- {name} ---")
-            installer()
+            try:
+                _run_installer(name, installer)
+            except SystemExit:
+                failures.append(name)
+        if failures:
+            failed_names = ", ".join(failures)
+            print(
+                f"Error: MCP installation failed for: {failed_names}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
         return
 
     installer = _INSTALLERS.get(target)
     if not installer:
-        targets = ', '.join(SUPPORTED_TARGETS)
+        targets = ", ".join(SUPPORTED_TARGETS)
         print(f"Error: Unknown target '{target}'.")
         print(f"Supported targets: {targets}, all")
         sys.exit(1)
 
-    installer()
+    _run_installer(target, installer)

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -5,6 +5,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import secrets
 import shlex
@@ -311,9 +312,13 @@ class ServonautTools:
             return await self._run_command_via_ssm(instance, command, args)
 
         # --- SSH (ssh / auto) ------------------------------------------
-        output, conn_failed, timed_out, key_source = await self._run_command_via_ssh(
-            instance, command,
-        )
+        (
+            output,
+            conn_failed,
+            timed_out,
+            failure_reason,
+            key_source,
+        ) = await self._run_command_via_ssh(instance, command)
         # Audit extra only when the vault key was used — local-key rows keep
         # their existing shape (no churn for the common case).
         key_extras = {'key_source': key_source} if key_source else {}
@@ -325,6 +330,12 @@ class ServonautTools:
                 'run_command', args, '', False, 'command_timeout', **key_extras,
             )
             return output  # already contains the human-readable timeout message
+
+        if failure_reason:
+            self._audit.log(
+                'run_command', args, '', False, failure_reason, **key_extras,
+            )
+            return output
 
         if not conn_failed:
             result = f"{output}\n[transport_used: ssh]"
@@ -373,20 +384,73 @@ class ServonautTools:
         )
         return any(sig in low for sig in signatures)
 
-    async def _run_command_via_ssh(self, instance: Dict, command: str):
-        """Run via SSH. Returns (output_or_msg, connection_failed, timed_out,
-        key_source).
+    def _is_ssh_authentication_failure(self, stderr_text: str) -> bool:
+        """Return whether stderr shows that SSH could not authenticate.
 
-        Three distinct outcomes (``key_source`` is ``'bw_personal'`` when the
+        Authentication failures are distinct from both an unreachable host
+        and a remote command that exits non-zero. In particular, an encrypted
+        local key cannot be used by a headless MCP server unless the client's
+        SSH-agent socket is forwarded.
+        """
+        low = stderr_text.lower()
+        signatures = (
+            "permission denied (publickey",
+            "permission denied, please try again",
+            "no more authentication methods to try",
+            "sign_and_send_pubkey: signing failed",
+            "incorrect passphrase supplied to decrypt private key",
+        )
+        return any(signature in low for signature in signatures)
+
+    async def _run_ssh_with_agent_fallback(
+        self,
+        conn: Dict[str, Any],
+        command: str,
+        timeout: int,
+    ) -> tuple[bytes, bytes, bool]:
+        """Run SSH once, then retry agent-only after a proven auth failure.
+
+        A configured identity file makes ``SSHService`` add
+        ``IdentitiesOnly=yes``. That is normally desirable, but it also stops
+        a forwarded agent from offering a different valid identity when the
+        configured file is unavailable, stale, or cannot be unlocked in a
+        headless client. Authentication failure happens before the remote
+        command starts, so this single retry cannot execute it twice.
+        """
+
+        def _build(key_path: Optional[str]) -> List[str]:
+            return self._ssh_service.build_ssh_command(
+                host=conn['host'], username=conn['username'], key_path=key_path,
+                proxy_args=conn['proxy_args'], remote_command=command,
+                port=conn.get('port'),
+                extra_options=conn.get('extra_options') or [],
+            )
+
+        stdout, stderr = await run_ssh_subprocess(
+            _build(conn.get('key_path')), timeout=timeout,
+        )
+        stderr_text = stderr.decode('utf-8', errors='replace') if stderr else ""
+        should_retry = bool(
+            conn.get('key_path')
+            and os.environ.get("SSH_AUTH_SOCK")
+            and self._is_ssh_authentication_failure(stderr_text)
+        )
+        if not should_retry:
+            return stdout, stderr, False
+
+        stdout, stderr = await run_ssh_subprocess(_build(None), timeout=timeout)
+        return stdout, stderr, True
+
+    async def _run_command_via_ssh(self, instance: Dict, command: str):
+        """Run via SSH and classify transport, timeout, and auth failures.
+
+        Four distinct outcomes (``key_source`` is ``'bw_personal'`` when the
         key came from a Bitwarden ref, else ``None`` — carried so the caller
         can tag its audit row):
-          - Success:          (output_str, False, False, key_source)
-          - Command timeout:  (timeout_msg, False, True, key_source)  — host
-                              IS reachable; the caller must NOT trigger SSM
-                              fallback.
-          - Connection error: (None, True, False, key_source) — sshd
-                              unreachable; caller may fall back to SSM when
-                              available.
+          - Success:          ``(output, False, False, None, key_source)``
+          - Command timeout:  ``(message, False, True, None, key_source)``
+          - Connection error: ``(None, True, False, None, key_source)``
+          - Other SSH error:  ``(message, False, False, reason, key_source)``
         """
         conn, cleanup = await self._resolve_connection_with_vault(instance)
         key_source = conn.get('key_source')
@@ -395,14 +459,12 @@ class ServonautTools:
         # config read raises (matches transfer_file's pattern).
         timeout = 0
         try:
-            ssh_cmd = self._ssh_service.build_ssh_command(
-                host=conn['host'], username=conn['username'], key_path=conn['key_path'],
-                proxy_args=conn['proxy_args'], remote_command=command,
-                port=conn.get('port'),
-                extra_options=conn.get('extra_options') or [],
-            )
             timeout = self._config_manager.get().mcp.command_timeout_seconds
-            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
+            stdout, stderr, used_agent_fallback = (
+                await self._run_ssh_with_agent_fallback(conn, command, timeout)
+            )
+            if used_agent_fallback:
+                key_source = 'ssh_agent'
         except asyncio.TimeoutError:
             # The SSH connection itself was alive (keepalives kept it open);
             # the *command* simply ran longer than the allowed budget.
@@ -412,9 +474,9 @@ class ServonautTools:
                 f"command timed out after {timeout}s "
                 f"(host reachable; raise mcp.command_timeout_seconds for long ops)"
             )
-            return (msg, False, True, key_source)
+            return (msg, False, True, None, key_source)
         except Exception as e:  # noqa: BLE001
-            return (f"Error: {e}", False, False, key_source)
+            return (f"Error: {e}", False, False, 'ssh_error', key_source)
         finally:
             # Per-call vault-key lifecycle: the MCP server is long-running,
             # so the temp key must not outlive this subprocess.
@@ -422,9 +484,22 @@ class ServonautTools:
                 await cleanup()
 
         stderr_text = stderr.decode('utf-8', errors='replace') if stderr else ""
+        if self._is_ssh_authentication_failure(stderr_text):
+            message = (
+                "Error: SSH authentication failed. "
+                + (
+                    "The configured key and forwarded SSH agent were both tried. "
+                    if key_source == 'ssh_agent'
+                    else "Forward SSH_AUTH_SOCK so the MCP server can use an "
+                         "unlocked agent identity. "
+                )
+                + "Verify the configured username and key."
+            )
+            return (message, False, False, 'ssh_auth_failed', key_source)
+
         # Empty stdout + a connection signature in stderr → sshd unreachable.
         if not stdout and self._is_ssh_connection_failure(stderr_text):
-            return (None, True, False, key_source)
+            return (None, True, False, None, key_source)
 
         output = stdout.decode('utf-8', errors='replace')
         lines = output.split('\n')
@@ -432,7 +507,7 @@ class ServonautTools:
             output = '\n'.join(lines[:self._max_lines]) + f'\n... (truncated, {len(lines)} total lines)'
         if stderr_text:
             output += f"\nSTDERR:\n{stderr_text}"
-        return (output, False, False, key_source)
+        return (output, False, False, None, key_source)
 
     async def _run_command_via_ssm(
         self, instance: Dict, command: str, args: Dict, ssh_fell_back: bool = False,
@@ -522,14 +597,12 @@ class ServonautTools:
         # must still trigger the temp-key cleanup in the finally.
         timeout = 0
         try:
-            ssh_cmd = self._ssh_service.build_ssh_command(
-                host=conn['host'], username=conn['username'], key_path=conn['key_path'],
-                proxy_args=conn['proxy_args'], remote_command=command,
-                port=conn.get('port'),
-                extra_options=conn.get('extra_options') or [],
-            )
             timeout = self._config_manager.get().mcp.command_timeout_seconds
-            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
+            stdout, stderr, used_agent_fallback = (
+                await self._run_ssh_with_agent_fallback(conn, command, timeout)
+            )
+            if used_agent_fallback:
+                key_extras = {'key_source': 'ssh_agent'}
         except asyncio.TimeoutError:
             # Every early return writes an audit row with a distinct reason
             # code; key_extras carries key_source so vault-key-backed failures
@@ -553,8 +626,18 @@ class ServonautTools:
                 await cleanup()
 
         output = stdout.decode('utf-8', errors='replace')
+        stderr_text = stderr.decode('utf-8', errors='replace') if stderr else ""
+        if self._is_ssh_authentication_failure(stderr_text):
+            self._audit.log(
+                'get_server_info', {'instance_id': instance_id}, '', False,
+                'ssh_auth_failed', **key_extras,
+            )
+            return (
+                "Error: SSH authentication failed. Verify the configured "
+                "username and key or the forwarded SSH agent identities."
+            )
         if stderr:
-            output += f"\nSTDERR:\n{stderr.decode('utf-8', errors='replace')}"
+            output += f"\nSTDERR:\n{stderr_text}"
 
         self._audit.log(
             'get_server_info', {'instance_id': instance_id}, output, True,
@@ -595,24 +678,35 @@ class ServonautTools:
 
             proxy_jump = self._connection_service.get_proxy_jump_string(profile) if profile else None
 
-            if direction == "upload":
-                scp_cmd = self._scp_service.build_upload_command(
-                    local_path=local_path, remote_path=remote_path,
-                    host=host, username=username, key_path=key_path,
-                    proxy_jump=proxy_jump, proxy_args=proxy_args or None,
-                    port=port,
-                    extra_options=extra_options,
-                )
-            else:
-                scp_cmd = self._scp_service.build_download_command(
+            def _build_scp(candidate_key_path: Optional[str]) -> List[str]:
+                if direction == "upload":
+                    return self._scp_service.build_upload_command(
+                        local_path=local_path, remote_path=remote_path,
+                        host=host, username=username, key_path=candidate_key_path,
+                        proxy_jump=proxy_jump, proxy_args=proxy_args or None,
+                        port=port, extra_options=extra_options,
+                    )
+                return self._scp_service.build_download_command(
                     remote_path=remote_path, local_path=local_path,
-                    host=host, username=username, key_path=key_path,
+                    host=host, username=username, key_path=candidate_key_path,
                     proxy_jump=proxy_jump, proxy_args=proxy_args or None,
-                    port=port,
-                    extra_options=extra_options,
+                    port=port, extra_options=extra_options,
                 )
 
-            returncode, stdout, stderr = await self._scp_service.execute_transfer(scp_cmd)
+            scp_cmd = _build_scp(key_path)
+            returncode, stdout, stderr = await self._scp_service.execute_transfer(
+                scp_cmd
+            )
+            if (
+                returncode != 0
+                and key_path
+                and os.environ.get("SSH_AUTH_SOCK")
+                and self._is_ssh_authentication_failure(stderr)
+            ):
+                returncode, stdout, stderr = await self._scp_service.execute_transfer(
+                    _build_scp(None)
+                )
+                key_extras = {'key_source': 'ssh_agent'}
         finally:
             if cleanup is not None:
                 await cleanup()
@@ -3315,29 +3409,53 @@ class ServonautTools:
         return conn, _cleanup
 
     async def _find_instance(self, instance_id: str) -> Optional[Dict]:
-        """Find instance by ID or name across all providers (AWS + custom + OVH + Hetzner)."""
-        aws_instances = await self._aws_service.fetch_instances_cached()
-        custom_instances = self._custom_server_service.list_as_instances()
-        ovh_instances = (
-            await self._ovh_service.fetch_instances_cached()
-            if self._ovh_service is not None
-            else []
-        )
-        hetzner_instances = (
-            await self._hetzner_service.fetch_instances_cached()
-            if self._hetzner_service is not None
-            else []
-        )
-        all_instances = (
-            aws_instances + custom_instances + ovh_instances + hetzner_instances
-        )
+        """Find an instance without querying providers after a match is known.
+
+        AWS keeps precedence for ambiguous names. An explicit ``custom-*`` ID
+        is resolved locally before any cloud API call, and a custom-server name
+        is returned immediately after the AWS check. This prevents a degraded
+        OVH or Hetzner API from delaying an unrelated custom-server SSH command.
+        """
         instance_id_lower = instance_id.lower()
-        for inst in all_instances:
-            if (inst.get('id') == instance_id
-                    or inst.get('id', '').lower() == instance_id_lower
-                    or inst.get('name') == instance_id
-                    or inst.get('name', '').lower() == instance_id_lower):
-                return inst
+
+        def _match(instances: List[Dict]) -> Optional[Dict]:
+            for instance in instances:
+                candidate_id = str(instance.get('id', ''))
+                candidate_name = str(instance.get('name', ''))
+                if (
+                    candidate_id.lower() == instance_id_lower
+                    or candidate_name.lower() == instance_id_lower
+                ):
+                    return instance
+            return None
+
+        custom_instances = self._custom_server_service.list_as_instances()
+        if instance_id_lower.startswith('custom-'):
+            match = _match(custom_instances)
+            if match is not None:
+                return match
+
+        aws_instances = await self._aws_service.fetch_instances_cached()
+        match = _match(aws_instances)
+        if match is not None:
+            return match
+
+        match = _match(custom_instances)
+        if match is not None:
+            return match
+
+        if self._ovh_service is not None:
+            ovh_instances = await self._ovh_service.fetch_instances_cached()
+            match = _match(ovh_instances)
+            if match is not None:
+                return match
+
+        if self._hetzner_service is not None:
+            hetzner_instances = await self._hetzner_service.fetch_instances_cached()
+            match = _match(hetzner_instances)
+            if match is not None:
+                return match
+
         return None
 
     async def _correlate_ovh_instance(self, instance: Dict) -> Optional[Dict]:
@@ -4195,13 +4313,11 @@ class ServonautTools:
         # Command build stays INSIDE the try — an exception there must still
         # trigger the temp-key cleanup in the finally.
         try:
-            ssh_cmd = self._ssh_service.build_ssh_command(
-                host=conn['host'], username=conn['username'],
-                key_path=conn['key_path'], proxy_args=conn['proxy_args'],
-                remote_command=command, port=conn.get('port'),
-                extra_options=conn.get('extra_options') or [],
+            stdout, stderr, used_agent_fallback = (
+                await self._run_ssh_with_agent_fallback(conn, command, timeout)
             )
-            stdout, stderr = await run_ssh_subprocess(ssh_cmd, timeout=timeout)
+            if used_agent_fallback and audit_extras is not None:
+                audit_extras['key_source'] = 'ssh_agent'
         finally:
             if cleanup is not None:
                 await cleanup()

--- a/src/servonaut/services/bw_resolver.py
+++ b/src/servonaut/services/bw_resolver.py
@@ -107,6 +107,13 @@ class BwResolver:
                 "Install it from https://bitwarden.com/help/cli/ and ensure it is on your PATH."
             )
 
+        env = self._build_env()
+        if not env.get("BW_SESSION"):
+            raise BwSessionMissingError(
+                "Bitwarden vault is locked or no session was forwarded to "
+                "this process. Run `bw unlock` and export BW_SESSION, then retry."
+            )
+
         logger.debug(
             "Resolving BW item %s via sshKey.privateKey (BW 2023.10+ native shape)",
             item_id,
@@ -117,7 +124,8 @@ class BwResolver:
             capture_output=True,
             text=True,
             timeout=_BW_TIMEOUT_SECONDS,
-            env=self._build_env(),
+            env=env,
+            stdin=subprocess.DEVNULL,
         )
 
         stderr = result.stderr or ""

--- a/tests/test_bw_resolver.py
+++ b/tests/test_bw_resolver.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from subprocess import CompletedProcess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -28,6 +28,12 @@ def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> Compl
 
 def _bw_item_json(private_key: object) -> str:
     return json.dumps({"sshKey": {"privateKey": private_key}})
+
+
+@pytest.fixture(autouse=True)
+def ambient_bw_session(monkeypatch):
+    """Provide non-sensitive fake session state for subprocess contract tests."""
+    monkeypatch.setenv("BW_SESSION", "test-session")
 
 
 class TestHappyPath:
@@ -161,6 +167,16 @@ class TestCustomBwBinary:
 class TestSessionInjection:
     """The injected session getter must reach ``bw`` via env, never argv;
     ambient ``BW_SESSION`` stays a fallback (Phase 1 security pins)."""
+
+    def test_missing_session_fails_without_starting_bw(self, monkeypatch):
+        monkeypatch.delenv("BW_SESSION")
+        with patch("shutil.which", return_value="/usr/bin/bw"), patch(
+            "subprocess.run"
+        ) as mock_run:
+            with pytest.raises(BwSessionMissingError) as exc_info:
+                BwResolver().resolve_ssh_key(VALID_ITEM_ID)
+        assert "session" in exc_info.value.message.lower()
+        mock_run.assert_not_called()
 
     def test_injected_session_passed_via_env_not_argv(self):
         with patch("shutil.which", return_value="/usr/bin/bw"), patch(

--- a/tests/test_mcp_installer.py
+++ b/tests/test_mcp_installer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,10 +16,10 @@ from servonaut.mcp.installer import SUPPORTED_TARGETS, install_mcp_server
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):
     """Redirect Path.home() and $CODEX_HOME into a throwaway directory."""
-    home = tmp_path / 'home'
+    home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setattr(Path, 'home', classmethod(lambda cls: home))
-    monkeypatch.delenv('CODEX_HOME', raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
     return home
 
 
@@ -26,7 +27,7 @@ def fake_home(tmp_path, monkeypatch):
 def stub_command(monkeypatch):
     """Pin the resolved MCP command so assertions are deterministic."""
     monkeypatch.setattr(
-        installer, '_resolve_mcp_command', lambda: ('/usr/bin/servonaut', ['--mcp'])
+        installer, "_resolve_mcp_command", lambda: ("/usr/bin/servonaut", ["--mcp"])
     )
 
 
@@ -36,7 +37,7 @@ def test_every_supported_target_has_an_installer():
 
 def test_unknown_target_exits_nonzero(capsys):
     with pytest.raises(SystemExit) as exc:
-        install_mcp_server('emacs')
+        install_mcp_server("emacs")
 
     assert exc.value.code == 1
     out = capsys.readouterr().out
@@ -50,158 +51,197 @@ def test_unknown_target_exits_nonzero(capsys):
 
 
 def test_agy_writes_mcp_servers_entry(fake_home):
-    install_mcp_server('agy')
+    install_mcp_server("agy")
 
-    config = json.loads((fake_home / '.gemini' / 'config' / 'mcp_config.json').read_text())
-    assert config['mcpServers']['servonaut'] == {
-        'command': '/usr/bin/servonaut',
-        'args': ['--mcp'],
-        'env': {},
+    config = json.loads(
+        (fake_home / ".gemini" / "config" / "mcp_config.json").read_text()
+    )
+    assert config["mcpServers"]["servonaut"] == {
+        "command": "/usr/bin/servonaut",
+        "args": ["--mcp"],
     }
 
 
 def test_agy_preserves_other_servers(fake_home):
-    config_path = fake_home / '.gemini' / 'config' / 'mcp_config.json'
+    config_path = fake_home / ".gemini" / "config" / "mcp_config.json"
     config_path.parent.mkdir(parents=True)
-    config_path.write_text(json.dumps({'mcpServers': {'other': {'command': 'x'}}}))
+    config_path.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}}))
 
-    install_mcp_server('agy')
+    install_mcp_server("agy")
 
     config = json.loads(config_path.read_text())
-    assert config['mcpServers']['other'] == {'command': 'x'}
-    assert 'servonaut' in config['mcpServers']
+    assert config["mcpServers"]["other"] == {"command": "x"}
+    assert "servonaut" in config["mcpServers"]
 
 
 def test_agy_handles_zero_byte_config(fake_home, capsys):
     """Antigravity ships an empty mcp_config.json — it must not warn or crash."""
-    config_path = fake_home / '.gemini' / 'config' / 'mcp_config.json'
+    config_path = fake_home / ".gemini" / "config" / "mcp_config.json"
     config_path.parent.mkdir(parents=True)
-    config_path.write_text('')
+    config_path.write_text("")
 
-    install_mcp_server('agy')
+    install_mcp_server("agy")
 
-    assert 'Could not parse' not in capsys.readouterr().out
+    assert "Could not parse" not in capsys.readouterr().out
     config = json.loads(config_path.read_text())
-    assert config['mcpServers']['servonaut']['command'] == '/usr/bin/servonaut'
+    assert config["mcpServers"]["servonaut"]["command"] == "/usr/bin/servonaut"
 
 
 # --- codex (TOML) ----------------------------------------------------------
 
 
 def test_codex_creates_config(fake_home):
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
-    text = (fake_home / '.codex' / 'config.toml').read_text()
-    assert '[mcp_servers.servonaut]' in text
+    text = (fake_home / ".codex" / "config.toml").read_text()
+    assert "[mcp_servers.servonaut]" in text
     assert 'command = "/usr/bin/servonaut"' in text
     assert 'args = ["--mcp"]' in text
+    assert 'env_vars = ["SSH_AUTH_SOCK", "BW_SESSION", "BWS_ACCESS_TOKEN"' in text
+    assert '"AWS_PROFILE"' in text
 
 
 def test_codex_honours_codex_home(fake_home, tmp_path, monkeypatch):
-    codex_home = tmp_path / 'alt-codex'
-    monkeypatch.setenv('CODEX_HOME', str(codex_home))
+    codex_home = tmp_path / "alt-codex"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
-    assert (codex_home / 'config.toml').exists()
-    assert not (fake_home / '.codex').exists()
+    assert (codex_home / "config.toml").exists()
+    assert not (fake_home / ".codex").exists()
 
 
 def test_codex_preserves_sibling_tables_and_leading_config(fake_home):
-    config_path = fake_home / '.codex' / 'config.toml'
+    config_path = fake_home / ".codex" / "config.toml"
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
         'model = "gpt-5"\n'
-        '\n'
-        '[mcp_servers.github]\n'
+        "\n"
+        "[mcp_servers.github]\n"
         'command = "gh-mcp"\n'
-        '\n'
-        '[mcp_servers.playwright]\n'
+        "\n"
+        "[mcp_servers.playwright]\n"
         'command = "npx"\n'
     )
 
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
     text = config_path.read_text()
     assert 'model = "gpt-5"' in text
     assert '[mcp_servers.github]\ncommand = "gh-mcp"' in text
     assert '[mcp_servers.playwright]\ncommand = "npx"' in text
-    assert '[mcp_servers.servonaut]' in text
+    assert "[mcp_servers.servonaut]" in text
 
 
 def test_codex_reinstall_preserves_user_tuning(fake_home):
     """Re-installing must not wipe hand-set timeouts on our own block."""
-    config_path = fake_home / '.codex' / 'config.toml'
+    config_path = fake_home / ".codex" / "config.toml"
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
-        '[mcp_servers.servonaut]\n'
+        "[mcp_servers.servonaut]\n"
         'command = "/old/path/servonaut"\n'
         'args = ["--mcp"]\n'
-        'startup_timeout_sec = 30\n'
-        'tool_timeout_sec = 180\n'
+        "startup_timeout_sec = 30\n"
+        "tool_timeout_sec = 180\n"
         'default_tools_approval_mode = "prompt"\n'
-        '\n'
-        '[mcp_servers.github]\n'
+        "\n"
+        "[mcp_servers.github]\n"
         'command = "gh-mcp"\n'
     )
 
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
     text = config_path.read_text()
     assert 'command = "/usr/bin/servonaut"' in text
-    assert '/old/path/servonaut' not in text
-    assert 'startup_timeout_sec = 30' in text
-    assert 'tool_timeout_sec = 180' in text
+    assert "/old/path/servonaut" not in text
+    assert "startup_timeout_sec = 30" in text
+    assert "tool_timeout_sec = 180" in text
     assert 'default_tools_approval_mode = "prompt"' in text
     # The managed keys must appear exactly once — no duplicate TOML keys.
     assert text.count('command = "/usr/bin/servonaut"') == 1
-    assert text.count('args = ') == 1
-    assert text.count('[mcp_servers.servonaut]') == 1
+    assert text.count("args = ") == 1
+    assert text.count("[mcp_servers.servonaut]") == 1
+
+
+def test_codex_preserves_existing_env_vars(fake_home):
+    """A user's broader forwarding policy must not be overwritten."""
+    config_path = fake_home / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "[mcp_servers.servonaut]\n"
+        'command = "/old/servonaut"\n'
+        'args = ["--mcp"]\n'
+        'env_vars = ["CUSTOM_AGENT_SOCKET"]\n'
+    )
+
+    install_mcp_server("codex")
+
+    text = config_path.read_text()
+    assert 'env_vars = ["CUSTOM_AGENT_SOCKET", "SSH_AUTH_SOCK"' in text
+    assert text.count("env_vars = ") == 1
+    assert text.count('"CUSTOM_AGENT_SOCKET"') == 1
+    assert text.count('"SSH_AUTH_SOCK"') == 1
 
 
 def test_codex_replaces_multiline_args_without_orphans(fake_home):
-    config_path = fake_home / '.codex' / 'config.toml'
+    config_path = fake_home / ".codex" / "config.toml"
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
-        '[mcp_servers.servonaut]\n'
+        "[mcp_servers.servonaut]\n"
         'command = "/old/servonaut"\n'
-        'args = [\n'
+        "args = [\n"
         '  "--mcp",\n'
         '  "--verbose",\n'
-        ']\n'
-        'tool_timeout_sec = 180\n'
+        "]\n"
+        "tool_timeout_sec = 180\n"
     )
 
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
     lines = config_path.read_text().splitlines()
     assert 'args = ["--mcp"]' in lines
     # No orphaned continuation lines from the replaced multi-line array.
     assert '  "--verbose",' not in lines
-    assert ']' not in lines
-    assert 'tool_timeout_sec = 180' in lines
+    assert "]" not in lines
+    assert "tool_timeout_sec = 180" in lines
 
 
 def test_codex_matches_quoted_table_header(fake_home):
-    config_path = fake_home / '.codex' / 'config.toml'
+    config_path = fake_home / ".codex" / "config.toml"
     config_path.parent.mkdir(parents=True)
     config_path.write_text(
-        '[mcp_servers."servonaut"]\n'
-        'command = "/old/servonaut"\n'
-        'tool_timeout_sec = 99\n'
+        '[mcp_servers."servonaut"]\ncommand = "/old/servonaut"\ntool_timeout_sec = 99\n'
     )
 
-    install_mcp_server('codex')
+    install_mcp_server("codex")
 
     text = config_path.read_text()
-    assert '/old/servonaut' not in text
-    assert 'tool_timeout_sec = 99' in text
+    assert "/old/servonaut" not in text
+    assert "tool_timeout_sec = 99" in text
     # Rewritten under the canonical bare-key header, and only once.
-    assert text.count('servonaut]') == 1
+    assert text.count("servonaut]") == 1
+
+
+def test_codex_stops_before_indented_sibling_table(fake_home):
+    config_path = fake_home / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "[mcp_servers.servonaut]\n"
+        'command = "/old/servonaut"\n'
+        "tool_timeout_sec = 99\n"
+        "  [mcp_servers.other]\n"
+        'command = "other-server"\n'
+    )
+
+    install_mcp_server("codex")
+
+    text = config_path.read_text()
+    assert "tool_timeout_sec = 99" in text
+    assert '  [mcp_servers.other]\ncommand = "other-server"' in text
 
 
 def test_toml_str_escapes_quotes_and_backslashes():
-    assert installer._toml_str(r'C:\bin\servonaut.exe') == r'"C:\\bin\\servonaut.exe"'
+    assert installer._toml_str(r"C:\bin\servonaut.exe") == r'"C:\\bin\\servonaut.exe"'
     assert installer._toml_str('say "hi"') == '"say \\"hi\\""'
 
 
@@ -213,6 +253,290 @@ def test_all_runs_every_installer(fake_home):
     stubs = {name: (lambda n=name: calls.append(n)) for name in SUPPORTED_TARGETS}
 
     with patch.dict(installer._INSTALLERS, stubs, clear=True):
-        install_mcp_server('all')
+        install_mcp_server("all")
 
     assert set(calls) == set(SUPPORTED_TARGETS)
+
+
+def test_all_continues_after_one_installer_fails(fake_home):
+    calls: list[str] = []
+
+    def fail() -> None:
+        calls.append("claude")
+        raise installer.MCPInstallerError("invalid test config")
+
+    stubs = {name: (lambda n=name: calls.append(n)) for name in SUPPORTED_TARGETS}
+    stubs["claude"] = fail
+
+    with patch.dict(installer._INSTALLERS, stubs, clear=True):
+        with pytest.raises(SystemExit) as exc_info:
+            install_mcp_server("all")
+
+    assert exc_info.value.code == 1
+    assert set(calls) == set(SUPPORTED_TARGETS)
+
+
+# --- Claude Code -----------------------------------------------------------
+
+
+def test_claude_uses_native_environment_references(fake_home):
+    install_mcp_server("claude")
+
+    config = json.loads((fake_home / ".claude.json").read_text())
+    entry = config["mcpServers"]["servonaut"]
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "/usr/bin/servonaut"
+    assert entry["args"] == ["--mcp"]
+    assert entry["env"]["SSH_AUTH_SOCK"] == "${SSH_AUTH_SOCK:-}"
+    assert entry["env"]["BWS_ACCESS_TOKEN"] == "${BWS_ACCESS_TOKEN:-}"
+
+
+def test_claude_reinstall_preserves_user_owned_fields(fake_home):
+    config_path = fake_home / ".claude.json"
+    original = {
+        "mcpServers": {
+            "other": {"command": "other-server"},
+            "servonaut": {
+                "command": "/old/servonaut",
+                "timeout": 123,
+                "env": {"CUSTOM_SETTING": "kept", "SSH_AUTH_SOCK": "/custom/socket"},
+            },
+        }
+    }
+    config_path.write_text(json.dumps(original))
+
+    install_mcp_server("claude")
+
+    config = json.loads(config_path.read_text())
+    entry = config["mcpServers"]["servonaut"]
+    assert entry["timeout"] == 123
+    assert entry["env"]["CUSTOM_SETTING"] == "kept"
+    assert entry["env"]["SSH_AUTH_SOCK"] == "/custom/socket"
+    assert config["mcpServers"]["other"] == {"command": "other-server"}
+
+
+# --- OpenCode --------------------------------------------------------------
+
+
+def test_opencode_classic_uses_native_environment_references(fake_home, monkeypatch):
+    monkeypatch.setattr(installer, "_installed_major_version", lambda _name: 1)
+    install_mcp_server("opencode")
+
+    config_path = fake_home / ".config" / "opencode" / "opencode.json"
+    entry = json.loads(config_path.read_text())["mcp"]["servonaut"]
+    assert entry["type"] == "local"
+    assert entry["enabled"] is True
+    assert entry["environment"]["SSH_AUTH_SOCK"] == "{env:SSH_AUTH_SOCK}"
+    assert entry["environment"]["BWS_ACCESS_TOKEN"] == "{env:BWS_ACCESS_TOKEN}"
+
+
+def test_opencode_v2_layout_is_detected_and_preserved(fake_home, monkeypatch):
+    config_path = fake_home / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps({"mcp": {"timeout": {"connect": 9000}, "servers": {}}})
+    )
+    monkeypatch.setattr(installer, "_installed_major_version", lambda _name: 2)
+
+    install_mcp_server("opencode")
+
+    config = json.loads(config_path.read_text())
+    assert config["mcp"]["timeout"] == {"connect": 9000}
+    entry = config["mcp"]["servers"]["servonaut"]
+    assert "enabled" not in entry
+    assert entry["command"] == ["/usr/bin/servonaut", "--mcp"]
+    assert entry["environment"]["SSH_AUTH_SOCK"] == "{env:SSH_AUTH_SOCK}"
+
+
+def test_opencode_v2_fresh_config_uses_servers_container(fake_home, monkeypatch):
+    monkeypatch.setattr(installer, "_installed_major_version", lambda _name: 2)
+    install_mcp_server("opencode")
+
+    config_path = fake_home / ".config" / "opencode" / "opencode.json"
+    config = json.loads(config_path.read_text())
+    assert "servonaut" in config["mcp"]["servers"]
+    assert "servonaut" not in config["mcp"]
+
+
+# --- Cursor, Windsurf, and VS Code -----------------------------------------
+
+
+def test_cursor_preserves_environment_without_unsafe_interpolation(fake_home):
+    config_path = fake_home / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True)
+    original = {"mcpServers": {"servonaut": {"timeout": 45, "env": {"CUSTOM": "ok"}}}}
+    config_path.write_text(json.dumps(original))
+
+    install_mcp_server("cursor")
+
+    entry = json.loads(config_path.read_text())["mcpServers"]["servonaut"]
+    assert entry["type"] == "stdio"
+    assert entry["timeout"] == 45
+    assert entry["env"] == {"CUSTOM": "ok"}
+
+
+def test_windsurf_uses_documented_environment_interpolation(fake_home):
+    install_mcp_server("windsurf")
+
+    config_path = fake_home / ".codeium" / "windsurf" / "mcp_config.json"
+    entry = json.loads(config_path.read_text())["mcpServers"]["servonaut"]
+    assert entry["command"] == "/usr/bin/servonaut"
+    assert entry["env"]["SSH_AUTH_SOCK"] == "${env:SSH_AUTH_SOCK}"
+    assert entry["env"]["BW_SESSION"] == "${env:BW_SESSION}"
+
+
+def test_vscode_writes_stdio_type_and_environment_references(fake_home):
+    install_mcp_server("vscode")
+
+    config_path = fake_home / ".config" / "Code" / "User" / "mcp.json"
+    entry = json.loads(config_path.read_text())["servers"]["servonaut"]
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "/usr/bin/servonaut"
+    assert entry["args"] == ["--mcp"]
+    assert entry["env"]["SSH_AUTH_SOCK"] == "${env:SSH_AUTH_SOCK}"
+
+
+# --- Gemini CLI ------------------------------------------------------------
+
+
+def test_gemini_writes_settings_with_explicit_sensitive_env_refs(fake_home):
+    install_mcp_server("gemini")
+
+    config_path = fake_home / ".gemini" / "settings.json"
+    entry = json.loads(config_path.read_text())["mcpServers"]["servonaut"]
+    assert entry["command"] == "/usr/bin/servonaut"
+    assert entry["args"] == ["--mcp"]
+    assert entry["env"]["SSH_AUTH_SOCK"] == "$SSH_AUTH_SOCK"
+    assert entry["env"]["BWS_ACCESS_TOKEN"] == "$BWS_ACCESS_TOKEN"
+
+
+def test_gemini_install_updates_user_mcp_policy_without_losing_entries(fake_home):
+    config_path = fake_home / ".gemini" / "settings.json"
+    config_path.parent.mkdir(parents=True)
+    original = {"mcp": {"allowed": ["other"], "excluded": ["servonaut", "blocked"]}}
+    config_path.write_text(json.dumps(original))
+
+    install_mcp_server("gemini")
+
+    config = json.loads(config_path.read_text())
+    assert config["mcp"]["allowed"] == ["other", "servonaut"]
+    assert config["mcp"]["excluded"] == ["blocked"]
+    assert "servonaut" in config["mcpServers"]
+
+
+# --- Config safety and dynamic references ---------------------------------
+
+
+def test_invalid_json_is_never_overwritten(fake_home, capsys):
+    config_path = fake_home / ".claude.json"
+    invalid = "{ this is not valid JSON"
+    config_path.write_text(invalid)
+
+    with pytest.raises(SystemExit) as exc_info:
+        install_mcp_server("claude")
+
+    assert exc_info.value.code == 1
+    assert config_path.read_text() == invalid
+    error = capsys.readouterr().err
+    assert "Refusing to overwrite invalid JSON" in error
+
+
+def test_configured_env_references_are_forwarded_by_name(fake_home):
+    config_path = fake_home / ".servonaut" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {"one": "$HCLOUD_TOKEN", "two": "${OVH_KEY}", "ignored": "Bearer $NOPE"}
+        )
+    )
+
+    install_mcp_server("codex")
+
+    text = (fake_home / ".codex" / "config.toml").read_text()
+    assert '"HCLOUD_TOKEN"' in text
+    assert '"OVH_KEY"' in text
+    assert '"NOPE"' not in text
+
+
+def test_codex_multiline_env_vars_keep_object_entries(fake_home):
+    config_path = fake_home / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        "[mcp_servers.servonaut]\n"
+        'command = "/old/servonaut"\n'
+        "env_vars = [\n"
+        '  "CUSTOM",\n'
+        '  { name = "REMOTE_TOKEN", source = "remote" },\n'
+        "]\n"
+        "tool_timeout_sec = 90\n"
+    )
+
+    install_mcp_server("codex")
+
+    text = config_path.read_text()
+    assert '{ name = "REMOTE_TOKEN", source = "remote" },' in text
+    assert text.count('"CUSTOM"') == 1
+    assert text.count('"SSH_AUTH_SOCK"') == 1
+    assert "tool_timeout_sec = 90" in text
+    assert text.count("env_vars = ") == 1
+
+
+def test_wrong_nested_config_type_is_not_replaced(fake_home):
+    config_path = fake_home / ".claude.json"
+    original = json.dumps({"mcpServers": []})
+    config_path.write_text(original)
+
+    with pytest.raises(SystemExit):
+        install_mcp_server("claude")
+
+    assert config_path.read_text() == original
+
+
+def test_atomic_reinstall_preserves_config_permissions(fake_home):
+    config_path = fake_home / ".claude.json"
+    config_path.write_text(json.dumps({"mcpServers": {}}))
+    config_path.chmod(0o640)
+
+    install_mcp_server("claude")
+
+    assert config_path.stat().st_mode & 0o777 == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation may need privileges")
+def test_atomic_reinstall_preserves_config_symlink(fake_home):
+    target_path = fake_home / "dotfiles" / "claude.json"
+    target_path.parent.mkdir()
+    target_path.write_text(json.dumps({"mcpServers": {}}))
+    config_path = fake_home / ".claude.json"
+    config_path.symlink_to(target_path)
+
+    install_mcp_server("claude")
+
+    assert config_path.is_symlink()
+    config = json.loads(target_path.read_text())
+    assert config["mcpServers"]["servonaut"]["command"] == "/usr/bin/servonaut"
+
+
+def test_opencode_reinstall_preserves_disabled_state_and_custom_env(
+    fake_home, monkeypatch
+):
+    config_path = fake_home / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    original = {
+        "mcp": {
+            "servonaut": {
+                "type": "local",
+                "enabled": False,
+                "environment": {"CUSTOM": "kept"},
+            }
+        }
+    }
+    config_path.write_text(json.dumps(original))
+    monkeypatch.setattr(installer, "_installed_major_version", lambda _name: 1)
+
+    install_mcp_server("opencode")
+
+    entry = json.loads(config_path.read_text())["mcp"]["servonaut"]
+    assert entry["enabled"] is False
+    assert entry["environment"]["CUSTOM"] == "kept"
+    assert entry["environment"]["SSH_AUTH_SOCK"] == "{env:SSH_AUTH_SOCK}"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -201,6 +201,26 @@ class TestListInstances:
         assert "-" in result
 
 
+class TestFindInstance:
+    def test_explicit_custom_id_skips_all_cloud_provider_fetches(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+
+        result = run(tools._find_instance("custom-ovh-web"))
+
+        assert result == SAMPLE_CUSTOM_INSTANCES[0]
+        tools._aws_service.fetch_instances_cached.assert_not_awaited()
+        tools._ovh_service.fetch_instances_cached.assert_not_awaited()
+
+    def test_custom_name_preserves_aws_precedence_but_skips_other_clouds(self):
+        tools = make_tools(custom_instances=SAMPLE_CUSTOM_INSTANCES)
+
+        result = run(tools._find_instance("ovh-web"))
+
+        assert result == SAMPLE_CUSTOM_INSTANCES[0]
+        tools._aws_service.fetch_instances_cached.assert_awaited_once()
+        tools._ovh_service.fetch_instances_cached.assert_not_awaited()
+
+
 class TestCheckStatus:
     def test_returns_instance_details(self):
         tools = make_tools()
@@ -269,6 +289,70 @@ class TestRunCommand:
             run(tools.run_command("i-abc123", "ls"))
         tools._ssh_service.build_ssh_command.assert_called_once()
 
+    def test_authentication_failure_is_returned_and_audited_as_error(self):
+        tools = make_tools(guard_level=GuardLevel.STANDARD)
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(
+                return_value=(b"", b"Permission denied (publickey).")
+            )
+            mock_process._transport = None
+            mock_exec.return_value = mock_process
+
+            result = run(tools.run_command("i-abc123", "ls"))
+
+        assert "SSH authentication failed" in result
+        assert "transport_used" not in result
+        audit_call = tools._audit.log.call_args
+        assert audit_call.args[3] is False
+        assert audit_call.args[4] == "ssh_auth_failed"
+
+    def test_authentication_failure_ignores_partial_stdout(self):
+        tools = make_tools(guard_level=GuardLevel.STANDARD)
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate = AsyncMock(
+                return_value=(b"SSH banner\n", b"Permission denied (publickey).")
+            )
+            mock_process._transport = None
+            mock_exec.return_value = mock_process
+
+            result = run(tools.run_command("i-abc123", "ls"))
+
+        assert "SSH authentication failed" in result
+        assert "SSH banner" not in result
+        assert "transport_used" not in result
+        audit_call = tools._audit.log.call_args
+        assert audit_call.args[3] is False
+        assert audit_call.args[4] == "ssh_auth_failed"
+
+    def test_authentication_failure_retries_forwarded_agent_without_key(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/test-agent.sock")
+        tools = make_tools(guard_level=GuardLevel.STANDARD)
+        subprocess_call = AsyncMock(
+            side_effect=[
+                (b"", b"Permission denied (publickey)."),
+                (b"ubuntu\n", b""),
+            ]
+        )
+
+        with patch(
+            "servonaut.mcp.tools.run_ssh_subprocess", new=subprocess_call
+        ):
+            result = run(tools.run_command("i-abc123", "ls"))
+
+        assert "ubuntu" in result
+        assert "[transport_used: ssh]" in result
+        assert subprocess_call.await_count == 2
+        build_calls = tools._ssh_service.build_ssh_command.call_args_list
+        assert build_calls[0].kwargs["key_path"] == "~/.ssh/test.pem"
+        assert build_calls[1].kwargs["key_path"] is None
+        audit_call = tools._audit.log.call_args
+        assert audit_call.args[3] is True
+        assert audit_call.kwargs["key_source"] == "ssh_agent"
+
 
 class TestGetLogs:
     def test_calls_run_command_with_tail(self):
@@ -320,6 +404,25 @@ class TestGetServerInfo:
         tools._audit.log.assert_called_once()
         assert tools._audit.log.call_args[0][0] == "get_server_info"
 
+    def test_authentication_failure_is_not_audited_as_success(self, monkeypatch):
+        monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+        tools = make_tools(guard_level=GuardLevel.DANGEROUS)
+        subprocess_call = AsyncMock(
+            return_value=(b"", b"Permission denied (publickey).")
+        )
+
+        with patch(
+            "servonaut.mcp.tools.run_ssh_subprocess", new=subprocess_call
+        ):
+            result = run(tools.get_server_info("i-abc123"))
+
+        assert "SSH authentication failed" in result
+        assert "STDERR" not in result
+        audit_call = tools._audit.log.call_args
+        assert audit_call.args[0] == "get_server_info"
+        assert audit_call.args[3] is False
+        assert audit_call.args[4] == "ssh_auth_failed"
+
 
 class TestTransferFile:
     def test_blocked_in_standard(self):
@@ -361,6 +464,31 @@ class TestTransferFile:
         tools._scp_service.execute_transfer = AsyncMock(return_value=(1, "", "Connection refused"))
         result = run(tools.transfer_file("i-abc123", "/local", "/remote", "download"))
         assert "failed" in result.lower()
+
+    def test_authentication_failure_retries_forwarded_agent_without_key(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/test-agent.sock")
+        tools = make_tools(guard_level=GuardLevel.DANGEROUS)
+        tools._scp_service.execute_transfer = AsyncMock(
+            side_effect=[
+                (1, "", "Permission denied (publickey)."),
+                (0, "", ""),
+            ]
+        )
+
+        result = run(
+            tools.transfer_file("i-abc123", "/local", "/remote", "download")
+        )
+
+        assert "successful" in result.lower()
+        assert tools._scp_service.execute_transfer.await_count == 2
+        build_calls = tools._scp_service.build_download_command.call_args_list
+        assert build_calls[0].kwargs["key_path"] == "~/.ssh/test.pem"
+        assert build_calls[1].kwargs["key_path"] is None
+        audit_call = tools._audit.log.call_args
+        assert audit_call.args[3] is True
+        assert audit_call.kwargs["key_source"] == "ssh_agent"
 
     def test_audit_logged_on_block(self):
         tools = make_tools(guard_level=GuardLevel.STANDARD)


### PR DESCRIPTION
## Summary

- preserve existing MCP client settings with atomic, symlink-safe installers and client-native environment forwarding
- add Gemini CLI installation and support current OpenCode configuration layouts
- classify SSH authentication failures correctly and retry through a forwarded SSH agent after configured-key authentication fails
- fail fast when a Bitwarden session is unavailable and avoid unrelated provider lookups for explicit custom instance IDs

## Validation

- focused MCP, installer, Bitwarden, SDK contract, dispatch, and documentation tests: 168 passed
- packaged stdio initialization and tool-list handshake
- non-mutating SSH command smoke test through the forwarded-agent path
- native MCP health checks for installed supported clients