### PR TITLE
fix: stabilize scan results and memory dashboard state

### DIFF
--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -677,16 +677,40 @@ class ServonautApp(App):
     def on_user_login_success(self) -> None:
         """Called by LoginScreen after a successful device-flow completion.
 
-        Kicks off the in-process relay listener in a background worker so
-        the login UI doesn't block. RelayManager.start() is idempotent while
-        the listener is already running, so calling this more than once is
-        safe.
+        Starts account-bound background services without blocking the login
+        UI. Relay startup and remembered Memory Sync reactivation are
+        independent: a missing relay configuration must not prevent a
+        previously enrolled device from silently unlocking.
         """
         self._init_relay_manager()
-        if self.relay_manager is None:
+        if self.relay_manager is not None:
+            self.run_worker(
+                self._start_relay_with_toast(),
+                name="relay_login_start",
+                exclusive=True,
+            )
+
+        sync = getattr(self, "memory_sync_service", None)
+        auth = getattr(self, "auth_service", None)
+        try:
+            should_reactivate = bool(
+                sync is not None
+                and auth is not None
+                and auth.is_authenticated
+                and auth.has_feature("memory_sync")
+                and sync.is_enrolled_locally()
+            )
+        except Exception:
+            should_reactivate = False
+        if not should_reactivate:
             return
-        self.run_worker(self._start_relay_with_toast(),
-                        name="relay_login_start", exclusive=True)
+
+        self.run_worker(
+            self._reactivate_memory_sync(),
+            name="memory_sync_login_reactivate",
+            group="memory_reactivate",
+            exclusive=True,
+        )
 
     async def _start_relay_with_toast(self) -> None:
         """Background worker that starts the relay and surfaces the outcome."""

--- a/src/servonaut/screens/memory.py
+++ b/src/servonaut/screens/memory.py
@@ -25,6 +25,13 @@ from textual.screen import ModalScreen, Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Static
 
 from servonaut.screens._binding_guard import check_action_passthrough
+from servonaut.services.memory.status import (
+    STATUS_FRESH,
+    STATUS_NONE,
+    STATUS_OPT_OUT,
+    STATUS_STALE,
+    compute_memory_status,
+)
 from servonaut.widgets.sidebar import Sidebar
 
 logger = logging.getLogger(__name__)
@@ -33,22 +40,22 @@ logger = logging.getLogger(__name__)
 def _sync_status_label(sync_service: Any) -> str:
     """Return a compact Rich markup string describing the sync status."""
     if sync_service is None:
-        return "[dim]Sync: unavailable[/dim]"
+        return "[dim]Cloud sync: unavailable[/dim]"
     try:
         status = sync_service.status
         state = status.state
         pending = status.pending_envelopes
         last = (status.last_sync_at or "never")[:19].replace("T", " ")
         if state == "running":
-            return f"[cyan]Sync: running[/cyan] · {pending} pending"
+            return f"[cyan]Cloud sync: running[/cyan] · {pending} pending"
         if state == "halted":
             reason = status.halted_reason or "unknown"
-            return f"[red]Sync: halted ({reason})[/red] · {pending} pending"
+            return f"[red]Cloud sync: halted ({reason})[/red] · {pending} pending"
         if state == "error":
-            return f"[red]Sync: error[/red] · last: {last}"
-        return f"[green]Sync: {state}[/green] · last: {last} · {pending} pending"
+            return f"[red]Cloud sync: error[/red] · last: {last}"
+        return f"[green]Cloud sync: {state}[/green] · last: {last} · {pending} pending"
     except Exception:
-        return "[dim]Sync: unknown[/dim]"
+        return "[dim]Cloud sync: unknown[/dim]"
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +87,52 @@ def _human_age(probed_at_str: str) -> str:
         return f"{int(age_seconds // 86400)}d ago"
     except (ValueError, TypeError):
         return "?"
+
+
+_MEMORY_STATUS_LABELS = {
+    STATUS_FRESH: "[green]● Fresh[/green]",
+    STATUS_STALE: "[yellow]● Stale[/yellow]",
+    STATUS_NONE: "[dim]○ Not probed[/dim]",
+    STATUS_OPT_OUT: "[red]⛔ Opted-out[/red]",
+}
+
+
+def _memory_scan_status_label(instance: Dict[str, Any], memory_service: Any) -> str:
+    """Return the current local scan status using the fleet-wide classifier."""
+    if memory_service is None:
+        return "[dim]Memory scan: unavailable[/dim]"
+
+    status = compute_memory_status(instance, memory_service)
+    status_label = _MEMORY_STATUS_LABELS.get(status, "[dim]unknown[/dim]")
+    label = f"[bold]Memory scan:[/bold] {status_label}"
+    if status not in (STATUS_FRESH, STATUS_STALE):
+        return label
+
+    instance_id = instance.get("id") or instance.get("name", "")
+    provider = instance.get("provider", "custom")
+    try:
+        modules = memory_service.get_all_modules(instance_id, provider)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "Could not load memory scan details for %s: %s",
+            instance_id,
+            exc,
+        )
+        return label
+
+    module_count = len(modules)
+    details = [f"{module_count} module{'s' if module_count != 1 else ''}"]
+    latest_probed_at = max(
+        (
+            module.get("probed_at", "")
+            for module in modules.values()
+            if isinstance(module, dict)
+        ),
+        default="",
+    )
+    if latest_probed_at:
+        details.append(f"last probe {_human_age(latest_probed_at)}")
+    return f"{label} · {' · '.join(details)}"
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +363,10 @@ class MemoryScreen(Screen):
                     id="memory-title",
                 ),
                 Static(
+                    "[dim]Memory scan: checking…[/dim]",
+                    id="memory-local-status",
+                ),
+                Static(
                     "[yellow]Memory disabled for this server.[/yellow]",
                     id="memory-opt-out-banner",
                     classes="hidden",
@@ -347,7 +404,7 @@ class MemoryScreen(Screen):
                     id="memory-actions",
                 ),
                 Horizontal(
-                    Static("[dim]Sync: unavailable[/dim]", id="memory-sync-status"),
+                    Static("[dim]Cloud sync: unavailable[/dim]", id="memory-sync-status"),
                     Button("S. Sync Now", id="btn_sync_now"),
                     id="memory-sync-row",
                 ),
@@ -376,7 +433,7 @@ class MemoryScreen(Screen):
         table.add_column("Age", key="age")
         self._render_table()
         self._refresh_sync_status()
-        self.set_interval(5, self._refresh_sync_status)
+        self.set_interval(5, self._refresh_statuses)
 
     # ------------------------------------------------------------------
     # Table rendering
@@ -389,6 +446,7 @@ class MemoryScreen(Screen):
         memory is disabled for this instance.  Stale rows are coloured
         yellow via Rich markup.
         """
+        self._refresh_local_memory_status()
         table = self.query_one("#memory-table", DataTable)
         banner = self.query_one("#memory-opt-out-banner", Static)
 
@@ -950,6 +1008,34 @@ class MemoryScreen(Screen):
     # Cloud sync actions (S binding)
     # ------------------------------------------------------------------
 
+    def _refresh_statuses(self) -> None:
+        """Refresh local scan freshness and cloud-sync state."""
+        self._refresh_local_memory_status()
+        self._refresh_sync_status()
+
+    def _refresh_local_memory_status(self) -> None:
+        """Update the local scan label from the latest stored modules."""
+        memory_service = getattr(self.app, "memory_service", None)
+        label = _memory_scan_status_label(self._instance, memory_service)
+        try:
+            self.query_one("#memory-local-status", Static).update(label)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def refresh_memory_status(self) -> None:
+        """Reload local memory after an app-owned fleet scan completes.
+
+        ``ServonautApp._refresh_fleet_panels_after_scan`` calls this hook on
+        whichever screen is active. This keeps the badge and module rows aligned
+        with the Fleet Memory screen immediately.
+        """
+        try:
+            self._render_table()
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Could not refresh per-instance memory status", exc_info=True,
+            )
+
     def _refresh_sync_status(self) -> None:
         """Poll the sync service status and update the status label.
 
