### PR TITLE
fix: ignore empty forwarded env vars and never persist a failed inventory fetch

### DIFF
--- a/.github/scripts/leak-scan.sh
+++ b/.github/scripts/leak-scan.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Leak Guard — fail a PR whose diff, title, or body contains internal /
+# Leak Guard — fail a PR whose diff, title, body, or commit messages contain internal /
 # coordination markers or secret-shaped values that must not enter this PUBLIC
 # repo. Plain grep, no external deps, no AI/Copilot. A deterministic BACKSTOP;
 # the first line of defence is genericizing while writing (see CONTRIBUTING.md
@@ -44,6 +44,10 @@ PHRASE_PATTERNS=(
   "coordination-phrase|cross[- ]team"
   "coordination-phrase|the (backend|server|dev|infra|ops) team"
   "deploy-identifier|prod-[0-9a-f]{7,}"
+  # Assistant-session links and attribution trailers are tooling artifacts,
+  # not part of a public change description.
+  "assistant-session-link|claude\.ai/code/session"
+  "assistant-session-trailer|^[A-Za-z]+-Session: *https?://"
 )
 
 # --- Tier 2: secret/PII shapes (name|PCRE). Matched value is never printed. -
@@ -132,6 +136,13 @@ scan_blob() {  # $1 = source label, $2 = file of text to scan
 
 scan_blob "pr-title" "$TMPDIR_SCAN/__pr_title"
 scan_blob "pr-body"  "$TMPDIR_SCAN/__pr_body"
+# Commit messages travel with the merge and are never re-editable, so they get
+# the same tiers as the PR body.
+: > "$TMPDIR_SCAN/__commits"
+if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+  git log --format=%B "${BASE_SHA}..${HEAD_SHA}" > "$TMPDIR_SCAN/__commits" 2>/dev/null || true
+fi
+scan_blob "commit-messages" "$TMPDIR_SCAN/__commits"
 for f in "${CHANGED[@]:-}"; do
   [ -z "$f" ] && continue
   git diff "${BASE_SHA}...${HEAD_SHA}" -- "$f" 2>/dev/null \
@@ -142,7 +153,7 @@ done
 # --- Tier 3: confidential denylist (values never echoed) -------------------
 if [ -n "$EXTRA_DENYLIST" ]; then
   {
-    cat "$TMPDIR_SCAN/__pr_title" "$TMPDIR_SCAN/__pr_body" 2>/dev/null
+    cat "$TMPDIR_SCAN/__pr_title" "$TMPDIR_SCAN/__pr_body" "$TMPDIR_SCAN/__commits" 2>/dev/null
     if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
       git diff "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+'
     fi

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,6 +1,6 @@
 name: Leak Guard
 
-# Public-repo backstop: fail a PR whose diff, title, or body contains internal /
+# Public-repo backstop: fail a PR whose diff, title, body, or commit messages contain internal /
 # coordination markers, secret-shaped values, or a term from the confidential
 # LEAK_DENYLIST secret. Re-runs on `edited` so a later body edit is also caught.
 #
@@ -48,7 +48,7 @@ jobs:
               cp ".github/$f" "$dest"
             fi
           done
-      - name: Scan diff + PR title/body for internal markers
+      - name: Scan diff + commit messages + PR title/body for internal markers
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,9 @@ This is a public repository — anything that lands in a commit, test, fixture, 
 - Real IP addresses tied to anyone's infrastructure, or details of a specific real-world incident.
 - Personal data (real emails, home-directory paths) — use `user@example.com`, `/home/user`.
 - Secrets of any kind (keys, tokens, passwords, private keys).
+- Tooling artifacts: assistant session links, attribution trailers, or coordination identifiers (agent names, thread ids). Describe the change itself.
 
-A **Leak Guard** CI check scans each PR's diff, title, and body for these patterns and a maintained denylist; it reports only *where* a match was found, never the value. It's a backstop, not a substitute for care while writing.
+A **Leak Guard** CI check scans each PR's diff, commit messages, title, and body for these patterns and a maintained denylist; it reports only *where* a match was found, never the value. It's a backstop, not a substitute for care while writing.
 
 If the guard flags a line that is a genuinely safe, vetted fixture (e.g. a documentation example key), add `leak-guard:allow` in a comment on that line to exempt it, or add the exact safe token to `.github/leak-allowlist.txt`.
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Jump to [MCP Server for AI Agents](#mcp-server-for-ai-agents).
 | Global | `Q` | Quit |
 | Global | `?` | Help screen |
 | Global | `Escape` | Go back / close |
+| Global | `Ctrl+P` | Command palette — "Go to …" jumps to any sidebar section from the keyboard |
 | Instance List | `/` | Focus search |
 | Instance List | `R` | Force-refresh from AWS |
 | Instance List | `S` | SSH to selected instance |

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -140,6 +140,35 @@ output within a session. Repeated IP addresses show the same fake IP.
 
 ---
 
+## Actions still reach the real server
+
+Redaction happens in place on the instance list, so the same dict that
+renders a row would also feed SSH, SCP, log probes, memory probes and the
+findings store. To keep those working while the screen stays fake:
+
+- `ServonautApp.connection_instance(row)` returns a copy of the record from
+  the snapshot taken before redaction, found by the row's fake id. Every
+  place that opens a connection (SSH from the table or the dashboard, run
+  command, browse files, transfer, logs, AI analysis, keyword scan, DB
+  credential scan, SSH-ref editor) hands that copy to the connection
+  services and keeps the redacted dict for anything it displays.
+- `ServonautApp.real_instance_id(id)` does the same for bare ids. The
+  memory service and store resolve every incoming id and instance dict on
+  entry, so fake ids never become directory names, index keys or sync-queue
+  keys, and per-server memory overrides are checked against the real name.
+- AI tool calls name servers by the id the model saw (a fake in demo mode);
+  the tool bridge maps it back before the relay executes.
+- Provider refreshes that land after startup are added to the pre-redaction
+  snapshot before they are redacted, so those rows resolve too.
+
+Outside demo mode both helpers return their input unchanged.
+
+Values you type while demo mode is on (a server added on the Custom Servers
+screen) render exactly as typed — the redactor remembers them for the
+session, so a recording can add a server without the table re-labelling it.
+Provider labels that are public taxonomy (`AWS`, `OVH`, `Hetzner`, …) pass
+through too, so the provider column stays true. Ids are always hashed.
+
 ## Known limitations
 
 The following patterns are intentionally **not** redacted. Each entry explains

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -12,6 +12,8 @@ Or auto-install into a coding agent:
 servonaut --mcp-install claude       # or: cursor, windsurf, vscode, opencode, codex, agy, gemini, all
 ```
 
+The installer forwards a fixed set of environment variables to the server by reference (`SSH_AUTH_SOCK`, `BW_SESSION`, `BWS_ACCESS_TOKEN`, the `AWS_*` credential and profile variables, `SERVONAUT_API_URL`, `SERVONAUT_MCP_URL`, plus any `$VARIABLE` referenced from your config). A variable that is not set when the agent starts arrives as an empty string; the server ignores those and falls back to each SDK's defaults (for AWS: the shared credentials file and the `default` profile), and lists the ignored names in `~/.servonaut/logs/servonaut.log` at startup.
+
 This document lists every exposed tool.  The full canonical list (with JSON Schemas) lives in `src/servonaut/mcp/tool_schemas.py`.  When adding a tool, put the schema there — both the MCP server and the built-in chat adapter pick it up automatically.
 
 ## Guard levels

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -382,6 +382,11 @@ class ServonautApp(App):
         # uses LogViewerService, and LogViewerService consults memory.logs
         # for cached readable paths. Wire the back-reference here.
         self.log_viewer_service.set_memory_service(self.memory_service)
+        # Demo mode: probes, storage keys and the sync queue must see the
+        # real record even though the screens hand over redacted rows.
+        self.memory_service.set_instance_resolver(
+            self.connection_instance, self.real_instance_id,
+        )
         self.ai_analysis_service = AIAnalysisService(self.config_manager)
         # Voice input — always constructed; the service itself reports whether
         # the optional audio/STT libraries and a microphone are present, and
@@ -999,6 +1004,9 @@ class ServonautApp(App):
                     servonaut_tools=getattr(self, "servonaut_tools", None),
                     ip_ban_service=getattr(self, "ip_ban_service", None),
                 )
+                # Demo mode: the model reasons over redacted rows and asks for
+                # tools by fake id; the relay needs the real one.
+                self.ai_tool_bridge.instance_id_resolver = self.real_instance_id
             except Exception as e:  # pragma: no cover
                 logger.debug("AIToolBridge init skipped: %s", e)
                 self.ai_tool_bridge = None
@@ -2067,6 +2075,86 @@ class ServonautApp(App):
         aws_instances = [i for i in self.instances if not i.get("is_custom")]
         other_instances = [i for i in self.instances if i.get("is_custom")]
         return resolve_instance_from_lists(id_or_name, aws_instances, other_instances)
+
+    # Sidebar targets reachable from the command palette (ctrl+p). The sidebar
+    # itself is mouse-only, so keyboard-only sessions and terminal recorders
+    # need a way to switch sections. Order mirrors the sidebar.
+    _PALETTE_NAVIGATION = (
+        ("Instances", "nav_list", "Fleet table: every server across providers"),
+        ("Custom Servers", "nav_custom_servers", "Add, edit and remove non-cloud servers"),
+        ("SSH Keys", "nav_keys", "SSH keys and agent configuration"),
+        ("Fleet Memory", "nav_memory", "Fleet-wide server memory"),
+        ("Sync Config", "nav_sync_config", "Push or pull your config across devices"),
+        ("Memory Sync", "nav_memory_sync", "Encrypted server-memory backup across devices"),
+        ("Secrets", "nav_secrets", "Secrets provider and DB-credential vault"),
+        ("BW SSH Vault", "nav_bw_vault", "Bitwarden SSH-key items and the servers using them"),
+        ("Findings", "nav_findings", "Proactive monitoring findings across the fleet"),
+        ("Drift Events", "nav_drift", "Configuration drift and anomaly events"),
+        ("Memory Export", "nav_memory_export", "Signed compliance export of server memory"),
+        ("Settings", "nav_settings", "Configuration, scan rules and AI provider"),
+        ("AWS Manage", "nav_aws_manage", "Create, start, stop, reboot and terminate EC2 instances"),
+        ("AWS Object Storage", "nav_aws_s3", "S3 buckets and objects"),
+        ("CloudWatch", "nav_cloudwatch", "CloudWatch log groups and events"),
+        ("IP Ban Manager", "nav_ip_ban", "Ban IPs via WAF, security groups or NACLs"),
+        ("CloudTrail", "nav_cloudtrail", "AWS API activity and events"),
+        ("OVH Manage", "nav_ovh_manage", "Create, start, stop, reboot and delete OVH instances"),
+        ("OVH DNS Zones", "nav_ovh_dns", "OVH DNS zones and records"),
+        ("OVH IP Management", "nav_ovh_ips", "OVH IP blocks and failover IPs"),
+        ("OVH Block Storage", "nav_ovh_storage", "OVH block storage volumes"),
+        ("OVH Billing", "nav_ovh_billing", "OVH invoices and consumption"),
+        ("OVH SSH Keys", "nav_ovh_ssh_keys", "SSH keys on OVH cloud projects"),
+        ("OVH Object Storage", "nav_ovh_s3", "OVH Object Storage buckets"),
+        ("Hetzner Manage", "nav_hetzner_manage", "Create, start, stop, reboot and delete Hetzner servers"),
+        ("Hetzner SSH Keys", "nav_hetzner_ssh_keys", "Hetzner project SSH keys"),
+        ("Hetzner Object Storage", "nav_hetzner_s3", "Hetzner Object Storage buckets"),
+        ("Account", "nav_login", "Sign in to your Servonaut account"),
+        ("Teams", "nav_teams", "Team members and shared access"),
+        ("Report a bug", "nav_bug_report", "Send a bug report after reviewing what it contains"),
+    )
+
+    def get_system_commands(self, screen):
+        """Textual command palette entries: the built-ins plus one "Go to …"
+        per sidebar section, so every screen is reachable from the keyboard."""
+        from textual.app import SystemCommand
+        from servonaut.widgets.sidebar import Sidebar
+
+        yield from super().get_system_commands(screen)
+        for title, target_id, help_text in self._PALETTE_NAVIGATION:
+            if target_id.startswith("nav_ovh") and getattr(self, "ovh_service", None) is None:
+                continue
+            if target_id.startswith("nav_hetzner") and getattr(self, "hetzner_service", None) is None:
+                continue
+            yield SystemCommand(
+                f"Go to {title}",
+                help_text,
+                lambda target=target_id: self.post_message(Sidebar.NavigationRequested(target)),
+            )
+
+    def real_instance_id(self, instance_id: str) -> str:
+        """The real id behind a demo-mode fake; identity outside demo mode."""
+        if not instance_id or not self.demo_mode or self.redaction_service is None:
+            return instance_id
+        return self.redaction_service.real_instance_id(instance_id)
+
+    def connection_instance(self, instance: dict) -> dict:
+        """The pristine record behind a (possibly demo-redacted) instance row.
+
+        Demo mode redacts ``app.instances`` in place so every rendering site
+        is covered without a guard. The price is that the same dict feeds
+        SSH/SCP command assembly, log probes, memory probes and storage keys.
+        Screens keep the redacted dict for everything they render and hand
+        THIS to anything that opens a connection or keys a store. Outside
+        demo mode it is the same dict; in demo mode it is a copy of the
+        snapshot taken before redaction, found by the row's fake id.
+        """
+        if not instance or not self.demo_mode or self.redaction_service is None:
+            return instance
+        import copy
+        real_id = self.redaction_service.real_instance_id(str(instance.get("id") or ""))
+        for pristine in self._instances_pristine or []:
+            if str(pristine.get("id") or "") == real_id:
+                return copy.deepcopy(pristine)
+        return instance
 
     def on_sidebar_navigation_requested(self, message: "Sidebar.NavigationRequested") -> None:
         """Handle navigation events from the sidebar."""

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -155,16 +155,19 @@ class ServonautApp(App):
     relay_state = reactive(None)
     relay_manager: Optional["RelayManager"] = None
 
-    def __init__(self, initial_screen=None, **kwargs) -> None:
+    def __init__(self, initial_screen=None, config_path=None, **kwargs) -> None:
         """Initialize the application.
 
         Args:
             initial_screen: Optional extra Screen instance to push on top of the
                 instance list after startup (e.g., OVHSetupScreen).
+            config_path: Alternative config file (``--config``); every other
+                runtime file keeps its usual location under ``~/.servonaut``.
             **kwargs: Passed through to Textual App.__init__.
         """
         super().__init__(**kwargs)
         self._initial_screen = initial_screen
+        self._config_path = config_path
 
     def notify(
         self,
@@ -320,7 +323,7 @@ class ServonautApp(App):
 
         from servonaut.services.update_service import UpdateService
         self.update_service = UpdateService()
-        self.config_manager = ConfigManager()
+        self.config_manager = ConfigManager(config_path=self._config_path)
         config = self.config_manager.get()
         if self.config_manager.load_error:
             self.notify(self.config_manager.load_error, severity="error", timeout=15)

--- a/src/servonaut/config/manager.py
+++ b/src/servonaut/config/manager.py
@@ -218,14 +218,20 @@ class ConfigManager:
         config_manager.update(cache_ttl_seconds=600)
     """
 
-    def __init__(self) -> None:
-        """Initialize the configuration manager."""
+    def __init__(self, config_path: Optional[Path] = None) -> None:
+        """Initialize the configuration manager.
+
+        Args:
+            config_path: Alternative config file to read and write instead of
+                ``~/.servonaut/config.json`` (the TUI's ``--config`` flag).
+                Every other runtime file keeps its usual location.
+        """
         self._config: Optional[AppConfig] = None
         self._load_error: Optional[str] = None
         _migrate_legacy_paths()
         _ensure_config_dir()
         load_secrets_env()
-        self._config_path = CONFIG_PATH
+        self._config_path = Path(config_path).expanduser() if config_path else CONFIG_PATH
 
     def load(self) -> AppConfig:
         """Load configuration from disk.

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -20,6 +20,19 @@ _LOG_MAX_BYTES = 2 * 1024 * 1024
 _LOG_BACKUP_COUNT = 5
 
 
+# Forwarded variables that reached this process as empty strings and were
+# removed before any SDK could read them. Filled by _prune_empty_env() at the
+# top of _main(); reported by _setup_logging() once a handler exists.
+_PRUNED_ENV_NAMES: tuple[str, ...] = ()
+
+
+def _prune_empty_env() -> None:
+    """Drop empty forwarded environment variables before dispatching."""
+    global _PRUNED_ENV_NAMES
+    from servonaut.mcp.installer import prune_empty_forwarded_env
+    _PRUNED_ENV_NAMES = prune_empty_forwarded_env()
+
+
 def _setup_logging(debug: bool = False) -> Path:
     """Configure logging to a size-rotated file (and optionally stderr).
 
@@ -59,6 +72,10 @@ def _setup_logging(debug: bool = False) -> Path:
     logging.getLogger('textual').setLevel(logging.WARNING)
 
     logging.getLogger(__name__).info("Servonaut started — log: %s", log_file)
+    if _PRUNED_ENV_NAMES:
+        logging.getLogger(__name__).info(
+            "Ignoring empty environment variables: %s", ", ".join(_PRUNED_ENV_NAMES)
+        )
     return log_file
 
 
@@ -753,6 +770,7 @@ def main() -> None:
 
 def _main() -> None:
     """Parse arguments and dispatch to the selected command."""
+    _prune_empty_env()
     parser = argparse.ArgumentParser(
         description='Servonaut — Interactive TUI for managing AWS EC2 SSH connections'
     )

--- a/src/servonaut/main.py
+++ b/src/servonaut/main.py
@@ -762,7 +762,8 @@ def _main() -> None:
     parser.add_argument('--debug', action='store_true',
                         help='Enable debug logging (also prints to stderr)')
     parser.add_argument('--config', type=str, default=None,
-                        help='Path to config file (default: ~/.servonaut/config.json)')
+                        help='Config file for the TUI (default: ~/.servonaut/config.json); '
+                             'other runtime files keep their usual location')
     parser.add_argument('--update', action='store_true',
                         help='Check for updates and upgrade if available')
     parser.add_argument('--install-desktop', action='store_true',
@@ -1050,7 +1051,7 @@ def _main() -> None:
 
     from servonaut.app import ServonautApp
     from servonaut.utils.native_stderr import redirect_native_stderr
-    app = ServonautApp()
+    app = ServonautApp(config_path=Path(args.config) if args.config else None)
     if args.demo:
         app.demo_mode = True
     # Native libraries (speech synthesis, PortAudio/ALSA) write straight

--- a/src/servonaut/mcp/installer.py
+++ b/src/servonaut/mcp/installer.py
@@ -32,6 +32,12 @@ class MCPInstallerError(RuntimeError):
 # Environment names are forwarded by reference, never by value. Provider SDK
 # names are stable public contracts; additional $ENV_VAR references are
 # discovered from the operator's Servonaut config at install time.
+#
+# A forwarded name that is unset when the agent starts arrives as an EMPTY
+# string (the references use ``${NAME:-}`` so the agent never refuses the
+# config). ``prune_empty_forwarded_env`` removes those at process start —
+# botocore, for one, treats ``AWS_PROFILE=""`` as a profile named "" and
+# fails every client.
 _BASE_FORWARD_ENV_VARS = (
     "SSH_AUTH_SOCK",
     "BW_SESSION",
@@ -209,6 +215,27 @@ def _required_forward_env_vars() -> tuple[str, ...]:
     return tuple(
         [*_BASE_FORWARD_ENV_VARS] + sorted(found.difference(_BASE_FORWARD_ENV_VARS))
     )
+
+
+def prune_empty_forwarded_env() -> tuple[str, ...]:
+    """Remove forwarded variables that reached this process as empty strings.
+
+    None of the forwarded names has a meaningful empty value, and several
+    break their SDK when empty (``AWS_PROFILE=""`` → ``ProfileNotFound`` on
+    every boto3 client, ``AWS_SHARED_CREDENTIALS_FILE=""`` → no shared
+    credentials, ``SERVONAUT_API_URL=""`` → an empty API base). Dropping
+    them restores each SDK's default behaviour.
+
+    Returns:
+        The names removed, in forward-list order, so the caller can log them
+        once logging is configured. Safe to call more than once.
+    """
+    pruned: list[str] = []
+    for name in _required_forward_env_vars():
+        if os.environ.get(name, None) == "":
+            del os.environ[name]
+            pruned.append(name)
+    return tuple(pruned)
 
 
 def _env_references(style: str) -> dict[str, str]:

--- a/src/servonaut/mcp/remote_client.py
+++ b/src/servonaut/mcp/remote_client.py
@@ -24,7 +24,7 @@ _DEFAULT_MCP_BASE = "https://mcp.servonaut.dev"
 
 def _mcp_base() -> str:
     """Read MCP base URL at call time so secrets loaded after import are picked up."""
-    return os.environ.get("SERVONAUT_MCP_URL", _DEFAULT_MCP_BASE)
+    return os.environ.get("SERVONAUT_MCP_URL") or _DEFAULT_MCP_BASE
 
 # Tools that always run locally (free tier)
 LOCAL_TOOLS = {

--- a/src/servonaut/mcp/server.py
+++ b/src/servonaut/mcp/server.py
@@ -21,6 +21,11 @@ def build_headless_tools(config_manager=None):
     storage, memory, secret provider) degrade to ``None`` exactly as the
     MCP server always has.
     """
+    from servonaut.mcp.installer import prune_empty_forwarded_env
+    pruned = prune_empty_forwarded_env()
+    if pruned:
+        logger.info("Ignoring empty environment variables: %s", ", ".join(pruned))
+
     from servonaut.config.manager import ConfigManager
     from servonaut.services.cache_service import CacheService
     from servonaut.services.aws_service import AWSService

--- a/src/servonaut/mcp/tools.py
+++ b/src/servonaut/mcp/tools.py
@@ -260,6 +260,17 @@ class ServonautTools:
             instances = [i for i in instances if i.get('state') == state]
 
         result = self._format_instances(instances)
+        for label, service in (
+            ("AWS", self._aws_service),
+            ("OVH", self._ovh_service),
+            ("Hetzner", self._hetzner_service),
+        ):
+            fetch_error = getattr(service, "last_fetch_error", None)
+            if isinstance(fetch_error, str) and fetch_error:
+                result += (
+                    f"\n\nWarning: the {label} inventory could not be refreshed "
+                    f"({fetch_error}); {label} rows come from the last successful fetch."
+                )
         self._audit.log('list_instances', {'region': region, 'state': state}, result, True)
         return result
 

--- a/src/servonaut/screens/_demo_resolve.py
+++ b/src/servonaut/screens/_demo_resolve.py
@@ -1,0 +1,39 @@
+"""Demo-mode resolution helpers for screens and widgets.
+
+Demo mode redacts the instance list in place, so a screen's row may carry a
+fake id and fake connection fields. ``ServonautApp.connection_instance`` /
+``real_instance_id`` map them back to the pristine record; these wrappers
+call them tolerantly so a screen keeps working against any app stand-in
+(tests, previews) that does not implement them.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def connection_instance(app: Any, instance: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The real record behind *instance*, or *instance* itself."""
+    if not isinstance(instance, dict):
+        return instance
+    resolver = getattr(app, "connection_instance", None)
+    if not callable(resolver):
+        return instance
+    try:
+        resolved = resolver(instance)
+    except Exception:  # noqa: BLE001 — a stand-in app must never break a screen
+        return instance
+    return resolved if isinstance(resolved, dict) else instance
+
+
+def real_instance_id(app: Any, instance_id: Optional[str]) -> Optional[str]:
+    """The real id behind a demo-mode fake, or *instance_id* itself."""
+    if not instance_id:
+        return instance_id
+    resolver = getattr(app, "real_instance_id", None)
+    if not callable(resolver):
+        return instance_id
+    try:
+        resolved = resolver(instance_id)
+    except Exception:  # noqa: BLE001
+        return instance_id
+    return resolved if isinstance(resolved, str) else instance_id

--- a/src/servonaut/screens/ai_analysis.py
+++ b/src/servonaut/screens/ai_analysis.py
@@ -23,7 +23,7 @@ from servonaut.utils.formatting import format_tokens_remaining
 from servonaut.utils.ssh_utils import run_ssh_subprocess
 from servonaut.widgets.progress_indicator import ProgressIndicator
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 logger = logging.getLogger(__name__)
 

--- a/src/servonaut/screens/ai_analysis.py
+++ b/src/servonaut/screens/ai_analysis.py
@@ -23,6 +23,7 @@ from servonaut.utils.formatting import format_tokens_remaining
 from servonaut.utils.ssh_utils import run_ssh_subprocess
 from servonaut.widgets.progress_indicator import ProgressIndicator
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +389,7 @@ class AIAnalysisScreen(Screen):
 
             # Resolve connection first to check host
             conn = service._resolve_connection(
-                self._instance,
+                connection_instance(self.app, self._instance),
                 self.app.ssh_service,
                 self.app.connection_service,
             )
@@ -496,7 +497,7 @@ class AIAnalysisScreen(Screen):
         try:
             service = self.app.log_viewer_service
             conn = service._resolve_connection(
-                self._instance,
+                connection_instance(self.app, self._instance),
                 self.app.ssh_service,
                 self.app.connection_service,
             )

--- a/src/servonaut/screens/command_overlay.py
+++ b/src/servonaut/screens/command_overlay.py
@@ -16,6 +16,7 @@ from textual.widgets import Input, Static
 from servonaut.screens._binding_guard import check_action_passthrough
 
 from servonaut.widgets.command_output import CommandOutput
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +88,11 @@ class CommandOverlay(ModalScreen):
     def on_mount(self) -> None:
         """Initialize connection details and focus input on mount."""
         # Resolve connection details — check for missing profiles
-        self._profile = self.app.connection_service.resolve_profile(self._instance)
+        # Demo mode redacts the row we display; connect to the real record.
+        conn = connection_instance(self.app, self._instance)
+        self._profile = self.app.connection_service.resolve_profile(conn)
         self._host = self.app.connection_service.get_target_host(
-            self._instance,
+            conn,
             self._profile
         )
         if self._profile:
@@ -97,24 +100,24 @@ class CommandOverlay(ModalScreen):
                 self._profile
             )
         self._extra_options = self.app.connection_service.get_extra_options(
-            self._instance, self._profile
+            conn, self._profile
         )
 
         # Warn if a connection rule matched but the profile is missing
         self._missing_profile = self._detect_missing_profile()
 
         config = self.app.config_manager.get()
-        if self._instance.get('is_custom'):
-            self._username = self._instance.get('username') or 'root'
-            self._key_path = self._instance.get('ssh_key') or self._instance.get('key_name') or None
+        if conn.get('is_custom'):
+            self._username = conn.get('username') or 'root'
+            self._key_path = conn.get('ssh_key') or conn.get('key_name') or None
         else:
             self._username = (
                 (self._profile.username if self._profile else None)
                 or config.default_username
             )
-            self._key_path = self.app.ssh_service.get_key_path(self._instance['id'])
-            if not self._key_path and self._instance.get('key_name'):
-                self._key_path = self.app.ssh_service.discover_key(self._instance['key_name'])
+            self._key_path = self.app.ssh_service.get_key_path(conn['id'])
+            if not self._key_path and conn.get('key_name'):
+                self._key_path = self.app.ssh_service.discover_key(conn['key_name'])
 
         # Load persisted history for this instance
         if self.app.command_history:

--- a/src/servonaut/screens/command_overlay.py
+++ b/src/servonaut/screens/command_overlay.py
@@ -16,7 +16,7 @@ from textual.widgets import Input, Static
 from servonaut.screens._binding_guard import check_action_passthrough
 
 from servonaut.widgets.command_output import CommandOutput
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 logger = logging.getLogger(__name__)
 

--- a/src/servonaut/screens/custom_servers.py
+++ b/src/servonaut/screens/custom_servers.py
@@ -227,12 +227,16 @@ class CustomServersScreen(Screen):
             return
 
         name = servers[row].name
+        shown = name
+        if self.app.demo_mode and self.app.redaction_service:
+            # The toast is on screen too: show the same fake name as the row.
+            shown = self.app.redaction_service.redact_name(name)
         if self.app.custom_server_service.remove_server(name):
             self._populate_table()
             self._refresh_app_instances()
-            self.app.notify(f"Removed server: {name}", severity="information")
+            self.app.notify(f"Removed server: {shown}", severity="information")
         else:
-            self.app.notify(f"Server '{name}' not found", severity="error")
+            self.app.notify(f"Server '{shown}' not found", severity="error")
 
     def _save_server(self) -> None:
         """Validate form and save the server."""
@@ -278,6 +282,12 @@ class CustomServersScreen(Screen):
             extra_ssh_options=extra_ssh_options,
         )
 
+        # Demo mode: what the operator typed on camera renders as typed.
+        if self.app.demo_mode and self.app.redaction_service:
+            self.app.redaction_service.keep_as_authored(
+                name, host, username, ssh_key, provider, group,
+            )
+
         # Try update first (if name already exists), else add
         if not self.app.custom_server_service.update_server(name, server):
             try:
@@ -292,9 +302,24 @@ class CustomServersScreen(Screen):
         self.app.notify(f"Saved server: {name}", severity="information")
 
     def _refresh_app_instances(self) -> None:
-        """Rebuild app.instances to include updated custom servers."""
-        aws_instances = [i for i in self.app.instances if not i.get('is_custom')]
-        self.app.instances = aws_instances + self.app.custom_server_service.list_as_instances()
+        """Rebuild app.instances to include updated custom servers.
+
+        Demo mode: the fresh custom rows are raw, so they go into the
+        pre-redaction snapshot first and are then redacted in place like the
+        rest of the list — otherwise a save or remove would put real names
+        back on the fleet table.
+        """
+        import copy
+        other_instances = [i for i in self.app.instances if not i.get('is_custom')]
+        custom = self.app.custom_server_service.list_as_instances()
+        pristine = getattr(self.app, "_instances_pristine", None)
+        if pristine is not None:
+            self.app._instances_pristine = [
+                i for i in pristine if not i.get('is_custom')
+            ] + copy.deepcopy(custom)
+        if self.app.demo_mode and self.app.redaction_service:
+            self.app.redaction_service.redact_instances(custom)
+        self.app.instances = other_instances + custom
 
     def action_back(self) -> None:
         """Navigate back to main menu."""

--- a/src/servonaut/screens/db_credential_scan.py
+++ b/src/servonaut/screens/db_credential_scan.py
@@ -27,6 +27,7 @@ from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,8 @@ class DbCredentialScanScreen(Screen):
         self._selected_token: str = ""
 
     def _instance_ref(self) -> str:
-        return str(self._instance.get("id") or self._instance.get("name") or "")
+        real = connection_instance(self.app, self._instance)
+        return str(real.get("id") or real.get("name") or "")
 
     def _custom_roots(self) -> List[str]:
         """Per-instance extra scan roots from config, if any."""
@@ -134,8 +136,9 @@ class DbCredentialScanScreen(Screen):
         """
         try:
             config = self.app.config_manager.get()
-            instance_id = str(self._instance.get("id") or "")
-            instance_name = str(self._instance.get("name") or "")
+            real = connection_instance(self.app, self._instance)
+            instance_id = str(real.get("id") or "")
+            instance_name = str(real.get("name") or "")
             profiles = config.db_profiles_for(instance_id, instance_name)
         except Exception:  # noqa: BLE001
             return set(), False

--- a/src/servonaut/screens/db_credential_scan.py
+++ b/src/servonaut/screens/db_credential_scan.py
@@ -27,7 +27,7 @@ from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 logger = logging.getLogger(__name__)
 

--- a/src/servonaut/screens/db_scan_roots.py
+++ b/src/servonaut/screens/db_scan_roots.py
@@ -25,6 +25,7 @@ from textual.widgets.option_list import Option
 
 from servonaut.widgets.remote_tree import RemoteTree
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,9 @@ class DbScanRootsScreen(Screen):
         if self._instance.get("is_custom"):
             username = self._instance.get("username") or "root"
         else:
-            profile = app.connection_service.resolve_profile(self._instance)
+            profile = app.connection_service.resolve_profile(
+                connection_instance(app, self._instance)
+            )
             username = (
                 (profile.username if profile else None)
                 or app.config_manager.get().default_username

--- a/src/servonaut/screens/db_scan_roots.py
+++ b/src/servonaut/screens/db_scan_roots.py
@@ -25,7 +25,7 @@ from textual.widgets.option_list import Option
 
 from servonaut.widgets.remote_tree import RemoteTree
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 logger = logging.getLogger(__name__)
 

--- a/src/servonaut/screens/file_browser.py
+++ b/src/servonaut/screens/file_browser.py
@@ -13,6 +13,8 @@ from servonaut.widgets.sidebar import Sidebar
 
 from servonaut.widgets.remote_tree import RemoteTree
 from servonaut.utils.match_utils import matches_conditions
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+
 
 if TYPE_CHECKING:
     from servonaut.services.scan_service import ScanService
@@ -44,6 +46,8 @@ def build_remote_tree(app, instance: dict, tree_id: str = "remote_tree") -> Remo
     default. Mirrors the original inline logic so behaviour is identical whether
     the tree is shown full-screen or embedded.
     """
+    # Demo mode redacts the row on screen; browse the real record.
+    instance = connection_instance(app, instance)
     config = app.config_manager.get()
     scan_paths = get_scan_paths_for_instance(config, instance)
     if instance.get('is_custom'):

--- a/src/servonaut/screens/file_browser.py
+++ b/src/servonaut/screens/file_browser.py
@@ -13,7 +13,7 @@ from servonaut.widgets.sidebar import Sidebar
 
 from servonaut.widgets.remote_tree import RemoteTree
 from servonaut.utils.match_utils import matches_conditions
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 
 if TYPE_CHECKING:

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -266,7 +266,14 @@ class InstanceListScreen(Screen):
                 self.app.instances = self._instances
                 self._update_table()
                 self._update_status_bar()
-                if new_ovh:
+                fetch_error = getattr(self.app.ovh_service, "last_fetch_error", None)
+                if isinstance(fetch_error, str) and fetch_error:
+                    self.app.notify(
+                        f"OVH refresh failed: {fetch_error}. Showing cached instances.",
+                        severity="warning",
+                        markup=False,
+                    )
+                elif new_ovh:
                     self.app.notify(
                         f"OVH refreshed: {len(new_ovh)} instances",
                         severity="information",
@@ -347,7 +354,17 @@ class InstanceListScreen(Screen):
                     self._update_table()
                     self._update_status_bar()
 
-                    if not new_instances:
+                    fetch_error = getattr(self.app.aws_service, "last_fetch_error", None)
+                    if isinstance(fetch_error, str) and fetch_error:
+                        # The service kept the previous cache; the rows on
+                        # screen are stale, not the truth. markup=False:
+                        # the text carries an SDK error string.
+                        self.app.notify(
+                            f"AWS refresh failed: {fetch_error}. Showing cached instances.",
+                            severity="warning",
+                            markup=False,
+                        )
+                    elif not new_instances:
                         self.app.notify(
                             "No EC2 instances found in any region.",
                             severity="information"

--- a/src/servonaut/screens/instance_list.py
+++ b/src/servonaut/screens/instance_list.py
@@ -18,6 +18,7 @@ from servonaut.widgets.progress_indicator import ProgressIndicator
 from servonaut.widgets.sidebar import Sidebar
 
 from typing import TYPE_CHECKING
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 if TYPE_CHECKING:
     from servonaut.app import ServonautApp
 
@@ -225,6 +226,21 @@ class InstanceListScreen(Screen):
             exclusive=False,
         )
 
+    def _replace_pristine_rows(self, flag: str, rows: list) -> None:
+        """Keep the pre-redaction snapshot in step with a provider refresh.
+
+        ``app.connection_instance`` finds the real record by fake id in that
+        snapshot, so rows fetched after startup must land there too — before
+        they are redacted in place.
+        """
+        import copy
+        pristine = self.app._instances_pristine
+        if pristine is None:
+            return
+        self.app._instances_pristine = [
+            i for i in pristine if not i.get(flag)
+        ] + copy.deepcopy(rows)
+
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         """Handle worker state changes.
 
@@ -242,6 +258,7 @@ class InstanceListScreen(Screen):
                 # Redact the fresh OVH data before merging — only new_ovh is
                 # raw here; non_ovh was already redacted on its own refresh.
                 if self.app.demo_mode and self.app.redaction_service:
+                    self._replace_pristine_rows('is_ovh', new_ovh)
                     self.app.redaction_service.redact_instances(new_ovh)
                 # Rebuild instance list: AWS+custom + fresh OVH data
                 non_ovh = [i for i in self._instances if not i.get('is_ovh')]
@@ -272,6 +289,7 @@ class InstanceListScreen(Screen):
                 # Redact the fresh Hetzner data before merging — only
                 # new_hetzner is raw; non_hetzner was already redacted.
                 if self.app.demo_mode and self.app.redaction_service:
+                    self._replace_pristine_rows('is_hetzner', new_hetzner)
                     self.app.redaction_service.redact_instances(new_hetzner)
                 non_hetzner = [
                     i for i in self._instances if not i.get('is_hetzner')
@@ -621,7 +639,7 @@ class InstanceListScreen(Screen):
     async def _open_ssh_ref_editor(self, instance: dict) -> None:
         from servonaut.screens.ssh_ref_editor import SshRefEditorModal
         provider = (instance.get("provider") or "aws").lower()
-        instance_id = instance.get("id")
+        instance_id = real_instance_id(self.app, instance.get("id"))
         existing = None
         try:
             existing = await self.app.bw_ssh_config_service.get_personal_instance_ref(
@@ -694,6 +712,9 @@ class InstanceListScreen(Screen):
         instance = self._get_selected_running_instance()
         if not instance:
             return
+        display = instance
+        # Demo mode redacts rows in place; connect to the real record.
+        instance = connection_instance(self.app, display)
 
         try:
             profile = self.app.connection_service.resolve_profile(instance)
@@ -755,10 +776,10 @@ class InstanceListScreen(Screen):
             )
 
             if self.app.terminal_service.launch_ssh_in_terminal(ssh_cmd):
-                name = instance.get('name') or instance.get('id', 'instance')
+                name = display.get('name') or display.get('id', 'instance')
                 via = f" via {profile.bastion_host}" if profile and profile.bastion_host else ""
                 self.app.notify(f"SSH session launched for {name}{via}")
-                self._maybe_show_memory_prompt(instance)
+                self._maybe_show_memory_prompt(display)
                 try:
                     self._maybe_pull_annotations(instance)
                 except Exception:

--- a/src/servonaut/screens/key_management.py
+++ b/src/servonaut/screens/key_management.py
@@ -87,17 +87,20 @@ class KeyManagementScreen(Screen):
         config = self.app.config_manager.get()
         default_key = config.default_key
 
-        def _s(x: str) -> str:
+        def _k(x: str) -> str:
+            # Key paths carry real names; show the same fake the fleet uses.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_key_name(x)
             return x
 
         if default_key:
             self.query_one("#current_default_key", Static).update(
-                f"Current: [bold]{_s(default_key)}[/bold]"
+                f"Current: [bold]{_k(default_key)}[/bold]"
             )
-            # Pre-fill input with current default
-            self.query_one("#input_default_key", Input).value = default_key
+            # Pre-fill input with current default — not in demo mode, where
+            # the editable field would put the real path on screen.
+            if not (self.app.demo_mode and self.app.redaction_service):
+                self.query_one("#input_default_key", Input).value = default_key
         else:
             self.query_one("#current_default_key", Static).update(
                 "[dim]Not set[/dim]"
@@ -112,15 +115,22 @@ class KeyManagementScreen(Screen):
         table.clear(columns=True)
         table.add_columns("Instance ID", "Key Path", "Actions")
 
-        def _s(x: str) -> str:
+        def _k(x: str) -> str:
+            # Key paths carry real names; show the same fake the fleet uses.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_key_name(x)
+            return x
+
+        def _i(x: str) -> str:
+            # Same fake id the fleet table shows for this instance.
+            if self.app.demo_mode and self.app.redaction_service:
+                return self.app.redaction_service.redact_instance_id(x)
             return x
 
         # Add mappings
         if config.instance_keys:
             for instance_id, key_path in config.instance_keys.items():
-                table.add_row(_s(instance_id), _s(key_path), "[Remove]")
+                table.add_row(_i(instance_id), _k(key_path), "[Remove]")
         else:
             # Show empty state
             table.add_row("[dim]No instance-specific keys configured[/dim]", "", "")
@@ -166,15 +176,16 @@ class KeyManagementScreen(Screen):
         table.clear(columns=True)
         table.add_columns("Key Path")
 
-        def _s(x: str) -> str:
+        def _k(x: str) -> str:
+            # Key paths carry real names; show the same fake the fleet uses.
             if self.app.demo_mode and self.app.redaction_service:
-                return self.app.redaction_service.scrub_stream(x)
+                return self.app.redaction_service.redact_key_name(x)
             return x
 
         # Add keys
         if keys:
             for key_path in keys:
-                table.add_row(_s(key_path))
+                table.add_row(_k(key_path))
         else:
             table.add_row("[dim]No SSH keys found in ~/.ssh/[/dim]")
 

--- a/src/servonaut/screens/log_picker.py
+++ b/src/servonaut/screens/log_picker.py
@@ -12,7 +12,7 @@ from textual.screen import ModalScreen, Screen
 from textual.timer import Timer
 from textual.widgets import Button, Footer, Header, Input, Label, OptionList, Static
 from textual.widgets.option_list import Option
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 if TYPE_CHECKING:
     from servonaut.services.log_viewer_service import LogViewerService

--- a/src/servonaut/screens/log_picker.py
+++ b/src/servonaut/screens/log_picker.py
@@ -12,6 +12,7 @@ from textual.screen import ModalScreen, Screen
 from textual.timer import Timer
 from textual.widgets import Button, Footer, Header, Input, Label, OptionList, Static
 from textual.widgets.option_list import Option
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 if TYPE_CHECKING:
     from servonaut.services.log_viewer_service import LogViewerService
@@ -673,7 +674,8 @@ class BrowseRemoteScreen(Screen[str]):
         from servonaut.widgets.remote_tree import RemoteTree
         from servonaut.services.log_viewer_service import LogViewerService
 
-        instance = self._instance
+        # Demo mode redacts the row on screen; browse the real record.
+        instance = connection_instance(self.app, self._instance)
         ssh_service = self.app.ssh_service
         connection_service = self.app.connection_service
         profile = connection_service.resolve_profile(instance)

--- a/src/servonaut/screens/log_viewer.py
+++ b/src/servonaut/screens/log_viewer.py
@@ -28,6 +28,7 @@ from servonaut.screens.log_picker import (
     REMOVE_PATH_SENTINEL,
     EDIT_PATH_SENTINEL,
 )
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,10 @@ class LogViewerScreen(Screen):
         self._reader_thread: Optional[threading.Thread] = None
         self._flush_timer = None
 
+    def _connection_instance(self) -> dict:
+        """The real record behind the (possibly demo-redacted) row we show."""
+        return connection_instance(self.app, self._instance)
+
     def compose(self) -> ComposeResult:
         name = self._instance.get("name") or self._instance.get("id", "unknown")
         yield Header()
@@ -146,7 +151,7 @@ class LogViewerScreen(Screen):
 
         try:
             available = await self.app.log_viewer_service.probe_log_paths(
-                self._instance,
+                self._connection_instance(),
                 self.app.ssh_service,
                 self.app.connection_service,
             )
@@ -175,7 +180,7 @@ class LogViewerScreen(Screen):
         """Scan remote directories in the background to discover more log files."""
         try:
             discovered = await self.app.log_viewer_service.scan_log_directories(
-                self._instance,
+                self._connection_instance(),
                 self.app.ssh_service,
                 self.app.connection_service,
             )
@@ -227,7 +232,7 @@ class LogViewerScreen(Screen):
         read_cmd = service.get_read_command(log_path, config.log_viewer_tail_lines)
 
         conn = service._resolve_connection(
-            self._instance,
+            self._connection_instance(),
             self.app.ssh_service,
             self.app.connection_service,
         )
@@ -532,7 +537,7 @@ class LogViewerScreen(Screen):
     def action_manage_paths(self) -> None:
         """Open the manage custom paths modal directly."""
         self._pause_stream_for_modal()
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
         current_paths = self.app.log_viewer_service.get_custom_paths(instance_id)
         self.app.push_screen(
             ManagePathsModal(
@@ -598,7 +603,7 @@ class LogViewerScreen(Screen):
 
     def _save_and_switch(self, path: str) -> None:
         """Save a path as custom and switch to viewing it."""
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
         service = self.app.log_viewer_service
         existing = service.get_custom_paths(instance_id)
         if path not in existing:
@@ -621,7 +626,7 @@ class LogViewerScreen(Screen):
 
     def _edit_custom_path(self, old_path: str, new_path: str) -> None:
         """Replace old_path with new_path in custom paths config."""
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
         service = self.app.log_viewer_service
         existing = service.get_custom_paths(instance_id)
         if old_path in existing:
@@ -641,7 +646,7 @@ class LogViewerScreen(Screen):
 
     def _remove_custom_path(self, path: str) -> None:
         """Remove a custom path from config and available logs."""
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
         service = self.app.log_viewer_service
         existing = service.get_custom_paths(instance_id)
         if path in existing:
@@ -701,7 +706,7 @@ class LogViewerScreen(Screen):
         if result is None:
             return
 
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
         service = self.app.log_viewer_service
         existing = service.get_custom_paths(instance_id)
         if result not in existing:

--- a/src/servonaut/screens/main_menu.py
+++ b/src/servonaut/screens/main_menu.py
@@ -12,6 +12,7 @@ from textual.widgets import Static, Button, Header, Footer
 
 from servonaut.widgets.progress_indicator import ProgressIndicator
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 
 class MainMenuScreen(Screen):
@@ -197,10 +198,13 @@ class MainMenuScreen(Screen):
             progress.start(f"Scanning {idx}/{total}: {name}...")
             try:
                 results = await self.app.scan_service.scan_server(
-                    instance, self.app.ssh_service, self.app.connection_service
+                    connection_instance(self.app, instance),
+                    self.app.ssh_service, self.app.connection_service
                 )
                 if results:
-                    self.app.keyword_store.save_results(instance['id'], results)
+                    self.app.keyword_store.save_results(
+                        real_instance_id(self.app, instance['id']), results
+                    )
                     scanned += 1
             except Exception as e:
                 self.app.notify(f"Scan failed for {name}: {e}", severity="error")

--- a/src/servonaut/screens/scan_results.py
+++ b/src/servonaut/screens/scan_results.py
@@ -11,7 +11,7 @@ from textual.widgets import Header, Footer, Static, Button, DataTable
 from textual.worker import Worker
 
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 
 class ScanResultsScreen(Screen):

--- a/src/servonaut/screens/scan_results.py
+++ b/src/servonaut/screens/scan_results.py
@@ -11,6 +11,7 @@ from textual.widgets import Header, Footer, Static, Button, DataTable
 from textual.worker import Worker
 
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 
 class ScanResultsScreen(Screen):
@@ -127,7 +128,7 @@ class ScanResultsScreen(Screen):
         # Run scan in worker
         self.run_worker(
             self.app.scan_service.scan_server(
-                self._instance,
+                connection_instance(self.app, self._instance),
                 self.app.ssh_service,
                 self.app.connection_service
             ),

--- a/src/servonaut/screens/scp_transfer.py
+++ b/src/servonaut/screens/scp_transfer.py
@@ -11,6 +11,7 @@ from textual.widgets import Header, Footer, Static, Input, Button, RadioSet, Rad
 from textual.worker import Worker
 
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 
 class SCPTransferScreen(Screen):
@@ -139,21 +140,23 @@ class SCPTransferScreen(Screen):
         # Update status
         status_output.update(f"[yellow]Preparing {self._transfer_direction}...[/yellow]")
 
-        # Resolve connection profile
-        profile = self.app.connection_service.resolve_profile(self._instance)
+        # Resolve connection profile — demo mode redacts the row we display,
+        # so transfer against the real record.
+        conn = connection_instance(self.app, self._instance)
+        profile = self.app.connection_service.resolve_profile(conn)
 
         # Get SSH key
-        key_path = self.app.ssh_service.get_key_path(self._instance['id'])
-        if not key_path and self._instance.get('key_name'):
-            key_path = self.app.ssh_service.discover_key(self._instance['key_name'])
+        key_path = self.app.ssh_service.get_key_path(conn['id'])
+        if not key_path and conn.get('key_name'):
+            key_path = self.app.ssh_service.discover_key(conn['key_name'])
 
         # Get target host and proxy args
-        host = self.app.connection_service.get_target_host(self._instance, profile)
+        host = self.app.connection_service.get_target_host(conn, profile)
         proxy_args = []
         if profile:
             proxy_args = self.app.connection_service.get_proxy_args(profile)
         extra_options = self.app.connection_service.get_extra_options(
-            self._instance, profile
+            conn, profile
         )
 
         # Get username from profile or use default

--- a/src/servonaut/screens/scp_transfer.py
+++ b/src/servonaut/screens/scp_transfer.py
@@ -11,7 +11,7 @@ from textual.widgets import Header, Footer, Static, Input, Button, RadioSet, Rad
 from textual.worker import Worker
 
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 
 class SCPTransferScreen(Screen):

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -18,7 +18,7 @@ from textual.widgets import Static, Button, Header, Footer
 from servonaut.utils.live_stats import LIVE_STATS_COMMAND, LiveStats, parse_live_stats
 from servonaut.utils.memory_panel import render_memory_panel
 from servonaut.widgets.sidebar import Sidebar
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import connection_instance
 
 #: Seconds between live-stats polls while the panel is active.
 _LIVE_STATS_INTERVAL = 3.0
@@ -1131,6 +1131,14 @@ class ServerActionsScreen(Screen):
         from servonaut.screens.findings import FindingsScreen
         self.app.push_screen(FindingsScreen(instance=self._instance))
 
+    def _display_host(self) -> str:
+        """The address as shown on this screen — a demo-mode fake when redacted."""
+        return (
+            self._instance.get("public_ip")
+            or self._instance.get("private_ip")
+            or self._instance.get("id", "")
+        )
+
     def action_manage_ssh_ref(self) -> None:
         """Push SshRefEditorModal directly to add/edit/delete the BW SSH ref."""
         self.run_worker(
@@ -1216,6 +1224,9 @@ class ServerActionsScreen(Screen):
             or conn.get("private_ip")
             or instance_id
         )
+        # The confirm dialog is on screen: it shows the row as displayed
+        # (a demo-mode fake); the probe itself uses the real host above.
+        shown_host = self._display_host()
 
         # Check if a BW ref is stored for this instance.
         try:
@@ -1244,7 +1255,7 @@ class ServerActionsScreen(Screen):
 
         # Push the confirm modal and await user's choice.
         confirmed = await self.app.push_screen_wait(
-            ConfirmSshVerifyModal(host=host, has_ref=has_ref)
+            ConfirmSshVerifyModal(host=shown_host, has_ref=has_ref)
         )
         if not confirmed:
             return

--- a/src/servonaut/screens/server_actions.py
+++ b/src/servonaut/screens/server_actions.py
@@ -18,6 +18,7 @@ from textual.widgets import Static, Button, Header, Footer
 from servonaut.utils.live_stats import LIVE_STATS_COMMAND, LiveStats, parse_live_stats
 from servonaut.utils.memory_panel import render_memory_panel
 from servonaut.widgets.sidebar import Sidebar
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 #: Seconds between live-stats polls while the panel is active.
 _LIVE_STATS_INTERVAL = 3.0
@@ -789,7 +790,8 @@ class ServerActionsScreen(Screen):
         )
         from servonaut.utils.ephemeral_key import persistent_bw_ssh_key
 
-        instance = self._instance
+        # Demo mode redacts the row we display; connect to the real record.
+        instance = connection_instance(self.app, self._instance)
         name = instance.get("name") or instance.get("id", "instance")
 
         # ------------------------------------------------------------------
@@ -1147,8 +1149,9 @@ class ServerActionsScreen(Screen):
             )
             return
 
-        provider = self._instance.get("provider", "aws").lower()
-        instance_id = self._instance.get("id")
+        conn = connection_instance(self.app, self._instance)
+        provider = conn.get("provider", "aws").lower()
+        instance_id = conn.get("id")
 
         try:
             existing = await self.app.bw_ssh_config_service.get_personal_instance_ref(
@@ -1205,11 +1208,12 @@ class ServerActionsScreen(Screen):
             )
             return
 
-        provider = self._instance.get("provider", "aws").lower()
-        instance_id = self._instance.get("id", "")
+        conn = connection_instance(self.app, self._instance)
+        provider = conn.get("provider", "aws").lower()
+        instance_id = conn.get("id", "")
         host = (
-            self._instance.get("public_ip")
-            or self._instance.get("private_ip")
+            conn.get("public_ip")
+            or conn.get("private_ip")
             or instance_id
         )
 

--- a/src/servonaut/screens/ssh_ref_editor.py
+++ b/src/servonaut/screens/ssh_ref_editor.py
@@ -15,6 +15,7 @@ from textual.widgets import Button, Collapsible, Input, Label, Static
 from servonaut.screens.bw_item_picker import BwItemPickerModal
 from servonaut.services.bw_ssh_config_service import BITWARDEN_PM_PROVIDER
 from servonaut.utils.validation import validate_instance_id, ValidationError
+from servonaut.screens._demo_resolve import connection_instance, real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -249,7 +250,7 @@ class SshRefEditorModal(ModalScreen[bool]):
             return
 
         provider = self._instance.get("provider", "aws").lower()
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
 
         ssh_credential_ref: dict = {"item_id": item_id_value}
         if collection_id_value:
@@ -304,7 +305,7 @@ class SshRefEditorModal(ModalScreen[bool]):
             return
 
         provider = self._instance.get("provider", "aws").lower()
-        instance_id = self._instance.get("id", "")
+        instance_id = real_instance_id(self.app, self._instance.get("id", ""))
 
         try:
             await bw_service.delete_personal_instance_ref(

--- a/src/servonaut/screens/ssh_ref_editor.py
+++ b/src/servonaut/screens/ssh_ref_editor.py
@@ -15,7 +15,7 @@ from textual.widgets import Button, Collapsible, Input, Label, Static
 from servonaut.screens.bw_item_picker import BwItemPickerModal
 from servonaut.services.bw_ssh_config_service import BITWARDEN_PM_PROVIDER
 from servonaut.utils.validation import validate_instance_id, ValidationError
-from servonaut.screens._demo_resolve import connection_instance, real_instance_id
+from servonaut.screens._demo_resolve import real_instance_id
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +84,22 @@ class SshRefEditorModal(ModalScreen[bool]):
         existing_collection_id = ref.get("collection_id", "") if isinstance(ref, dict) else ""
         existing_vault_url = ref.get("vault_url", "") if isinstance(ref, dict) else ""
 
+        # Demo mode: the stored ids identify the operator's vault records.
+        # Show a same-shaped fake on the Selected line and leave the editable
+        # fields empty — a save with an empty item id is rejected, so the
+        # stored ref cannot be overwritten with the fake.
+        redaction = getattr(self.app, "redaction_service", None)
+        self._demo = bool(getattr(self.app, "demo_mode", False) and redaction)
+        if self._demo:
+            shown_item_id = redaction.redact_instance_id(existing_item_id) if existing_item_id else ""
+            existing_item_id = existing_collection_id = existing_vault_url = ""
+        else:
+            shown_item_id = existing_item_id
+
         # Pre-existing ref: we only persisted the UUID, so show it on the
         # Selected line until/unless the user re-picks from the vault.
-        if existing_item_id:
-            self._selected_item_name = existing_item_id
+        if shown_item_id:
+            self._selected_item_name = shown_item_id
 
         buttons: list = [
             Button("Cancel", variant="default", id="cancel_btn"),
@@ -153,6 +165,10 @@ class SshRefEditorModal(ModalScreen[bool]):
         inner = cfg.get("config") or {}
         self._default_vault_url = inner.get("vault_url", "") or ""
         self._default_collection_id = inner.get("default_collection_id", "") or ""
+        if getattr(self, "_demo", False):
+            # Same reasoning as the stored ids: keep the vault URL and the
+            # collection id off the editable fields while recording.
+            return
         try:
             vault_input = self.query_one("#vault_url", Input)
             if not vault_input.value and self._default_vault_url:

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -1167,6 +1167,11 @@ class AIToolBridge(_FloorDangerousMixin):
             or call.args.get("target_server_id")
             or ""
         )
+        # Demo mode: the model reasons over redacted rows and names servers
+        # by fake id; the relay needs the real one.
+        resolver = getattr(self, "instance_id_resolver", None)
+        if callable(resolver) and target:
+            target = resolver(str(target))
         ttl = int(call.args.get("ttl_seconds") or self._default_ttl_seconds)
 
         # Build the relay payload. Args we forward verbatim by tool:

--- a/src/servonaut/services/api_client.py
+++ b/src/servonaut/services/api_client.py
@@ -39,7 +39,7 @@ _TEAM_SLUG_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 def _api_base() -> str:
     """Read API base URL at call time so secrets loaded after import are picked up."""
-    return os.environ.get("SERVONAUT_API_URL", _DEFAULT_API_BASE)
+    return os.environ.get("SERVONAUT_API_URL") or _DEFAULT_API_BASE
 
 
 class APIError(Exception):

--- a/src/servonaut/services/auth_service.py
+++ b/src/servonaut/services/auth_service.py
@@ -28,7 +28,7 @@ CLIENT_ID = "servonaut-cli"
 
 def _api_base() -> str:
     """Read API base URL at call time so secrets loaded after import are picked up."""
-    return os.environ.get("SERVONAUT_API_URL", _DEFAULT_API_BASE)
+    return os.environ.get("SERVONAUT_API_URL") or _DEFAULT_API_BASE
 ENTITLEMENT_TTL = 3600  # 1 hour cache
 # Stale-while-revalidate window for the per-team
 # ``GET /api/v1/teams/{slug}/secrets-config`` response. Deliberately

--- a/src/servonaut/services/aws_service.py
+++ b/src/servonaut/services/aws_service.py
@@ -27,6 +27,15 @@ class AWSNotConfiguredError(AWSError):
     """Raised when AWS credentials or region are not configured."""
 
 
+class AWSFetchError(AWSError):
+    """Raised when the instance inventory could not be fetched at all.
+
+    Separates "AWS answered with zero instances" (a valid, cacheable result)
+    from "the call never succeeded" (profile, credentials, network), so a
+    failed refresh is never persisted as an empty fleet.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Module-level compiled regexes for input validation
 # ---------------------------------------------------------------------------
@@ -51,6 +60,11 @@ class AWSService(InstanceServiceInterface):
             cache_service: Cache service instance for instance data.
         """
         self.cache_service = cache_service
+        # Why the last refresh could not be trusted, or None after a complete
+        # successful fetch. Surfaces (TUI notify, MCP list_instances) read it
+        # to tell the operator they are looking at cached data.
+        self.last_fetch_error: Optional[str] = None
+        self._failed_regions: List[str] = []
 
     async def fetch_instances(self) -> List[dict]:
         """Fetch instances from AWS across all regions.
@@ -58,6 +72,10 @@ class AWSService(InstanceServiceInterface):
         Returns:
             List of instance dictionaries with keys: id, name, type, state,
             public_ip, private_ip, region, key_name.
+
+        Raises:
+            AWSFetchError: the region list could not be read or every region
+                failed. Callers must not treat that as "no instances".
         """
         logger.debug("Fetching instances from AWS")
 
@@ -84,7 +102,31 @@ class AWSService(InstanceServiceInterface):
                 logger.debug(f"Using cached instances (age: {self.cache_service.get_age()})")
                 return cached
 
-        instances = await self.fetch_instances()
+        try:
+            instances = await self.fetch_instances()
+        except AWSFetchError as exc:
+            self.last_fetch_error = str(exc)
+            stale = self.cache_service.load_any()
+            if stale is not None:
+                logger.warning(
+                    "AWS fetch failed (%s); keeping %d cached instances",
+                    exc, len(stale),
+                )
+                return stale
+            logger.warning("AWS fetch failed (%s); no cached instances to fall back on", exc)
+            return []
+
+        if self._failed_regions:
+            # A partial inventory is shown but never persisted: writing it
+            # would silently drop every instance in the failed regions.
+            self.last_fetch_error = (
+                f"{len(self._failed_regions)} region(s) failed: "
+                + ", ".join(self._failed_regions)
+            )
+            logger.warning("AWS fetch incomplete (%s); cache left untouched", self.last_fetch_error)
+            return instances
+
+        self.last_fetch_error = None
         self.cache_service.save(instances)
         return instances
 
@@ -94,23 +136,29 @@ class AWSService(InstanceServiceInterface):
         Returns:
             List of instance dictionaries.
         """
+        self._failed_regions = []
         try:
             ec2_client = boto3.client('ec2')
             regions = [region['RegionName'] for region in ec2_client.describe_regions()['Regions']]
         except Exception as e:
             logger.error(f"Error fetching AWS regions: {e}")
-            return []
+            raise AWSFetchError(f"could not list AWS regions: {e}") from e
 
-        instances = []
+        instances: List[dict] = []
+        last_error: Optional[Exception] = None
         for region in regions:
             try:
                 logger.debug(f"Fetching instances from region: {region}")
-                region_instances = self._fetch_region(region)
-                instances.extend(region_instances)
+                instances.extend(self._fetch_region(region))
             except Exception as e:
                 logger.error(f"Error fetching instances from {region}: {e}")
-                continue
+                self._failed_regions.append(region)
+                last_error = e
 
+        if regions and len(self._failed_regions) == len(regions):
+            raise AWSFetchError(
+                f"all {len(regions)} AWS regions failed: {last_error}"
+            ) from last_error
         return instances
 
     def _fetch_region(self, region: str) -> List[dict]:
@@ -122,19 +170,14 @@ class AWSService(InstanceServiceInterface):
         Returns:
             List of instance dictionaries for this region.
         """
-        try:
-            ec2 = boto3.resource('ec2', region_name=region)
-            region_instances = []
+        ec2 = boto3.resource('ec2', region_name=region)
+        region_instances = []
 
-            for instance in ec2.instances.all():
-                instance_data = self._extract_instance_data(instance, region)
-                region_instances.append(instance_data)
+        for instance in ec2.instances.all():
+            instance_data = self._extract_instance_data(instance, region)
+            region_instances.append(instance_data)
 
-            return region_instances
-
-        except Exception as e:
-            logger.error(f"Error fetching instances from region {region}: {e}")
-            return []
+        return region_instances
 
     def _extract_instance_data(self, instance, region: str) -> dict:
         """Extract instance data into standardized dictionary.

--- a/src/servonaut/services/memory/service.py
+++ b/src/servonaut/services/memory/service.py
@@ -17,7 +17,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from .interfaces import MemoryServiceInterface, MemoryModuleMissingError, ModuleProberInterface, ModuleResult
 from .redaction import default_redactor, noop_redactor, scan_for_secrets
@@ -187,6 +187,11 @@ class MemoryService(MemoryServiceInterface):
         self._probers: List[ModuleProberInterface] = probers or []
         self._ssh_service = ssh_service
         self._connection_service = connection_service
+        # Demo mode resolvers (identity until the app wires them): every
+        # instance dict / id entering the public surface is mapped back to
+        # the real record before probes, storage keys or the sync queue.
+        self._resolve_instance: Callable[[Dict[str, Any]], Dict[str, Any]] = lambda inst: inst
+        self._resolve_id: Callable[[str], str] = lambda instance_id: instance_id
         # Optional sync service hook — set after construction via set_sync_service()
         # to break circular dependency (MemoryService ↔ MemorySyncService).
         self._sync_service: Optional["_MemorySyncService"] = None
@@ -205,6 +210,7 @@ class MemoryService(MemoryServiceInterface):
         Legacy API — returns only the successful modules.  New callers that
         need per-module failure reasons should use :meth:`build_report`.
         """
+        instance = self._resolve_instance(instance)
         report = await self.build_report(instance, modules)
         return report.successes
 
@@ -228,6 +234,7 @@ class MemoryService(MemoryServiceInterface):
             ``BuildReport`` with per-module successes, failures, and an
             ``overall_reason`` code when the report produced zero successes.
         """
+        instance = self._resolve_instance(instance)
         instance_id = instance.get("id") or instance.get("name", "")
         provider = instance.get("provider", "custom")
         name = instance.get("name", instance_id)
@@ -338,6 +345,7 @@ class MemoryService(MemoryServiceInterface):
         For T1 this is identical to ``build``.  T2 may add staleness checks
         to skip fresh modules.
         """
+        instance = self._resolve_instance(instance)
         return await self.build(instance, modules)
 
     async def refresh_report(
@@ -346,6 +354,7 @@ class MemoryService(MemoryServiceInterface):
         modules: Optional[List[str]] = None,
     ) -> BuildReport:
         """Re-probe with full success/failure reporting (see ``build_report``)."""
+        instance = self._resolve_instance(instance)
         return await self.build_report(instance, modules)
 
     def get(
@@ -355,6 +364,7 @@ class MemoryService(MemoryServiceInterface):
         provider: str = "custom",
     ) -> Optional[Dict[str, Any]]:
         """Return stored JSON dict for *module* on *instance_id*, or ``None``."""
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_module(instance_id, module, provider)
 
     async def get_summary(
@@ -375,6 +385,7 @@ class MemoryService(MemoryServiceInterface):
         Returns:
             Markdown summary string, never exceeding ``max_tokens * 4`` chars.
         """
+        instance_meta = self._resolve_instance(instance_meta)
         summary = build_summary_markdown(
             store=self._store,
             instance_meta=instance_meta,
@@ -397,6 +408,7 @@ class MemoryService(MemoryServiceInterface):
         Returns:
             Path to the written ``summary.md`` file.
         """
+        instance_meta = self._resolve_instance(instance_meta)
         summary = await self.get_summary(instance_meta)
         instance_id = instance_meta.get("id") or instance_meta.get("name", "")
         provider = instance_meta.get("provider", "custom")
@@ -409,6 +421,7 @@ class MemoryService(MemoryServiceInterface):
         provider: str = "custom",
     ) -> None:
         """Delete stored memory for *instance_id*."""
+        instance_id = self._resolve_id(instance_id)
         self._store.clear(instance_id, modules, provider)
 
     async def pin(
@@ -434,6 +447,7 @@ class MemoryService(MemoryServiceInterface):
             MemoryModuleMissingError: If no stored data exists for *module*.
             ValueError: If *instance_id* or *module* fails safety validation.
         """
+        instance_id = self._resolve_id(instance_id)
         from .store import _validate_module_name  # noqa: PLC0415
         _validate_module_name(module)
         data = self._store.get_module(instance_id, module, provider)
@@ -503,6 +517,7 @@ class MemoryService(MemoryServiceInterface):
         Returns:
             List of stale module name strings.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.stale_modules(instance_id, self._config, provider)
 
     def get_all_modules(
@@ -514,6 +529,7 @@ class MemoryService(MemoryServiceInterface):
             instance_id: Instance identifier.
             provider: Provider slug.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_all_modules(instance_id, provider)
 
     def get_annotations_path(
@@ -525,6 +541,7 @@ class MemoryService(MemoryServiceInterface):
             instance_id: Instance identifier.
             provider: Provider slug.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_annotations_path(instance_id, provider)
 
     def read_annotations(self, instance_id: str, provider: str = "custom") -> str:
@@ -536,6 +553,7 @@ class MemoryService(MemoryServiceInterface):
             instance_id: Instance identifier.
             provider: Provider slug.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.read_annotations(instance_id, provider)
 
     def write_annotations(
@@ -550,6 +568,7 @@ class MemoryService(MemoryServiceInterface):
             content: Raw annotation text to write.
             provider: Provider slug.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.write_annotations(instance_id, content, provider)
 
     def get_annotations_meta(self, instance_id: str) -> Dict[str, Any]:
@@ -560,6 +579,7 @@ class MemoryService(MemoryServiceInterface):
         Args:
             instance_id: Instance identifier.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_annotations_meta(instance_id)
 
     def set_annotations_meta(
@@ -580,6 +600,7 @@ class MemoryService(MemoryServiceInterface):
             annotations_synced_at: ISO-8601 timestamp of last successful sync.
             annotations_modified_at: ISO-8601 timestamp of last local modification.
         """
+        instance_id = self._resolve_id(instance_id)
         self._store.set_annotations_meta(
             instance_id,
             annotations_hash=annotations_hash,
@@ -621,6 +642,7 @@ class MemoryService(MemoryServiceInterface):
             include_superseded: When ``False`` (default), superseded findings
                 are excluded.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.list_findings(
             instance_id, provider, include_superseded=include_superseded
         )
@@ -640,6 +662,7 @@ class MemoryService(MemoryServiceInterface):
             finding_id: Finding identifier.
             provider: Provider slug.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_finding(instance_id, finding_id, provider)
 
     def get_findings_meta(self, instance_id: str) -> Dict[str, Any]:
@@ -650,6 +673,7 @@ class MemoryService(MemoryServiceInterface):
         Args:
             instance_id: Instance identifier.
         """
+        instance_id = self._resolve_id(instance_id)
         return self._store.get_findings_meta(instance_id)
 
     def set_findings_meta(self, instance_id: str, **kw: Any) -> None:
@@ -662,6 +686,7 @@ class MemoryService(MemoryServiceInterface):
             **kw: Forwarded to ``MemoryStore.set_findings_meta``
                 (``findings_count``, ``findings_synced_at``).
         """
+        instance_id = self._resolve_id(instance_id)
         self._store.set_findings_meta(instance_id, **kw)
 
     # ------------------------------------------------------------------
@@ -702,6 +727,7 @@ class MemoryService(MemoryServiceInterface):
         Raises:
             ValueError: If *title* is empty after stripping.
         """
+        instance = self._resolve_instance(instance)
         instance_id = instance.get("id") or instance.get("name", "")
         provider = instance.get("provider", "custom")
         instance_name = instance.get("name", "")
@@ -838,6 +864,7 @@ class MemoryService(MemoryServiceInterface):
             ``_body_truncated=True`` once cumulative body chars exceed 12000.
             Returns ``[]`` when memory is disabled (by id OR name).
         """
+        instance_id = self._resolve_id(instance_id)
         if self.is_memory_disabled(instance_id, instance_name):
             return []
 
@@ -922,6 +949,7 @@ class MemoryService(MemoryServiceInterface):
             Dict with ``created``, ``updated``, ``skipped``,
             ``active_after`` (count of non-superseded findings after merge).
         """
+        instance_id = self._resolve_id(instance_id)
         created = 0
         updated = 0
         skipped = 0
@@ -1018,6 +1046,7 @@ class MemoryService(MemoryServiceInterface):
             summary_tokens: Approximate token count of the summary.
             annotations_hash: SHA-256 hex hash of annotations content (if any).
         """
+        instance_id = self._resolve_id(instance_id)
         self._store.update_index(
             instance_id=instance_id,
             name=name,
@@ -1041,7 +1070,39 @@ class MemoryService(MemoryServiceInterface):
             return False
         if not self._config.enabled:
             return True
-        return self._config.is_instance_disabled(instance_id, instance_name)
+        # Per-server overrides are keyed by the REAL id / name.
+        resolved = self._resolve_instance({"id": instance_id, "name": instance_name})
+        return self._config.is_instance_disabled(
+            str(resolved.get("id") or instance_id),
+            str(resolved.get("name") or instance_name),
+        )
+
+    def set_instance_resolver(
+        self,
+        instance_resolver: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]],
+        instance_id_resolver: Optional[Callable[[str], str]],
+    ) -> None:
+        """Install the demo-mode resolvers (dict → pristine dict, id → real id).
+
+        The TUI redacts its instance list in place for display; anything that
+        reaches this service from a screen may therefore carry a fake id and
+        fake connection fields. Both resolvers are identity outside demo mode.
+        """
+        def _dict(inst: Dict[str, Any]) -> Dict[str, Any]:
+            if not instance_resolver or not isinstance(inst, dict):
+                return inst
+            out = instance_resolver(inst)
+            return out if isinstance(out, dict) else inst
+
+        def _id(instance_id: str) -> str:
+            if not instance_id_resolver or not instance_id:
+                return instance_id
+            out = instance_id_resolver(instance_id)
+            return out if isinstance(out, str) else instance_id
+
+        self._resolve_instance = _dict
+        self._resolve_id = _id
+        self._store.set_instance_id_resolver(_id)
 
     def set_sync_service(self, svc: Optional["_MemorySyncService"]) -> None:
         """Wire the optional sync service after construction.
@@ -1200,6 +1261,7 @@ class MemoryService(MemoryServiceInterface):
         Returns:
             Async callable ``(command: str) -> (stdout, stderr, returncode)``.
         """
+        instance = self._resolve_instance(instance)
         return self._make_ssh_runner(instance)
 
     def _make_ssh_runner(self, instance: Dict[str, Any]) -> Any:

--- a/src/servonaut/services/memory/store.py
+++ b/src/servonaut/services/memory/store.py
@@ -212,6 +212,13 @@ class MemoryStore:
         self._root = root or MEMORY_ROOT
         self._index_path = self._root / "index.json"
         self._redactor = redactor
+        # Demo mode hands screens redacted rows; their fake ids must never
+        # become directory names or index keys. Identity until wired.
+        self._resolve_id: Callable[[str], str] = lambda instance_id: instance_id
+
+    def set_instance_id_resolver(self, resolver: Optional[Callable[[str], str]]) -> None:
+        """Map every incoming instance id through *resolver* (fake → real)."""
+        self._resolve_id = resolver or (lambda instance_id: instance_id)
 
     # ------------------------------------------------------------------
     # Path helpers
@@ -219,6 +226,7 @@ class MemoryStore:
 
     def _instance_dir(self, instance_id: str, provider: str = "custom") -> Path:
         """Return the directory for a given instance (without creating it)."""
+        instance_id = self._resolve_id(instance_id)
         slug = _provider_slug(provider)
         return self._root / slug / instance_id
 
@@ -560,6 +568,7 @@ class MemoryStore:
             summary_tokens: Approximate token count of the summary.
             annotations_hash: SHA-256 hash of annotations content (if any).
         """
+        instance_id = self._resolve_id(instance_id)
         index = self._load_index()
         instances = index.setdefault("instances", {})
 
@@ -584,12 +593,14 @@ class MemoryStore:
 
     def _remove_from_index(self, instance_id: str) -> None:
         """Remove *instance_id* from the index (called by ``clear``)."""
+        instance_id = self._resolve_id(instance_id)
         index = self._load_index()
         index.get("instances", {}).pop(instance_id, None)
         self._save_index(index)
 
     def get_index_entry(self, instance_id: str) -> Optional[Dict[str, Any]]:
         """Return the index entry for *instance_id*, or ``None``."""
+        instance_id = self._resolve_id(instance_id)
         return self._load_index().get("instances", {}).get(instance_id)
 
     # ------------------------------------------------------------------
@@ -805,6 +816,7 @@ class MemoryStore:
         Raises:
             ValueError: If *instance_id* fails safety validation.
         """
+        instance_id = self._resolve_id(instance_id)
         _validate_instance_id(instance_id)
         return self._instance_dir(instance_id, provider) / "findings"
 

--- a/src/servonaut/services/ovh_service.py
+++ b/src/servonaut/services/ovh_service.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)
 _OVH_CACHE_PATH = Path.home() / '.servonaut' / 'ovh_cache.json'
 _OVH_CACHE_TTL_SECONDS = 300  # 5 minutes
 
+
+class OVHFetchError(Exception):
+    """Raised when no enabled OVH resource type could be listed.
+
+    Separates "OVH answered with zero instances" (a valid, cacheable result)
+    from "every call failed" (revoked key, network), so a failed refresh is
+    never persisted as an empty fleet.
+    """
+
 # OVH does not reliably raise the specific ``InvalidCredential`` subclass —
 # a revoked or expired key surfaces as a plain ``APIError`` whose message
 # text is the only stable signal. Match on substrings, not exception class.
@@ -76,6 +85,10 @@ class OVHService:
         """
         self._config = config
         self._client = None  # lazy-initialized
+        # Why the last refresh could not be trusted, or None after a complete
+        # successful fetch. Read by the instance list and MCP list_instances.
+        self.last_fetch_error: Optional[str] = None
+        self._failed_sources: List[str] = []
 
     def _get_client(self):
         """Lazy-initialize the OVH API client.
@@ -134,25 +147,35 @@ class OVHService:
         """
         logger.debug("Fetching instances from OVHcloud")
         instances: List[dict] = []
+        self._failed_sources = []
+        attempted = 0
+        last_error: Optional[Exception] = None
 
         if self._config.include_dedicated:
+            attempted += 1
             try:
                 dedicated = await asyncio.to_thread(self._fetch_dedicated)
                 instances.extend(dedicated)
                 logger.debug("Fetched %d OVH dedicated servers", len(dedicated))
             except Exception as e:
                 logger.error("Error fetching OVH dedicated servers: %s", e)
+                self._failed_sources.append("dedicated")
+                last_error = e
 
         if self._config.include_vps:
+            attempted += 1
             try:
                 vps = await asyncio.to_thread(self._fetch_vps)
                 instances.extend(vps)
                 logger.debug("Fetched %d OVH VPS instances", len(vps))
             except Exception as e:
                 logger.error("Error fetching OVH VPS instances: %s", e)
+                self._failed_sources.append("vps")
+                last_error = e
 
         if self._config.include_cloud:
             for project_id in self._config.cloud_project_ids:
+                attempted += 1
                 try:
                     cloud = await asyncio.to_thread(self._fetch_cloud, project_id)
                     instances.extend(cloud)
@@ -165,6 +188,13 @@ class OVHService:
                         "Error fetching OVH Cloud instances for project %s: %s",
                         project_id, e
                     )
+                    self._failed_sources.append(f"cloud:{project_id}")
+                    last_error = e
+
+        if attempted and len(self._failed_sources) == attempted:
+            raise OVHFetchError(
+                f"all {attempted} OVH source(s) failed: {last_error}"
+            ) from last_error
 
         logger.info("Fetched %d total OVH instances", len(instances))
         return instances
@@ -184,7 +214,32 @@ class OVHService:
                 logger.debug("Using cached OVH instances")
                 return cached
 
-        instances = await self.fetch_instances()
+        try:
+            instances = await self.fetch_instances()
+        except OVHFetchError as exc:
+            # Don't poison the cache — keep the previous good entries.
+            self.last_fetch_error = str(exc)
+            stale = self._load_cache(ignore_ttl=True)
+            if stale is not None:
+                logger.warning(
+                    "OVH fetch failed (%s); keeping %d cached instances",
+                    exc, len(stale),
+                )
+                return stale
+            logger.warning("OVH fetch failed (%s); no cached instances to fall back on", exc)
+            return []
+
+        if self._failed_sources:
+            # A partial inventory is shown but never persisted: writing it
+            # would silently drop every instance behind the failed sources.
+            self.last_fetch_error = (
+                f"{len(self._failed_sources)} source(s) failed: "
+                + ", ".join(self._failed_sources)
+            )
+            logger.warning("OVH fetch incomplete (%s); cache left untouched", self.last_fetch_error)
+            return instances
+
+        self.last_fetch_error = None
         self._save_cache(instances)
         return instances
 

--- a/src/servonaut/services/redaction_service.py
+++ b/src/servonaut/services/redaction_service.py
@@ -174,6 +174,11 @@ class RedactionService:
         # fed back in on a re-render is returned unchanged (idempotence).
         self._id_cache: dict[str, str] = {}
         self._fake_ids: set[str] = set()
+        self._real_id_by_fake: dict[str, str] = {}
+        # Values the operator typed while demo mode was on (a server added
+        # on camera): shown as typed, never hashed. Nothing real is in here
+        # unless the operator chose to type it in front of the recorder.
+        self._authored: set[str] = set()
         self._counter: int = 0
         # Tracks every fake name ever emitted by redact_name so that
         # a second scrub_stream pass does not re-replace already-fake names
@@ -199,9 +204,13 @@ class RedactionService:
         self._ip_cache[ip] = fake
         return fake
 
+    def keep_as_authored(self, *values: str) -> None:
+        """Remember values typed during this demo session so they render as typed."""
+        self._authored.update(v for v in values if isinstance(v, str) and v)
+
     def redact_name(self, name: str) -> str:
         """Map a real server name to a fake but realistic one."""
-        if not name or name == "-":
+        if not name or name == "-" or name in self._authored:
             return name
         if name in self._name_cache:
             return self._name_cache[name]
@@ -233,7 +242,18 @@ class RedactionService:
         if fake != instance_id:
             self._id_cache[instance_id] = fake
             self._fake_ids.add(fake)
+            self._real_id_by_fake[fake] = instance_id
         return fake
+
+    def real_instance_id(self, instance_id: str) -> str:
+        """Inverse of ``redact_instance_id`` for fakes emitted this session.
+
+        Anything else (a real id, an empty string) comes back unchanged, so
+        callers can apply it unconditionally.
+        """
+        if not instance_id:
+            return instance_id
+        return self._real_id_by_fake.get(instance_id, instance_id)
 
     def _fake_instance_id(self, instance_id: str) -> str:
         digest = hashlib.sha256(instance_id.encode()).hexdigest()
@@ -265,7 +285,7 @@ class RedactionService:
 
     def redact_hostname(self, hostname: str) -> str:
         """Map a real hostname/FQDN to a fake one."""
-        if not hostname or hostname == "-":
+        if not hostname or hostname == "-" or hostname in self._authored:
             return hostname
         # Idempotence guard (mirrors redact_ip): a fake host fed back in on a
         # re-render must not re-hash to a different fake.
@@ -302,7 +322,7 @@ class RedactionService:
 
     def redact_key_name(self, key: str) -> str:
         """Map a real SSH key name/path to a fake one."""
-        if not key or key == "-":
+        if not key or key == "-" or key in self._authored:
             return key
         fake = _hash_pick(key, _KEY_NAMES)
         if "/" in key:
@@ -310,20 +330,26 @@ class RedactionService:
         return fake
 
     def redact_provider(self, provider: str) -> str:
-        """Map a real provider name to a fake one."""
+        """Map a provider label to a pool one; pool labels pass through.
+
+        The pool is public taxonomy (AWS, OVH, Hetzner …), so a real label
+        that is already in it stays put and the provider column stays true.
+        """
         if not provider or provider == "-":
+            return provider
+        if provider in _PROVIDERS:
             return provider
         return _hash_pick(provider, _PROVIDERS)
 
     def redact_group(self, group: str) -> str:
         """Map a real group name to a fake one."""
-        if not group or group == "-":
+        if not group or group == "-" or group in self._authored:
             return group
         return _hash_pick(group, _GROUPS)
 
     def redact_username(self, username: str) -> str:
         """Map a real username to a fake one."""
-        if not username or username == "-":
+        if not username or username == "-" or username in self._authored:
             return username
         return _hash_pick(username, _USERNAMES)
 
@@ -474,8 +500,18 @@ class RedactionService:
 
         Known limitation: loopback ``::1`` and compressed forms with only one
         colon group are not matched — see docs/demo-mode.md.
+
+        Clock times and durations (``19:15:03``, ``1:23:45``) share the
+        two-colon digit shape and are left alone: an address is only assumed
+        when the match has hex letters or at least three colons.
         """
-        return _IPV6_RE.sub("2001:db8::1", text)
+        def _replace(m: re.Match) -> str:
+            value = m.group(0)
+            if value.count(":") <= 2 and not re.search(r"[a-fA-F]", value):
+                return value
+            return "2001:db8::1"
+
+        return _IPV6_RE.sub(_replace, text)
 
     def redact_ecr_host(self, text: str) -> str:
         """Replace the AWS account-ID component in ECR hostnames.

--- a/src/servonaut/styles/screens/custom_servers.tcss
+++ b/src/servonaut/styles/screens/custom_servers.tcss
@@ -23,6 +23,11 @@
 }
 
 #add_form {
+    /* Container defaults to `height: 1fr` + hidden overflow: inside the
+       scrolling column that left a 7-row box on a 47-row terminal with
+       every Input clipped below it. Auto height lets the column scroll
+       through the whole form; the Save row stays docked. */
+    height: auto;
     border: round $primary;
     padding: 1;
     margin: 1 0;

--- a/tests/test_aws3_coverage_gaps.py
+++ b/tests/test_aws3_coverage_gaps.py
@@ -41,7 +41,7 @@ import pytest
 # AWSService legacy fetch paths
 # ---------------------------------------------------------------------------
 
-from servonaut.services.aws_service import AWSService
+from servonaut.services.aws_service import AWSFetchError, AWSService
 from servonaut.services.cache_service import CacheService
 
 
@@ -60,10 +60,12 @@ def aws_svc(cache_svc):
 class TestAWSServiceLegacyFetch:
     """Cover the existing fetch_instances / _fetch_* methods."""
 
-    def test_fetch_all_regions_returns_empty_on_error(self, aws_svc) -> None:
+    def test_fetch_all_regions_raises_when_regions_cannot_be_listed(self, aws_svc) -> None:
+        # A failed inventory must surface as an error, never as "no
+        # instances": the cached path persists whatever comes back.
         with patch("boto3.client", side_effect=Exception("no creds")):
-            result = aws_svc._fetch_all_regions()
-        assert result == []
+            with pytest.raises(AWSFetchError, match="no creds"):
+                aws_svc._fetch_all_regions()
 
     def test_fetch_all_regions_aggregates_instances(self, aws_svc) -> None:
         mock_ec2_client = MagicMock()
@@ -95,10 +97,12 @@ class TestAWSServiceLegacyFetch:
         assert result[0]["name"] == "prod-web"
         assert result[0]["region"] == "us-east-1"
 
-    def test_fetch_region_returns_empty_on_exception(self, aws_svc) -> None:
+    def test_fetch_region_propagates_the_exception(self, aws_svc) -> None:
+        # _fetch_all_regions counts failed regions; swallowing here would
+        # make a denied region look empty.
         with patch("boto3.resource", side_effect=Exception("denied")):
-            result = aws_svc._fetch_region("us-east-1")
-        assert result == []
+            with pytest.raises(Exception, match="denied"):
+                aws_svc._fetch_region("us-east-1")
 
     def test_extract_instance_data_no_tags(self, aws_svc) -> None:
         mock_instance = MagicMock()

--- a/tests/test_aws_fetch_cache_guard.py
+++ b/tests/test_aws_fetch_cache_guard.py
@@ -1,0 +1,172 @@
+"""A failed AWS inventory fetch must never be persisted as an empty fleet.
+
+Regression for the cache wipe: an MCP server whose environment carried
+``AWS_PROFILE=""`` could not list regions, the service returned ``[]`` and
+``fetch_instances_cached`` saved that over a good cache, so the TUI loaded a
+"fresh" empty inventory and skipped its own fetch.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from servonaut.services.aws_service import AWSFetchError, AWSService
+from servonaut.services.cache_service import CacheService
+
+CACHED = [{'id': 'i-0123456789abcdef0', 'name': 'web-1', 'region': 'eu-west-2'}]
+FRESH = [{'id': 'i-0fedcba987654321f', 'name': 'web-2', 'region': 'eu-west-2'}]
+PROFILE_ERROR = RuntimeError("The config profile () could not be found")
+
+
+def _cache(stale=CACHED):
+    cache = MagicMock(spec=CacheService)
+    cache.load.return_value = None  # expired: every cached call must fetch
+    cache.load_any.return_value = stale
+    return cache
+
+
+def _regions(*names):
+    """boto3 stand-in whose ec2 client lists the given regions."""
+    boto3 = MagicMock()
+    boto3.client.return_value.describe_regions.return_value = {
+        'Regions': [{'RegionName': n} for n in names],
+    }
+    return boto3
+
+
+def _regions_failing():
+    boto3 = MagicMock()
+    boto3.client.return_value.describe_regions.side_effect = PROFILE_ERROR
+    return boto3
+
+
+@pytest.mark.asyncio
+async def test_regions_failure_raises_instead_of_returning_empty():
+    svc = AWSService(_cache())
+    with patch('servonaut.services.aws_service.boto3', _regions_failing()):
+        with pytest.raises(AWSFetchError, match="could not list AWS regions"):
+            await svc.fetch_instances()
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_keeps_stale_cache_and_never_saves():
+    cache = _cache()
+    svc = AWSService(cache)
+    with patch('servonaut.services.aws_service.boto3', _regions_failing()):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == CACHED
+    cache.save.assert_not_called()
+    assert "config profile" in svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_without_any_cache_returns_empty_and_never_saves():
+    cache = _cache(stale=None)
+    svc = AWSService(cache)
+    with patch('servonaut.services.aws_service.boto3', _regions_failing()):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == []
+    cache.save.assert_not_called()
+    assert svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_every_region_failing_counts_as_a_failed_fetch():
+    cache = _cache()
+    svc = AWSService(cache)
+    svc._fetch_region = MagicMock(side_effect=PROFILE_ERROR)
+    with patch('servonaut.services.aws_service.boto3', _regions('eu-west-2', 'us-east-1')):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == CACHED
+    cache.save.assert_not_called()
+    assert "all 2 AWS regions failed" in svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_partial_region_failure_is_shown_but_not_persisted():
+    cache = _cache()
+    svc = AWSService(cache)
+    svc._fetch_region = MagicMock(
+        side_effect=lambda region: FRESH if region == 'eu-west-2' else (_ for _ in ()).throw(PROFILE_ERROR)
+    )
+    with patch('servonaut.services.aws_service.boto3', _regions('eu-west-2', 'us-east-1')):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == FRESH
+    cache.save.assert_not_called()
+    assert "us-east-1" in svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_successful_fetch_saves_and_clears_the_error():
+    cache = _cache()
+    svc = AWSService(cache)
+    svc.last_fetch_error = "stale from an earlier failure"
+    svc._fetch_region = MagicMock(return_value=FRESH)
+    with patch('servonaut.services.aws_service.boto3', _regions('eu-west-2')):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == FRESH
+    cache.save.assert_called_once_with(FRESH)
+    assert svc.last_fetch_error is None
+
+
+@pytest.mark.asyncio
+async def test_genuinely_empty_account_is_a_valid_cacheable_result():
+    cache = _cache()
+    svc = AWSService(cache)
+    svc._fetch_region = MagicMock(return_value=[])
+    with patch('servonaut.services.aws_service.boto3', _regions('eu-west-2')):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == []
+    cache.save.assert_called_once_with([])
+    assert svc.last_fetch_error is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_cache_is_served_without_touching_aws():
+    cache = _cache()
+    cache.load.return_value = CACHED
+    svc = AWSService(cache)
+    with patch('servonaut.services.aws_service.boto3', _regions_failing()) as boto3:
+        result = await svc.fetch_instances_cached()
+
+    assert result == CACHED
+    boto3.client.assert_not_called()
+
+
+# --- MCP surface -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_instances_warns_when_the_inventory_is_stale():
+    from tests.test_mcp_tools import make_tools
+
+    aws = MagicMock()
+    aws.fetch_instances_cached = AsyncMock(return_value=CACHED)
+    aws.last_fetch_error = "could not list AWS regions: The config profile () could not be found"
+    tools = make_tools(aws_service=aws)
+
+    out = await tools.list_instances()
+
+    assert 'web-1' in out
+    assert 'Warning: the AWS inventory could not be refreshed' in out
+    assert 'config profile' in out
+
+
+@pytest.mark.asyncio
+async def test_list_instances_has_no_warning_after_a_good_fetch():
+    from tests.test_mcp_tools import make_tools
+
+    aws = MagicMock()
+    aws.fetch_instances_cached = AsyncMock(return_value=CACHED)
+    aws.last_fetch_error = None
+    tools = make_tools(aws_service=aws)
+
+    out = await tools.list_instances()
+
+    assert 'Warning' not in out

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -1,0 +1,40 @@
+"""``servonaut --config <path>`` must actually be used by the TUI."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from servonaut.config.manager import ConfigManager, CONFIG_PATH
+
+
+def test_config_manager_reads_and_writes_the_given_file(tmp_path) -> None:
+    path = tmp_path / "recording.json"
+    path.write_text(json.dumps({"version": 4, "default_username": "deploy"}))
+    manager = ConfigManager(config_path=path)
+    assert manager._config_path == path
+    assert manager.get().default_username == "deploy"
+
+
+def test_config_manager_defaults_to_the_home_file() -> None:
+    assert ConfigManager()._config_path == CONFIG_PATH
+
+
+def test_app_passes_the_path_to_its_config_manager(tmp_path) -> None:
+    from servonaut.app import ServonautApp
+
+    app = ServonautApp(config_path=tmp_path / "recording.json")
+    assert app._config_path == tmp_path / "recording.json"
+
+
+def test_main_forwards_the_flag(tmp_path) -> None:
+    from servonaut import main as main_module
+
+    fake_app = MagicMock()
+    with patch("servonaut.app.ServonautApp", return_value=fake_app) as cls, \
+            patch("servonaut.utils.native_stderr.redirect_native_stderr"), \
+            patch.object(main_module, "_setup_logging", return_value=None), \
+            patch("sys.argv", ["servonaut", "--config", str(tmp_path / "recording.json"), "--debug"]):
+        main_module.main()
+    assert cls.call_args.kwargs["config_path"] == tmp_path / "recording.json"
+    fake_app.run.assert_called_once()

--- a/tests/test_custom_servers_form_layout.py
+++ b/tests/test_custom_servers_form_layout.py
@@ -1,0 +1,50 @@
+"""Style guard: the Custom Servers add form must not be clipped.
+
+Screen tests that build their own wrapper app never load the stylesheet, so
+this one mounts ``CSS_FILES`` and measures the real layout: the form has to
+grow to its content (height auto) and every input must lie inside it, on a
+47-row terminal as well as a tall one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.widgets import Input
+
+from servonaut.screens.custom_servers import CustomServersScreen
+from servonaut.styles import CSS_FILES
+
+
+class _Host(App):
+    CSS_PATH = CSS_FILES
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.demo_mode = False
+        self.redaction_service = None
+        self.custom_server_service = MagicMock()
+        self.custom_server_service.list_servers.return_value = []
+        self.instances = []
+
+    def on_mount(self) -> None:
+        self.push_screen(CustomServersScreen())
+
+
+@pytest.mark.parametrize("size", [(166, 47), (120, 40), (166, 70)])
+@pytest.mark.asyncio
+async def test_add_form_encloses_every_input(size) -> None:
+    app = _Host()
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        await pilot.press("n")
+        await pilot.pause()
+        screen = app.screen
+        form = screen.query_one("#add_form")
+        assert str(form.styles.height) == "auto"
+        bottom = form.region.y + form.region.height
+        for widget in screen.query("#add_form Input"):
+            assert widget.region.y + widget.region.height <= bottom, widget.id
+        assert isinstance(app.focused, Input)

--- a/tests/test_demo_mode_connection_resolver.py
+++ b/tests/test_demo_mode_connection_resolver.py
@@ -1,0 +1,360 @@
+"""Demo mode keeps rendering the redacted row but connects to the real one.
+
+``ServonautApp.connection_instance`` maps a redacted row back to the
+pre-redaction snapshot by its fake id; ``real_instance_id`` does the same
+for bare ids. The memory layer resolves on entry so fake ids never become
+directory names, index keys or sync-queue keys. Neutral fixtures only.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from servonaut.app import ServonautApp
+from servonaut.services.redaction_service import RedactionService
+
+
+REAL_ROW = {
+    "id": "i-0abc123def456789a", "name": "web-prod-7", "public_ip": "9.9.9.9",
+    "private_ip": "10.0.0.7", "region": "eu-west-1", "type": "t3.micro",
+    "state": "running", "key_name": "prod-key",
+}
+
+
+def _demo_app(rows):
+    """A stand-in with exactly the attributes the resolver methods read."""
+    import copy
+    svc = RedactionService()
+    pristine = copy.deepcopy(rows)
+    redacted = copy.deepcopy(rows)
+    svc.redact_instances(redacted)
+    app = SimpleNamespace(demo_mode=True, redaction_service=svc,
+                          _instances_pristine=pristine, instances=redacted)
+    app.real_instance_id = lambda i: ServonautApp.real_instance_id(app, i)
+    app.connection_instance = lambda inst: ServonautApp.connection_instance(app, inst)
+    return app
+
+
+class TestRedactionServiceInverse:
+    def test_real_instance_id_round_trip(self) -> None:
+        svc = RedactionService()
+        for real in ("i-0abc123def456789a", "custom-web-1", "12345678",
+                     "vps-1a2b3c4d.vps.corp-example.net"):
+            fake = svc.redact_instance_id(real)
+            assert svc.real_instance_id(fake) == real
+
+    def test_unknown_and_empty_pass_through(self) -> None:
+        svc = RedactionService()
+        assert svc.real_instance_id("i-unknown") == "i-unknown"
+        assert svc.real_instance_id("") == ""
+
+
+class TestAppResolver:
+    def test_outside_demo_mode_returns_the_same_object(self) -> None:
+        app = SimpleNamespace(demo_mode=False, redaction_service=None, _instances_pristine=None)
+        row = dict(REAL_ROW)
+        assert ServonautApp.connection_instance(app, row) is row
+        assert ServonautApp.real_instance_id(app, "i-x") == "i-x"
+
+    def test_demo_row_resolves_to_pristine_copy(self) -> None:
+        app = _demo_app([REAL_ROW])
+        shown = app.instances[0]
+        assert shown["id"] != REAL_ROW["id"]
+        assert shown["public_ip"] != REAL_ROW["public_ip"]
+        real = app.connection_instance(shown)
+        assert real == REAL_ROW
+        assert real is not app._instances_pristine[0], "callers must get a copy"
+        assert app.real_instance_id(shown["id"]) == REAL_ROW["id"]
+
+    def test_unknown_row_falls_back_to_itself(self) -> None:
+        app = _demo_app([REAL_ROW])
+        stray = {"id": "i-notinsnapshot", "public_ip": "192.0.2.9"}
+        assert app.connection_instance(stray) is stray
+
+
+class TestMemoryStoreResolver:
+    def test_fake_id_lands_under_the_real_directory(self, tmp_path) -> None:
+        from servonaut.services.memory.store import MemoryStore
+
+        store = MemoryStore(root=tmp_path)
+        store.set_instance_id_resolver(lambda i: {"i-fake": "i-real"}.get(i, i))
+        assert store._instance_dir("i-fake", "aws") == store._instance_dir("i-real", "aws")
+        assert "i-fake" not in str(store._instance_dir("i-fake", "aws"))
+        store.update_index("i-fake", "web-prod-7", "aws", ["os"])
+        index = json.loads((tmp_path / "index.json").read_text())
+        assert "i-real" in index["instances"]
+        assert "i-fake" not in index["instances"]
+        assert store.get_index_entry("i-fake") is not None
+
+    def test_identity_without_a_resolver(self, tmp_path) -> None:
+        from servonaut.services.memory.store import MemoryStore
+
+        store = MemoryStore(root=tmp_path)
+        assert "i-real" in str(store._instance_dir("i-real", "aws"))
+
+
+class TestMemoryServiceResolver:
+    def _service(self):
+        from servonaut.services.memory.service import MemoryService
+
+        config = MagicMock()
+        config.enabled = True
+        config.redaction_enabled = True
+        store = MagicMock()
+        svc = MemoryService(config=config, store=store)
+        return svc, config, store
+
+    def test_wires_dict_and_id_resolvers(self) -> None:
+        svc, _, store = self._service()
+        svc.set_instance_resolver(lambda d: {"id": "i-real", "name": "web-prod-7"},
+                                  lambda i: "i-real")
+        store.set_instance_id_resolver.assert_called_once()
+        assert svc._resolve_id("i-fake") == "i-real"
+        assert svc._resolve_instance({"id": "i-fake"}) == {"id": "i-real", "name": "web-prod-7"}
+
+    def test_non_dict_and_non_str_results_are_ignored(self) -> None:
+        svc, _, _ = self._service()
+        svc.set_instance_resolver(lambda d: None, lambda i: 42)
+        assert svc._resolve_id("i-fake") == "i-fake"
+        assert svc._resolve_instance({"id": "i-fake"}) == {"id": "i-fake"}
+
+    def test_is_memory_disabled_checks_the_real_id_and_name(self) -> None:
+        svc, config, _ = self._service()
+        config.is_instance_disabled.return_value = False
+        svc.set_instance_resolver(lambda d: {"id": "i-real", "name": "web-prod-7"}, lambda i: "i-real")
+        svc.is_memory_disabled("i-fake", "api-staging-3")
+        config.is_instance_disabled.assert_called_once_with("i-real", "web-prod-7")
+
+    def test_store_calls_receive_the_real_id(self) -> None:
+        svc, _, store = self._service()
+        svc.set_instance_resolver(None, lambda i: {"i-fake": "i-real"}.get(i, i))
+        svc.get_all_modules("i-fake", "aws")
+        args = store.get_all_modules.call_args.args
+        assert args[0] == "i-real"
+
+
+class TestInstanceListSshConnect:
+    def test_connects_to_the_real_host_but_names_the_fake_row(self) -> None:
+        from servonaut.screens.instance_list import InstanceListScreen
+
+        screen = object.__new__(InstanceListScreen)
+        app = _demo_app([REAL_ROW])
+        shown = app.instances[0]
+        mock_app = MagicMock()
+        mock_app.demo_mode = True
+        mock_app.connection_instance = app.connection_instance
+        mock_app.real_instance_id = app.real_instance_id
+        mock_app.connection_service.resolve_profile.return_value = None
+        mock_app.connection_service.get_target_host.side_effect = lambda inst, profile: inst.get("public_ip")
+        mock_app.connection_service.get_extra_options.return_value = []
+        mock_app.ssh_service.get_key_path.return_value = "/tmp/prod-key.pem"
+        mock_app.ssh_service.build_ssh_command.return_value = ["ssh", "9.9.9.9"]
+        mock_app.terminal_service.launch_ssh_in_terminal.return_value = True
+        mock_app.config_manager.get.return_value.default_username = "ubuntu"
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "_get_selected_running_instance", return_value=shown), \
+                    patch.object(screen, "_maybe_show_memory_prompt") as prompt:
+                screen.action_ssh_connect()
+
+        host_arg = mock_app.connection_service.get_target_host.call_args.args[0]
+        assert host_arg["public_ip"] == "9.9.9.9", "connection must use the real record"
+        assert mock_app.ssh_service.get_key_path.call_args.args[0] == REAL_ROW["id"]
+        toast = mock_app.notify.call_args.args[0]
+        assert shown["name"] in toast and REAL_ROW["name"] not in toast
+        prompt.assert_called_once_with(shown)
+
+
+class TestProviderRefreshKeepsPristineInStep:
+    def test_replace_pristine_rows_swaps_provider_rows(self) -> None:
+        from servonaut.screens.instance_list import InstanceListScreen
+
+        screen = object.__new__(InstanceListScreen)
+        mock_app = MagicMock()
+        mock_app._instances_pristine = [
+            {"id": "i-1", "name": "aws-1"},
+            {"id": "old-vps", "name": "old", "is_ovh": True},
+        ]
+        fresh = [{"id": "vps-new.vps.corp-example.net", "name": "new", "is_ovh": True}]
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen._replace_pristine_rows("is_ovh", fresh)
+        ids = [i["id"] for i in mock_app._instances_pristine]
+        assert ids == ["i-1", "vps-new.vps.corp-example.net"]
+        assert mock_app._instances_pristine[1] is not fresh[0], "snapshot must be a copy"
+
+
+class TestToolBridgeTargetResolution:
+    def test_relay_target_is_mapped_when_a_resolver_is_installed(self) -> None:
+        from servonaut.services.ai_tool_bridge import AIToolBridge
+        from servonaut.services.relay_listener import CommandType
+
+        bridge = object.__new__(AIToolBridge)
+        bridge.instance_id_resolver = lambda i: {"i-fake": "i-real"}.get(i, i)
+        bridge._default_ttl_seconds = 30
+        call = SimpleNamespace(
+            name="run_command", tool_call_id="tc-1", conversation_id="conv-1",
+            args={"instance_id": "i-fake", "command": "uptime"},
+        )
+        request = bridge._build_command_request(call, CommandType.RUN_COMMAND)
+        assert request.target_server_id == "i-real"
+
+    def test_identity_without_a_resolver(self) -> None:
+        from servonaut.services.ai_tool_bridge import AIToolBridge
+        from servonaut.services.relay_listener import CommandType
+
+        bridge = object.__new__(AIToolBridge)
+        bridge._default_ttl_seconds = 30
+        call = SimpleNamespace(
+            name="run_command", tool_call_id="tc-1", conversation_id="conv-1",
+            args={"instance_id": "i-real", "command": "uptime"},
+        )
+        assert bridge._build_command_request(call, CommandType.RUN_COMMAND).target_server_id == "i-real"
+
+
+class TestIpv6RuleLeavesClockTimesAlone:
+    def test_clock_times_and_durations_survive(self) -> None:
+        svc = RedactionService()
+        assert svc.scrub_stream("Sep  2 19:15:03 web1 sshd[12]: Accepted") == "Sep  2 19:15:03 web1 sshd[12]: Accepted"
+        assert svc.scrub_stream(" 19:15:03 up 55 days, load average: 0.00") == " 19:15:03 up 55 days, load average: 0.00"
+        assert svc.scrub_stream("took 1:23:45") == "took 1:23:45"
+
+    def test_addresses_are_still_redacted(self) -> None:
+        svc = RedactionService()
+        assert "2001:db8::1" in svc.scrub_stream("2001:db8:85a3:0:0:8a2e:370:7334")
+        assert "2001:db8::1" in svc.scrub_stream("fd12:3456:789a:1:2:3:4:5")
+        assert "2001:0:0:1" not in svc.scrub_stream("2001:0:0:1:2:3:4:5")
+
+
+class TestAuthoredValuesPassThrough:
+    """What the operator types while recording renders as typed."""
+
+    def test_authored_fields_survive_redaction(self) -> None:
+        svc = RedactionService()
+        svc.keep_as_authored("cache-blue-4", "192.0.2.10", "deploy", "~/.ssh/deploy-key", "web-servers")
+        row = {"id": "custom-cache-blue-4", "name": "cache-blue-4", "public_ip": "192.0.2.10",
+               "private_ip": "192.0.2.10", "username": "deploy", "ssh_key": "~/.ssh/deploy-key",
+               "provider": "Hetzner", "group": "web-servers", "region": "Hetzner", "is_custom": True}
+        svc.redact_instance(row)
+        assert row["name"] == "cache-blue-4"
+        assert row["public_ip"] == "192.0.2.10"
+        assert row["username"] == "deploy"
+        assert row["ssh_key"] == "~/.ssh/deploy-key"
+        assert row["group"] == "web-servers"
+        assert row["id"] != "custom-cache-blue-4", "ids are always hashed"
+
+    def test_unauthored_values_are_still_replaced(self) -> None:
+        svc = RedactionService()
+        assert svc.redact_name("web-prod-7") != "web-prod-7"
+        assert svc.redact_username("alice") != "alice"
+        assert svc.redact_key_name("~/.ssh/acme_deploy") != "~/.ssh/acme_deploy"
+        assert svc.redact_group("acme-clients") != "acme-clients"
+
+    def test_provider_labels_from_the_pool_stay_true(self) -> None:
+        svc = RedactionService()
+        assert svc.redact_provider("OVH") == "OVH"
+        assert svc.redact_provider("Hetzner") == "Hetzner"
+        assert svc.redact_provider("ExampleHost") != "ExampleHost"
+
+    def test_save_marks_typed_values_as_authored(self) -> None:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        mock_app = MagicMock()
+        mock_app.demo_mode = True
+        mock_app.redaction_service = RedactionService()
+        mock_app.custom_server_service.update_server.return_value = True
+        values = {"#input_name": "cache-blue-4", "#input_host": "192.0.2.10", "#input_username": "deploy",
+                  "#input_ssh_key": "", "#input_port": "22", "#input_provider": "Hetzner", "#input_group": "web-servers"}
+        widgets = {}
+
+        def _query_one(selector, widget_type=None):
+            w = widgets.setdefault(str(selector), MagicMock())
+            if str(selector) in values:
+                w.value = values[str(selector)]
+            else:
+                w.text = ""
+            return w
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one), \
+                    patch.object(screen, "_populate_table"), patch.object(screen, "_refresh_app_instances"), \
+                    patch.object(screen, "_hide_form"):
+                screen._save_server()
+        assert mock_app.redaction_service.redact_name("cache-blue-4") == "cache-blue-4"
+        assert mock_app.redaction_service.redact_group("web-servers") == "web-servers"
+
+
+class TestCustomServersRefreshRedacts:
+    def test_saved_rows_are_redacted_and_snapshotted(self) -> None:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        svc = RedactionService()
+        mock_app = MagicMock()
+        mock_app.demo_mode = True
+        mock_app.redaction_service = svc
+        mock_app.instances = [{"id": "i-1", "name": "aws-1"}]
+        mock_app._instances_pristine = [{"id": "i-1", "name": "aws-1"}]
+        raw = {"id": "custom-acme-web-1", "name": "acme-web-1", "public_ip": "9.9.9.9",
+               "private_ip": "9.9.9.9", "is_custom": True}
+        mock_app.custom_server_service.list_as_instances.return_value = [raw]
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            screen._refresh_app_instances()
+        shown = [i for i in mock_app.instances if i.get("is_custom")][0]
+        assert shown["name"] != "acme-web-1" and shown["public_ip"] != "9.9.9.9"
+        kept = [i for i in mock_app._instances_pristine if i.get("is_custom")][0]
+        assert kept["name"] == "acme-web-1" and kept is not raw
+
+
+class TestPaletteNavigation:
+    def test_every_target_is_a_sidebar_button(self) -> None:
+        import re
+        from pathlib import Path
+        import servonaut.widgets.sidebar as sidebar_module
+
+        source = Path(sidebar_module.__file__).read_text(encoding="utf-8")
+        sidebar_ids = set(re.findall(r'"(nav_[a-z0-9_]+)"', source))
+        for _, target_id, _ in ServonautApp._PALETTE_NAVIGATION:
+            assert target_id in sidebar_ids, target_id
+
+    def test_commands_post_navigation_messages(self) -> None:
+        from servonaut.widgets.sidebar import Sidebar
+
+        app = object.__new__(ServonautApp)
+        app.ovh_service = None
+        app.hetzner_service = None
+        posted = []
+        app.post_message = lambda message: posted.append(message)
+        with patch("textual.app.App.get_system_commands", return_value=iter(())):
+            commands = list(ServonautApp.get_system_commands(app, None))
+        titles = [c.title for c in commands]
+        assert "Go to Custom Servers" in titles
+        assert not any(t.startswith("Go to OVH") or t.startswith("Go to Hetzner") for t in titles)
+        next(c for c in commands if c.title == "Go to Custom Servers").callback()
+        assert isinstance(posted[0], Sidebar.NavigationRequested)
+        assert posted[0].target_id == "nav_custom_servers"
+
+
+class TestCustomServersRemoveToast:
+    def test_toast_names_the_fake_row_in_demo_mode(self) -> None:
+        from servonaut.screens.custom_servers import CustomServersScreen
+
+        screen = object.__new__(CustomServersScreen)
+        mock_app = MagicMock()
+        mock_app.demo_mode = True
+        mock_app.redaction_service = RedactionService()
+        server = SimpleNamespace(name="acme-web-1")
+        mock_app.custom_server_service.list_servers.return_value = [server]
+        mock_app.custom_server_service.remove_server.return_value = True
+        table = MagicMock()
+        table.cursor_row = 0
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=table), \
+                    patch.object(screen, "_populate_table"), patch.object(screen, "_refresh_app_instances"):
+                screen.action_remove_server()
+        mock_app.custom_server_service.remove_server.assert_called_once_with("acme-web-1")
+        toast = mock_app.notify.call_args.args[0]
+        assert "acme-web-1" not in toast
+        assert mock_app.redaction_service.redact_name("acme-web-1") in toast

--- a/tests/test_demo_mode_connection_resolver.py
+++ b/tests/test_demo_mode_connection_resolver.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 from servonaut.app import ServonautApp
@@ -358,3 +360,145 @@ class TestCustomServersRemoveToast:
         toast = mock_app.notify.call_args.args[0]
         assert "acme-web-1" not in toast
         assert mock_app.redaction_service.redact_name("acme-web-1") in toast
+
+
+class TestKeyManagementRedaction:
+    """The SSH Keys screen shows the fleet's fakes, never real ids or key paths."""
+
+    @staticmethod
+    def _app():
+        mock_app = MagicMock()
+        mock_app.demo_mode = True
+        mock_app.redaction_service = RedactionService()
+        return mock_app
+
+    def test_mappings_use_the_fleet_fakes(self) -> None:
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = self._app()
+        mock_app.config_manager.get.return_value.instance_keys = {"i-0abc123def456789a": "~/.ssh/acme_prod"}
+        rows: list = []
+        table = MagicMock()
+        table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=table):
+                screen._load_instance_mappings()
+        cells = " ".join(str(c) for c in rows[0])
+        assert "i-0abc123def456789a" not in cells and "acme_prod" not in cells
+        assert rows[0][0] == mock_app.redaction_service.redact_instance_id("i-0abc123def456789a")
+
+    def test_available_keys_are_redacted(self) -> None:
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = self._app()
+        mock_app.ssh_service.list_available_keys.return_value = ["~/.ssh/acme_prod", "~/.ssh/id_ed25519"]
+        rows: list = []
+        table = MagicMock()
+        table.add_row.side_effect = lambda *args, **kwargs: rows.append(args)
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", return_value=table):
+                screen._load_available_keys()
+        cells = " ".join(str(c) for row in rows for c in row)
+        assert "acme_prod" not in cells and "id_ed25519" not in cells
+
+    def test_default_key_is_shown_fake_and_not_prefilled(self) -> None:
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = self._app()
+        mock_app.config_manager.get.return_value.default_key = "~/.ssh/acme_prod"
+        widgets: dict = {}
+
+        def _query_one(selector, widget_type=None):
+            return widgets.setdefault(str(selector), MagicMock())
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._load_default_key()
+        shown = str(widgets["#current_default_key"].update.call_args.args[0])
+        assert "acme_prod" not in shown
+        field = widgets.get("#input_default_key")
+        assert field is None or field.value != "~/.ssh/acme_prod"
+
+    def test_default_key_prefilled_outside_demo(self) -> None:
+        from servonaut.screens.key_management import KeyManagementScreen
+
+        screen = object.__new__(KeyManagementScreen)
+        mock_app = MagicMock()
+        mock_app.demo_mode = False
+        mock_app.config_manager.get.return_value.default_key = "~/.ssh/acme_prod"
+        widgets: dict = {}
+
+        def _query_one(selector, widget_type=None):
+            return widgets.setdefault(str(selector), MagicMock())
+
+        with patch.object(type(screen), "app", new_callable=lambda: property(lambda self: mock_app)):
+            with patch.object(screen, "query_one", side_effect=_query_one):
+                screen._load_default_key()
+        assert widgets["#input_default_key"].value == "~/.ssh/acme_prod"
+
+
+class TestVerifyDialogHost:
+    def test_display_host_is_the_row_as_shown(self) -> None:
+        from servonaut.screens.server_actions import ServerActionsScreen
+
+        screen = object.__new__(ServerActionsScreen)
+        screen._instance = {"id": "i-fake", "public_ip": "192.0.2.9", "private_ip": "10.0.0.9"}
+        assert screen._display_host() == "192.0.2.9"
+        screen._instance = {"id": "i-fake", "private_ip": "10.0.0.9"}
+        assert screen._display_host() == "10.0.0.9"
+        screen._instance = {"id": "i-fake"}
+        assert screen._display_host() == "i-fake"
+
+
+class TestSshRefEditorDemoMode:
+    """Stored vault ids are shown as same-shaped fakes and never prefilled."""
+
+    ITEM = "123e4567-e89b-12d3-a456-426614174000"  # leak-guard:allow (RFC 4122 example UUID)
+
+    def _host(self, demo: bool):
+        from textual.app import App
+        from servonaut.screens.ssh_ref_editor import SshRefEditorModal
+
+        item = self.ITEM
+
+        class _Host(App):
+            def __init__(self) -> None:
+                super().__init__()
+                self.demo_mode = demo
+                self.redaction_service = RedactionService() if demo else None
+                self.bw_ssh_config_service = None
+                self.auth_service = None
+
+            def on_mount(self) -> None:
+                self.push_screen(SshRefEditorModal(
+                    {"id": "i-fake", "name": "web-canary-7"},
+                    existing_ref={"ssh_credential_ref": {"item_id": item}},
+                ))
+
+        return _Host()
+
+    @pytest.mark.asyncio
+    async def test_demo_mode_masks_the_item_id(self) -> None:
+        from textual.widgets import Input
+
+        app = self._host(demo=True)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            modal = app.screen
+            assert modal._selected_item_name and modal._selected_item_name != self.ITEM
+            assert len(modal._selected_item_name) == 36
+            assert modal.query_one("#item_id", Input).value == ""
+
+    @pytest.mark.asyncio
+    async def test_outside_demo_the_item_id_is_prefilled(self) -> None:
+        from textual.widgets import Input
+
+        app = self._host(demo=False)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            modal = app.screen
+            assert modal._selected_item_name == self.ITEM
+            assert modal.query_one("#item_id", Input).value == self.ITEM

--- a/tests/test_demo_mode_coverage.py
+++ b/tests/test_demo_mode_coverage.py
@@ -1046,7 +1046,7 @@ class TestFleetMemoryRemoteRender:
             {
                 "id": "i-0abc123def456789a",
                 "name": "web-prod-7",
-                "provider": "AWS",
+                "provider": "ExampleCloud",
                 "source": "remote",
                 "modules": 3,
                 "drift_7d": 0,
@@ -1071,7 +1071,7 @@ class TestFleetMemoryRemoteRender:
         all_cells = " ".join(str(c) for row in table_rows for c in row)
         assert "web-prod-7" not in all_cells, "Real server name leaked in fleet table"
         assert "i-0abc123def456789a" not in all_cells, "Real instance ID leaked"
-        assert "AWS" not in all_cells, "Real provider leaked"
+        assert "ExampleCloud" not in all_cells, "Real provider leaked"
 
     def test_remote_rows_unchanged_without_demo(self) -> None:
         """Without demo mode, rows render with original values."""
@@ -1086,7 +1086,7 @@ class TestFleetMemoryRemoteRender:
             {
                 "id": "i-0abc123def456789a",
                 "name": "web-prod-7",
-                "provider": "AWS",
+                "provider": "ExampleCloud",
                 "source": "remote",
                 "modules": 0,
                 "drift_7d": 0,

--- a/tests/test_env_hygiene.py
+++ b/tests/test_env_hygiene.py
@@ -1,0 +1,143 @@
+"""Empty forwarded environment variables are dropped at process start.
+
+Agent configs written by ``--mcp-install`` reference forwarded variables as
+``${NAME:-}``, so a name that is unset when the agent starts reaches the MCP
+server as ``NAME=""``. botocore treats ``AWS_PROFILE=""`` as a profile named
+"" and fails every client with ``ProfileNotFound``; the readers for the
+Servonaut URLs used to accept "" as an override too.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+import servonaut.main as main_mod
+from servonaut.mcp import installer
+from servonaut.mcp.installer import prune_empty_forwarded_env
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def test_prune_drops_only_empty_forwarded_names(fake_home, monkeypatch):
+    monkeypatch.setenv("AWS_PROFILE", "")
+    monkeypatch.setenv("SSH_AUTH_SOCK", "")
+    monkeypatch.setenv("AWS_REGION", "eu-west-2")
+    monkeypatch.setenv("UNRELATED_EMPTY", "")
+
+    pruned = prune_empty_forwarded_env()
+
+    assert pruned == ("SSH_AUTH_SOCK", "AWS_PROFILE")
+    assert "AWS_PROFILE" not in os.environ
+    assert "SSH_AUTH_SOCK" not in os.environ
+    assert os.environ["AWS_REGION"] == "eu-west-2"
+    assert os.environ["UNRELATED_EMPTY"] == ""
+
+
+def test_prune_covers_names_referenced_from_the_config(fake_home, monkeypatch):
+    cfg_dir = fake_home / ".servonaut"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(json.dumps({"ai": {"gemini_api_key": "$MY_AI_TOKEN"}}))
+    monkeypatch.setenv("MY_AI_TOKEN", "")
+
+    pruned = prune_empty_forwarded_env()
+
+    assert "MY_AI_TOKEN" in pruned
+    assert "MY_AI_TOKEN" not in os.environ
+
+
+def test_prune_is_idempotent_and_quiet_when_nothing_is_empty(fake_home, monkeypatch):
+    for name in installer._BASE_FORWARD_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_PROFILE", "")
+
+    assert prune_empty_forwarded_env() == ("AWS_PROFILE",)
+    assert prune_empty_forwarded_env() == ()
+
+
+def test_main_prunes_before_any_command_runs(fake_home, monkeypatch):
+    monkeypatch.setenv("AWS_PROFILE", "")
+    monkeypatch.setattr(main_mod, "_PRUNED_ENV_NAMES", ())
+    monkeypatch.setattr("sys.argv", ["servonaut", "--version"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod._main()
+
+    assert excinfo.value.code == 0
+    assert "AWS_PROFILE" not in os.environ
+    assert main_mod._PRUNED_ENV_NAMES == ("AWS_PROFILE",)
+
+
+def test_setup_logging_reports_the_pruned_names(fake_home, monkeypatch):
+    monkeypatch.setattr(main_mod, "_PRUNED_ENV_NAMES", ("AWS_PROFILE", "AWS_CONFIG_FILE"))
+    root = logging.getLogger()
+    previous = root.handlers[:]
+    try:
+        log_file = main_mod._setup_logging()
+        for handler in root.handlers:
+            handler.flush()
+        text = log_file.read_text(encoding="utf-8")
+    finally:
+        for handler in root.handlers[:]:
+            if handler not in previous:
+                handler.close()
+                root.removeHandler(handler)
+        for handler in previous:
+            if handler not in root.handlers:
+                root.addHandler(handler)
+
+    assert "Ignoring empty environment variables: AWS_PROFILE, AWS_CONFIG_FILE" in text
+
+
+@pytest.mark.parametrize(
+    "module_path, func, var, default_attr",
+    [
+        ("servonaut.services.api_client", "_api_base", "SERVONAUT_API_URL", "_DEFAULT_API_BASE"),
+        ("servonaut.services.auth_service", "_api_base", "SERVONAUT_API_URL", "_DEFAULT_API_BASE"),
+        ("servonaut.mcp.remote_client", "_mcp_base", "SERVONAUT_MCP_URL", "_DEFAULT_MCP_BASE"),
+    ],
+)
+def test_empty_url_override_falls_back_to_the_default(monkeypatch, module_path, func, var, default_attr):
+    import importlib
+
+    module = importlib.import_module(module_path)
+    monkeypatch.setenv(var, "")
+    assert getattr(module, func)() == getattr(module, default_attr)
+
+    monkeypatch.setenv(var, "https://staging.example.com")
+    assert getattr(module, func)() == "https://staging.example.com"
+
+
+def test_installer_env_block_with_nothing_set_is_safe_for_botocore_once_pruned(fake_home, monkeypatch):
+    """Cross-seam check: the installer's output meets its consumer.
+
+    Render the env block ``--mcp-install claude`` writes, expand it the way
+    the agent does when none of the variables is set (``${NAME:-}`` → ""),
+    and put it in front of the AWS SDK. The installer tests only ever
+    asserted the JSON shape; nothing ran the SDK under that JSON.
+    """
+    import botocore.session
+    from botocore.exceptions import ProfileNotFound
+
+    block = installer._env_references("claude")
+    assert "AWS_PROFILE" in block
+    for name, reference in block.items():
+        assert reference == f"${{{name}:-}}"
+        monkeypatch.setenv(name, "")
+
+    with pytest.raises(ProfileNotFound):
+        botocore.session.get_session().get_scoped_config()
+
+    prune_empty_forwarded_env()
+
+    botocore.session.get_session().get_scoped_config()  # no raise
+    assert "AWS_PROFILE" not in os.environ

--- a/tests/test_ovh_fetch_cache_guard.py
+++ b/tests/test_ovh_fetch_cache_guard.py
@@ -1,0 +1,108 @@
+"""A failed OVH inventory fetch must never be persisted as an empty fleet.
+
+Same class as the AWS cache wipe: a revoked key made every per-type call
+fail, ``fetch_instances`` returned ``[]`` and ``fetch_instances_cached``
+saved it over the good cache.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from servonaut.services.ovh_service import OVHFetchError, OVHService
+from tests.test_ovh_service import _make_config
+
+CACHED = [{'id': 'vps-1', 'name': 'web-1', 'provider_type': 'vps'}]
+FRESH = [{'id': 'vps-2', 'name': 'web-2', 'provider_type': 'vps'}]
+
+
+def _raise(message="Invalid credential"):
+    def _inner(*_args, **_kwargs):
+        raise Exception(message)
+    return _inner
+
+
+def _service(stale=CACHED):
+    svc = OVHService(_make_config(include_dedicated=True, include_vps=True, include_cloud=False))
+    svc._load_cache = lambda ignore_ttl=False: (stale if ignore_ttl else None)  # expired
+    svc._save_cache = lambda instances: saved.append(instances)
+    return svc
+
+
+saved: list = []
+
+
+@pytest.fixture(autouse=True)
+def _reset_saved():
+    saved.clear()
+
+
+@pytest.mark.asyncio
+async def test_every_source_failing_raises_instead_of_returning_empty():
+    svc = _service()
+    with patch.object(svc, "_fetch_dedicated", side_effect=_raise()), \
+         patch.object(svc, "_fetch_vps", side_effect=_raise()):
+        with pytest.raises(OVHFetchError, match="all 2 OVH source"):
+            await svc.fetch_instances()
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_keeps_stale_cache_and_never_saves():
+    svc = _service()
+    with patch.object(svc, "_fetch_dedicated", side_effect=_raise()), \
+         patch.object(svc, "_fetch_vps", side_effect=_raise()):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == CACHED
+    assert saved == []
+    assert "Invalid credential" in svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_failed_fetch_without_any_cache_returns_empty_and_never_saves():
+    svc = _service(stale=None)
+    with patch.object(svc, "_fetch_dedicated", side_effect=_raise()), \
+         patch.object(svc, "_fetch_vps", side_effect=_raise()):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == []
+    assert saved == []
+    assert svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_is_shown_but_not_persisted():
+    svc = _service()
+    with patch.object(svc, "_fetch_dedicated", side_effect=_raise()), \
+         patch.object(svc, "_fetch_vps", return_value=FRESH):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == FRESH
+    assert saved == []
+    assert "dedicated" in svc.last_fetch_error
+
+
+@pytest.mark.asyncio
+async def test_successful_fetch_saves_and_clears_the_error():
+    svc = _service()
+    svc.last_fetch_error = "stale from an earlier failure"
+    with patch.object(svc, "_fetch_dedicated", return_value=[]), \
+         patch.object(svc, "_fetch_vps", return_value=FRESH):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == FRESH
+    assert saved == [FRESH]
+    assert svc.last_fetch_error is None
+
+
+@pytest.mark.asyncio
+async def test_genuinely_empty_account_is_a_valid_cacheable_result():
+    svc = _service()
+    with patch.object(svc, "_fetch_dedicated", return_value=[]), \
+         patch.object(svc, "_fetch_vps", return_value=[]):
+        result = await svc.fetch_instances_cached(force_refresh=True)
+
+    assert result == []
+    assert saved == [[]]
+    assert svc.last_fetch_error is None


### PR DESCRIPTION
## Summary

Since v2.25.1, `servonaut --mcp-install claude` forwards a fixed set of environment variables to the MCP server as `${NAME:-}` references. A variable that is not set when the agent starts therefore reaches the server as an empty string. botocore treats `AWS_PROFILE=""` as a profile literally named `""` and fails every client with `ProfileNotFound`, so the MCP server could not make any AWS call. Worse, the instance fetch swallowed that error and returned an empty list, and `fetch_instances_cached` saved it over a good cache. The TUI then loaded a "fresh" empty inventory, skipped its own fetch, and showed no AWS instances until a forced refresh.

## Changes

- **Empty forwarded variables are dropped at process start.** `prune_empty_forwarded_env()` in the installer module removes forwarded names whose value is `""` (the `AWS_*` family, `SSH_AUTH_SOCK`, `BW_SESSION`, `BWS_ACCESS_TOKEN`, the Servonaut URLs, and any `$VARIABLE` referenced from the config). It runs first thing in `main()` for every mode and again in the shared headless constructor, and the removed names are logged once logging is up. The `${NAME:-}` references stay: a reference without a default makes the agent refuse the whole config.
- **A failed fetch never overwrites the cache.** `AWSService` raises `AWSFetchError` when the region list cannot be read or every region fails, and `fetch_instances_cached` then returns the existing cache (any age) without saving. A partial fetch (some regions failed) is returned for display but not persisted either. A genuinely empty account is still a valid, cacheable result. `last_fetch_error` records why the last refresh could not be trusted.
- **The OVH inventory gets the same guard.** Every OVH resource type swallowed its own error, so a revoked key produced an empty list that was saved over the OVH cache. `OVHFetchError` is raised when every enabled source fails, the previous cache is kept, and a partial result is shown but not persisted. Hetzner already behaved this way.
- **Operators are told when they look at stale data.** The instance list shows a warning toast after a failed AWS or OVH refresh instead of "No EC2 instances found", and MCP `list_instances` appends a warning line per affected provider.
- **Empty URL overrides fall back to the defaults.** `SERVONAUT_API_URL=""` and `SERVONAUT_MCP_URL=""` no longer replace the production endpoints with an empty base.
- Regression tests for both cache guards and the pruning, plus a cross-seam test that renders the installer's env block, expands it with nothing set, and asserts the AWS SDK works once pruned. `docs/mcp-tools.md` documents the forwarding and the log line.

## Also included: demo-mode connection resolver

This branch also carries the demo-mode work that keeps the screen redacted while every action reaches the real server. Demo mode redacts the instance list in place, and the same dict used to feed every action that starts from a row, so SSH, run command, browse, transfer, logs, AI analysis, scans, the SSH-ref editor, memory lookups and AI tool-call targets all used the fake id and address. Now:

- `ServonautApp.connection_instance()` and `real_instance_id()` return the pre-redaction record for a redacted row; screens display the redacted dict and hand the real record to anything that opens a connection or keys a store. The memory store and service resolve ids on entry, and the AI tool bridge maps a fake target id back before the relay executes.
- Values typed while demo mode is on render as typed, pool provider labels pass through, and the IPv6 stream rule no longer turns clock times into addresses. The SSH Keys screen and the SSH-ref editor show same-shaped fakes instead of stored ids.
- Custom Servers rows are re-redacted after a save or remove, and the add form grows to its content instead of being clipped on smaller terminals.
- `Ctrl+P` gains a "Go to …" command-palette entry for every sidebar section, and the TUI honours `--config`, which was parsed but never applied.
- Regression tests for each surface, a stylesheet-mounted layout guard for the add form, and `docs/demo-mode.md` updated.

Existing installs need no reinstall of the agent config: the server ignores the empty values on its next start.

