### PR TITLE
fix: log viewer honours memory opt-outs when choosing its first log

### DIFF
--- a/src/servonaut/services/log_viewer_service.py
+++ b/src/servonaut/services/log_viewer_service.py
@@ -202,6 +202,30 @@ class LogViewerService(LogViewerServiceInterface):
             self.last_probe_probed_at = None
             return []
 
+    def _memory_cache_opted_out(self, instance_id: str, instance_name: str) -> bool:
+        """True when memory must not be consulted for this instance.
+
+        The memory read API has no opt-out check of its own, so the viewer
+        used to serve cached probed paths even for servers the operator had
+        opted out (``memory.per_server_overrides``), a disabled ``logs``
+        module, or memory switched off entirely. Those operators expect the
+        configured path list to win, which only happens on a live probe.
+        """
+        try:
+            config = self._config_manager.get()
+            disabled_modules = list(getattr(config.memory, "disabled_modules", []) or [])
+        except Exception:  # config shape is not this method's concern
+            disabled_modules = []
+        if "logs" in disabled_modules:
+            return True
+        checker = getattr(self._memory_service, "is_memory_disabled", None)
+        if not callable(checker):
+            return False
+        try:
+            return checker(instance_id, instance_name) is True
+        except Exception:
+            return False
+
     def _lookup_cached_log_paths(self, instance: dict) -> Optional[List[str]]:
         """Return cached probed_paths for *instance* or ``None`` on cache miss.
 
@@ -215,6 +239,8 @@ class LogViewerService(LogViewerServiceInterface):
 
         instance_id = instance.get("id") or instance.get("name", "")
         if not instance_id:
+            return None
+        if self._memory_cache_opted_out(instance_id, str(instance.get("name") or "")):
             return None
         provider = instance.get("provider", "custom")
 

--- a/tests/test_log_viewer_service.py
+++ b/tests/test_log_viewer_service.py
@@ -512,6 +512,86 @@ class TestProbeLogPathsUsesMemoryCache:
         assert "/var/log/syslog" in result
         assert service.last_probe_source == "live"
 
+    def _ssh_and_conn(self):
+        ssh = MagicMock()
+        ssh.build_ssh_command.return_value = ["ssh", "fake"]
+        ssh.get_key_path.return_value = None
+        ssh.discover_key.return_value = None
+        conn = MagicMock()
+        conn.resolve_profile.return_value = None
+        conn.get_target_host.return_value = "1.2.3.4"
+        conn.get_extra_options.return_value = []
+        return ssh, conn
+
+    def _cached_memory(self, is_disabled: bool):
+        from datetime import datetime, timezone
+
+        mem = MagicMock()
+        mem.get.return_value = {
+            "observed": {"probed_paths": ["/var/log/syslog", "/var/log/auth.log"]},
+            "probed_at": datetime.now(tz=timezone.utc).isoformat(),
+            "ttl_seconds": 86400,
+        }
+        mem.is_memory_disabled.return_value = is_disabled
+        return mem
+
+    def test_per_server_opt_out_skips_the_cache(self):
+        """A server opted out of memory gets a live probe of the configured
+        paths, not the stale cached list — the opt-out must hold on reads too."""
+        mem = self._cached_memory(is_disabled=True)
+        config = AppConfig()
+        config.log_viewer_default_paths = ["/var/log/fail2ban.log"]
+        service = LogViewerService(FakeConfigManager(config), memory_service=mem)
+        ssh, conn = self._ssh_and_conn()
+
+        async def fake_spawn(cmd, timeout):
+            return (b"/var/log/fail2ban.log\n", b"")
+
+        with patch(
+            "servonaut.services.log_viewer_service.run_ssh_subprocess",
+            side_effect=fake_spawn,
+        ):
+            result = asyncio.run(service.probe_log_paths(self._instance(), ssh, conn))
+
+        assert result == ["/var/log/fail2ban.log"]
+        assert service.last_probe_source == "live"
+        mem.is_memory_disabled.assert_called_once_with("i-cache-test", "cache-host")
+
+    def test_disabled_logs_module_skips_the_cache(self):
+        mem = self._cached_memory(is_disabled=False)
+        config = AppConfig()
+        config.memory.disabled_modules = ["logs"]
+        config.log_viewer_default_paths = ["/var/log/fail2ban.log"]
+        service = LogViewerService(FakeConfigManager(config), memory_service=mem)
+        ssh, conn = self._ssh_and_conn()
+
+        async def fake_spawn(cmd, timeout):
+            return (b"/var/log/fail2ban.log\n", b"")
+
+        with patch(
+            "servonaut.services.log_viewer_service.run_ssh_subprocess",
+            side_effect=fake_spawn,
+        ):
+            result = asyncio.run(service.probe_log_paths(self._instance(), ssh, conn))
+
+        assert result == ["/var/log/fail2ban.log"]
+        assert service.last_probe_source == "live"
+        mem.get.assert_not_called()
+
+    def test_cache_still_served_when_nothing_is_opted_out(self):
+        mem = self._cached_memory(is_disabled=False)
+        service = self._make_service_with_memory(mem)
+        ssh, conn = self._ssh_and_conn()
+
+        with patch(
+            "servonaut.services.log_viewer_service.run_ssh_subprocess",
+            new_callable=AsyncMock,
+        ) as spawn:
+            result = asyncio.run(service.probe_log_paths(self._instance(), ssh, conn))
+
+        assert result == ["/var/log/syslog", "/var/log/auth.log"]
+        spawn.assert_not_called()
+
     def test_cache_empty_probed_paths_falls_back(self):
         """A logs module exists but probed_paths is empty → fallback to SSH."""
         mem = MagicMock()


### PR DESCRIPTION
## Summary

The log viewer opens on the first path of the server's cached `memory.logs.probed_paths`. That lookup read the memory store unconditionally, so a server opted out of memory through `memory.per_server_overrides`, a `disabled_modules` list containing `logs`, or memory switched off entirely still got the cached list instead of the configured `log_viewer_default_paths`. The opt-out promised that memory would not be consulted for that server; on this read path it was.

## Changes

- `LogViewerService._lookup_cached_log_paths` now treats an opted-out server as a cache miss: per-server `memory_disabled`, a disabled `logs` module, or memory disabled globally (checked through `MemoryService.is_memory_disabled`, which resolves both id and name). The live probe of the configured paths then runs, so the configured order wins.
- Tests for the three opt-out cases and for the unchanged cache-hit path.

No behaviour change for servers that have not opted out.
