### PR TITLE
fix: CloudTrail browser failures and demo-mode gaps in the AWS screens

### DIFF
--- a/src/servonaut/screens/aws_create.py
+++ b/src/servonaut/screens/aws_create.py
@@ -390,7 +390,7 @@ class AWSCreateScreen(Screen):
             self._key_pairs = await svc.list_key_pairs(region)
             for kp in self._key_pairs:
                 tbl.add_row(
-                    escape_cell(kp.get("key_name", "")),
+                    escape_cell(self._demo_key_name(kp.get("key_name", ""))),
                     escape_cell(kp.get("key_pair_id", "")),
                     escape_cell((kp.get("fingerprint", "") or "")[:32]),
                     key=kp.get("key_name", ""),
@@ -451,8 +451,8 @@ class AWSCreateScreen(Screen):
             for sg in self._security_groups:
                 tbl.add_row(
                     escape_cell(sg.get("group_id", "")),
-                    escape_cell(sg.get("group_name", "")),
-                    escape_cell(sg.get("description", "")[:60]),
+                    escape_cell(self._demo_name(sg.get("group_name", ""))),
+                    escape_cell(self._demo_text(sg.get("description", ""))[:60]),
                     escape_cell(sg.get("vpc_id", "")),
                     key=sg.get("group_id", ""),
                 )
@@ -522,6 +522,24 @@ class AWSCreateScreen(Screen):
                 exclusive=True,
                 name="aws_create_submit",
             )
+
+    # Demo mode: key-pair names, security-group names and their free-text
+    # descriptions are operator-authored identifiers; the table keys stay
+    # raw so a launch still targets the real resource.
+    def _demo_key_name(self, value: str) -> str:
+        if self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.redact_key_name(value)
+        return value
+
+    def _demo_name(self, value: str) -> str:
+        if self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.redact_name(value)
+        return value
+
+    def _demo_text(self, value: str) -> str:
+        if self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.scrub_stream(value)
+        return value
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -14,6 +14,9 @@ from textual.screen import Screen
 from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Select, Static
 
 from servonaut.screens._binding_guard import check_action_passthrough
