### PR TITLE
fix: cover custom servers, provider wizards, account and relay panels in demo mode

### DIFF
--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -72,6 +72,11 @@ raw data through a demo-mode-enabled app without triggering redaction.
 | Hostnames | `web-prod-7.eu-central-1.compute.internal` | `monitor-12.example.com` |
 | SSH key names | `my-prod-key` | `deploy-key` |
 | Usernames | `alice` | `ubuntu` (from fake pool) |
+| Dashed-IP host fragments in streams | `ns123.ip-9-9-9-9.eu` | `ns123.ip-198-51-100-42.eu` (same mapping as the dotted IP) |
+| Host columns (zones, reverse DNS, service names, custom hosts) | `mail.company.com` | `mail-12.example.com` |
+| IPv6 on host columns | `2a01:…::1/128` | `2001:db8:1a2b::3c4d/128` (clean doc-range fake; streams still use the constant `2001:db8::1`) |
+| SSH key labels (OVH / Hetzner key screens, Hetzner wizard) | `alice@example.org` | `deploy-key` (pool name) |
+| Provider instance IDs (`vps-1a2b3c4d.vps.provider.net`, `12345678`, a UUID, `<uuid>/<uuid>`) | same shape | Hash-derived, same shape (`web-12.example.com`, digits, UUID); unknown shapes pass through |
 
 **Redaction is deterministic:** the same input always maps to the same fake
 output within a session. Repeated IP addresses show the same fake IP.
@@ -99,6 +104,15 @@ output within a session. Repeated IP addresses show the same fake IP.
 | Surface | Redaction applied |
 |---|---|
 | Instance list | Instance fields (in-place at startup / on refresh) |
+| Custom Servers table | Every column through the same per-field redactors as the instance list (name, host, username, key path, provider, group) — a server keeps one fake identity across both views. Editing an existing server is disabled while demo mode is on (the form would show the real values); adding a new one still works |
+| Hetzner create wizard | Project SSH-key names in the key table and in the confirm dialog (key labels are user-chosen and often an email address) |
+| AWS / OVH / Hetzner managers | Rows show fake ids; start / stop / reboot / delete keep using the real provider id through a per-screen map, so the manager actions work while recording |
+| OVH / Hetzner SSH key screens | Key labels shown as pool key names |
+| Account / Login | "Logged in as" email (deterministic fake) |
+| Relay status screen | Backend `client_ids` (they embed the OS user and machine name) |
+| OVH DNS Zones | Zone names, record sub-domains and targets, reverse-DNS hostnames and IP blocks |
+| OVH IP Management | Address, routed-to service name, reverse |
+| OVH Billing | Service names (domains and dashed-IP hostnames) |
 | Log viewer | Every SSH `tail -f` line via `scrub_stream` |
 | Terminal overlay (command output) | `append_output` and `append_error` |
 | CloudWatch events table | `message` and `log_stream` columns |

--- a/src/servonaut/screens/aws_manager.py
+++ b/src/servonaut/screens/aws_manager.py
@@ -180,8 +180,16 @@ class AWSManagerScreen(Screen):
             self._instances = list(instances)
             # Redact the fresh list in-place so _render_table never sees raw
             # names / IPs — mirrors the app-startup redact_instances pattern.
+            self._api_ids = {}
             if self.app.demo_mode and self.app.redaction_service:
+                # Rows carry demo-mode fakes; API calls need the real ids,
+                # so remember the mapping before redacting in place.
+                raw_ids = [str(i.get("id") or "") for i in self._instances]
                 self.app.redaction_service.redact_instances(self._instances)
+                self._api_ids = {
+                    str(i.get("id") or ""): raw
+                    for i, raw in zip(self._instances, raw_ids)
+                }
             self._render_table()
             n = len(instances)
             if n == 0:
@@ -246,6 +254,11 @@ class AWSManagerScreen(Screen):
         if row < 0 or row >= len(self._instances):
             return None
         return self._instances[row]
+
+    def _api_id(self, inst: dict) -> str:
+        """Real provider id for an API call; the row may carry a demo-mode fake."""
+        shown = str(inst.get("id") or "")
+        return getattr(self, "_api_ids", {}).get(shown, shown)
 
     def _sync_action_buttons(self) -> None:
         """Toggle button enabled state based on the selected row's EC2 state.
@@ -376,7 +389,7 @@ class AWSManagerScreen(Screen):
         inst = self._selected_instance()
         if inst is None:
             return
-        instance_id = str(inst.get("id") or "")
+        instance_id = self._api_id(inst)
         region = str(inst.get("region") or "")
         if not instance_id or not region:
             self.notify(
@@ -445,7 +458,7 @@ class AWSManagerScreen(Screen):
 
     async def _do_terminate(self, inst: dict) -> None:
         """Prompt with typed confirmation then terminate the instance."""
-        instance_id = str(inst.get("id") or "")
+        instance_id = self._api_id(inst)
         region = str(inst.get("region") or "")
         name = inst.get("name", instance_id) or instance_id
 

--- a/src/servonaut/screens/custom_servers.py
+++ b/src/servonaut/screens/custom_servers.py
@@ -109,25 +109,46 @@ class CustomServersScreen(Screen):
         table.add_columns("Name", "Host", "Port", "Username", "Key", "Provider", "Group")
 
     def _populate_table(self) -> None:
-        """Populate DataTable with current custom servers."""
+        """Populate DataTable with current custom servers.
+
+        Demo mode routes every cell through the same per-field redactors
+        ``RedactionService.redact_instance`` applies to the Instances table,
+        so a server carries one fake identity across both views.  A stream
+        scrub is not enough here: server names, bare hostnames, key paths and
+        group names have no stream rule and would render verbatim.
+        """
         table = self.query_one("#custom_servers_table", DataTable)
         table.clear()
 
-        def _s(x: str) -> str:
-            if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
-            return x
+        redaction = None
+        if self.app.demo_mode and self.app.redaction_service:
+            redaction = self.app.redaction_service
 
         for server in self.app.custom_server_service.list_servers():
-            table.add_row(
-                _s(server.name),
-                _s(server.host),
+            table.add_row(*self._display_row(server, redaction))
+
+    @staticmethod
+    def _display_row(server: CustomServer, redaction) -> tuple:
+        """Cells for one table row, redacted when ``redaction`` is set."""
+        if redaction is None:
+            return (
+                server.name,
+                server.host,
                 str(server.port),
-                _s(server.username),
+                server.username,
                 server.ssh_key or "-",
                 server.provider or "-",
                 server.group or "-",
             )
+        return (
+            redaction.redact_name(server.name),
+            redaction.redact_host(server.host),
+            str(server.port),
+            redaction.redact_username(server.username),
+            redaction.redact_key_name(server.ssh_key) if server.ssh_key else "-",
+            redaction.redact_provider(server.provider) if server.provider else "-",
+            redaction.redact_group(server.group) if server.group else "-",
+        )
 
     def _hide_form(self) -> None:
         """Hide the add/edit form AND its docked Save/Cancel row."""
@@ -140,6 +161,16 @@ class CustomServersScreen(Screen):
         The bottom-docked action row is mirrored: when the form is
         visible the row is too, so Save / Cancel are always reachable.
         """
+        if server is not None and self.app.demo_mode and self.app.redaction_service:
+            # The form is bound to the real record; pre-filling it would put
+            # the raw host, key path and SSH options on screen.
+            self.app.notify(
+                "Editing is disabled in demo mode — the form would show "
+                "the real values.",
+                severity="warning",
+            )
+            return
+
         form = self.query_one("#add_form")
         form.display = True
         self.query_one("#add_form_actions").display = True

--- a/src/servonaut/screens/hetzner_create.py
+++ b/src/servonaut/screens/hetzner_create.py
@@ -265,8 +265,13 @@ class HetznerCreateScreen(Screen):
         try:
             self._ssh_keys = await svc.list_ssh_keys()
             for key in self._ssh_keys:
