### PR TITLE
feat: demo mode can replay a scripted chat conversation

### DIFF
--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -211,3 +211,28 @@ why or documents the accepted trade-off.
   returns the same result as calling it once.
 - `redact_ip` is idempotent: doc-range IPs (192.0.2.x, 198.51.100.x,
   203.0.113.x) are short-circuited and returned unchanged.
+
+## Scripted chat replay
+
+The chat panel's answers and tool rows come from the AI gateway and your fleet's real tools, so a recording of a live conversation can still show real names. For demos, screenshots and offline walkthroughs, demo mode can replay a script instead:
+
+```bash
+SERVONAUT_DEMO_CHAT_REPLAY=~/demo/chat.sse servonaut --demo
+```
+
+The script is a plain `text/event-stream` body using the gateway's event names (`conversation`, `token`, `tool_call`, `tool_result`, `usage`, `done`), plus two comment directives the replay understands:
+
+```
+: delay 1.5
+event: token
+data: {"text": "Checking that server now. "}
+
+event: tool_call
+data: {"tool_call_id": "tc_1", "tool": "run_command", "args": {"instance_id": "custom-abc123", "command": "uptime"}, "guard_level": "standard"}
+
+: wait tool-result
+event: tool_result
+data: {"tool_call_id": "tc_1", "status": "ok", "result_summary": "{{tool_result}}"}
+```
+
+`: delay N` pauses before the next event, and `: wait tool-result` holds the stream until you have approved and run the tool, exactly as the gateway does. Tool calls are executed for real through the usual confirm modal, and `{{tool_result}}` is replaced with what the tool returned. Replay only affects the chat stream and its tool-result reply; every other request still reaches the API, and the variable is ignored outside demo mode.

--- a/src/servonaut/app.py
+++ b/src/servonaut/app.py
@@ -947,6 +947,18 @@ class ServonautApp(App):
             except Exception as e:  # pragma: no cover
                 logger.debug("ServonautProvider direct init skipped: %s", e)
                 self.servonaut_provider = None
+            # Demo mode can replay a scripted chat instead of calling the
+            # gateway (recordings, screenshots, offline demos). No-op unless
+            # SERVONAUT_DEMO_CHAT_REPLAY names a script.
+            if self.demo_mode:
+                try:
+                    from servonaut.services.ai_providers.demo_replay import (
+                        maybe_install_demo_chat_replay,
+                    )
+                    if maybe_install_demo_chat_replay(self.api_client, True) is not None:
+                        self.notify("Demo chat replay active", severity="information")
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.debug("Demo chat replay not installed: %s", e)
             # T4.5 — provider preference resolver. Pure (no I/O) — safe
             # to construct even when other paid-tier wiring fails.
             try:

--- a/src/servonaut/services/ai_providers/demo_replay.py
+++ b/src/servonaut/services/ai_providers/demo_replay.py
@@ -1,0 +1,230 @@
+"""Scripted chat replay for demo mode.
+
+Demo mode redacts what the TUI shows, but the chat panel's answers and
+tool rows come from the hosted gateway and the fleet's real tools, which
+the stream scrubber only partly covers. For recordings, screenshots and
+offline demos the panel can instead replay a script: a plain SSE fixture
+served through an :mod:`httpx` transport, so the very same stream parser,
+tool bridge, confirm modal and rendering run as with the real gateway.
+
+Activation needs BOTH demo mode and ``SERVONAUT_DEMO_CHAT_REPLAY`` set to a
+readable script; every other request the client makes still goes to the
+real API through the wrapped transport.
+
+Script format — a standard ``text/event-stream`` body plus SSE comment
+lines the replay understands::
+
+    : delay 1.5            pause 1.5 s before the next event
+    : wait tool-result     hold the stream until the CLI has POSTed a tool result
+    event: token
+    data: {"text": "Checking "}
+
+    event: tool_call
+    data: {"tool_call_id": "tc_1", "tool": "run_command", "args": {...}, "guard_level": "standard"}
+
+    : wait tool-result
+    event: tool_result
+    data: {"tool_call_id": "tc_1", "status": "ok", "result_summary": "{{tool_result}}"}
+
+``{{tool_result}}`` inside an event is replaced with the (JSON-escaped,
+truncated) result the CLI posted, so the row shows what really ran.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Mapping, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "SERVONAUT_DEMO_CHAT_REPLAY"
+CHAT_PATH = "/api/ai/chat"
+TOOL_RESULT_PATH = "/api/ai/chat/tool-result"
+RESULT_PLACEHOLDER = "{{tool_result}}"
+_RESULT_MAX_CHARS = 600
+# Comment heartbeat while a ``wait`` step holds the stream, so the
+# panel's dead-stream watchdog (35 s) never fires during a long approval.
+_WAIT_PING_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class ScriptStep:
+    """One replay step: an SSE event block, a pause, or a hold point."""
+
+    kind: str  # "event" | "delay" | "wait"
+    event: bytes = b""
+    seconds: float = 0.0
+
+
+def parse_script(text: str) -> List[ScriptStep]:
+    """Turn a script into steps.
+
+    Comment lines (``:`` prefix) are directives when they read
+    ``: delay <seconds>`` or ``: wait tool-result``; any other comment is
+    dropped. Event blocks end at a blank line and are kept verbatim.
+    """
+    steps: List[ScriptStep] = []
+    block: List[str] = []
+
+    def flush() -> None:
+        body = "".join(block).strip()
+        if body:
+            steps.append(ScriptStep("event", event=(body + "\n\n").encode("utf-8")))
+        block.clear()
+
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith(":"):
+            words = stripped[1:].split()
+            if len(words) == 2 and words[0] == "delay":
+                try:
+                    seconds = float(words[1])
+                except ValueError:
+                    continue  # not a directive, just a comment
+                flush()
+                steps.append(ScriptStep("delay", seconds=max(0.0, seconds)))
+            elif words[:2] == ["wait", "tool-result"]:
+                flush()
+                steps.append(ScriptStep("wait"))
+            continue
+        if stripped == "":
+            flush()
+            continue
+        block.append(line)
+    flush()
+    return steps
+
+
+def _escape_for_json_string(value: str) -> str:
+    return json.dumps(value)[1:-1]
+
+
+class DemoChatReplayTransport(httpx.AsyncBaseTransport):
+    """Serve the chat stream from a script; pass everything else through."""
+
+    def __init__(
+        self,
+        steps: List[ScriptStep],
+        inner: Optional[httpx.AsyncBaseTransport] = None,
+    ) -> None:
+        self._steps = steps
+        self._inner = inner
+        self._tool_result_received: Optional[asyncio.Event] = None
+        self.last_tool_result: Optional[Dict[str, Any]] = None
+        self.stream_requests = 0
+
+    def _event(self) -> asyncio.Event:
+        if self._tool_result_received is None:
+            self._tool_result_received = asyncio.Event()
+        return self._tool_result_received
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path.endswith(TOOL_RESULT_PATH):
+            try:
+                self.last_tool_result = json.loads(request.content or b"{}")
+            except ValueError:
+                self.last_tool_result = {"result": request.content.decode("utf-8", "replace")}
+            self._event().set()
+            return httpx.Response(202, json={}, request=request)
+        if request.method == "POST" and path.endswith(CHAT_PATH):
+            self.stream_requests += 1
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream", "cache-control": "no-cache"},
+                stream=_ReplayStream(self),
+                request=request,
+            )
+        if self._inner is not None:
+            return await self._inner.handle_async_request(request)
+        return httpx.Response(
+            404, json={"error": "demo chat replay: no route"}, request=request,
+        )
+
+    async def aclose(self) -> None:
+        if self._inner is not None:
+            await self._inner.aclose()
+
+    def _render(self, event: bytes) -> bytes:
+        if RESULT_PLACEHOLDER.encode() not in event:
+            return event
+        posted = self.last_tool_result or {}
+        raw = str(posted.get("result") or posted.get("error") or "").strip()
+        if len(raw) > _RESULT_MAX_CHARS:
+            raw = raw[:_RESULT_MAX_CHARS] + "…"
+        return event.replace(
+            RESULT_PLACEHOLDER.encode(), _escape_for_json_string(raw).encode("utf-8")
+        )
+
+    async def iter_script(self) -> AsyncIterator[bytes]:
+        for step in self._steps:
+            if step.kind == "delay":
+                await asyncio.sleep(step.seconds)
+            elif step.kind == "wait":
+                event = self._event()
+                while not event.is_set():
+                    try:
+                        await asyncio.wait_for(event.wait(), timeout=_WAIT_PING_SECONDS)
+                    except asyncio.TimeoutError:
+                        yield b": ping\n\n"
+                event.clear()
+            else:
+                yield self._render(step.event)
+
+
+class _ReplayStream(httpx.AsyncByteStream):
+    def __init__(self, transport: DemoChatReplayTransport) -> None:
+        self._transport = transport
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        async for chunk in self._transport.iter_script():
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+def replay_script_path(
+    demo_mode: bool, environ: Optional[Mapping[str, str]] = None,
+) -> Optional[Path]:
+    """Return the script to replay, or None when replay must stay off.
+
+    Off unless demo mode is active AND the variable names a readable file;
+    a variable that points nowhere is logged and ignored rather than
+    silently switching the chat back to the real gateway.
+    """
+    env = os.environ if environ is None else environ
+    raw = (env.get(ENV_VAR) or "").strip()
+    if not demo_mode or not raw:
+        return None
+    path = Path(raw).expanduser()
+    if not path.is_file():
+        logger.warning("%s points at a missing script; chat replay stays off", ENV_VAR)
+        return None
+    return path
+
+
+def install_demo_chat_replay(api_client: Any, path: Path) -> DemoChatReplayTransport:
+    """Wrap the client's HTTP in a replay transport built from ``path``."""
+    steps = parse_script(path.read_text(encoding="utf-8"))
+    inner = api_client.transport or httpx.AsyncHTTPTransport()
+    transport = DemoChatReplayTransport(steps, inner=inner)
+    api_client.transport = transport
+    logger.info("Demo chat replay active: %s (%d steps)", path.name, len(steps))
+    return transport
+
+
+def maybe_install_demo_chat_replay(
+    api_client: Any, demo_mode: bool, environ: Optional[Mapping[str, str]] = None,
+) -> Optional[DemoChatReplayTransport]:
+    """Install the replay when demo mode and the environment ask for it."""
+    path = replay_script_path(demo_mode, environ)
+    if path is None or api_client is None:
+        return None
+    return install_demo_chat_replay(api_client, path)