@@ -1042,22 +1128,52 @@ class MemoryScreen(Screen):
     # ------------------------------------------------------------------
 
     def action_build_ai_summary(self) -> None:
-        """Start the AI summary flow: provider disclosure → consent → dispatch."""
+        """Refresh entitlement, then start disclosure → consent → dispatch."""
         ai_service = getattr(self.app, "ai_summary_service", None)
         if ai_service is None:
             self.app.notify("AI summary service not available.", severity="warning")
             return
-        auth = getattr(self.app, "auth_service", None)
-        if auth and not auth.has_feature("memory_ai_summary"):
-            from servonaut.widgets.upsell_modal import UpsellModal
-            self.app.push_screen(UpsellModal("memory_ai_summary"))
-            return
-        instance_id = self._instance.get("id") or self._instance.get("name", "")
         self.run_worker(
-            self._do_ai_summary_flow(instance_id),
+            self._start_ai_summary_flow(),
             group="memory_ai_summary",
             name="memory_ai_summary",
         )
+
+    async def _start_ai_summary_flow(self) -> None:
+        """Recheck server overrides before deciding whether to show an upsell."""
+        auth = getattr(self.app, "auth_service", None)
+        if auth:
+            if not getattr(auth, "is_authenticated", False):
+                self.app.notify(
+                    "Sign in to verify AI summary access.",
+                    severity="warning",
+                )
+                return
+
+            fetch_entitlements = getattr(auth, "fetch_entitlements", None)
+            refreshed_entitlements = None
+            if callable(fetch_entitlements):
+                try:
+                    refreshed_entitlements = await fetch_entitlements()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("AI-summary entitlement refresh failed: %s", exc)
+
+            if refreshed_entitlements is None:
+                self.app.notify(
+                    "Could not verify AI summary access. "
+                    "Check your connection and retry.",
+                    severity="warning",
+                )
+                return
+
+            if not auth.has_feature("memory_ai_summary"):
+                from servonaut.widgets.upsell_modal import UpsellModal
+
+                self.app.push_screen(UpsellModal("memory_ai_summary"))
+                return
+
+        instance_id = self._instance.get("id") or self._instance.get("name", "")
+        await self._do_ai_summary_flow(instance_id)
 
     async def _do_ai_summary_flow(self, instance_id: str) -> None:
         """Worker: full AI summary flow per spec §3.6."""
@@ -1068,8 +1184,23 @@ class MemoryScreen(Screen):
             # Step 1: fetch provider info (contains retention_text to show verbatim)
             provider_info = await ai_service.get_provider_info()
         except Exception as exc:
+            from servonaut.services.memory.interfaces import UpsellRequired
+
+            if isinstance(exc, UpsellRequired):
+                logger.error("AI summary API denied the verified entitlement")
+                self.app.notify(
+                    "AI summary access was accepted locally, but the server denied it. "
+                    "Your account entitlement has not reached the summary API yet.",
+                    severity="error",
+                    markup=False,
+                )
+                return
             logger.error("AI provider info failed: %s", exc)
-            self.app.notify(f"Could not fetch AI provider info: {exc}", severity="error")
+            self.app.notify(
+                f"Could not fetch AI provider info: {exc}",
+                severity="error",
+                markup=False,
+            )
             return
 
         # Step 2: show provider disclosure verbatim and ask for confirmation.

--- a/src/servonaut/screens/memory_keys.py
+++ b/src/servonaut/screens/memory_keys.py
@@ -136,9 +136,15 @@ class PassphraseEnrolModal(ModalScreen[Optional[PassphraseResult]]):
         Binding("enter", "confirm", "Enrol", show=False),
     ]
 
-    def __init__(self, mode: str = "enrol") -> None:
+    def __init__(
+        self,
+        mode: str = "enrol",
+        *,
+        remember_default: bool = False,
+    ) -> None:
         super().__init__()
         self._mode = mode
+        self._remember_default = remember_default
         # Lazily check keychain availability at construction time.  Using a
         # lazy import avoids a hard dep on keyring at module load.
         try:
@@ -176,10 +182,10 @@ class PassphraseEnrolModal(ModalScreen[Optional[PassphraseResult]]):
             Static("", id="enrol-mismatch", classes="" if is_enrol else "hidden"),
             Horizontal(
                 Static(
-                    "Remember on this device (auto-unlock)",
+                    "Keep unlocked for 30 days (secure OS keychain)",
                     id="enrol-remember-label",
                 ),
-                Switch(value=False, id="enrol-remember"),
+                Switch(value=self._remember_default, id="enrol-remember"),
                 id="enrol-remember-row",
                 classes=remember_classes,
             ),

--- a/src/servonaut/screens/memory_sync_setup.py
+++ b/src/servonaut/screens/memory_sync_setup.py
@@ -120,11 +120,16 @@ class MemorySyncSetupScreen(Screen):
 
         # 3. Solo+ — figure out configured state
         configured = sync is not None and getattr(sync, "is_configured", False)
+        try:
+            enrolled = bool(sync is not None and sync.is_enrolled_locally())
+        except Exception:
+            enrolled = False
         if configured:
             self._set_status("● Active", "$success")
             body.mount(self._build_status_card(auth, sync))
         else:
-            self._set_status("⚪ Not set up yet", "$warning")
+            status_label = "⚪ Locked" if enrolled else "⚪ Not set up yet"
+            self._set_status(status_label, "$warning")
             body.mount(self._build_setup_card(auth))
 
     def _set_status(self, text: str, color: str) -> None:
@@ -202,8 +207,10 @@ class MemorySyncSetupScreen(Screen):
                     "Enter your passphrase to unlock the encrypted store on "
                     "this device. First time? You'll be asked to create a "
                     "passphrase — Servonaut wraps your private key with it "
-                    "locally, so even we can't read your data. Same passphrase "
-                    "unlocks the store on every subsequent launch.",
+                    "locally, so even we can't read your data. To avoid entering "
+                    "it after every restart, choose “Keep unlocked for 30 days” "
+                    "in the secure OS-keychain prompt. Otherwise the key stays "
+                    "unlocked only for this Servonaut session.",
                     classes="msync_card_body",
                 ),
                 self._build_benefits_list(benefits),
@@ -258,6 +265,12 @@ class MemorySyncSetupScreen(Screen):
         auto_unlock_label = "off"
         is_remembered = False
         try:
+            from servonaut.services.memory import passphrase_store
+
+            remember_available = passphrase_store.keyring_available()
+        except Exception:
+            remember_available = False
+        try:
             cfg = self.app.config_manager.get()
             is_remembered = bool(
                 getattr(cfg.memory, "sync_remember_device", False)
@@ -284,6 +297,8 @@ class MemorySyncSetupScreen(Screen):
                 auto_unlock_label = "off"
         except Exception:
             pass
+        if not remember_available:
+            auto_unlock_label = "unavailable (no supported OS keychain)"
 
         actions_children: list = [
             Button("Sync now", variant="primary", id="msync_btn_sync_now"),
@@ -293,6 +308,10 @@ class MemorySyncSetupScreen(Screen):
         if is_remembered:
             actions_children.append(
                 Button("Forget on this device", id="msync_btn_forget")
+            )
+        elif remember_available:
+            actions_children.append(
+                Button("Enable auto-unlock", id="msync_btn_remember")
             )
 
         return Container(
@@ -363,6 +382,13 @@ class MemorySyncSetupScreen(Screen):
                 self._do_setup(),
                 group="memory_sync",
                 name="msync_setup",
+                exclusive=True,
+            )
+        elif bid == "msync_btn_remember":
+            self.run_worker(
+                self._do_remember(),
+                group="memory_sync",
+                name="msync_remember",
                 exclusive=True,
             )
         elif bid == "msync_btn_sync_now":
@@ -686,6 +712,93 @@ class MemorySyncSetupScreen(Screen):
             logger.warning("_do_rotate: keychain update failed: %s", exc)
         self.app.notify("Keypair rotated.", severity="information")
         self._render_state()
+
+    async def _do_remember(self) -> None:
+        """Verify and remember the sync passphrase for automatic unlock."""
+        sync = getattr(self.app, "memory_sync_service", None)
+        if sync is None or not getattr(sync, "is_configured", False):
+            self.app.notify(
+                "Unlock Memory Sync before enabling auto-unlock.",
+                severity="warning",
+                markup=False,
+            )
+            return
+
+        from servonaut.screens.memory_keys import PassphraseEnrolModal
+
+        result = await self.app.push_screen_wait(
+            PassphraseEnrolModal(mode="unlock", remember_default=True)
+        )
+        if result is None or not result.remember:
+            return
+        if not sync.can_unwrap_local(result.passphrase):
+            self.app.notify(
+                "Wrong passphrase — auto-unlock remains off.",
+                severity="error",
+                markup=False,
+            )
+            return
+
+        if not self._store_remembered_passphrase(result.passphrase):
+            return
+        self.app.notify(
+            "Auto-unlock enabled for 30 days on this device.",
+            severity="information",
+            markup=False,
+        )
+        self._render_state()
+
+    def _store_remembered_passphrase(self, passphrase: str) -> bool:
+        """Store *passphrase* in a trusted keychain and stamp its expiry."""
+        from servonaut.services.memory import passphrase_store
+
+        if not passphrase_store.keyring_available():
+            self.app.notify(
+                "No trusted OS keychain is available on this device.",
+                severity="warning",
+                markup=False,
+            )
+            return False
+        if not passphrase_store.store_passphrase(passphrase):
+            self.app.notify(
+                "The OS keychain could not store the passphrase.",
+                severity="error",
+                markup=False,
+            )
+            return False
+
+        cfg = None
+        original_memory = None
+        try:
+            import dataclasses as _dc
+            from datetime import datetime, timedelta, timezone
+
+            from servonaut.config.schema import DEFAULT_REMEMBER_TTL_DAYS
+
+            expires_at = (
+                datetime.now(timezone.utc)
+                + timedelta(days=DEFAULT_REMEMBER_TTL_DAYS)
+            ).isoformat()
+            cfg = self.app.config_manager.get()
+            original_memory = cfg.memory
+            updated_mem = _dc.replace(
+                cfg.memory,
+                sync_remember_device=True,
+                sync_remember_expires_at=expires_at,
+            )
+            self.app.config_manager.update(memory=updated_mem)
+        except Exception as exc:
+            passphrase_store.clear_passphrase()
+            if cfg is not None and original_memory is not None:
+                cfg.memory = original_memory
+            logger.warning("_do_remember: config update failed: %s", exc)
+            self.app.notify(
+                "Auto-unlock could not be enabled; no passphrase was retained.",
+                severity="error",
+                markup=False,
+            )
+            return False
+        return True
 
     def _do_disable(self) -> None:
         sync = getattr(self.app, "memory_sync_service", None)

--- a/src/servonaut/screens/scan_results.py
+++ b/src/servonaut/screens/scan_results.py
@@ -57,8 +57,8 @@ class ScanResultsScreen(Screen):
 
     def on_mount(self) -> None:
         """Load cached scan results when mounted."""
-        self._load_cached_results()
         self._setup_table()
+        self._load_cached_results()
 
     def _setup_table(self) -> None:
         """Setup DataTable columns and styling."""

--- a/src/servonaut/screens/settings/base.py
+++ b/src/servonaut/screens/settings/base.py
@@ -119,6 +119,13 @@ class SettingsPanel(Vertical):
         """
         raise NotImplementedError
 
+    def refresh_external_state(self) -> None:
+        """Refresh state managed outside this settings form.
+
+        Called when the parent Settings screen resumes after a pushed screen.
+        Most panels have no external state and intentionally do nothing.
+        """
+
     # ------------------------------------------------------------------
     # Dirty tracking
     # ------------------------------------------------------------------

--- a/src/servonaut/screens/settings/panels/memory.py
+++ b/src/servonaut/screens/settings/panels/memory.py
@@ -71,6 +71,12 @@ class MemoryPanel(SettingsPanel):
         height: auto;
         margin: 0 0 0 2;
     }
+    MemoryPanel #memory_device_auto_unlock_status {
+        width: 1fr;
+    }
+    MemoryPanel #memory_manage_device_auto_unlock {
+        min-width: 12;
+    }
     """
 
     # ------------------------------------------------------------------
@@ -89,6 +95,13 @@ class MemoryPanel(SettingsPanel):
         yield Horizontal(
             Static("Sync encryption enabled", classes="label"),
             Switch(id="memory_sync_encryption"),
+            classes="setting_row",
+        )
+        yield Static("Device auto-unlock", classes="memory-section-label")
+        yield Horizontal(
+            Static("Remembered unlock", classes="label"),
+            Static("", id="memory_device_auto_unlock_status"),
+            Button("Manage…", id="memory_manage_device_auto_unlock"),
             classes="setting_row",
         )
 
@@ -196,6 +209,9 @@ class MemoryPanel(SettingsPanel):
         self.query_one("#memory_enabled", Switch).value = mem.enabled
         self.query_one("#memory_sync_encryption", Switch).value = (
             config.sync_encryption_enabled
+        )
+        self.query_one("#memory_device_auto_unlock_status", Static).update(
+            self._device_auto_unlock_status(mem)
         )
 
         # Privacy
@@ -462,15 +478,52 @@ class MemoryPanel(SettingsPanel):
         self._dirty_watch()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Refresh dirty marker when list/map editor rows are added or removed."""
+        """Open remembered-unlock management or refresh dirty state."""
+        if event.button.id == "memory_manage_device_auto_unlock":
+            event.stop()
+            self._open_device_auto_unlock_management()
+            return
         super().on_button_pressed(event)
         # Propagated button events from StringListEditor / KeyValueEditor
         # that were NOT the panel Save button still warrant a dirty check.
         self._dirty_watch()
 
+    def _open_device_auto_unlock_management(self) -> None:
+        """Push the sole setup screen that can enable or forget auto-unlock."""
+        from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+        self.app.push_screen(MemorySyncSetupScreen())
+
+    def refresh_external_state(self) -> None:
+        """Refresh remembered-unlock status after the setup screen closes."""
+        try:
+            config = self.app.config_manager.get()
+            status = self._device_auto_unlock_status(config.memory)
+            self.query_one("#memory_device_auto_unlock_status", Static).update(status)
+        except Exception as exc:  # pragma: no cover - defensive UI refresh
+            logger.debug("Could not refresh device auto-unlock status: %s", exc)
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _device_auto_unlock_status(memory_config: Any) -> str:
+        """Describe remembered unlock without reading any credential material."""
+        try:
+            from servonaut.services.memory import passphrase_store
+
+            if not passphrase_store.keyring_available():
+                return "Unavailable (no trusted OS keychain)"
+        except Exception:
+            return "Unavailable (no trusted OS keychain)"
+
+        if not getattr(memory_config, "sync_remember_device", False):
+            return "Off"
+
+        from servonaut.config.schema import DEFAULT_REMEMBER_TTL_DAYS
+
+        return f"On ({DEFAULT_REMEMBER_TTL_DAYS}-day re-prompt)"
 
     def _parse_non_negative_int(
         self, raw: str, field_id: str, label: str

--- a/src/servonaut/screens/settings/panels/memory_sync.py
+++ b/src/servonaut/screens/settings/panels/memory_sync.py
@@ -1,8 +1,9 @@
 """Memory Sync settings panel.
 
-Exposes the three server-side Memory Sync preferences:
+Exposes the four server-side Memory Sync preferences:
 - Digest frequency (Select: off / weekly / monthly)
 - Mercure push enabled (Switch)
+- Auto-sync while Servonaut is running (Switch)
 - AI consent mode (Select: off / client / server_60s)
 
 Settings are stored on the servonaut.dev backend, NOT in config.json.
@@ -52,7 +53,7 @@ _SELECT_BLANK = Select.BLANK  # sentinel for un-set Select values
 
 
 class MemorySyncPanel(SettingsPanel):
-    """Server-side Memory Sync settings: digest frequency, Mercure push, AI consent.
+    """Server-side digest, push, auto-sync, and AI-consent settings.
 
     Conditionally shown only when the user has the ``memory_sync``
     entitlement AND the device keypair is enrolled.  All persistence goes
@@ -133,7 +134,7 @@ class MemorySyncPanel(SettingsPanel):
                 classes="setting_row",
             ),
             Horizontal(
-                Static("Auto-sync memory to cloud", classes="label"),
+                Static("Auto-sync (60s, app open)", classes="label"),
                 Switch(value=False, id="settings_msync_auto_sync"),
                 classes="setting_row",
             ),

--- a/src/servonaut/screens/settings/shell.py
+++ b/src/servonaut/screens/settings/shell.py
@@ -22,6 +22,7 @@ import logging
 from typing import Dict, Optional
 
 from rich.markup import escape
+from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -145,6 +146,12 @@ class SettingsScreen(Screen):
         # active button exists. Re-assert the highlight once everything settled.
         if self._active_id is not None:
             self.call_after_refresh(self._set_nav_active, self._active_id)
+
+    def on_screen_resume(self, _event: events.ScreenResume) -> None:
+        """Refresh the active panel after a pushed management screen closes."""
+        current = self._current_panel()
+        if current is not None:
+            current.refresh_external_state()
 
     def _build_nav(self) -> None:
         """Mount one collapsible :class:`SidebarSection` per group.

--- a/src/servonaut/services/auth_service.py
+++ b/src/servonaut/services/auth_service.py
@@ -437,15 +437,19 @@ class AuthService(AuthServiceInterface):
     def get_plan_features(self) -> dict:
         """Return features for the current plan.
 
-        Resolution: start from the plan→feature fallback, then overlay any
-        backend-provided entitlements on top so explicit backend values win
-        but missing keys fall back to plan defaults.
+        Resolution order is plan fallback → legacy nested flags → current flat
+        flags → account-specific custom limits. Later values win, while missing
+        keys retain the earlier fallback. This also handles hybrid payloads
+        during backend migrations.
 
         Backend payload shapes supported:
         - Nested ``{"features": {...}}`` (legacy)
         - Flat ``{"memory_sync": 1, "memory_envelope_soft_cap": 50000, ...}``
           (current staging) — numeric quotas are ignored, only bool/0/1 keys
           are treated as feature flags.
+        - Account-specific boolean overrides under ``{"custom_limits": {...}}``.
+          These are applied last so an explicit override wins over plan and
+          regular entitlement values.
 
         Without the merge, a flat backend payload that omits ``config_sync``
         would silently strip it from a Solo user's feature set.
@@ -454,10 +458,17 @@ class AuthService(AuthServiceInterface):
         merged = dict(self._PLAN_FEATURES.get(plan, {}))
         ents = self._get_cached_entitlements()
         if ents:
-            if isinstance(ents.get("features"), dict):
-                merged.update(ents["features"])
-            else:
-                merged.update(self._features_from_top_level(ents))
+            nested_features = ents.get("features")
+            if isinstance(nested_features, dict):
+                merged.update(
+                    self._known_bool_features_from_mapping(nested_features)
+                )
+            merged.update(self._features_from_top_level(ents))
+            custom_limits = ents.get("custom_limits")
+            if isinstance(custom_limits, dict):
+                merged.update(
+                    self._known_bool_features_from_mapping(custom_limits)
+                )
         return merged
 
     # Explicit allowlist of keys the backend exposes as boolean feature flags.
@@ -490,6 +501,27 @@ class AuthService(AuthServiceInterface):
         "proactive_monitoring",
     })
 