+                name = str(key.get("name", ""))
+                # Key labels are user-chosen (an email address is common) --
+                # shown as a pool key name when demo mode is on.
+                if self.app.demo_mode and self.app.redaction_service:
+                    name = self.app.redaction_service.redact_key_name(name)
                 tbl.add_row(
-                    key.get("name", ""),
+                    name,
                     key.get("id", ""),
                     key.get("fingerprint", "")[:32],
                 )
@@ -286,6 +291,12 @@ class HetznerCreateScreen(Screen):
             logger.error("Failed to load Hetzner SSH keys: %s", exc)
             self.notify(f"Could not load SSH keys: {exc}",
                         severity="error", markup=False)
+
+    def _display_key_name(self, name: str) -> str:
+        """Key label as shown on screen -- a pool key name in demo mode."""
+        if name and self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.redact_key_name(name)
+        return name
 
     @staticmethod
     def _preselect_default(
@@ -381,7 +392,7 @@ class HetznerCreateScreen(Screen):
         if 0 <= key_row < len(self._ssh_keys):
             picked = self._ssh_keys[key_row]
             ssh_keys = [picked.get("name") or picked.get("id") or ""]
-            ssh_key_label = picked.get("name", "")
+            ssh_key_label = self._display_key_name(picked.get("name", ""))
 
         # Pre-flight check: if the user didn't pick a row AND no default
         # is configured in Settings, surface a clear actionable message
@@ -413,7 +424,7 @@ class HetznerCreateScreen(Screen):
             # Wizard is delegating to the configured default — show the
             # actual value in the confirm modal so the user sees what's
             # about to be injected, not just a generic "(default)".
-            ssh_key_label = f"{config_default} (config default)"
+            ssh_key_label = f"{self._display_key_name(config_default)} (config default)"
 
         type_name = server_type.get("name", "")
         image_name = image.get("name", "")

--- a/src/servonaut/screens/hetzner_manager.py
+++ b/src/servonaut/screens/hetzner_manager.py
@@ -177,8 +177,16 @@ class HetznerManagerScreen(Screen):
             # Redact the fresh list in-place so _render_table never sees raw
             # names / IPs / regions — mirrors the app-startup redact_instances
             # pattern (on_mount only redacts self.app.instances, not this list).
+            self._api_ids = {}
             if self.app.demo_mode and self.app.redaction_service:
+                # Rows carry demo-mode fakes; API calls need the real ids,
+                # so remember the mapping before redacting in place.
+                raw_ids = [str(i.get("id") or "") for i in self._instances]
                 self.app.redaction_service.redact_instances(self._instances)
+                self._api_ids = {
+                    str(i.get("id") or ""): raw
+                    for i, raw in zip(self._instances, raw_ids)
+                }
             self._render_table()
             n = len(instances)
             if n == 0:
@@ -244,6 +252,11 @@ class HetznerManagerScreen(Screen):
         if row < 0 or row >= len(self._instances):
             return None
         return self._instances[row]
+
+    def _api_id(self, inst: dict) -> str:
+        """Real provider id for an API call; the row may carry a demo-mode fake."""
+        shown = str(inst.get("id") or "")
+        return getattr(self, "_api_ids", {}).get(shown, shown)
 
     def _sync_action_buttons(self) -> None:
         """Toggle button enabled state based on the selected row's state.
@@ -340,7 +353,7 @@ class HetznerManagerScreen(Screen):
         inst = self._selected_instance()
         if inst is None:
             return
-        identifier = str(inst.get("id") or inst.get("name") or "")
+        identifier = self._api_id(inst) or str(inst.get("name") or "")
         if not identifier:
             self.notify(
                 "Selected row has no id/name to act on.",
@@ -385,7 +398,7 @@ class HetznerManagerScreen(Screen):
         await self._load_instances()
 
     async def _do_delete(self, inst: dict) -> None:
-        identifier = str(inst.get("id") or inst.get("name") or "")
+        identifier = self._api_id(inst) or str(inst.get("name") or "")
         from servonaut.screens.confirm_action import ConfirmActionScreen
         confirmed = await self.app.push_screen_wait(
             ConfirmActionScreen(

--- a/src/servonaut/screens/hetzner_ssh_keys.py
+++ b/src/servonaut/screens/hetzner_ssh_keys.py
@@ -181,8 +181,10 @@ class HetznerSSHKeysScreen(Screen):
             return
 
         def _s(x: str) -> str:
+            # Key labels are user-chosen (client names, an email address) --
+            # shown as a pool key name in demo mode, like the instance list.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_key_name(x)
             return x
 
         table = self.query_one("#hetzner_ssh_keys_table", DataTable)

--- a/src/servonaut/screens/login.py
+++ b/src/servonaut/screens/login.py
@@ -337,6 +337,8 @@ class LoginScreen(Screen):
         if not feature_lines:
             feature_lines = ["  [dim]No features listed[/dim]"]
 
+        if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None):
+            email = self.app.redaction_service.scrub_stream(email)
         self.query_one("#account_info", Static).update(f"[bold]Logged in as:[/bold] {email}")
         self.query_one("#plan_info", Static).update(f"[bold]Plan:[/bold] {plan}")
         self.query_one("#entitlements_info", Static).update(
@@ -366,8 +368,11 @@ class LoginScreen(Screen):
                 return
             # Refresh succeeded — update email if now available
             if hasattr(auth, "_token") and auth._token and auth._token.email:
+                email = auth._token.email
+                if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None):
+                    email = self.app.redaction_service.scrub_stream(email)
                 self.query_one("#account_info", Static).update(
-                    f"[bold]Logged in as:[/bold] {auth._token.email}"
+                    f"[bold]Logged in as:[/bold] {email}"
                 )
         except Exception:
             pass

--- a/src/servonaut/screens/ovh_billing.py
+++ b/src/servonaut/screens/ovh_billing.py
@@ -289,13 +289,14 @@ class OVHBillingScreen(Screen):
             if not services:
                 tbl.add_row("[dim]No services found[/dim]", "", "", "", "")
                 return
-            def _s(x: str) -> str:
+            def _h(x: str) -> str:
+                # Service names are domains or dashed-IP hostnames.
                 if self.app.demo_mode and self.app.redaction_service:
-                    return self.app.redaction_service.scrub_stream(x)
+                    return self.app.redaction_service.redact_host(x)
                 return x
 
             for service in services:
-                name = _s(str(service.get("name", "")))
+                name = _h(str(service.get("name", "")))
                 svc_type = str(service.get("type", ""))
                 status = str(service.get("status", ""))
                 status_display = {

--- a/src/servonaut/screens/ovh_dns.py
+++ b/src/servonaut/screens/ovh_dns.py
@@ -236,16 +236,18 @@ class OVHDNSScreen(Screen):
             self.notify("OVH DNS service not available", severity="error")
             return
 
-        def _s(x: str) -> str:
+        def _h(x: str) -> str:
+            # Zone names are hostnames by definition -- the stream scrubber
+            # has no bare-hostname rule, so route through redact_host.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_host(x)
             return x
 
         try:
             domains = await svc.list_domains()
             self._domains = domains
             for domain in domains:
-                tbl.add_row(_s(domain))
+                tbl.add_row(_h(domain))
             if domains:
                 self._set_domains_status(None)
             else:
@@ -290,13 +292,14 @@ class OVHDNSScreen(Screen):
         if svc is None:
             return
 
-        def _s(x: str) -> str:
+        def _h(x: str) -> str:
+            # Zone, sub-domain and target are hosts (or an IP) by definition.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_host(x)
             return x
 
         self.query_one("#selected_zone", Static).update(
-            f"Records for: [bold]{_s(zone_name)}[/bold]"
+            f"Records for: [bold]{_h(zone_name)}[/bold]"
         )
 
         try:
@@ -306,8 +309,8 @@ class OVHDNSScreen(Screen):
                 sub = rec.get("subDomain") or "@"
                 tbl.add_row(
                     str(rec.get("fieldType", "")),
-                    _s(sub),
-                    _s(str(rec.get("target", ""))),
+                    _h(sub),
+                    _h(str(rec.get("target", ""))),
                     str(rec.get("ttl", "")),
                 )
         except Exception as exc:
@@ -330,9 +333,10 @@ class OVHDNSScreen(Screen):
             logger.error("_load_rdns: list_ips failed: %s", exc)
             return
 
-        def _s(x: str) -> str:
+        def _h(x: str) -> str:
+            # IP, reverse hostname and IP block are hosts by definition.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_host(x)
             return x
 
         for ip_info in ip_blocks:
@@ -352,9 +356,9 @@ class OVHDNSScreen(Screen):
                         }
                         self._rdns_entries.append(record)
                         tbl.add_row(
-                            _s(ip_addr),
-                            _s(hostname) if hostname else "[dim]not set[/dim]",
-                            _s(ip_block),
+                            _h(ip_addr),
+                            _h(hostname) if hostname else "[dim]not set[/dim]",
+                            _h(ip_block),
                         )
             except Exception as exc:
                 logger.error("_load_rdns: list_reverse_dns(%r) failed: %s", ip_block, exc)

--- a/src/servonaut/screens/ovh_ip_management.py
+++ b/src/servonaut/screens/ovh_ip_management.py
@@ -205,9 +205,11 @@ class OVHIPManagementScreen(Screen):
             self.notify("No IPs found on this account.", severity="information")
             return
 
-        def _s(x: str) -> str:
+        def _h(x: str) -> str:
+            # Address, routed-to service name and reverse are hosts by
+            # definition (OVH service names carry a dashed IP).
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_host(x)
             return x
 
         for ip in self._ips:
@@ -219,7 +221,7 @@ class OVHIPManagementScreen(Screen):
                 else ip.get("routedTo") or "—"
             )
             reverse = str(ip.get("reverse") or "—")
-            table.add_row(_s(ip_addr), ip_type, _s(routed_to), _s(reverse))
+            table.add_row(_h(ip_addr), ip_type, _h(routed_to), _h(reverse))
 
     # ------------------------------------------------------------------
     # Move failover IP

--- a/src/servonaut/screens/ovh_manager.py
+++ b/src/servonaut/screens/ovh_manager.py
@@ -170,8 +170,16 @@ class OVHManagerScreen(Screen):
             # Redact the fresh list in-place; OVH names are often FQDNs
             # (ns1.bigcorp.com) which are especially identifying.
             # Mirrors the app-startup redact_instances pattern.
+            self._api_ids = {}
             if self.app.demo_mode and self.app.redaction_service:
+                # Rows carry demo-mode fakes; API calls need the real ids,
+                # so remember the mapping before redacting in place.
+                raw_ids = [str(i.get("id") or "") for i in self._instances]
                 self.app.redaction_service.redact_instances(self._instances)
+                self._api_ids = {
+                    str(i.get("id") or ""): raw
+                    for i, raw in zip(self._instances, raw_ids)
+                }
             self._render_table()
             n = len(instances)
             if n == 0:
@@ -248,6 +256,11 @@ class OVHManagerScreen(Screen):
         if row < 0 or row >= len(self._instances):
             return None
         return self._instances[row]
+
+    def _api_id(self, inst: dict) -> str:
+        """Real provider id for an API call; the row may carry a demo-mode fake."""
+        shown = str(inst.get("id") or "")
+        return getattr(self, "_api_ids", {}).get(shown, shown)
 
     def _sync_action_buttons(self) -> None:
         """Toggle button enabled state per row's provider_type + state.
@@ -352,7 +365,7 @@ class OVHManagerScreen(Screen):
         if inst is None:
             return
         ptype = (inst.get("provider_type", "") or "").lower()
-        identifier = str(inst.get("id") or "")
+        identifier = self._api_id(inst)
         if not identifier or not ptype:
             self.notify(
                 "Selected row is missing id/provider_type to act on.",
@@ -416,7 +429,7 @@ class OVHManagerScreen(Screen):
 
     async def _do_delete(self, inst: dict) -> None:
         ptype = (inst.get("provider_type", "") or "").lower()
-        composite_id = str(inst.get("id") or "")
+        composite_id = self._api_id(inst)
         # Cloud composite id is "<project_id>/<inst_id>" — split for the
         # OVHCloudService call which takes them separately.
         project_id, _, inst_id = composite_id.partition("/")

--- a/src/servonaut/screens/ovh_ssh_keys.py
+++ b/src/servonaut/screens/ovh_ssh_keys.py
@@ -194,8 +194,10 @@ class OVHSSHKeysScreen(Screen):
             return
 
         def _s(x: str) -> str:
+            # Key labels are user-chosen (client names, an email address) --
+            # shown as a pool key name in demo mode, like the instance list.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_key_name(x)
             return x
 
         table = self.query_one("#ssh_keys_table", DataTable)

--- a/src/servonaut/services/redaction_service.py
+++ b/src/servonaut/services/redaction_service.py
@@ -125,6 +125,29 @@ _EMAIL_RE = re.compile(
 )
 
 
+# Dashed-IP host fragments: OVH dedicated / VPS service names look like
+# ``ns3141592.ip-51-195-150-236.eu``.  The IPv4 rule cannot see the dashed
+# form, so it gets its own rule that reuses the ``redact_ip`` mapping.
+_DASHED_IP_RE = re.compile(r"\bip-(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})\b")
+
+# A bare hostname / FQDN on its own: dotted labels and nothing else.  Callers
+# also require at least one letter so a pure IPv4 literal never matches.
+_BARE_HOSTNAME_RE = re.compile(
+    r"^[A-Za-z0-9_](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?"
+    r"(?:\.[A-Za-z0-9_](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?)+\.?$"
+)
+_IPV4_WITH_PREFIX_RE = re.compile(r"^(\d{1,3}(?:\.\d{1,3}){3})(/\d{1,2})?$")
+_FAKE_HOST_SUFFIX = ".example.com"
+# One whole IPv6 address (2-7 colons), optionally with a /prefix.
+_IPV6_HOST_RE = re.compile(
+    r"^([0-9A-Fa-f]{0,4}(?::[0-9A-Fa-f]{0,4}){2,7})(/\d{1,3})?$"
+)
+_FAKE_IPV6_PREFIX = "2001:db8:"
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
 def _hash_int(value: str, modulo: int) -> int:
     """Deterministic hash of a string to an int in [0, modulo)."""
     digest = hashlib.sha256(value.encode()).hexdigest()
@@ -145,7 +168,12 @@ class RedactionService:
 
     def __init__(self) -> None:
         self._ip_cache: dict[str, str] = {}
+        self._ipv6_cache: dict[str, str] = {}
         self._name_cache: dict[str, str] = {}
+        # Instance ids: real -> fake, plus the set of fakes emitted so a fake
+        # fed back in on a re-render is returned unchanged (idempotence).
+        self._id_cache: dict[str, str] = {}
+        self._fake_ids: set[str] = set()
         self._counter: int = 0
         # Tracks every fake name ever emitted by redact_name so that
         # a second scrub_stream pass does not re-replace already-fake names
@@ -187,23 +215,90 @@ class RedactionService:
         return fake
 
     def redact_instance_id(self, instance_id: str) -> str:
-        """Map a real instance ID to a fake one preserving format."""
+        """Map a real instance ID to a fake one preserving its format.
+
+        Covers AWS ``i-…`` and ``custom-…`` ids, hostname-shaped provider
+        service names, OVH Public Cloud composites ``<project>/<instance>``,
+        UUIDs and purely numeric ids.  Unknown shapes pass through unchanged.
+        Idempotent within a session: a fake fed back in is returned as-is.
+        """
         if not instance_id:
             return instance_id
-        fake_hex = hashlib.sha256(instance_id.encode()).hexdigest()[:17]
+        if instance_id in self._fake_ids:
+            return instance_id
+        cached = self._id_cache.get(instance_id)
+        if cached is not None:
+            return cached
+        fake = self._fake_instance_id(instance_id)
+        if fake != instance_id:
+            self._id_cache[instance_id] = fake
+            self._fake_ids.add(fake)
+        return fake
+
+    def _fake_instance_id(self, instance_id: str) -> str:
+        digest = hashlib.sha256(instance_id.encode()).hexdigest()
         if instance_id.startswith("custom-"):
-            return f"custom-{fake_hex[:12]}"
+            return f"custom-{digest[:12]}"
         if instance_id.startswith("i-"):
-            return f"i-{fake_hex}"
+            return f"i-{digest[:17]}"
+        if "/" in instance_id:
+            # OVH Public Cloud composite "<project_id>/<instance_id>".
+            return "/".join(
+                self._fake_instance_id(part) if part else part
+                for part in instance_id.split("/")
+            )
+        if _UUID_RE.match(instance_id):
+            return (
+                f"{digest[:8]}-{digest[8:12]}-{digest[12:16]}-"
+                f"{digest[16:20]}-{digest[20:32]}"
+            )
+        if instance_id.isdigit():
+            digits = str(int(digest[:24], 16))
+            return digits[:len(instance_id)].rjust(len(instance_id), "7")
+        if (
+            "." in instance_id
+            and any(c.isalpha() for c in instance_id)
+            and _BARE_HOSTNAME_RE.match(instance_id)
+        ):
+            return self.redact_hostname(instance_id)
         return instance_id
 
     def redact_hostname(self, hostname: str) -> str:
         """Map a real hostname/FQDN to a fake one."""
         if not hostname or hostname == "-":
             return hostname
+        # Idempotence guard (mirrors redact_ip): a fake host fed back in on a
+        # re-render must not re-hash to a different fake.
+        if hostname.endswith(_FAKE_HOST_SUFFIX):
+            return hostname
         prefix = _hash_pick(hostname, _NAME_PREFIXES)
         num = _hash_int(hostname, 100) + 1
-        return f"{prefix}-{num}.example.com"
+        return f"{prefix}-{num}{_FAKE_HOST_SUFFIX}"
+
+    def redact_host(self, value: str) -> str:
+        """Redact a display value that is a host *by definition*.
+
+        Accepts an IPv4 literal (optionally with a ``/prefix``), a bare
+        hostname / FQDN, or free text, and dispatches to ``redact_ip``,
+        ``redact_hostname`` or ``scrub_stream`` respectively.
+
+        ``scrub_stream`` deliberately has no bare-hostname rule (it would
+        false-positive on ordinary prose), so columns that always hold a
+        host -- DNS zones, reverse-DNS targets, provider service names,
+        custom-server hosts, instance IP fields -- route through this.
+        """
+        if not value or value in ("-", "—", "N/A"):
+            return value
+        stripped = value.strip()
+        ip_match = _IPV4_WITH_PREFIX_RE.match(stripped)
+        if ip_match:
+            return self.redact_ip(ip_match.group(1)) + (ip_match.group(2) or "")
+        v6_match = _IPV6_HOST_RE.match(stripped)
+        if v6_match:
+            return self.redact_ipv6_address(v6_match.group(1)) + (v6_match.group(2) or "")
+        if _BARE_HOSTNAME_RE.match(stripped) and any(c.isalpha() for c in stripped):
+            return self.redact_hostname(stripped)
+        return self.scrub_stream(value)
 
     def redact_key_name(self, key: str) -> str:
         """Map a real SSH key name/path to a fake one."""
@@ -238,10 +333,13 @@ class RedactionService:
             instance["name"] = self.redact_name(instance["name"])
         if instance.get("id"):
             instance["id"] = self.redact_instance_id(instance["id"])
+        # Custom servers copy their host into the IP fields, so these may be
+        # FQDNs -- redact_host keeps the IP mapping for real IPs and gives a
+        # hostname a hostname-shaped fake instead of hashing it into an IP.
         if instance.get("public_ip"):
-            instance["public_ip"] = self.redact_ip(instance["public_ip"])
+            instance["public_ip"] = self.redact_host(instance["public_ip"])
         if instance.get("private_ip"):
-            instance["private_ip"] = self.redact_ip(instance["private_ip"])
+            instance["private_ip"] = self.redact_host(instance["private_ip"])
         if instance.get("key_name"):
             instance["key_name"] = self.redact_key_name(instance["key_name"])
         if instance.get("ssh_key"):
@@ -252,9 +350,9 @@ class RedactionService:
             instance["group"] = self.redact_group(instance["group"])
         if instance.get("username"):
             instance["username"] = self.redact_username(instance["username"])
-        # Hostnames in custom servers
+        # Hostnames in custom servers (may also be a plain IP)
         if instance.get("host"):
-            instance["host"] = self.redact_hostname(instance["host"])
+            instance["host"] = self.redact_host(instance["host"])
         # Tags may contain client names
         if instance.get("tags") and isinstance(instance["tags"], dict):
             instance["tags"] = {
@@ -339,6 +437,33 @@ class RedactionService:
             return f"{m.group(1)}{fake_name}"
         return _LOG_GROUP_RE.sub(_replace, text)
 
+    def redact_ipv6_address(self, address: str) -> str:
+        """Map one whole IPv6 address to a clean RFC 3849 doc-range address.
+
+        The stream rule (``redact_ipv6``) substitutes a constant and leaves
+        compressed forms looking malformed; a host column holds exactly one
+        address, so it gets a deterministic ``2001:db8:xxxx::yyyy`` instead.
+        """
+        if not address or address.lower().startswith(_FAKE_IPV6_PREFIX):
+            return address
+        cached = self._ipv6_cache.get(address)
+        if cached is not None:
+            return cached
+        head = _hash_int(address, 0xFFFF)
+        tail = _hash_int(address + "tail", 0xFFFF) + 1
+        fake = f"{_FAKE_IPV6_PREFIX}{head:x}::{tail:x}"
+        self._ipv6_cache[address] = fake
+        return fake
+
+    def redact_dashed_ip(self, text: str) -> str:
+        """Replace ``ip-A-B-C-D`` host fragments with the dashed form of the
+        doc-range IP ``redact_ip`` maps ``A.B.C.D`` to (same session mapping,
+        so a dashed and a dotted spelling of one host agree on screen)."""
+        def _replace(m: re.Match) -> str:
+            dotted = ".".join(m.groups())
+            return "ip-" + self.redact_ip(dotted).replace(".", "-")
+        return _DASHED_IP_RE.sub(_replace, text)
+
     def redact_ipv6(self, text: str) -> str:
         """Replace IPv6 addresses with the RFC 3849 documentation address.
 
@@ -417,6 +542,7 @@ class RedactionService:
         Composition order (tested, order matters — see below):
           1. memory.redaction.default_redactor — secrets first (API keys, JWTs …)
           2. self.redact_text             — IPv4 → RFC 5737 doc-range
+          2b. self.redact_dashed_ip       — ip-A-B-C-D fragments, same mapping
           3. self.redact_arn              — ARN account-id → 000000000000
           4. self.redact_account_id       — bare 12-digit AWS account
           5. self.redact_log_group        — /aws/<svc>/<name>
@@ -463,6 +589,7 @@ class RedactionService:
         try:
             text = default_redactor(text)
             text = self.redact_text(text)
+            text = self.redact_dashed_ip(text)
             text = self.redact_ipv6(text)
             text = self.redact_arn(text)
             text = self.redact_ecr_host(text)

--- a/src/servonaut/widgets/relay_indicator.py
+++ b/src/servonaut/widgets/relay_indicator.py
@@ -236,6 +236,9 @@ class RelayStatusScreen(Screen):
         if last_hb:
             parts.append(f"last heartbeat {last_hb}")
         if clients:
+            if getattr(self.app, "demo_mode", False) and getattr(self.app, "redaction_service", None):
+                # A client id embeds the OS user and the machine model.
+                clients = [self.app.redaction_service.redact_name(str(c)) for c in clients]
             parts.append(f"client_ids={clients}")
         self.query_one("#backend_status", Static).update(" · ".join(parts))
 

--- a/tests/test_demo_mode_coverage.py
+++ b/tests/test_demo_mode_coverage.py
@@ -3023,3 +3023,642 @@ class TestObjectStorageDemoMode:
         assert "customer-db-dump.sql" not in all_cells, (
             f"Identifying object key leaked into table in demo mode: {all_cells!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Panel coverage: host columns, Custom Servers, Hetzner wizard, Account, Relay
+# ---------------------------------------------------------------------------
+# Neutral fixtures only: 9.9.9.9 / 1.1.1.1 as "real" public IPs (doc-range
+# IPs are treated as already-fake by redact_ip), corp-example.net as the real
+# domain, and no provider or customer naming from any real environment.
+
+def _custom_server(**overrides):
+    from servonaut.config.schema import CustomServer
+
+    fields = dict(
+        name="acme-web-1",
+        host="web1.corp-example.net",
+        username="alice",
+        ssh_key="~/.ssh/acme_deploy_key",
+        port=22,
+        provider="ExampleHost",
+        group="acme-clients",
+        extra_ssh_options=[],
+    )
+    fields.update(overrides)
+    return CustomServer(**fields)
+
+
+def _app_property(mock_app):
+    """Patch target for a screen's read-only ``app`` property."""
+    return lambda: property(lambda self: mock_app)
+
+
+class TestRedactHost:
+    """redact_host dispatches IP / CIDR / FQDN / free text and is idempotent."""
+
+    def test_ipv4_uses_the_ip_mapping(self) -> None:
+        svc = RedactionService()
+        assert svc.redact_host("9.9.9.9") == svc.redact_ip("9.9.9.9")
+        assert svc.redact_host("9.9.9.9").startswith(("192.0.2.", "198.51.100.", "203.0.113."))
+
+    def test_cidr_keeps_the_prefix(self) -> None:
+        svc = RedactionService()
+        assert svc.redact_host("9.9.9.9/32") == svc.redact_ip("9.9.9.9") + "/32"
+
+    def test_fqdn_becomes_example_com(self) -> None:
+        svc = RedactionService()
+        out = svc.redact_host("mail.corp-example.net")
+        assert out.endswith(".example.com")
+        assert "corp-example" not in out
+
+    def test_dashed_ip_service_name_is_a_hostname(self) -> None:
+        svc = RedactionService()
+        out = svc.redact_host("ns1234.ip-9-9-9-9.eu")
+        assert out.endswith(".example.com")
+        assert "9-9-9-9" not in out
+
+    def test_plain_label_and_placeholders_pass_through(self) -> None:
+        svc = RedactionService()
+        for value in ("primary", "-", "—", "N/A", ""):
+            assert svc.redact_host(value) == value
+
+    def test_idempotent(self) -> None:
+        svc = RedactionService()
+        for value in ("mail.corp-example.net", "9.9.9.9", "9.9.9.9/24", "ns1.ip-9-9-9-9.eu"):
+            once = svc.redact_host(value)
+            assert svc.redact_host(once) == once, value
+
+    def test_doc_range_ip_untouched(self) -> None:
+        svc = RedactionService()
+        assert svc.redact_host("198.51.100.7") == "198.51.100.7"
+
+
+class TestScrubStreamDashedIp:
+    """``ip-A-B-C-D`` fragments follow the same mapping as the dotted IP."""
+
+    def test_dashed_fragment_maps_like_the_dotted_ip(self) -> None:
+        svc = RedactionService()
+        out = svc.scrub_stream("host ns1.ip-9-9-9-9.eu and 9.9.9.9")
+        fake = svc.redact_ip("9.9.9.9")
+        assert "9-9-9-9" not in out
+        assert "9.9.9.9" not in out
+        assert f"ip-{fake.replace('.', '-')}" in out
+        assert fake in out
+
+    def test_idempotent(self) -> None:
+        svc = RedactionService()
+        once = svc.scrub_stream("ns1.ip-9-9-9-9.eu")
+        assert svc.scrub_stream(once) == once
+
+
+class TestRedactInstanceHostFields:
+    """Custom servers copy an FQDN host into the IP fields."""
+
+    def test_fqdn_in_ip_fields_gets_a_hostname_fake(self) -> None:
+        svc = RedactionService()
+        inst = {
+            "name": "acme-web", "public_ip": "web1.corp-example.net",
+            "private_ip": "web1.corp-example.net", "host": "9.9.9.9", "is_custom": True,
+        }
+        svc.redact_instance(inst)
+        assert inst["public_ip"].endswith(".example.com")
+        assert "corp-example" not in inst["private_ip"]
+        assert inst["host"] == svc.redact_ip("9.9.9.9")
+
+    def test_real_ip_mapping_unchanged(self) -> None:
+        svc = RedactionService()
+        inst = {"name": "x", "public_ip": "9.9.9.9"}
+        svc.redact_instance(inst)
+        assert inst["public_ip"] == svc.redact_ip("9.9.9.9")
+
+
+class TestCustomServersDemoMode:
+    """Custom Servers table + edit form under demo mode."""
+
+    @staticmethod
+    def _run_populate(mock_app, servers) -> list:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        mock_app.custom_server_service.list_servers.return_value = servers
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", return_value=mock_table):
+                screen._populate_table()
+        return rows
+
+    def test_every_column_redacted_and_consistent_with_instance_list(self) -> None:
+        mock_app = _make_mock_app(demo=True)
+        server = _custom_server()
+        rows = self._run_populate(mock_app, [server])
+        assert len(rows) == 1
+        cells = " ".join(str(c) for c in rows[0])
+        for real in (server.name, server.host, server.ssh_key, server.provider,
+                     server.group, server.username):
+            assert real not in cells, f"{real!r} leaked: {cells!r}"
+        redaction = mock_app.redaction_service
+        # The same fake identity the Instances table shows for this server.
+        assert rows[0][0] == redaction.redact_name(server.name)
+        assert rows[0][1] == redaction.redact_host(server.host)
+        assert rows[0][2] == "22"
+
+    def test_raw_without_demo(self) -> None:
+        mock_app = _make_mock_app(demo=False)
+        server = _custom_server()
+        rows = self._run_populate(mock_app, [server])
+        assert rows[0][0] == server.name
+        assert rows[0][1] == server.host
+        assert rows[0][4] == server.ssh_key
+
+    def test_edit_form_blocked_in_demo_mode(self) -> None:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        mock_app = _make_mock_app(demo=True)
+        query_one = MagicMock()
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", query_one):
+                screen._show_form(_custom_server())
+        query_one.assert_not_called()
+        mock_app.notify.assert_called_once()
+        assert mock_app.notify.call_args.kwargs.get("severity") == "warning"
+
+    def test_add_form_still_opens_in_demo_mode(self) -> None:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        mock_app = _make_mock_app(demo=True)
+        query_one = MagicMock()
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", query_one):
+                screen._show_form()
+        assert query_one.called
+        mock_app.notify.assert_not_called()
+
+
+class TestHetznerCreateWizardDemoMode:
+    """Project SSH-key labels in the create wizard are scrubbed in demo mode."""
+
+    @staticmethod
+    def _run_load_keys(mock_app, keys) -> list:
+        import asyncio
+        from servonaut.screens.hetzner_create import HetznerCreateScreen
+
+        screen = object.__new__(HetznerCreateScreen)
+        screen._ssh_keys = []
+
+        async def _list_ssh_keys():
+            return list(keys)
+
+        mock_app.hetzner_service.list_ssh_keys = _list_ssh_keys
+        mock_app.config_manager.get.return_value.hetzner.default_hetzner_ssh_key = ""
+        rows: list = []
+        mock_table = MagicMock()
+        mock_table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "query_one", return_value=mock_table):
+                    await screen._load_ssh_keys()
+
+        asyncio.run(_run())
+        return rows
+
+    def test_email_key_label_scrubbed(self) -> None:
+        mock_app = _make_mock_app(demo=True)
+        rows = self._run_load_keys(
+            mock_app, [{"name": "ops@example.org", "id": 7, "fingerprint": "aa:bb:cc"}],
+        )
+        cells = " ".join(str(c) for c in rows[0])
+        assert "ops@example.org" not in cells
+        assert rows[0][0] == mock_app.redaction_service.redact_key_name("ops@example.org")
+
+    def test_raw_without_demo(self) -> None:
+        mock_app = _make_mock_app(demo=False)
+        rows = self._run_load_keys(
+            mock_app, [{"name": "ops@example.org", "id": 7, "fingerprint": "aa:bb:cc"}],
+        )
+        assert rows[0][0] == "ops@example.org"
+
+
+class TestLoginScreenDemoMode:
+    """The Account panel's 'Logged in as' email is a fake in demo mode."""
+
+    @staticmethod
+    def _make_auth(email: str) -> MagicMock:
+        auth = MagicMock()
+        auth._token.email = email
+        auth.plan = "solo"
+        auth.get_plan_features.return_value = {}
+        auth._get_cached_entitlements.return_value = {}
+        return auth
+
+    @staticmethod
+    def _widgets():
+        widgets: dict = {}
+
+        def _query_one(selector, widget_type=None):
+            return widgets.setdefault(str(selector), MagicMock())
+
+        return widgets, _query_one
+
+    def test_logged_in_email_scrubbed(self) -> None:
+        from servonaut.screens.login import LoginScreen
+
+        screen = object.__new__(LoginScreen)
+        mock_app = _make_mock_app(demo=True)
+        mock_app.auth_service = self._make_auth("alice@example.org")
+        widgets, query_one = self._widgets()
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", side_effect=query_one):
+                screen._show_logged_in_state()
+        text = str(widgets["#account_info"].update.call_args.args[0])
+        assert "alice@example.org" not in text
+        assert "@example.com" in text
+
+    def test_validate_session_scrubs_refreshed_email(self) -> None:
+        import asyncio
+        from servonaut.screens.login import LoginScreen
+
+        screen = object.__new__(LoginScreen)
+        mock_app = _make_mock_app(demo=True)
+        auth = self._make_auth("alice@example.org")
+
+        async def _validate_token():
+            return True
+
+        auth.validate_token = _validate_token
+        mock_app.auth_service = auth
+        widgets, query_one = self._widgets()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "query_one", side_effect=query_one):
+                    await screen._validate_session()
+
+        asyncio.run(_run())
+        text = str(widgets["#account_info"].update.call_args.args[0])
+        assert "alice@example.org" not in text
+
+    def test_raw_without_demo(self) -> None:
+        from servonaut.screens.login import LoginScreen
+
+        screen = object.__new__(LoginScreen)
+        mock_app = _make_mock_app(demo=False)
+        mock_app.auth_service = self._make_auth("alice@example.org")
+        widgets, query_one = self._widgets()
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", side_effect=query_one):
+                screen._show_logged_in_state()
+        assert "alice@example.org" in str(widgets["#account_info"].update.call_args.args[0])
+
+
+class TestRelayStatusDemoMode:
+    """Backend client ids embed the OS user + machine name."""
+
+    @staticmethod
+    def _run_refresh(mock_app) -> str:
+        import asyncio
+        import json
+        from servonaut.widgets import relay_indicator as mod
+
+        screen = object.__new__(mod.RelayStatusScreen)
+        tools = MagicMock()
+
+        async def _relay_status():
+            return json.dumps({
+                "connected": True,
+                "last_heartbeat_at": "2026-01-01T00:00:00+00:00",
+                "client_ids": ["alice-thinkpad-x1-deadbeef"],
+            })
+
+        tools.relay_status = _relay_status
+        widget = MagicMock()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(mod, "_build_mcp_tools_for_this_app", return_value=tools):
+                    with patch.object(screen, "query_one", return_value=widget):
+                        await screen._refresh_backend()
+
+        asyncio.run(_run())
+        return str(widget.update.call_args.args[0])
+
+    def test_client_ids_redacted(self) -> None:
+        text = self._run_refresh(_make_mock_app(demo=True))
+        assert "alice-thinkpad-x1-deadbeef" not in text
+        assert "client_ids=" in text
+
+    def test_raw_without_demo(self) -> None:
+        text = self._run_refresh(_make_mock_app(demo=False))
+        assert "alice-thinkpad-x1-deadbeef" in text
+
+
+class TestOvhHostColumnsDemoMode:
+    """OVH columns that hold hosts by definition go through redact_host."""
+
+    @staticmethod
+    def _rows_collector():
+        rows: list = []
+        table = MagicMock()
+        table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        return rows, table
+
+    def test_dns_zone_names_redacted(self) -> None:
+        import asyncio
+        from servonaut.screens.ovh_dns import OVHDNSScreen
+
+        screen = object.__new__(OVHDNSScreen)
+        screen._domains = []
+        mock_app = _make_mock_app(demo=True)
+        svc = MagicMock()
+
+        async def _list_domains():
+            return ["corp-example.net"]
+
+        svc.list_domains = _list_domains
+        rows, table = self._rows_collector()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "_get_dns_service", return_value=svc), \
+                        patch.object(screen, "query_one", return_value=table), \
+                        patch.object(screen, "_set_domains_status"):
+                    await screen._load_domains()
+
+        asyncio.run(_run())
+        assert rows and "corp-example" not in str(rows[0][0])
+        assert str(rows[0][0]).endswith(".example.com")
+
+    def test_dns_record_targets_and_zone_header_redacted(self) -> None:
+        import asyncio
+        from servonaut.screens.ovh_dns import OVHDNSScreen
+
+        screen = object.__new__(OVHDNSScreen)
+        screen._records = []
+        mock_app = _make_mock_app(demo=True)
+        svc = MagicMock()
+
+        async def _list_records(zone):
+            return [{"fieldType": "CNAME", "subDomain": "www",
+                     "target": "web.corp-example.net.", "ttl": 3600}]
+
+        svc.list_records = _list_records
+        rows, table = self._rows_collector()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "_get_dns_service", return_value=svc), \
+                        patch.object(screen, "query_one", return_value=table):
+                    await screen._load_records("corp-example.net")
+
+        asyncio.run(_run())
+        cells = " ".join(str(c) for row in rows for c in row)
+        assert "corp-example" not in cells
+        header = str(table.update.call_args.args[0])
+        assert "corp-example" not in header
+
+    def test_ip_table_routed_to_and_reverse_redacted(self) -> None:
+        from servonaut.screens.ovh_ip_management import OVHIPManagementScreen
+
+        screen = object.__new__(OVHIPManagementScreen)
+        screen._ips = [{
+            "ip": "9.9.9.9/32", "type": "failover",
+            "routedTo": {"serviceName": "ns1234.ip-9-9-9-9.eu"},
+            "reverse": "mail.corp-example.net.",
+        }]
+        mock_app = _make_mock_app(demo=True)
+        rows, table = self._rows_collector()
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            with patch.object(screen, "query_one", return_value=table):
+                screen._populate_table()
+        cells = " ".join(str(c) for row in rows for c in row)
+        assert "9.9.9.9" not in cells
+        assert "9-9-9-9" not in cells
+        assert "corp-example" not in cells
+        assert "/32" in cells
+
+    def test_billing_service_names_redacted(self) -> None:
+        import asyncio
+        from servonaut.screens.ovh_billing import OVHBillingScreen
+
+        screen = object.__new__(OVHBillingScreen)
+        mock_app = _make_mock_app(demo=True)
+        svc = MagicMock()
+
+        async def _get_service_list():
+            return [
+                {"name": "corp-example.net", "type": "domain", "status": "ok",
+                 "expiration": "2027-01-01", "auto_renew": True},
+                {"name": "ns1234.ip-9-9-9-9.eu", "type": "dedicated", "status": "ok",
+                 "expiration": "", "auto_renew": False},
+            ]
+
+        svc.get_service_list = _get_service_list
+        mock_app.ovh_billing_service = svc
+        rows, table = self._rows_collector()
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "query_one", return_value=table):
+                    await screen._load_services()
+
+        asyncio.run(_run())
+        cells = " ".join(str(c) for row in rows for c in row)
+        assert len(rows) == 2
+        assert "corp-example" not in cells
+        assert "9-9-9-9" not in cells
+
+
+class TestRedactInstanceIdFormats:
+    """Provider ids keep their shape but never their value."""
+
+    def test_hostname_shaped_service_name(self) -> None:
+        svc = RedactionService()
+        out = svc.redact_instance_id("vps-1a2b3c4d.vps.corp-example.net")
+        assert out.endswith(".example.com")
+        assert "1a2b3c4d" not in out
+
+    def test_uuid_and_composite(self) -> None:
+        svc = RedactionService()
+        project = "123e4567-e89b-12d3-a456-426614174000"  # leak-guard:allow (RFC 4122 example UUID)
+        instance = "9f8e7d6c-5b4a-3210-fedc-ba9876543210"  # leak-guard:allow (synthetic test UUID)
+        out = svc.redact_instance_id(project)
+        assert out != project and len(out) == 36 and out.count("-") == 4
+        composite = svc.redact_instance_id(f"{project}/{instance}")
+        assert composite.count("/") == 1
+        assert project not in composite and instance not in composite
+
+    def test_numeric_keeps_length(self) -> None:
+        svc = RedactionService()
+        out = svc.redact_instance_id("12345678")
+        assert out != "12345678" and out.isdigit() and len(out) == 8
+
+    def test_idempotent_within_a_session(self) -> None:
+        svc = RedactionService()
+        for real in ("i-0abc123def456789a", "custom-web-1", "12345678",
+                     "vps-1a2b3c4d.vps.corp-example.net",
+                     "123e4567-e89b-12d3-a456-426614174000"):  # leak-guard:allow (RFC 4122 example UUID)
+            fake = svc.redact_instance_id(real)
+            assert svc.redact_instance_id(fake) == fake, real
+            assert svc.redact_instance_id(real) == fake, real
+
+    def test_unknown_shape_unchanged(self) -> None:
+        assert RedactionService().redact_instance_id("srv-12345") == "srv-12345"
+
+
+class TestRedactHostIpv6:
+    def test_whole_address_gets_clean_doc_range_fake(self) -> None:
+        svc = RedactionService()
+        out = svc.redact_host("fd12:3456:789a::1/128")
+        assert out.startswith("2001:db8:") and out.endswith("/128")
+        assert "fd12" not in out and "::" in out
+        assert svc.redact_host("fd12:3456:789a::1") == out[:-4]
+
+    def test_idempotent(self) -> None:
+        svc = RedactionService()
+        once = svc.redact_host("fd12:3456:789a::1")
+        assert svc.redact_host(once) == once
+
+
+class TestManagerApiIdMapping:
+    """Manager rows show a fake id, but actions still use the real one."""
+
+    @staticmethod
+    def _load(screen_cls, service_attr, raw_instance):
+        import asyncio
+
+        screen = object.__new__(screen_cls)
+        screen._loading = False
+        screen._instances = []
+        mock_app = _make_mock_app(demo=True)
+
+        async def _fake_fetch(force_refresh=False):
+            return [dict(raw_instance)]
+
+        svc = MagicMock()
+        svc.fetch_instances_cached = _fake_fetch
+        setattr(mock_app, service_attr, svc)
+        rows: list = []
+        table = MagicMock()
+        table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        status = MagicMock()
+
+        def _query_one(selector, widget_type=None):
+            return table if "table" in str(selector) else status
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "query_one", side_effect=_query_one):
+                    with patch.object(screen, "_sync_action_buttons", create=True):
+                        await screen._load_instances()
+
+        asyncio.run(_run())
+        return screen, rows
+
+    def test_ovh_service_name_id(self) -> None:
+        from servonaut.screens.ovh_manager import OVHManagerScreen
+
+        raw = {"name": "ns1.corp-example.net", "id": "vps-1a2b3c4d.vps.corp-example.net",
+               "public_ip": "9.9.9.9", "region": "os-uk2", "type": "vps-le-4-4-80",
+               "state": "running", "provider_type": "vps"}
+        screen, rows = self._load(OVHManagerScreen, "ovh_service", raw)
+        cells = " ".join(str(c) for c in rows[0])
+        assert "1a2b3c4d" not in cells and "corp-example" not in cells
+        assert screen._instances[0]["id"] != raw["id"]
+        assert screen._api_id(screen._instances[0]) == raw["id"]
+
+    def test_hetzner_numeric_id(self) -> None:
+        from servonaut.screens.hetzner_manager import HetznerManagerScreen
+
+        raw = {"name": "web-prod-7", "id": "12345678", "public_ip": "9.9.9.9",
+               "region": "fsn1", "type": "cx22", "state": "running",
+               "created_at": "2024-01-01T00:00:00Z"}
+        screen, rows = self._load(HetznerManagerScreen, "hetzner_service", raw)
+        cells = " ".join(str(c) for c in rows[0])
+        assert "12345678" not in cells
+        assert screen._api_id(screen._instances[0]) == "12345678"
+
+    def test_aws_instance_id(self) -> None:
+        from servonaut.screens.aws_manager import AWSManagerScreen
+
+        raw = {"name": "web-prod-7", "id": "i-0abc123def456789a", "public_ip": "9.9.9.9",
+               "private_ip": "10.0.0.7", "region": "eu-west-1", "type": "t3.micro",
+               "state": "running", "key_name": "prod-key"}
+        screen, rows = self._load(AWSManagerScreen, "aws_service", raw)
+        cells = " ".join(str(c) for c in rows[0])
+        assert "i-0abc123def456789a" not in cells
+        assert screen._api_id(screen._instances[0]) == "i-0abc123def456789a"
+
+    def test_without_demo_ids_pass_straight_through(self) -> None:
+        from servonaut.screens.hetzner_manager import HetznerManagerScreen
+
+        screen = object.__new__(HetznerManagerScreen)
+        assert screen._api_id({"id": "12345678"}) == "12345678"
+
+
+class TestSshKeyLabelsDemoMode:
+    """OVH / Hetzner key screens and the Hetzner wizard show pool key names."""
+
+    @staticmethod
+    def _run_load(screen_cls, wire_service, key):
+        import asyncio
+
+        screen = object.__new__(screen_cls)
+        screen._keys = []
+        screen._project_id = "p1"
+        mock_app = _make_mock_app(demo=True)
+
+        async def _list(*args, **kwargs):
+            return [dict(key)]
+
+        wire_service(mock_app, _list)
+        rows: list = []
+        table = MagicMock()
+        table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+
+        async def _run():
+            with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+                with patch.object(screen, "query_one", return_value=table):
+                    with patch.object(screen, "_set_status", create=True), \
+                            patch.object(screen, "_sync_action_buttons", create=True):
+                        await screen._load_keys()
+
+        asyncio.run(_run())
+        return mock_app, rows
+
+    def test_ovh_key_label(self) -> None:
+        from servonaut.screens.ovh_ssh_keys import OVHSSHKeysScreen
+
+        def _wire(app, fn):
+            app.ovh_cloud_service.list_ssh_keys = fn
+
+        key = {"name": "client-laptop-key", "id": "k1", "fingerprint": "aa:bb",
+               "public_key": "ssh-ed25519 AAAA"}
+        mock_app, rows = self._run_load(OVHSSHKeysScreen, _wire, key)
+        assert rows[0][0] == mock_app.redaction_service.redact_key_name("client-laptop-key")
+
+    def test_hetzner_key_label(self) -> None:
+        from servonaut.screens.hetzner_ssh_keys import HetznerSSHKeysScreen
+
+        def _wire(app, fn):
+            app.hetzner_service.list_ssh_keys = fn
+
+        key = {"name": "ops@example.org", "id": 7, "fingerprint": "aa:bb"}
+        mock_app, rows = self._run_load(HetznerSSHKeysScreen, _wire, key)
+        assert rows[0][0] == mock_app.redaction_service.redact_key_name("ops@example.org")
+
+    def test_wizard_confirm_label(self) -> None:
+        from servonaut.screens.hetzner_create import HetznerCreateScreen
+
+        screen = object.__new__(HetznerCreateScreen)
+        mock_app = _make_mock_app(demo=True)
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            shown = screen._display_key_name("ops@example.org")
+        assert shown == mock_app.redaction_service.redact_key_name("ops@example.org")
+        mock_app.demo_mode = False
+        with patch.object(type(screen), "app", new_callable=_app_property(mock_app)):
+            assert screen._display_key_name("ops@example.org") == "ops@example.org"