--- a/src/servonaut/services/ai_sse.py
+++ b/src/servonaut/services/ai_sse.py
@@ -162,6 +162,9 @@ async def stream_sse(
     client_kwargs: Dict[str, Any] = {"timeout": timeout}
     if _TEST_TRANSPORT is not None:
         client_kwargs["transport"] = _TEST_TRANSPORT
+    elif getattr(api_client, "transport", None) is not None:
+        # Same seam the plain requests use (demo-mode chat replay).
+        client_kwargs["transport"] = api_client.transport
     async with httpx.AsyncClient(**client_kwargs) as client:
         try:
             async with aconnect_sse(

--- a/src/servonaut/services/ai_tool_bridge.py
+++ b/src/servonaut/services/ai_tool_bridge.py
@@ -1030,7 +1030,9 @@ class AIToolBridge(_FloorDangerousMixin):
         # server knows about that this version's handler does not. Drop
         # the unknown keys and say so in the result, instead of failing a
         # call whose supported arguments were perfectly serviceable.
-        accepted_args, dropped_args = _split_supported_args(handler, call.args)
+        accepted_args, dropped_args = _split_supported_args(
+            handler, self._resolve_target_args(call.args),
+        )
         if dropped_args:
             logger.warning(
                 "Local tool %r: ignoring unsupported argument(s) %s",
@@ -1148,6 +1150,26 @@ class AIToolBridge(_FloorDangerousMixin):
         )
         self._audit_tool_call(call, result, allowed=True, reason="ok_local")
         return result
+
+    _TARGET_ARG_KEYS = ("instance_id", "server_id", "target_server_id")
+
+    def _resolve_target_args(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Map demo-mode fake instance ids back to the real ones.
+
+        Demo mode shows redacted ids, so a model that reads the screen (or
+        the operator who types one) passes the fake id. The relay path
+        mapped ``target`` already; local tools such as ``disk_usage`` took
+        the raw argument and answered "Instance not found".
+        """
+        resolver = getattr(self, "instance_id_resolver", None)
+        if not callable(resolver):
+            return dict(args)
+        resolved = dict(args)
+        for key in self._TARGET_ARG_KEYS:
+            value = resolved.get(key)
+            if isinstance(value, str) and value:
+                resolved[key] = resolver(value)
+        return resolved
 
     def _build_command_request(
         self,

--- a/src/servonaut/services/api_client.py
+++ b/src/servonaut/services/api_client.py
@@ -180,11 +180,27 @@ _CODE_TO_EXC: Dict[str, Type[APIError]] = {
 }
 
 
+def _json_or_success(response: Any) -> Any:
+    """Decode a JSON body, treating 204 and empty bodies as plain success.
+
+    Some endpoints acknowledge with 202/204 and no body (the chat
+    tool-result reply is one); decoding those used to raise.
+    """
+    if response.status_code == 204 or not response.content:
+        return {"success": True}
+    return response.json()
+
+
 class APIClient(APIClientInterface):
     """Authenticated HTTP client for the Servonaut API."""
 
     def __init__(self, auth_service: 'AuthService') -> None:
         self._auth = auth_service
+        # Optional httpx transport used by every request this client makes.
+        # None (the default) means real HTTP. Demo-mode chat replay installs
+        # a scripted transport here so the panel can be recorded without a
+        # gateway; tests can inject a MockTransport the same way.
+        self.transport: Optional[Any] = None
 
     def _get_headers(self) -> Dict[str, str]:
         headers: Dict[str, str] = {
@@ -293,7 +309,10 @@ class APIClient(APIClientInterface):
         if accept != "application/json":
             headers["Accept"] = accept
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        client_kwargs: Dict[str, Any] = {"timeout": timeout}
+        if self.transport is not None:
+            client_kwargs["transport"] = self.transport
+        async with httpx.AsyncClient(**client_kwargs) as client:
             response = await client.request(
                 method, url, headers=headers, json=json, params=params
             )
@@ -324,33 +343,25 @@ class APIClient(APIClientInterface):
         response = await self._request(
             "POST", path, timeout=timeout, json=json, retry_on_401=retry_on_401
         )
-        if response.status_code == 204:
-            return {"success": True}
-        return response.json()
+        return _json_or_success(response)
 
     async def patch(self, path: str, *, json: Optional[Any] = None, timeout: float = DEFAULT_TIMEOUT_SECONDS, retry_on_401: bool = True, **kwargs: Any) -> Dict[str, Any]:
         response = await self._request(
             "PATCH", path, timeout=timeout, json=json, retry_on_401=retry_on_401
         )
-        if response.status_code == 204:
-            return {"success": True}
-        return response.json()
+        return _json_or_success(response)
 
     async def put(self, path: str, *, json: Optional[Any] = None, timeout: float = DEFAULT_TIMEOUT_SECONDS, retry_on_401: bool = True, **kwargs: Any) -> Dict[str, Any]:
         response = await self._request(
             "PUT", path, timeout=timeout, json=json, retry_on_401=retry_on_401
         )
-        if response.status_code == 204:
-            return {"success": True}
-        return response.json()
+        return _json_or_success(response)
 
     async def delete(self, path: str, *, timeout: float = DEFAULT_TIMEOUT_SECONDS, params: Optional[Dict[str, Any]] = None, retry_on_401: bool = True, **kwargs: Any) -> Dict[str, Any]:
         response = await self._request(
             "DELETE", path, timeout=timeout, params=params, retry_on_401=retry_on_401
         )
-        if response.status_code == 204:
-            return {"success": True}
-        return response.json()
+        return _json_or_success(response)
 
     async def stream_sse(
         self,

--- a/tests/test_ai_tool_bridge.py
+++ b/tests/test_ai_tool_bridge.py
@@ -1723,3 +1723,25 @@ def test_circuit_breaker_arg_order_is_canonical():
         )
     )
     assert result.status == "denied"
+
+
+def test_local_tool_resolves_demo_instance_ids_before_dispatch():
+    """Demo mode shows fake ids; a local tool must receive the real one,
+    exactly as the relay path already does for ``target``."""
+    fake_tools = MagicMock()
+    fake_tools.get_server_info = AsyncMock(return_value="instance: custom-real")
+    bridge, _, relay, _, _ = _make_bridge(servonaut_tools=fake_tools)
+    bridge.instance_id_resolver = lambda value: {"custom-fake": "custom-real"}.get(value, value)
+
+    call = _call(
+        tool="describe_instance",
+        guard_level="readonly",
+        args={"instance_id": "custom-fake"},
+    )
+    result = run(bridge.handle_tool_call(call))
+
+    relay.execute.assert_not_awaited()
+    fake_tools.get_server_info.assert_awaited_once_with(instance_id="custom-real")
+    assert result.status == "ok"
+    # The call object itself keeps what the model sent.
+    assert call.args["instance_id"] == "custom-fake"

--- a/tests/test_demo_chat_replay.py
+++ b/tests/test_demo_chat_replay.py
@@ -1,0 +1,184 @@
+"""Demo-mode chat replay: scripted SSE through the real stream pipeline."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from servonaut.services import ai_sse
+from servonaut.services.ai_providers import demo_replay
+from servonaut.services.ai_providers.demo_replay import (
+    DemoChatReplayTransport,
+    ScriptStep,
+    install_demo_chat_replay,
+    maybe_install_demo_chat_replay,
+    parse_script,
+    replay_script_path,
+)
+from servonaut.services.ai_sse import stream_sse
+from servonaut.services.api_client import APIClient
+
+SCRIPT = """\
+: a comment the replay ignores
+event: conversation
+data: {"conversation_id": "conv_demo"}
+
+: delay 0.01
+event: token
+data: {"text": "Checking "}
+
+event: tool_call
+data: {"tool_call_id": "tc_1", "tool": "run_command", "args": {"instance_id": "custom-abc", "command": "uptime"}, "guard_level": "standard"}
+
+: wait tool-result
+event: tool_result
+data: {"tool_call_id": "tc_1", "status": "ok", "result_summary": "{{tool_result}}"}
+
+event: token
+data: {"text": "Load is low."}
+
+event: usage
+data: {"model": "demo", "vendor": "demo", "input_tokens": 1, "output_tokens": 1, "cached_tokens": 0, "tool_calls_count": 1, "fallback_used": false}
+"""
+
+
+def _api_client() -> APIClient:
+    # Same mocked AuthService the SSE tests use — enough for ``_get_headers``.
+    from tests.test_sse_stream import _make_api_client
+
+    return _make_api_client()
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# --- parsing ---------------------------------------------------------------
+
+def test_parse_script_keeps_events_and_reads_directives():
+    steps = parse_script(SCRIPT)
+    kinds = [s.kind for s in steps]
+    assert kinds == ["event", "delay", "event", "event", "wait", "event", "event", "event"]
+    assert steps[1].seconds == pytest.approx(0.01)
+    assert steps[0].event.startswith(b"event: conversation\n")
+    assert steps[0].event.endswith(b"\n\n")
+
+
+def test_parse_script_ignores_unknown_comments_and_blank_runs():
+    steps = parse_script(": hello\n\n\n: delay nope\nevent: token\ndata: {}\n")
+    assert [s.kind for s in steps] == ["event"]
+
+
+# --- replay through the real stream pipeline --------------------------------
+
+def test_replay_streams_events_and_waits_for_the_tool_result(monkeypatch):
+    monkeypatch.setattr(ai_sse, "_TEST_TRANSPORT", None)
+    api = _api_client()
+    transport = DemoChatReplayTransport(parse_script(SCRIPT))
+    api.transport = transport
+
+    async def scenario():
+        seen = []
+        posted = asyncio.Event()
+
+        async def consume():
+            async for event in stream_sse(api, "/api/ai/chat", {"task": "chat"}):
+                seen.append(event)
+                if event["event"] == "tool_call":
+                    # The CLI executes the tool and posts the result; the
+                    # stream must hold until then.
+                    await asyncio.sleep(0.05)
+                    assert seen[-1]["event"] == "tool_call"
+                    await api.post(
+                        "/api/ai/chat/tool-result",
+                        json={"tool_call_id": "tc_1", "status": "ok", "result": " 12:00 up 5 days, load 0.10\n"},
+                    )
+                    posted.set()
+
+        await asyncio.wait_for(consume(), timeout=5)
+        return seen, posted.is_set()
+
+    events, posted = run(scenario())
+    names = [e["event"] for e in events]
+    assert names == ["conversation", "token", "tool_call", "tool_result", "token", "usage"]
+    assert posted
+    assert events[3]["data"]["result_summary"] == "12:00 up 5 days, load 0.10"
+    assert transport.last_tool_result["tool_call_id"] == "tc_1"
+    assert transport.stream_requests == 1
+
+
+def test_wait_step_emits_ping_comments_while_holding(monkeypatch):
+    monkeypatch.setattr(demo_replay, "_WAIT_PING_SECONDS", 0.01)
+    transport = DemoChatReplayTransport([ScriptStep("wait"), ScriptStep("event", event=b"event: token\ndata: {}\n\n")])
+
+    async def scenario():
+        chunks = []
+        gen = transport.iter_script()
+        chunks.append(await gen.__anext__())  # first ping while waiting
+        chunks.append(await gen.__anext__())
+        # release the hold
+        await transport.handle_async_request(
+            httpx.Request("POST", "https://api.example.com/api/ai/chat/tool-result", content=b"{}")
+        )
+        async for chunk in gen:
+            chunks.append(chunk)
+        return chunks
+
+    chunks = run(scenario())
+    assert chunks[0] == b": ping\n\n"
+    assert chunks[-1].startswith(b"event: token")
+
+
+def test_other_requests_pass_through_to_the_inner_transport():
+    inner = httpx.MockTransport(lambda request: httpx.Response(200, json={"me": "real"}))
+    transport = DemoChatReplayTransport([], inner=inner)
+    api = _api_client()
+    api.transport = transport
+
+    assert run(api.get("/api/v1/me")) == {"me": "real"}
+
+
+def test_without_inner_transport_unknown_routes_are_404():
+    transport = DemoChatReplayTransport([])
+    api = _api_client()
+    api.transport = transport
+    with pytest.raises(Exception):
+        run(api.get("/api/v1/me"))
+
+
+# --- gating ----------------------------------------------------------------
+
+def test_replay_script_path_requires_demo_mode_and_a_readable_file(tmp_path):
+    script = tmp_path / "chat.sse"
+    script.write_text(SCRIPT)
+    assert replay_script_path(False, {"SERVONAUT_DEMO_CHAT_REPLAY": str(script)}) is None
+    assert replay_script_path(True, {}) is None
+    assert replay_script_path(True, {"SERVONAUT_DEMO_CHAT_REPLAY": str(tmp_path / "missing.sse")}) is None
+    assert replay_script_path(True, {"SERVONAUT_DEMO_CHAT_REPLAY": str(script)}) == script
+
+
+def test_install_wraps_the_client_and_maybe_install_is_a_no_op_without_env(tmp_path):
+    script = tmp_path / "chat.sse"
+    script.write_text(SCRIPT)
+    api = _api_client()
+    assert maybe_install_demo_chat_replay(api, True, {}) is None
+    assert api.transport is None
+
+    transport = maybe_install_demo_chat_replay(api, True, {"SERVONAUT_DEMO_CHAT_REPLAY": str(script)})
+    assert isinstance(transport, DemoChatReplayTransport)
+    assert api.transport is transport
+    assert len(transport._steps) == len(parse_script(SCRIPT))
+
+
+def test_install_keeps_an_existing_transport_as_the_inner_one(tmp_path):
+    script = tmp_path / "chat.sse"
+    script.write_text(SCRIPT)
+    api = _api_client()
+    inner = httpx.MockTransport(lambda request: httpx.Response(200, json={"ok": True}))
+    api.transport = inner
+    transport = install_demo_chat_replay(api, script)
+    assert transport._inner is inner
+    assert run(api.get("/api/anything")) == {"ok": True}


### PR DESCRIPTION
## Summary

Demo mode redacts what the TUI shows, but the chat panel's answers and tool rows come from the AI gateway and the fleet's real tools, and the stream scrubber covers addresses, hosts, emails and URLs, not instance names, container names or memory summaries. A recording or screenshot of a live conversation could therefore still show real data. This adds a scripted replay for exactly those cases, and fixes two things found while building it.

## Changes

- **Scripted chat replay.** With demo mode on and `SERVONAUT_DEMO_CHAT_REPLAY` pointing at a script, the hosted provider replays that script instead of calling the gateway. The script is a plain `text/event-stream` body using the gateway's own event names, plus two comment directives: `: delay N` paces the stream and `: wait tool-result` holds it until the CLI has posted the tool's result, as the gateway does. `{{tool_result}}` in an event is replaced with what the tool really returned. The replay runs through the same stream parser, tool bridge, confirm modals and rendering as a real conversation; every other request still reaches the API. Off outside demo mode, and a variable that points at a missing file is logged and ignored.
- **Transport seam on the API client.** `APIClient.transport` (default `None`) is used by every request the client makes, and the SSE helper honours it, so the replay needs no monkeypatching. Empty `202`/`204` bodies now decode as success; the chat tool-result acknowledgement is one.
- **Locally executed AI tools resolve demo ids.** Tools that run in the CLI process (`disk_usage`, `describe_instance`, …) received the redacted instance id and answered "Instance not found"; they now go through the same resolver the relay path already used.
- Tests for the parser, the paced and held stream, pass-through, gating and the id resolution. `docs/demo-mode.md` documents the script format.