+import re
+
+_EC2_ID_RE = re.compile(r"i-[0-9a-f]{8,17}")
 
 _AWS_REGIONS = [
     ("US East (N. Virginia)", "us-east-1"),
@@ -213,7 +216,7 @@ class CloudTrailBrowserScreen(Screen):
             table.add_row(
                 str(event_time),
                 ev.get("event_name", ""),       # public taxonomy — NOT scrubbed
-                _s(ev.get("username", "")),
+                self._u(ev.get("username", "")),
                 _s(ev.get("source_ip", "")),
                 _s(ev.get("resource_name", "") or ev.get("resource_type", "")),
                 ev.get("region", ""),            # public taxonomy — NOT scrubbed
@@ -273,7 +276,7 @@ class CloudTrailBrowserScreen(Screen):
         self.query_one("#event_detail_text", Static).update(
             f"[bold]Event:[/bold] {event.get('event_name', '')}\n"
             f"[bold]Time:[/bold] {event_time}\n"
-            f"[bold]User:[/bold] {_s(event.get('username', ''))}\n"
+            f"[bold]User:[/bold] {self._u(event.get('username', ''))}\n"
             f"[bold]Source IP:[/bold] {_s(event.get('source_ip', ''))}\n"
             f"[bold]Resource Type:[/bold] {_s(event.get('resource_type', ''))}\n"
             f"[bold]Resource Name:[/bold] {_s(event.get('resource_name', ''))}\n"
@@ -302,7 +305,7 @@ class CloudTrailBrowserScreen(Screen):
             lines = [
                 f"Event:          {event.get('event_name', '')}",
                 f"Time:           {event_time}",
-                f"User:           {_s(event.get('username', ''))}",
+                f"User:           {self._u(event.get('username', ''))}",
                 f"Source IP:      {_s(event.get('source_ip', ''))}",
                 f"Resource Type:  {_s(event.get('resource_type', ''))}",
                 f"Resource Name:  {_s(event.get('resource_name', ''))}",
@@ -317,7 +320,7 @@ class CloudTrailBrowserScreen(Screen):
             text = "\n".join(lines)
         else:
             text = "\n".join(
-                f"{ev.get('event_name', '')} | {_s(ev.get('username', ''))} | {_s(ev.get('source_ip', ''))}"
+                f"{ev.get('event_name', '')} | {self._u(ev.get('username', ''))} | {_s(ev.get('source_ip', ''))}"
                 for ev in self._events
             )
 
@@ -336,6 +339,16 @@ class CloudTrailBrowserScreen(Screen):
     # ------------------------------------------------------------------
     # Fetch / Back
     # ------------------------------------------------------------------
+
+    def _u(self, username: str) -> str:
+        """Demo-mode username: instance-role sessions carry the instance id
+        (same fake as the fleet table); human IAM names get a pool name."""
+        if not (self.app.demo_mode and self.app.redaction_service):
+            return username
+        svc = self.app.redaction_service
+        if _EC2_ID_RE.fullmatch(username or ""):
+            return svc.redact_instance_id(username)
+        return svc.redact_username(username)
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -379,6 +379,10 @@ class CloudTrailBrowserScreen(Screen):
         start_time = end_time - timedelta(minutes=minutes)
 
         try:
+            # Honour the configured cap (0 = everything in the window); a
+            # busy account can hold thousands of events per hour.
+            config = self.app.config_manager.get()
+            max_events = int(getattr(config, "cloudtrail_max_events", 0) or 0)
             events = await self.app.cloudtrail_service.lookup_events(
                 region=region,
                 start_time=start_time,
@@ -386,7 +390,7 @@ class CloudTrailBrowserScreen(Screen):
                 event_name=event_name,
                 username=username,
                 resource_type=resource_type,
-                max_results=0,
+                max_results=max_events,
             )
         except Exception as exc:
             self.app.notify(f"CloudTrail fetch failed: {exc}", severity="error")

--- a/src/servonaut/screens/ip_ban.py
+++ b/src/servonaut/screens/ip_ban.py
@@ -107,11 +107,19 @@ class IPBanScreen(Screen):
         else:
             self.query_one("#ban_config_selector", Select).focus()
 
+    def _demo_config_name(self, name: str) -> str:
+        """Ban configurations are named by the operator (often after the
+        site they protect); demo mode shows a pool name instead. Values
+        and lookups keep the real name."""
+        if self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.redact_name(name)
+        return name
+
     def _get_config_options(self) -> List[tuple]:
         configs = self.app.ip_ban_service.get_configs()
         if not configs:
             return []
-        return [(f"{c.name} ({c.method})", c.name) for c in configs]
+        return [(f"{self._demo_config_name(c.name)} ({c.method})", c.name) for c in configs]
 
     def _setup_table(self) -> None:
         table = self.query_one("#banned_table", DataTable)
@@ -168,7 +176,7 @@ class IPBanScreen(Screen):
                 if self.app.demo_mode and self.app.redaction_service:
                     ip = self.app.redaction_service.redact_ip(ip)
                     msg = self.app.redaction_service.scrub_stream(msg)
-                    config = self.app.redaction_service.scrub_stream(config)
+                    config = self._demo_config_name(config)
                 color = "green" if success else "red"
                 audit_log.write(
                     f"[{color}]{ts} {action}[/{color}] "
@@ -213,9 +221,15 @@ class IPBanScreen(Screen):
                     display_ip = self.app.redaction_service.redact_ip(bare_ip)
                     if "/" in ip:
                         display_ip = f"{display_ip}/32"
-                table.add_row(display_ip, str(count) if count else "-", config_name, method)
+                table.add_row(
+                    display_ip, str(count) if count else "-",
+                    self._demo_config_name(config_name), method,
+                )
             if not banned:
-                self.app.notify(f"No IPs currently banned in '{config_name}'")
+                self.app.notify(
+                    f"No IPs currently banned in '{self._demo_config_name(config_name)}'",
+                    markup=False,
+                )
         except Exception as e:
             self.app.notify(f"Error loading banned IPs: {e}", severity="error")
 

--- a/src/servonaut/services/cloudtrail_service.py
+++ b/src/servonaut/services/cloudtrail_service.py
@@ -95,9 +95,12 @@ class CloudTrailService(CloudTrailServiceInterface):
         except (json.JSONDecodeError, TypeError):
             detail = {}
 
+        # CloudTrail does not guarantee either key on a resource entry
+        # (some services omit ResourceType), so never index them directly.
         resources = event.get("Resources") or []
-        resource_type = resources[0]["ResourceType"] if resources else ""
-        resource_name = resources[0]["ResourceName"] if resources else ""
+        first = resources[0] if resources and isinstance(resources[0], dict) else {}
+        resource_type = str(first.get("ResourceType") or "")
+        resource_name = str(first.get("ResourceName") or "")
 
         return {
             "event_time": event.get("EventTime", ""),

--- a/src/servonaut/services/redaction_service.py
+++ b/src/servonaut/services/redaction_service.py
@@ -128,6 +128,7 @@ _EMAIL_RE = re.compile(
 # Dashed-IP host fragments: OVH dedicated / VPS service names look like
 # ``ns3141592.ip-51-195-150-236.eu``.  The IPv4 rule cannot see the dashed
 # form, so it gets its own rule that reuses the ``redact_ip`` mapping.
+_EC2_ID_RE = re.compile(r"\bi-[0-9a-f]{8,17}\b")
 _DASHED_IP_RE = re.compile(r"\bip-(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})\b")
 
 # A bare hostname / FQDN on its own: dotted labels and nothing else.  Callers
@@ -481,6 +482,17 @@ class RedactionService:
         self._ipv6_cache[address] = fake
         return fake
 
+    def redact_ec2_ids(self, text: str) -> str:
+        """Replace EC2 instance ids embedded in free text.
+
+        CloudTrail usernames for instance-role sessions, log lines and tool
+        output all carry ``i-…`` ids; the fake keeps the id shape and is the
+        same one the fleet table shows for that instance.
+        """
+        if not text:
+            return text
+        return _EC2_ID_RE.sub(lambda m: self.redact_instance_id(m.group(0)), text)
+
     def redact_dashed_ip(self, text: str) -> str:
         """Replace ``ip-A-B-C-D`` host fragments with the dashed form of the
         doc-range IP ``redact_ip`` maps ``A.B.C.D`` to (same session mapping,
@@ -626,6 +638,7 @@ class RedactionService:
             text = default_redactor(text)
             text = self.redact_text(text)
             text = self.redact_dashed_ip(text)
+            text = self.redact_ec2_ids(text)
             text = self.redact_ipv6(text)
             text = self.redact_arn(text)
             text = self.redact_ecr_host(text)

--- a/tests/test_aws_create_screen.py
+++ b/tests/test_aws_create_screen.py
@@ -300,3 +300,74 @@ class TestCreateFlow:
         assert call_kwargs["name_tag"] == "test-server"
         assert call_kwargs["region"] == "us-east-1"
         assert call_kwargs["ami_id"] == "ami-0abc12345678def90"
+
+
+# ---------------------------------------------------------------------------
+# Demo mode: operator-authored names in the wizard tables are redacted
+# ---------------------------------------------------------------------------
+
+class TestDemoModeRedaction:
+    """Key-pair and security-group rows must not show real names in demo
+    mode; the row keys stay raw so a launch still targets the resource."""
+
+    def _demo_app(self, svc):
+        from servonaut.services.redaction_service import RedactionService
+
+        app = _mock_app(aws_service=svc, demo_mode=True)
+        app.redaction_service = RedactionService()
+        return app
+
+    @pytest.mark.asyncio
+    async def test_key_pair_names_are_redacted(self) -> None:
+        svc = _make_mock_aws_service()
+        svc.list_key_pairs = AsyncMock(return_value=[
+            {"key_name": "customer-prod-web-key", "key_pair_id": "key-0123", "fingerprint": "ab:cd"},
+        ])
+        app = self._demo_app(svc)
+        screen = AWSCreateScreen()
+        table = MagicMock()
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=table):
+            await screen._load_key_pairs("us-east-1")
+
+        assert table.add_row.called
+        args, kwargs = table.add_row.call_args
+        assert "customer-prod-web-key" not in str(args[0])
+        assert args[0] == app.redaction_service.redact_key_name("customer-prod-web-key")
+        assert kwargs["key"] == "customer-prod-web-key"
+
+    @pytest.mark.asyncio
+    async def test_security_group_names_and_descriptions_are_redacted(self) -> None:
+        svc = _make_mock_aws_service()
+        svc.list_security_groups = AsyncMock(return_value=[
+            {"group_id": "sg-0123", "group_name": "customer-shop-web",
+             "description": "web tier for shop.example.com from 203.0.113.9", "vpc_id": "vpc-1"},
+        ])
+        app = self._demo_app(svc)
+        screen = AWSCreateScreen()
+        table = MagicMock()
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=table):
+            await screen._load_security_groups("us-east-1")
+
+        args, kwargs = table.add_row.call_args
+        assert args[0] == "sg-0123"
+        assert "customer-shop-web" not in args[1]
+        assert args[1] == app.redaction_service.redact_name("customer-shop-web")
+        assert kwargs["key"] == "sg-0123"
+
+    @pytest.mark.asyncio
+    async def test_rows_are_raw_outside_demo_mode(self) -> None:
+        svc = _make_mock_aws_service()
+        svc.list_key_pairs = AsyncMock(return_value=[
+            {"key_name": "customer-prod-web-key", "key_pair_id": "key-0123", "fingerprint": "ab:cd"},
+        ])
+        app = _mock_app(aws_service=svc)
+        screen = AWSCreateScreen()
+        table = MagicMock()
+        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+             patch.object(screen, "query_one", return_value=table):
+            await screen._load_key_pairs("us-east-1")
+
+        args, _ = table.add_row.call_args
+        assert args[0] == "customer-prod-web-key"

--- a/tests/test_cloudtrail_browser_cap.py
+++ b/tests/test_cloudtrail_browser_cap.py
@@ -1,0 +1,49 @@
+"""The CloudTrail browser fetches at most ``cloudtrail_max_events`` per lookup."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from servonaut.config.schema import AppConfig
+from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _app(max_events: int):
+    app = MagicMock()
+    app.demo_mode = False
+    app.redaction_service = None
+    cfg = AppConfig()
+    cfg.cloudtrail_max_events = max_events
+    app.config_manager.get.return_value = cfg
+    app.cloudtrail_service.lookup_events = AsyncMock(return_value=[])
+    return app
+
+
+def test_fetch_passes_the_configured_cap():
+    app = _app(100)
+    screen = CloudTrailBrowserScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+         patch.object(screen, "query_one", return_value=MagicMock()), \
+         patch.object(screen, "_populate_table"), \
+         patch.object(screen, "_update_pager"):
+        _run(screen._fetch_events("eu-west-2", 60, "", "", ""))
+
+    kwargs = app.cloudtrail_service.lookup_events.await_args.kwargs
+    assert kwargs["max_results"] == 100
+    assert kwargs["region"] == "eu-west-2"
+
+
+def test_zero_cap_means_everything_in_the_window():
+    app = _app(0)
+    screen = CloudTrailBrowserScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app), \
+         patch.object(screen, "query_one", return_value=MagicMock()), \
+         patch.object(screen, "_populate_table"), \
+         patch.object(screen, "_update_pager"):
+        _run(screen._fetch_events("eu-west-2", 60, "", "", ""))
+
+    assert app.cloudtrail_service.lookup_events.await_args.kwargs["max_results"] == 0

--- a/tests/test_cloudtrail_service.py
+++ b/tests/test_cloudtrail_service.py
@@ -212,12 +212,12 @@ def test_parse_event_tolerates_resources_without_type_or_name(service):
         "EventTime": datetime(2024, 1, 15, 10, 30, 0),
         "EventName": "AssumeRole",
         "Username": "alice",
-        "Resources": [{"ResourceName": "arn:aws:iam::000000000000:role/demo"}],
+        "Resources": [{"ResourceName": "demo-role"}],
         "CloudTrailEvent": "{}",
     }
     result = service._parse_event(raw, "eu-west-2")
     assert result["resource_type"] == ""
-    assert result["resource_name"].endswith("role/demo")
+    assert result["resource_name"] == "demo-role"
 
     raw["Resources"] = [{"ResourceType": "AWS::IAM::Role"}]
     result = service._parse_event(raw, "eu-west-2")

--- a/tests/test_cloudtrail_service.py
+++ b/tests/test_cloudtrail_service.py
@@ -203,3 +203,23 @@ def test_lookup_events_uses_config_lookback_hours(service):
     # Config has lookback_hours=12, so start_time should be ~12 hours ago
     expected_start = before - timedelta(hours=12)
     assert abs((start_time - expected_start).total_seconds()) < 5
+
+
+def test_parse_event_tolerates_resources_without_type_or_name(service):
+    """Some services emit resource entries without ResourceType (or with
+    a bare name); the browser used to fail every fetch on those."""
+    raw = {
+        "EventTime": datetime(2024, 1, 15, 10, 30, 0),
+        "EventName": "AssumeRole",
+        "Username": "alice",
+        "Resources": [{"ResourceName": "arn:aws:iam::000000000000:role/demo"}],
+        "CloudTrailEvent": "{}",
+    }
+    result = service._parse_event(raw, "eu-west-2")
+    assert result["resource_type"] == ""
+    assert result["resource_name"].endswith("role/demo")
+
+    raw["Resources"] = [{"ResourceType": "AWS::IAM::Role"}]
+    result = service._parse_event(raw, "eu-west-2")
+    assert result["resource_type"] == "AWS::IAM::Role"
+    assert result["resource_name"] == ""

--- a/tests/test_demo_mode_cloudtrail_redaction.py
+++ b/tests/test_demo_mode_cloudtrail_redaction.py
@@ -1,0 +1,44 @@
+"""Demo mode: EC2 instance ids in free text and CloudTrail usernames are redacted."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+from servonaut.services.redaction_service import RedactionService
+
+
+def test_scrub_stream_replaces_ec2_instance_ids_consistently():
+    svc = RedactionService()
+    real = "i-0abc12345678def01"
+    out = svc.scrub_stream(f"UpdateInstanceInformation by {real} from {real}")
+    assert real not in out
+    fake = svc.redact_instance_id(real)
+    assert out.count(fake) == 2
+    assert fake.startswith("i-") and len(fake) == len(real)
+
+
+def _demo_app():
+    app = MagicMock()
+    app.demo_mode = True
+    app.redaction_service = RedactionService()
+    return app
+
+
+def test_browser_redacts_instance_role_and_human_usernames():
+    app = _demo_app()
+    screen = CloudTrailBrowserScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app):
+        assert screen._u("i-0abc12345678def01") == app.redaction_service.redact_instance_id("i-0abc12345678def01")
+        human = screen._u("jane.doe")
+        assert human != "jane.doe"
+        assert human == app.redaction_service.redact_username("jane.doe")
+        assert screen._u("") == ""
+
+
+def test_browser_leaves_usernames_alone_outside_demo_mode():
+    app = MagicMock()
+    app.demo_mode = False
+    app.redaction_service = None
+    screen = CloudTrailBrowserScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app):
+        assert screen._u("jane.doe") == "jane.doe"

--- a/tests/test_ip_ban_screen_demo.py
+++ b/tests/test_ip_ban_screen_demo.py
@@ -1,0 +1,41 @@
+"""IP Ban screen: operator-named ban configurations are redacted in demo mode."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from servonaut.screens.ip_ban import IPBanScreen
+from servonaut.services.redaction_service import RedactionService
+
+
+def _app(demo: bool):
+    app = MagicMock()
+    app.demo_mode = demo
+    app.redaction_service = RedactionService() if demo else None
+    app.ip_ban_service.get_configs.return_value = [
+        SimpleNamespace(name="customer-shop-waf", method="waf"),
+        SimpleNamespace(name="ops-nacl", method="nacl"),
+    ]
+    return app
+
+
+def test_config_options_show_pool_names_but_keep_real_values_in_demo_mode():
+    app = _app(demo=True)
+    screen = IPBanScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app):
+        options = screen._get_config_options()
+
+    labels = [label for label, _ in options]
+    values = [value for _, value in options]
+    assert values == ["customer-shop-waf", "ops-nacl"]
+    assert all("customer-shop-waf" not in label for label in labels)
+    assert labels[0] == f"{app.redaction_service.redact_name('customer-shop-waf')} (waf)"
+
+
+def test_config_options_are_raw_outside_demo_mode():
+    app = _app(demo=False)
+    screen = IPBanScreen()
+    with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=app):
+        options = screen._get_config_options()
+
+    assert options[0] == ("customer-shop-waf (waf)", "customer-shop-waf")


### PR DESCRIPTION
## Summary

Two of these are real bugs in the CloudTrail browser that affect everyone, not just demo mode: the browser failed every fetch on this account, and when it did work it asked for every event in the window. The other three close demo-mode gaps in the AWS launch wizard, the IP Ban screen and the stream scrubber.

## Changes

- **CloudTrail: every fetch failed with `KeyError: 'ResourceType'`.** CloudTrail resource entries do not always carry both keys, and the event parser indexed `ResourceType` and `ResourceName` directly, so a single such event ended the fetch with an error toast and an empty table. `AssumeRole` events from instance profiles have that shape, which makes them common on any account using SSM or instance roles. The parser now reads both fields defensively.
- **CloudTrail: the browser asked for every event in the window.** It passed `max_results=0`, which on a busy account means thousands of events and a long wait behind a "Loading" status. It now passes `cloudtrail_max_events` (default 100); zero still means fetch everything.
- **Launch wizard, demo mode:** the key-pair and security-group tables rendered the account's real names and descriptions. Rows now show redacted names while the row keys stay raw, so a launch still targets the real resource.
- **IP Ban screen, demo mode:** ban configurations are named by the operator, often after the site they protect, and the selector, banned table and audit log showed those names raw. They now render as pool names; values and lookups keep the real name.
- **Instance ids in streamed text, demo mode:** `scrub_stream` had no rule for `i-…` ids, so any id embedded in free text (CloudTrail's username column for instance-role sessions, log lines, tool output) stayed real while the fleet table showed a fake. Ids in streamed text now map to the same fake the table uses, and the CloudTrail username column redacts human IAM names to pool names.
- Tests for each: the tolerant resource parsing, the event cap, and the three redaction paths.