+    @staticmethod
+    def _coerce_bool_feature(value: object) -> Optional[bool]:
+        """Coerce a backend boolean or strict integer boolean."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
+        return None
+
+    @classmethod
+    def _known_bool_features_from_mapping(cls, values: dict) -> dict:
+        """Return allowlisted boolean feature flags from one mapping."""
+        out: dict = {}
+        for key, value in values.items():
+            if key not in cls._KNOWN_BOOL_FEATURES:
+                continue
+            coerced = cls._coerce_bool_feature(value)
+            if coerced is not None:
+                out[key] = coerced
+        return out
+
     @classmethod
     def _features_from_top_level(cls, ents: dict) -> dict:
         """Project the known-bool feature flags from a flat entitlements dict.
@@ -500,14 +532,7 @@ class AuthService(AuthServiceInterface):
         — including new quotas or features the client doesn't know about
         yet — are silently skipped.
         """
-        out: dict = {}
-        for key, value in ents.items():
-            if key not in cls._KNOWN_BOOL_FEATURES:
-                continue
-            if isinstance(value, bool):
-                out[key] = value
-            elif isinstance(value, int) and value in (0, 1):
-                out[key] = bool(value)
+        out = cls._known_bool_features_from_mapping(ents)
 
         # Quota → boolean derivations. The backend prefers to ship a single
         # int quota and let clients derive the boolean feature flag, so any
@@ -951,31 +976,35 @@ class AuthService(AuthServiceInterface):
 
     @classmethod
     def _extract_bool_feature(cls, ents: Optional[dict], key: str) -> Optional[bool]:
-        """Pull a single bool feature flag from either payload shape.
+        """Pull one feature using nested → flat → custom-limit precedence.
 
         Returns ``None`` when the key is absent (so callers can distinguish
         "missing" from "explicitly false"). Mirrors the coercion rules in
-        :meth:`_features_from_top_level`.
+        :meth:`get_plan_features`; invalid values are ignored rather than
+        overriding an earlier valid value.
         """
         if not ents or not isinstance(ents, dict):
             return None
-        # Nested shape first.
+
+        resolved = None
         nested = ents.get("features")
         if isinstance(nested, dict) and key in nested:
-            value = nested[key]
-            if isinstance(value, bool):
-                return value
-            if isinstance(value, int) and value in (0, 1):
-                return bool(value)
-            return None
-        # Flat shape.
+            value = cls._coerce_bool_feature(nested[key])
+            if value is not None:
+                resolved = value
+
         if key in ents:
-            value = ents[key]
-            if isinstance(value, bool):
-                return value
-            if isinstance(value, int) and value in (0, 1):
-                return bool(value)
-        return None
+            value = cls._coerce_bool_feature(ents[key])
+            if value is not None:
+                resolved = value
+
+        custom_limits = ents.get("custom_limits")
+        if isinstance(custom_limits, dict) and key in custom_limits:
+            value = cls._coerce_bool_feature(custom_limits[key])
+            if value is not None:
+                resolved = value
+
+        return resolved
 
     @property
     def has_dangerous_ai_tools(self) -> bool:

--- a/src/servonaut/styles/screens/memory.tcss
+++ b/src/servonaut/styles/screens/memory.tcss
@@ -4,6 +4,7 @@
    =================================================================== */
 
 /* --- Sync / AI action rows in MemoryScreen --- */
+#memory-local-status,
 #memory-sync-row,
 #memory-ai-row {
     height: auto;
@@ -13,6 +14,7 @@
     border-top: wide $panel;
 }
 
+#memory-local-status,
 #memory-sync-status,
 #memory-ai-status {
     width: 1fr;
@@ -357,6 +359,10 @@
 
 .msync_card_actions Button {
     margin-right: 1;
+    min-width: 18;
+}
+
+#msync_btn_remember {
     min-width: 18;
 }
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -110,6 +110,100 @@ class TestAuthServiceBasic:
         assert not svc.has_feature("config_snapshots")
         assert not svc.has_feature("ai_requests_per_day")
 