--- a/tests/test_demo_mode_lint.py
+++ b/tests/test_demo_mode_lint.py
@@ -426,10 +426,10 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "— not user-origin server data. URL is a servonaut.io link, "
                    "not a customer hostname."),
 
-    # hetzner_create.py — server types, images, locations, and SSH keys are
-    # provider taxonomy from the Hetzner API (product names like 'cx22',
-    # 'ubuntu-22.04', 'fsn1'). SSH key names in _load_ssh_keys are user-named
-    # but this is a setup wizard that runs before demo recording starts.
+    # hetzner_create.py — server types, images, and locations are provider
+    # taxonomy from the Hetzner API (product names like 'cx22', 'ubuntu-22.04',
+    # 'fsn1'). SSH key names in _load_ssh_keys are user-chosen labels (often an
+    # email address) and carry their own demo-mode guard — not allow-listed.
     AllowlistEntry("screens/hetzner_create.py", "_load_server_types", "add_row",
                    "Renders Hetzner product taxonomy (server type names, cores, "
                    "memory, price) — provider-defined strings, not user PII."),
@@ -439,10 +439,6 @@ _ALLOWLIST: List[AllowlistEntry] = [
     AllowlistEntry("screens/hetzner_create.py", "_load_locations", "add_row",
                    "Renders Hetzner datacenter taxonomy (fsn1, nbg1 etc.) "
                    "— provider-defined strings, not user PII."),
-    AllowlistEntry("screens/hetzner_create.py", "_load_ssh_keys", "add_row",
-                   "Setup-wizard screen for creating a new server; SSH key names "
-                   "shown here are a selection UI before any demo recording begins "
-                   "— accepted limitation documented in demo-mode spec §2."),
 
     # hetzner_manager.py — _render_table feeds from self._instances which is
     # now redacted in-place before _render_table is called (CRITICAL-3.1 fix).
@@ -484,19 +480,13 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes 'N matches (of M total)' count label — "
                    "code-controlled integers, not file content."),
 