+    def test_custom_limits_enable_account_specific_feature(
+        self, authenticated_service
+    ):
+        """An explicit account override must win over the Solo plan default."""
+        authenticated_service._apply_entitlements({
+            "plan": "solo",
+            "features": {"memory_ai_summary": False},
+            "custom_limits": {
+                "memory_ai_summary": 1,
+                "ai_requests_per_day": 1,
+                "future_toggle": True,
+            },
+        })
+
+        assert authenticated_service.has_feature("memory_ai_summary") is True
+        assert authenticated_service.has_feature("ai_requests_per_day") is False
+        assert authenticated_service.has_feature("future_toggle") is False
+
+    def test_hybrid_payload_merges_flat_flags_after_nested_features(
+        self, authenticated_service
+    ):
+        """A current flat flag must override the same legacy nested flag."""
+        authenticated_service._apply_entitlements({
+            "plan": "solo",
+            "features": {"memory_ai_summary": False},
+            "memory_ai_summary": 1,
+        })
+
+        assert authenticated_service.has_feature("memory_ai_summary") is True
+
+    def test_hybrid_dangerous_flag_keeps_cache_and_feature_in_sync(
+        self, authenticated_service
+    ):
+        """The dedicated cache must use the same hybrid payload precedence."""
+        authenticated_service._apply_entitlements({
+            "plan": "teams",
+            "features": {"allow_dangerous_ai_tools": True},
+            "allow_dangerous_ai_tools": False,
+        })
+
+        assert authenticated_service.has_feature("allow_dangerous_ai_tools") is False
+        assert authenticated_service.has_dangerous_ai_tools is False
+
+    def test_custom_limits_can_disable_plan_feature(self, authenticated_service):
+        """An explicit false override must also beat an enabled plan feature."""
+        authenticated_service._apply_entitlements({
+            "plan": "teams",
+            "features": {"memory_ai_summary": True},
+            "memory_ai_summary": True,
+            "custom_limits": {"memory_ai_summary": False},
+        })
+
+        assert authenticated_service.has_feature("memory_ai_summary") is False
+
+    @pytest.mark.parametrize("custom_limits", [None, [], "invalid"])
+    def test_malformed_custom_limits_are_ignored(
+        self, authenticated_service, custom_limits
+    ):
+        """Malformed override containers must not hide valid entitlements."""
+        authenticated_service._apply_entitlements({
+            "plan": "solo",
+            "features": {"memory_ai_summary": True},
+            "custom_limits": custom_limits,
+        })
+
+        assert authenticated_service.has_feature("memory_ai_summary") is True
+
+    def test_custom_limits_update_dangerous_tools_cache(
+        self, authenticated_service
+    ):
+        """The dedicated hot-path cache must use the same override precedence."""
+        authenticated_service._apply_entitlements({
+            "plan": "teams",
+            "features": {"allow_dangerous_ai_tools": False},
+            "custom_limits": {"allow_dangerous_ai_tools": True},
+        })
+
+        assert authenticated_service.has_dangerous_ai_tools is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["false", "true", 2, -1, 1.0],
+    )
+    def test_nested_features_require_strict_boolean_values(
+        self, authenticated_service, value
+    ):
+        """Serialized or out-of-range values must never grant a feature."""
+        authenticated_service._apply_entitlements({
+            "plan": "solo",
+            "features": {"memory_ai_summary": value},
+        })
+
+        assert authenticated_service.has_feature("memory_ai_summary") is False
+
     def test_get_status_unauthenticated(self, auth_service):
         status = auth_service.get_status()
         assert not status["authenticated"]

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -301,6 +301,9 @@ _ALLOWLIST: List[AllowlistEntry] = [
     AllowlistEntry("screens/memory.py", "_refresh_sync_status", "update",
                    "Updates sync-status labels (last sync time, sync state badge) "
                    "— code-controlled status strings, not memory raw_output."),
+    AllowlistEntry("screens/memory.py", "_refresh_local_memory_status", "update",
+                   "Updates the local scan freshness label with module counts and "
+                   "timestamps — never memory raw_output content."),
     AllowlistEntry("screens/memory.py", "_do_ai_summary_flow", "update",
                    "Updates AI summary UI label with a code-controlled status/error "
                    "string — not memory raw_output content."),
@@ -516,6 +519,9 @@ _ALLOWLIST: List[AllowlistEntry] = [
     AllowlistEntry("screens/memory_sync_setup.py", "_do_forget", "update",
                    "config_manager.update(memory=...) to reset the remember flag — "
                    "config write, not a widget/UI write; no server-origin data."),
+    AllowlistEntry("screens/memory_sync_setup.py", "_store_remembered_passphrase", "update",
+                   "config_manager.update(memory=...) persists the device-unlock "
+                   "expiry — config write, not a widget/UI write."),
 
     # ovh_billing.py — current usage and spend history write formatted currency
     # amounts and dates (no customer hostnames or IPs); invoice page writes

--- a/tests/test_memory_auto_unlock_action.py
+++ b/tests/test_memory_auto_unlock_action.py
@@ -1,0 +1,137 @@
+"""Regression coverage for enabling remembered Memory Sync unlock."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from servonaut.config.schema import (
+    DEFAULT_REMEMBER_TTL_DAYS,
+    AppConfig,
+    MemoryConfig,
+)
+from servonaut.screens.memory_keys import PassphraseResult
+from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+
+def _make_screen_stub(
+    *,
+    passphrase: str = "test-passphrase",
+    can_unwrap: bool = True,
+    update_side_effect: Exception | None = None,
+) -> SimpleNamespace:
+    """Build only the collaborators used by ``_do_remember``."""
+    config_manager = MagicMock()
+    config_manager.get.return_value = AppConfig(memory=MemoryConfig())
+    config_manager.update.side_effect = update_side_effect
+
+    sync = MagicMock()
+    sync.is_configured = True
+    sync.can_unwrap_local.return_value = can_unwrap
+
+    app = SimpleNamespace(
+        memory_sync_service=sync,
+        config_manager=config_manager,
+        notify=MagicMock(),
+        push_screen_wait=AsyncMock(
+            return_value=PassphraseResult(passphrase=passphrase, remember=True)
+        ),
+    )
+    stub = SimpleNamespace(app=app, _render_state=MagicMock())
+    stub._store_remembered_passphrase = (  # type: ignore[attr-defined]
+        lambda candidate: MemorySyncSetupScreen._store_remembered_passphrase(
+            stub, candidate
+        )
+    )
+    return stub
+
+
+@pytest.mark.asyncio
+async def test_remember_verified_passphrase_stores_keychain_and_stamps_expiry() -> None:
+    """A verified passphrase enables the 30-day, device-local opt-in."""
+    import servonaut.services.memory.passphrase_store as passphrase_store
+
+    stub = _make_screen_stub()
+    before = datetime.now(timezone.utc)
+
+    with (
+        patch.object(passphrase_store, "keyring_available", return_value=True),
+        patch.object(passphrase_store, "store_passphrase", return_value=True) as store,
+    ):
+        await MemorySyncSetupScreen._do_remember(stub)  # type: ignore[arg-type]
+
+    stub.app.memory_sync_service.can_unwrap_local.assert_called_once_with(
+        "test-passphrase"
+    )
+    store.assert_called_once_with("test-passphrase")
+    assert stub.app.push_screen_wait.call_args.args[0]._remember_default is True
+
+    updated_memory = stub.app.config_manager.update.call_args.kwargs["memory"]
+    assert updated_memory.sync_remember_device is True
+    expiry = datetime.fromisoformat(updated_memory.sync_remember_expires_at)
+    expected = before + timedelta(days=DEFAULT_REMEMBER_TTL_DAYS)
+    assert expected - timedelta(seconds=2) <= expiry <= expected + timedelta(seconds=2)
+    stub._render_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_remember_wrong_passphrase_never_stores_or_updates_config() -> None:
+    """An unverified passphrase never reaches the OS keychain."""
+    import servonaut.services.memory.passphrase_store as passphrase_store
+
+    stub = _make_screen_stub(can_unwrap=False)
+    with patch.object(passphrase_store, "store_passphrase") as store:
+        await MemorySyncSetupScreen._do_remember(stub)  # type: ignore[arg-type]
+
+    store.assert_not_called()
+    stub.app.config_manager.update.assert_not_called()
+    stub._render_state.assert_not_called()
+    assert any(
+        "Wrong passphrase" in call.args[0] for call in stub.app.notify.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_without_trusted_keychain_keeps_config_unchanged() -> None:
+    """Auto-unlock remains off when this device has no trusted keychain."""
+    import servonaut.services.memory.passphrase_store as passphrase_store
+
+    stub = _make_screen_stub()
+    with (
+        patch.object(passphrase_store, "keyring_available", return_value=False),
+        patch.object(passphrase_store, "store_passphrase") as store,
+    ):
+        await MemorySyncSetupScreen._do_remember(stub)  # type: ignore[arg-type]
+
+    store.assert_not_called()
+    stub.app.config_manager.update.assert_not_called()
+    stub._render_state.assert_not_called()
+    assert any(
+        "No trusted OS keychain" in call.args[0]
+        for call in stub.app.notify.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_remember_config_failure_clears_newly_stored_passphrase() -> None:
+    """A config write failure leaves no passphrase stored in the keychain."""
+    import servonaut.services.memory.passphrase_store as passphrase_store
+
+    stub = _make_screen_stub(update_side_effect=OSError("config unavailable"))
+    with (
+        patch.object(passphrase_store, "keyring_available", return_value=True),
+        patch.object(passphrase_store, "store_passphrase", return_value=True) as store,
+        patch.object(passphrase_store, "clear_passphrase") as clear,
+    ):
+        await MemorySyncSetupScreen._do_remember(stub)  # type: ignore[arg-type]
+
+    store.assert_called_once_with("test-passphrase")
+    clear.assert_called_once()
+    stub._render_state.assert_not_called()
+    assert any(
+        "no passphrase was retained" in call.args[0]
+        for call in stub.app.notify.call_args_list
+    )

--- a/tests/test_memory_dashboard_regressions.py
+++ b/tests/test_memory_dashboard_regressions.py
@@ -1,0 +1,265 @@
+"""Regression tests for the instance-dashboard Memory screen."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import DataTable, Static
+
+from servonaut.screens.memory import MemoryScreen
+
+
+_INSTANCE = {
+    "id": "server-1",
+    "name": "Example server",
+    "provider": "custom",
+}
+
+
+def _module(module_name: str) -> dict[str, object]:
+    """Return a freshly probed memory module."""
+    return {
+        "module": module_name,
+        "instance_id": _INSTANCE["id"],
+        "observed": {"version": "1.0"},
+        "declared": {},
+        "probed_at": datetime.now(tz=timezone.utc).isoformat(),
+        "ttl_seconds": 86400,
+    }
+
+
+def _memory_service(modules: dict[str, dict[str, object]]) -> MagicMock:
+    """Return a memory service whose store can change while mounted."""
+    service = MagicMock()
+    service.snapshot_stale_seconds = 86400
+    service.is_memory_disabled.return_value = False
+    service.get_all_modules.side_effect = lambda *_args: dict(modules)
+    service.stale_modules.return_value = []
+    return service
+
+
+def _never_synced_service() -> MagicMock:
+    """Return an active cloud-sync service with no completed sync."""
+    service = MagicMock()
+    service.is_configured = True
+    service.status = SimpleNamespace(
+        state="idle",
+        pending_envelopes=0,
+        last_sync_at=None,
+        halted_reason=None,
+    )
+    return service
+
+
+class _MemoryApp(App):
+    """Minimal host app for the per-instance Memory screen."""
+
+    def __init__(
+        self,
+        modules: dict[str, dict[str, object]],
+        *,
+        auth_service: MagicMock | None = None,
+        sync_service: MagicMock | None = None,
+    ) -> None:
+        super().__init__()
+        self.demo_mode = False
+        self.redaction_service = None
+        self.memory_service = _memory_service(modules)
+        self.memory_sync_service = sync_service
+        self.auth_service = auth_service
+        self.ai_summary_service = MagicMock()
+
+    def on_mount(self) -> None:
+        self.push_screen(MemoryScreen(dict(_INSTANCE)))
+
+
+@pytest.mark.asyncio
+async def test_fresh_scan_is_distinct_from_never_synced_cloud_state() -> None:
+    """Fresh local memory must not be presented as an unsynchronised scan."""
+    modules = {"os": _module("os"), "services": _module("services")}
+    app = _MemoryApp(modules, sync_service=_never_synced_service())
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+
+        local_status = app.screen.query_one("#memory-local-status", Static)
+        cloud_status = app.screen.query_one("#memory-sync-status", Static)
+
+        local_text = str(local_status.render())
+        cloud_text = str(cloud_status.render())
+        assert "Memory scan: ● Fresh" in local_text
+        assert "2 modules" in local_text
+        assert "last probe" in local_text
+        assert "Cloud sync: idle" in cloud_text
+        assert "last: never" in cloud_text
+
+
+@pytest.mark.asyncio
+async def test_fleet_scan_refresh_hook_reloads_status_and_module_rows() -> None:
+    """The app-owned fleet scan hook must update an already-mounted screen."""
+    modules: dict[str, dict[str, object]] = {}
+    app = _MemoryApp(modules)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        screen = app.screen
+        table = screen.query_one("#memory-table", DataTable)
+        status = screen.query_one("#memory-local-status", Static)
+
+        assert "Not probed" in str(status.render())
+        assert table.row_count == 0
+
+        modules["os"] = _module("os")
+        screen.refresh_memory_status()
+        await pilot.pause()
+
+        assert "Fresh" in str(status.render())
+        assert "1 module" in str(status.render())
+        assert table.row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_rechecks_account_override_before_upsell() -> None:
+    """A freshly returned test-account override must unlock the summary flow."""
+    entitlement = {"enabled": False}
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.plan = "solo"
+    auth.has_feature.side_effect = lambda feature: (
+        feature == "memory_ai_summary" and entitlement["enabled"]
+    )
+
+    async def _fetch_entitlements() -> dict[str, bool]:
+        entitlement["enabled"] = True
+        return {"memory_ai_summary": True}
+
+    auth.fetch_entitlements = AsyncMock(side_effect=_fetch_entitlements)
+    app = _MemoryApp({}, auth_service=auth)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        screen = app.screen
+        flow = AsyncMock()
+        screen._do_ai_summary_flow = flow
+
+        screen.action_build_ai_summary()
+        for _ in range(20):
+            await pilot.pause(0.01)
+            if flow.await_count:
+                break
+
+        auth.fetch_entitlements.assert_awaited_once_with()
+        flow.assert_awaited_once_with("server-1")
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_still_upsells_unentitled_solo_after_refresh() -> None:
+    """Refreshing entitlements must not unlock an ordinary Solo account."""
+    from servonaut.widgets.upsell_modal import UpsellModal
+
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.plan = "solo"
+    auth.has_feature.return_value = False
+    auth.fetch_entitlements = AsyncMock(return_value={"memory_ai_summary": False})
+    app = _MemoryApp({}, auth_service=auth)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        app.screen.action_build_ai_summary()
+        for _ in range(20):
+            await pilot.pause(0.01)
+            if isinstance(app.screen, UpsellModal):
+                break
+
+        auth.fetch_entitlements.assert_awaited_once_with()
+        assert isinstance(app.screen, UpsellModal)
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_rechecks_cached_access_before_proceeding() -> None:
+    """A removed override must take effect before the summary flow starts."""
+    from servonaut.widgets.upsell_modal import UpsellModal
+
+    entitlement = {"enabled": True}
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.has_feature.side_effect = lambda feature: (
+        feature == "memory_ai_summary" and entitlement["enabled"]
+    )
+
+    async def _fetch_entitlements() -> dict[str, bool]:
+        entitlement["enabled"] = False
+        return {"memory_ai_summary": False}
+
+    auth.fetch_entitlements = AsyncMock(side_effect=_fetch_entitlements)
+    app = _MemoryApp({}, auth_service=auth)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        app.screen.action_build_ai_summary()
+        for _ in range(20):
+            await pilot.pause(0.01)
+            if isinstance(app.screen, UpsellModal):
+                break
+
+        auth.fetch_entitlements.assert_awaited_once_with()
+        assert isinstance(app.screen, UpsellModal)
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_refresh_failure_does_not_show_false_upsell() -> None:
+    """An unverifiable entitlement must produce a retry warning, not an upsell."""
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.has_feature.return_value = False
+    auth.fetch_entitlements = AsyncMock(return_value=None)
+    app = _MemoryApp({}, auth_service=auth)
+    app.notify = MagicMock()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        screen = app.screen
+        await screen._start_ai_summary_flow()
+
+        auth.fetch_entitlements.assert_awaited_once_with()
+        app.notify.assert_called_once_with(
+            "Could not verify AI summary access. "
+            "Check your connection and retry.",
+            severity="warning",
+        )
+        assert app.screen is screen
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_server_denial_explains_entitlement_projection() -> None:
+    """A backend 403 after local access must not be presented as a generic error."""
+    from servonaut.services.memory.interfaces import UpsellRequired
+
+    auth = MagicMock()
+    auth.is_authenticated = True
+    auth.has_feature.return_value = True
+    auth.fetch_entitlements = AsyncMock(
+        return_value={"memory_ai_summary": True}
+    )
+    app = _MemoryApp({}, auth_service=auth)
+    app.ai_summary_service.get_provider_info = AsyncMock(
+        side_effect=UpsellRequired("memory_ai_summary")
+    )
+    app.notify = MagicMock()
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause(0.2)
+        await app.screen._start_ai_summary_flow()
+
+        app.notify.assert_called_once_with(
+            "AI summary access was accepted locally, but the server denied it. "
+            "Your account entitlement has not reached the summary API yet.",
+            severity="error",
+            markup=False,
+        )

--- a/tests/test_memory_screens.py
+++ b/tests/test_memory_screens.py
@@ -75,9 +75,15 @@ def _make_drift_service(events: list | None = None) -> MagicMock:
 class _EnrolApp(App):
     """Minimal host that pushes PassphraseEnrolModal."""
 
-    def __init__(self, mode: str = "enrol") -> None:
+    def __init__(
+        self,
+        mode: str = "enrol",
+        *,
+        remember_default: bool = False,
+    ) -> None:
         super().__init__()
         self._mode = mode
+        self._remember_default = remember_default
         self.dismissed_value = "__sentinel__"
 
     def on_mount(self) -> None:
@@ -86,7 +92,11 @@ class _EnrolApp(App):
         def _on_dismiss(result):
             self.dismissed_value = result
 
-        self.push_screen(PassphraseEnrolModal(mode=self._mode), _on_dismiss)
+        modal = PassphraseEnrolModal(
+            mode=self._mode,
+            remember_default=self._remember_default,
+        )
+        self.push_screen(modal, _on_dismiss)
 
 
 class TestPassphraseEnrolModal:
@@ -135,6 +145,24 @@ class TestPassphraseEnrolModal:
             await pilot.pause()
             title = app.screen.query_one("#enrol-title", Static)
             assert "Unlock" in str(title.content)
+
+    @pytest.mark.asyncio
+    async def test_remember_copy_explains_keychain_and_30_day_window(self):
+        app = _EnrolApp(mode="unlock")
+        async with app.run_test(size=(100, 24)) as pilot:
+            await pilot.pause()
+            label = app.screen.query_one("#enrol-remember-label", Static)
+            rendered = str(label.render())
+            assert "30 days" in rendered
+            assert "OS keychain" in rendered
+
+    @pytest.mark.asyncio
+    async def test_remember_can_be_preselected_by_explicit_manage_action(self):
+        app = _EnrolApp(mode="unlock", remember_default=True)
+        async with app.run_test(size=(100, 24)) as pilot:
+            await pilot.pause()
+            remember = app.screen.query_one("#enrol-remember", Switch)
+            assert remember.value is True
 
 
 # ---------------------------------------------------------------------------
@@ -513,6 +541,50 @@ class TestSettingsScreenMemorySync:
         sent_delta = last_call_args[0] if last_call_args else last_call_kwargs.get("delta", {})
         assert "auto_sync_enabled" in sent_delta
         assert sent_delta["auto_sync_enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_auto_unlock_status_refreshes_after_manage_screen_back(self):
+        """Returning from Manage refreshes the device-local unlock status."""
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+        with patch(
+            "servonaut.services.memory.passphrase_store.keyring_available",
+            return_value=True,
+        ):
+            app = _SettingsApp(
+                has_memory_sync_feature=True,
+                sync_configured=True,
+            )
+            app.memory_sync_service.status = SimpleNamespace(
+                last_sync_at=None,
+                quota=None,
+                pending_envelopes=0,
+            )
+            app.memory_sync_service.get_key_material.return_value = None
+            async with app.run_test(size=(140, 48)) as pilot:
+                await pilot.pause()
+                app.screen._switch_to("memory")
+                await pilot.pause()
+                panel = app.screen._panels["memory"]
+                status = panel.query_one(
+                    "#memory_device_auto_unlock_status", Static
+                )
+                assert status.render().plain == "Off"
+
+                await pilot.click("#memory_manage_device_auto_unlock")
+                await pilot.pause()
+                assert isinstance(app.screen, MemorySyncSetupScreen)
+
+                app._config.memory = replace(
+                    app._config.memory,
+                    sync_remember_device=True,
+                )
+                await pilot.press("escape")
+                await pilot.pause()
+                assert status.render().plain == "On (30-day re-prompt)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_sync_reactivate.py
+++ b/tests/test_memory_sync_reactivate.py
@@ -21,11 +21,11 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
+import inspect
 import types
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -124,6 +124,45 @@ async def _run_prompt(stub: SimpleNamespace) -> None:
     await ServonautApp.prompt_memory_sync_unlock(stub)  # type: ignore[arg-type]
 
 
+def _scheduled_worker_coroutine_names(stub: SimpleNamespace) -> set[str]:
+    """Return worker coroutine names and close each un-awaited coroutine.
+
+    ``on_user_login_success`` intentionally hands coroutines to Textual's
+    worker scheduler. These focused unit tests replace that scheduler with a
+    mock, so they own closing the captured coroutines.
+    """
+    coroutine_names: set[str] = set()
+    for worker_call in stub.run_worker.call_args_list:
+        coroutine = worker_call.args[0]
+        assert inspect.iscoroutine(coroutine)
+        coroutine_names.add(coroutine.cr_code.co_name)
+        coroutine.close()
+    return coroutine_names
+
+
+def _make_login_lifecycle_stub(
+    *,
+    relay_manager: object | None,
+    enrolled_locally: bool,
+) -> SimpleNamespace:
+    """Build the minimal app shape consumed by ``on_user_login_success``."""
+    sync_service = _make_sync_service(enrolled_locally=enrolled_locally)
+    stub = SimpleNamespace(
+        relay_manager=relay_manager,
+        memory_sync_service=sync_service,
+        auth_service=_make_auth_service(),
+        run_worker=MagicMock(),
+        _init_relay_manager=MagicMock(),
+    )
+    stub._reactivate_memory_sync = types.MethodType(
+        ServonautApp._reactivate_memory_sync, stub
+    )
+    stub._start_relay_with_toast = types.MethodType(
+        ServonautApp._start_relay_with_toast, stub
+    )
+    return stub
+
+
 # ---------------------------------------------------------------------------
 # Guard conditions — must be no-ops
 # ---------------------------------------------------------------------------
@@ -172,6 +211,52 @@ class TestReactivateGuards:
         stub = _make_stub(sync_service=sync, auth_service=None)
         await _run_reactivate(stub)
         stub.bootstrap_memory_cloud.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Login lifecycle — reactivation is independent from the relay listener
+# ---------------------------------------------------------------------------
+
+
+class TestLoginReactivatesEnrolledMemorySync:
+    def test_enrolled_device_schedules_reactivation_without_relay_manager(self) -> None:
+        """A live login must restore an enrolled device even without a relay."""
+        stub = _make_login_lifecycle_stub(
+            relay_manager=None,
+            enrolled_locally=True,
+        )
+
+        ServonautApp.on_user_login_success(stub)  # type: ignore[arg-type]
+
+        worker_coroutines = _scheduled_worker_coroutine_names(stub)
+        assert worker_coroutines == {"_reactivate_memory_sync"}
+
+    def test_enrolled_device_schedules_relay_and_memory_workers(self) -> None:
+        """Relay startup must not suppress the independent Memory Sync worker."""
+        stub = _make_login_lifecycle_stub(
+            relay_manager=MagicMock(),
+            enrolled_locally=True,
+        )
+
+        ServonautApp.on_user_login_success(stub)  # type: ignore[arg-type]
+
+        worker_coroutines = _scheduled_worker_coroutine_names(stub)
+        assert worker_coroutines == {
+            "_start_relay_with_toast",
+            "_reactivate_memory_sync",
+        }
+
+    def test_unenrolled_device_does_not_schedule_memory_reactivation(self) -> None:
+        """Logging in alone must not create an unlock flow for a new device."""
+        stub = _make_login_lifecycle_stub(
+            relay_manager=MagicMock(),
+            enrolled_locally=False,
+        )
+
+        ServonautApp.on_user_login_success(stub)  # type: ignore[arg-type]
+
+        worker_coroutines = _scheduled_worker_coroutine_names(stub)
+        assert worker_coroutines == {"_start_relay_with_toast"}
 
 
 # ---------------------------------------------------------------------------
@@ -801,7 +886,6 @@ class TestLogoutClearsMemorySyncState:
     def _make_app_stub(self, *, has_sync: bool = True) -> Any:
         """Build a minimal stub for on_user_logout."""
         from servonaut.config.schema import AppConfig, MemoryConfig
-        import dataclasses as _dc
 
         memory_cfg = MemoryConfig(sync_remember_device=True)
         cfg = AppConfig(memory=memory_cfg)

--- a/tests/test_scan_results_screen.py
+++ b/tests/test_scan_results_screen.py
@@ -1,0 +1,61 @@
+"""Regression tests for the scan results screen."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import DataTable, Static
+
+from servonaut.screens.scan_results import ScanResultsScreen
+
+
+class _ScanResultsApp(App):
+    """Minimal host app for mounting the scan results screen."""
+
+    def __init__(self, results: list[dict[str, str]]) -> None:
+        super().__init__()
+        self.demo_mode = False
+        self.redaction_service = None
+        self.keyword_store = MagicMock()
+        self.keyword_store.get_results.return_value = results
+
+    def on_mount(self) -> None:
+        self.push_screen(
+            ScanResultsScreen({"id": "i-example", "name": "Example server"})
+        )
+
+
+@pytest.mark.asyncio
+async def test_cached_results_populate_after_table_columns_are_created() -> None:
+    """Cached rows must not be inserted before the table has columns."""
+    results = [
+        {
+            "source": "path:~",
+            "content": "first line\nsecond line",
+            "timestamp": "2026-08-25T12:00:00",
+        }
+    ]
+    app = _ScanResultsApp(results)
+
+    async with app.run_test(headless=True) as pilot:
+        await pilot.pause()
+
+        table = app.screen.query_one("#results_table", DataTable)
+        status = app.screen.query_one("#scan_status", Static)
+
+        assert [str(column.label) for column in table.columns.values()] == [
+            "Source",
+            "Content",
+            "Timestamp",
+        ]
+        assert table.row_count == 1
+        assert table.get_row_at(0) == [
+            "path:~",
+            "first line second line",
+            "2026-08-25T12:00:00",
+        ]
+        assert "Loaded 1 cached results" in str(status.render())
+
+    app.keyword_store.get_results.assert_called_once_with("i-example")

--- a/tests/test_settings_memory_panel.py
+++ b/tests/test_settings_memory_panel.py
@@ -14,13 +14,12 @@ widget mounting, real ConfigManager writes, and real disk round-trips.
 
 from __future__ import annotations
 
-import dataclasses
 from typing import Optional, Type
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from textual.app import App
-from textual.widgets import Input, Switch
+from textual.widgets import Input, Static, Switch
 
 from servonaut.config.manager import ConfigManager
 from servonaut.config.schema import AppConfig, MemoryConfig
@@ -238,3 +237,86 @@ class TestMemoryPanelPersistRoundTrip:
         assert fresh.auto_scan_enabled is True
         assert "containers" in fresh.disabled_modules
         assert fresh.per_server_overrides == {"db-1": {"memory_disabled": False}}
+
+
+# ---------------------------------------------------------------------------
+# Device auto-unlock — read-only status and setup navigation
+# ---------------------------------------------------------------------------
+
+
+def _auto_unlock_status(panel: SettingsPanel) -> str:
+    """Return the rendered read-only auto-unlock status."""
+    return panel.query_one("#memory_device_auto_unlock_status", Static).render().plain
+
+
+class TestMemoryPanelDeviceAutoUnlock:
+    @pytest.mark.asyncio
+    async def test_shows_unavailable_without_a_trusted_os_keychain(
+        self, tmp_path
+    ) -> None:
+        """The panel never implies auto-unlock works without a trusted backend."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        with patch(
+            "servonaut.services.memory.passphrase_store.keyring_available",
+            return_value=False,
+        ):
+            app = _PanelHost(MemoryPanel, manager)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert _auto_unlock_status(app.panel) == (
+                    "Unavailable (no trusted OS keychain)"
+                )
+
+    @pytest.mark.asyncio
+    async def test_shows_off_when_the_device_has_not_opted_in(self, tmp_path) -> None:
+        """A usable keychain remains off until setup explicitly remembers it."""
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        with patch(
+            "servonaut.services.memory.passphrase_store.keyring_available",
+            return_value=True,
+        ):
+            app = _PanelHost(MemoryPanel, manager)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert _auto_unlock_status(app.panel) == "Off"
+
+    @pytest.mark.asyncio
+    async def test_shows_on_with_the_reprompt_window(self, tmp_path) -> None:
+        """A remembered device identifies the bounded automatic-unlock period."""
+        config = AppConfig(memory=MemoryConfig(sync_remember_device=True))
+        manager = _temp_config_manager(tmp_path, config)
+        with patch(
+            "servonaut.services.memory.passphrase_store.keyring_available",
+            return_value=True,
+        ):
+            app = _PanelHost(MemoryPanel, manager)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                assert _auto_unlock_status(app.panel) == "On (30-day re-prompt)"
+
+    @pytest.mark.asyncio
+    async def test_manage_opens_setup_without_marking_form_dirty(
+        self, tmp_path
+    ) -> None:
+        """Management delegates to Memory Sync setup and changes no form state."""
+        from servonaut.screens.memory_sync_setup import MemorySyncSetupScreen
+
+        manager = _temp_config_manager(tmp_path, AppConfig())
+        with patch(
+            "servonaut.services.memory.passphrase_store.keyring_available",
+            return_value=True,
+        ):
+            app = _PanelHost(MemoryPanel, manager)
+            app.push_screen = MagicMock()
+            async with app.run_test(size=(140, 48)) as pilot:
+                await pilot.pause()
+                assert app.panel.is_dirty() is False
+
+                await pilot.click("#memory_manage_device_auto_unlock")
+                await pilot.pause()
+
+                app.push_screen.assert_called_once()
+                screen = app.push_screen.call_args.args[0]
+                assert isinstance(screen, MemorySyncSetupScreen)
+                assert app.panel.is_dirty() is False
+                assert manager.get().memory.sync_remember_device is False


### PR DESCRIPTION
## Summary

- Initialize Scan Results columns before loading cached rows, preventing cached results from being added to an unconfigured table.
- Refresh per-instance Memory status from the latest stored modules and keep dashboard state aligned after fleet scans.
- Refresh and normalize AI-summary entitlements before gating the action, including account-level feature overrides.
- Add opt-in OS-keychain device unlock with expiry, plus login/restart reactivation and Settings controls.

## Validation

- 146 focused regression and repository guard tests passed.
- Full suite: 7,651 passed and 6 skipped locally. Eight optional Hetzner SDK tests could not run because hcloud is not installed in the local environment; CI installs that project extra.
- Public leak guard passed.
- Committed diff check passed.