-    # login.py — all update() calls are hard-coded login-flow status strings
-    # (OAuth device flow URL, 'Logging in...', 'Logged in as ...').
-    # The 'Logged in as' string in _show_logged_in_state may carry a username —
-    # but the login screen is pre-demo (demo mode cannot be active before login).
+    # login.py — the update() calls below write hard-coded login-flow status
+    # strings (OAuth device flow URL, 'Logging in...'). The 'Logged in as'
+    # email in _show_logged_in_state / _validate_session is reachable in demo
+    # mode (the Account panel is a sidebar entry) and carries its own guard.
     AllowlistEntry("screens/login.py", "_submit", "update",
                    "Writes hard-coded 'Logging in...' / 'Invalid credentials' "
                    "strings — code-controlled login-flow status."),
-    AllowlistEntry("screens/login.py", "_show_logged_in_state", "update",
-                   "Shows logged-in username and session info — pre-demo screen "
-                   "(demo mode cannot be active before login completes)."),
-    AllowlistEntry("screens/login.py", "_validate_session", "update",
-                   "Writes hard-coded session-validation status strings "
-                   "— code-controlled constants."),
     AllowlistEntry("screens/login.py", "_start_login", "update",
                    "Writes 'Starting login...' — hard-coded string."),
     AllowlistEntry("screens/login.py", "_cancel_login", "update",
@@ -763,15 +753,11 @@ _ALLOWLIST: List[AllowlistEntry] = [
                    "Writes empty string to hide the indicator — no user data."),
 
     # relay_indicator.py — _refresh_local writes relay state label and lock owner
-    # PID (integer + mode); _refresh_backend writes connection state, last
-    # heartbeat timestamp, and client_ids from the relay backend. None of these
-    # are user PII — they are internal relay connection metadata.
+    # PID (integer + mode). _refresh_backend also writes client_ids, which embed
+    # the OS user and machine model, so it carries its own demo-mode guard.
     AllowlistEntry("widgets/relay_indicator.py", "_refresh_local", "update",
                    "Writes relay lock state label and owner PID/mode (integers) "
                    "— internal relay metadata, not user PII."),
-    AllowlistEntry("widgets/relay_indicator.py", "_refresh_backend", "update",
-                   "Writes relay backend connection state, heartbeat timestamps, "
-                   "and client_ids — internal relay metadata, not user PII."),
 
     # server_actions.py — _run_ssh_probe writes a private key to a tmpfile
     # (tempfile.NamedTemporaryFile). `tf.write(private_key_body)` is a filesystem


### PR DESCRIPTION
## Summary

`servonaut --demo` is meant to make every screen safe to record. Several panels only ran their values through the stream scrubber, which has no rule for server names, bare hostnames, key paths or groups, so those values rendered verbatim. This change closes those gaps and documents the new coverage in `docs/demo-mode.md`.

## Changes

- **Redaction service**: `redact_host` handles an IPv4 address (with optional prefix length), an IPv6 address, a bare hostname or free text. Dashed-IP host fragments (`ip-a-b-c-d`) follow the same mapping as the dotted IP. Instance ids keep their shape (`i-…`, hostname-style service names, UUIDs, `<project>/<instance>` composites, numeric ids) but never their value. Hostname and IPv6 fakes are idempotent across re-renders.
- **Custom Servers**: every column goes through the same per-field redactors as the instance list, so a server keeps one fake identity in both views. Editing an existing server is refused while demo mode is on, because the form is bound to the real record; adding a server still works.
- **AWS, OVH and Hetzner managers**: rows show a fake id, while start / stop / reboot / delete keep using the real provider id through a per-screen map.
- **Hetzner create wizard and the OVH / Hetzner SSH-key screens**: key labels are shown as pool key names, since labels are user-chosen and often an email address.
- **Account screen**: the "Logged in as" email is a deterministic fake.
- **Relay status screen**: backend client ids are redacted; they embed the OS user and machine name.
- **OVH DNS zones, records, reverse DNS, IP management and billing services**: host columns go through `redact_host`.
- Lint allowlist entries that described these surfaces as unreachable in demo mode are removed, and regression tests cover each surface.

