### PR TITLE
feat: CloudTrail filters you can pick or type, paging that keeps going, and combining that no longer lies

### DIFF
--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -68,7 +68,7 @@ raw data through a demo-mode-enabled app without triggering redaction.
 | S3 URIs | `s3://company-prod-data/logs` | `s3://<fake-name>/logs` |
 | Instance names | `web-prod-7` | `api-staging-3` (deterministic) |
 | Instance IPs | `54.234.1.99` | `198.51.100.42` (RFC 5737 doc-range) |
-| Instance IDs (fields, and inside streamed text) | `i-0abc123def456789a` | `i-<sha256-derived>` — the same fake the fleet table shows |
+| Instance IDs | `i-0abc123def456789a` | `i-<sha256-derived>` |
 | Hostnames | `web-prod-7.eu-central-1.compute.internal` | `monitor-12.example.com` |
 | SSH key names | `my-prod-key` | `deploy-key` |
 | Usernames | `alice` | `ubuntu` (from fake pool) |
@@ -80,6 +80,10 @@ raw data through a demo-mode-enabled app without triggering redaction.
 
 **Redaction is deterministic:** the same input always maps to the same fake
 output within a session. Repeated IP addresses show the same fake IP.
+
+Instance IDs are replaced inside streamed text too — log lines, tool output
+and CloudTrail's username column for instance-role sessions — using the same
+fake the fleet table shows for that instance.
 
 ---
 

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -68,7 +68,7 @@ raw data through a demo-mode-enabled app without triggering redaction.
 | S3 URIs | `s3://company-prod-data/logs` | `s3://<fake-name>/logs` |
 | Instance names | `web-prod-7` | `api-staging-3` (deterministic) |
 | Instance IPs | `54.234.1.99` | `198.51.100.42` (RFC 5737 doc-range) |
-| Instance IDs | `i-0abc123def456789a` | `i-<sha256-derived>` |
+| Instance IDs (fields, and inside streamed text) | `i-0abc123def456789a` | `i-<sha256-derived>` — the same fake the fleet table shows |
 | Hostnames | `web-prod-7.eu-central-1.compute.internal` | `monitor-12.example.com` |
 | SSH key names | `my-prod-key` | `deploy-key` |
 | Usernames | `alice` | `ubuntu` (from fake pool) |
@@ -107,6 +107,7 @@ output within a session. Repeated IP addresses show the same fake IP.
 | Custom Servers table | Every column through the same per-field redactors as the instance list (name, host, username, key path, provider, group) — a server keeps one fake identity across both views. Editing an existing server is disabled while demo mode is on (the form would show the real values); adding a new one still works |
 | Hetzner create wizard | Project SSH-key names in the key table and in the confirm dialog (key labels are user-chosen and often an email address) |
 | AWS / OVH / Hetzner managers | Rows show fake ids; start / stop / reboot / delete keep using the real provider id through a per-screen map, so the manager actions work while recording |
+| AWS launch wizard | Key-pair names, security-group names and descriptions in the selection tables; the row keys keep the real value so a launch still targets the right resource |
 | OVH / Hetzner SSH key screens | Key labels shown as pool key names |
 | Account / Login | "Logged in as" email (deterministic fake) |
 | Relay status screen | Backend `client_ids` (they embed the OS user and machine name) |
@@ -120,9 +121,11 @@ output within a session. Repeated IP addresses show the same fake IP.
 | CloudWatch top-IPs table | IP column (`display_ip`, raw used for network calls) |
 | CloudWatch IP info panel | Header shows `display_ip`; httpx call uses raw IP |
 | CloudTrail events table | `username`, `source_ip`, `resource_name` columns |
+| CloudTrail filter pickers | Username option labels; the value behind an option stays real so the lookup still works |
 | CloudTrail event detail | All PII fields + raw event JSON blob |
 | IP ban audit log | `ip_address` and `message` fields |
 | IP ban banned-IPs table | Display IP column (`display_ip`) |
+| IP ban configurations | Configuration names in the selector, the banned table and the audit log (operator-chosen, often named after the site they protect) |
 | Memory screen (observed / declared) | `obs_str` and `decl_str` values only |
 | AI chat panel (streaming) | Full scrub on every token (always-scrub; heuristic removed); tool-result rows scrubbed; tool messages scrubbed on reload |
 | AI analysis screen | Log text, `_raw_text` buffer, AI output, and error messages scrubbed |

--- a/src/servonaut/config/migration.py
+++ b/src/servonaut/config/migration.py
@@ -153,6 +153,32 @@ def migrate_v1_to_v2(v1_data: Dict[str, Any]) -> Dict[str, Any]:
     return v2_data
 
 
+# The v5 default for ``cloudtrail_max_events``. Only this exact value is
+# raised by the v6 migration, so a deliberate choice is never overwritten.
+_V5_CLOUDTRAIL_MAX_EVENTS = 100
+_V6_CLOUDTRAIL_MAX_EVENTS = 500
+
+
+def _migrate_v5_to_v6(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Migrate a v5 configuration dictionary to v6.
+
+    v5 shipped ``cloudtrail_max_events: 100``, and the CloudTrail browser
+    shows 100 events per page — so the cap allowed exactly one page and the
+    pager could never turn. v6 raises that to 500 (five pages, and about two
+    seconds against a day of events).
+
+    Every saved config carries the key, so raising the dataclass default
+    alone would reach nobody who had ever saved settings. Only the old
+    default value is raised; any other number is a deliberate choice and is
+    left alone.
+    """
+    out = dict(data)
+    out['version'] = 6
+    if out.get('cloudtrail_max_events') == _V5_CLOUDTRAIL_MAX_EVENTS:
+        out['cloudtrail_max_events'] = _V6_CLOUDTRAIL_MAX_EVENTS
+    return out
+
+
 def migrate_to_latest(data: Dict[str, Any]) -> Dict[str, Any]:
     """Run every migration step needed to bring ``data`` up to ``CONFIG_VERSION``.
 
@@ -164,7 +190,8 @@ def migrate_to_latest(data: Dict[str, Any]) -> Dict[str, Any]:
         (which lands at ``CONFIG_VERSION`` via its own short-circuit).
       - ``version == 2`` → run :func:`_migrate_v2_to_v3` then chain.
       - ``version == 3`` → run :func:`_migrate_v3_to_v4` then chain.
-      - ``version == 4`` → run :func:`_migrate_v4_to_v5`.
+      - ``version == 4`` → run :func:`_migrate_v4_to_v5` then chain.
+      - ``version == 5`` → run :func:`_migrate_v5_to_v6`.
       - ``version >= CONFIG_VERSION`` → return as-is.
     """
     out = data
@@ -180,6 +207,9 @@ def migrate_to_latest(data: Dict[str, Any]) -> Dict[str, Any]:
         current = out.get('version')
     if current == 4:
         out = _migrate_v4_to_v5(out)
+        current = out.get('version')
+    if current == 5:
+        out = _migrate_v5_to_v6(out)
         current = out.get('version')
     return out
 

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -1227,7 +1227,7 @@ class AppConfig:
     log_viewer_max_lines: int = 10000
     log_viewer_tail_lines: int = 100
     cloudtrail_default_region: str = ""
-    cloudtrail_max_events: int = 100
+    cloudtrail_max_events: int = 500
     cloudtrail_default_lookback_hours: int = 24
     cloudtrail_default_lookback_minutes: int = 0
     cloudwatch_default_region: str = ""

--- a/src/servonaut/config/schema.py
+++ b/src/servonaut/config/schema.py
@@ -9,7 +9,7 @@ from typing import Any, List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-CONFIG_VERSION = 5
+CONFIG_VERSION = 6
 
 # Known :class:`SecretProviderInterface` implementations the CLI
 # recognises. Any value outside this set, however received (server

--- a/src/servonaut/mcp/tool_schemas.py
+++ b/src/servonaut/mcp/tool_schemas.py
@@ -1240,8 +1240,9 @@ TOOL_SCHEMAS: Dict[str, Dict[str, Any]] = {
     "cloudtrail_lookup_events": {
         "description": (
             "Look up AWS CloudTrail management events with optional filters "
-            "(event name, username, resource type). Useful for auditing who "
-            "changed what, and from which source IP."
+            "(event name, username, resource type). Filters are exact, "
+            "case-sensitive matches and may be combined. Useful for auditing "
+            "who changed what, and from which source IP."
         ),
         "schema": {
             "type": "object",

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -82,6 +82,7 @@ class CloudTrailBrowserScreen(Screen):
         self._selected_row: Optional[int] = None
         self._current_page: int = 0
         self._cap_reached: bool = False
+        self._fleet_names_cache: Optional[Dict[str, str]] = None
         # set_options() resets a Select and fires Changed; ignore those.
         self._suppress_filter_events: bool = False
 
@@ -222,7 +223,8 @@ class CloudTrailBrowserScreen(Screen):
             previous = select.value
             options = [
                 (
-                    f"{self._u(value) if field == 'username' else value}  ({count})",
+                    f"{self._username_label(value) if field == 'username' else value}"
+                    f"  ({count})",
                     value,
                 )
                 for value, count in sorted(
@@ -308,7 +310,7 @@ class CloudTrailBrowserScreen(Screen):
             table.add_row(
                 str(event_time),
                 ev.get("event_name", ""),       # public taxonomy — NOT scrubbed
-                self._u(ev.get("username", "")),
+                self._username_label(ev.get("username", "")),
                 _s(ev.get("source_ip", "")),
                 _s(ev.get("resource_name", "") or ev.get("resource_type", "")),
                 ev.get("region", ""),            # public taxonomy — NOT scrubbed
@@ -368,7 +370,7 @@ class CloudTrailBrowserScreen(Screen):
         self.query_one("#event_detail_text", Static).update(
             f"[bold]Event:[/bold] {event.get('event_name', '')}\n"
             f"[bold]Time:[/bold] {event_time}\n"
-            f"[bold]User:[/bold] {self._u(event.get('username', ''))}\n"
+            f"[bold]User:[/bold] {self._user_detail(event.get('username', ''))}\n"
             f"[bold]Source IP:[/bold] {_s(event.get('source_ip', ''))}\n"
             f"[bold]Resource Type:[/bold] {_s(event.get('resource_type', ''))}\n"
             f"[bold]Resource Name:[/bold] {_s(event.get('resource_name', ''))}\n"
@@ -431,6 +433,49 @@ class CloudTrailBrowserScreen(Screen):
     # ------------------------------------------------------------------
     # Fetch / Back
     # ------------------------------------------------------------------
+
+    def _user_detail(self, username: str) -> str:
+        """Name and id together, where there is room for both."""
+        label = self._username_label(username)
+        shown = self._u(username)
+        return label if label == shown else f"{label} ({shown})"
+
+    def _fleet_names(self) -> Dict[str, str]:
+        """Real instance id to real instance name, from the fleet.
+
+        Reads the pre-redaction snapshot when demo mode is on, so the
+        lookup key is the real id CloudTrail reports.
+        """
+        if getattr(self, "_fleet_names_cache", None) is None:
+            rows = (
+                getattr(self.app, "_instances_pristine", None)
+                or getattr(self.app, "instances", None)
+                or []
+            )
+            names: Dict[str, str] = {}
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                instance_id = str(row.get("id") or "")
+                name = str(row.get("name") or "")
+                if instance_id and name:
+                    names[instance_id] = name
+            self._fleet_names_cache = names
+        return self._fleet_names_cache
+
+    def _username_label(self, username: str) -> str:
+        """Name the machine behind an instance-role session.
+
+        CloudTrail names those sessions after the instance id, which reads
+        as noise in a picker; the fleet already knows what that id is
+        called. Anything it cannot resolve keeps its own display rules.
+        """
+        name = self._fleet_names().get(username or "")
+        if not name:
+            return self._u(username)
+        if self.app.demo_mode and self.app.redaction_service:
+            return self.app.redaction_service.redact_name(name)
+        return name
 
     def _u(self, username: str) -> str:
         """Demo-mode username: instance-role sessions carry the instance id
@@ -505,6 +550,7 @@ class CloudTrailBrowserScreen(Screen):
             return
 
         self._events = events
+        self._fleet_names_cache = None
         self._cap_reached = bool(max_events) and len(events) >= max_events
         self._refresh_filter_options()
         self._apply_filters()

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -289,7 +289,7 @@ class CloudTrailBrowserScreen(Screen):
             next_btn.disabled = True
         else:
             page_info.update(
-                f"Page {self._current_page + 1} of {total}  [dim]({summary})[/dim]"
+                f"Page {self._current_page + 1} of {total}   [dim]{summary}[/dim]"
             )
             prev_btn.disabled = self._current_page == 0
             next_btn.disabled = self._current_page >= total - 1

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -281,7 +281,7 @@ class CloudTrailBrowserScreen(Screen):
         else:
             summary = f"{loaded} events"
         if summary and self._cap_reached:
-            summary += " (cap reached - Fetch searches the whole window)"
+            summary += " (cap reached - narrow the range or filters, then Fetch)"
 
         if total <= 1:
             page_info.update(f"[dim]{summary}[/dim]" if summary else "")

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -11,8 +11,8 @@ from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 
 from servonaut.widgets.sidebar import Sidebar
-from textual.screen import Screen
-from textual.widgets import Button, DataTable, Footer, Header, Label, Select, Static
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Select, Static
 
 from servonaut.screens._binding_guard import check_action_passthrough
 import re
@@ -55,6 +55,9 @@ _TIME_RANGE_OPTIONS = [
     ("Last 90 days", 129600),
 ]
 
+# Chosen from the picker to type a value the loaded events do not contain.
+_TYPE_A_VALUE = "\x00type-a-value"
+
 # Picker id -> the parsed-event field it narrows.
 _FILTER_FIELDS = (
     ("ct_select_event_name", "event_name"),
@@ -62,6 +65,61 @@ _FILTER_FIELDS = (
     ("ct_select_resource_type", "resource_type"),
 )
 _PAGE_SIZE = 100
+
+
+class FilterValueModal(ModalScreen[Optional[str]]):
+    """Ask for a filter value the loaded events do not contain.
+
+    The pickers can only offer what has been fetched, so a value further
+    back in the window would be unreachable. A typed value is sent to the
+    API, which searches the whole window for it.
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=True)]
+
+    def __init__(self, field_label: str, example: str) -> None:
+        super().__init__()
+        self._field_label = field_label
+        self._example = example
+
+    def compose(self) -> ComposeResult:
+        yield Container(
+            Static(
+                f"[bold cyan]Filter by {self._field_label}[/bold cyan]",
+                id="ct_value_modal_title",
+            ),
+            Static(
+                "[dim]Matched exactly, and case-sensitively, against the whole "
+                "time range.[/dim]",
+                id="ct_value_modal_hint",
+            ),
+            Input(placeholder=self._example, id="ct_value_input"),
+            Horizontal(
+                Button("Search", variant="primary", id="btn_ct_value_ok"),
+                Button("Cancel", id="btn_ct_value_cancel"),
+                id="ct_value_modal_buttons",
+            ),
+            id="ct_value_modal",
+        )
+
+    def on_mount(self) -> None:
+        self.query_one("#ct_value_input", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn_ct_value_ok":
+            self._submit()
+        else:
+            self.dismiss(None)
+
+    def _submit(self) -> None:
+        value = self.query_one("#ct_value_input", Input).value.strip()
+        self.dismiss(value or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
 
 class CloudTrailBrowserScreen(Screen):
@@ -83,6 +141,9 @@ class CloudTrailBrowserScreen(Screen):
         self._current_page: int = 0
         self._cap_reached: bool = False
         self._fleet_names_cache: Optional[Dict[str, str]] = None
+        self._next_token: Optional[Dict[str, str]] = None
+        self._loading_more: bool = False
+        self._fetch_args: Optional[Dict[str, Any]] = None
         # set_options() resets a Select and fires Changed; ignore those.
         self._suppress_filter_events: bool = False
 
@@ -206,7 +267,8 @@ class CloudTrailBrowserScreen(Screen):
                 value = self.query_one(f"#{widget_id}", Select).value
             except Exception:  # noqa: BLE001 - screen may not be composed yet
                 value = Select.NULL
-            values[field] = "" if value is Select.NULL else str(value)
+            text = "" if value is Select.NULL else str(value)
+            values[field] = "" if text == _TYPE_A_VALUE else text
         return values
 
     def _refresh_filter_options(self) -> None:
@@ -231,13 +293,58 @@ class CloudTrailBrowserScreen(Screen):
                     counts.items(), key=lambda item: (-item[1], item[0])
                 )
             ]
+            # A value further back in the window is not in the loaded events,
+            # so keep a typed one listed and always offer to type another.
+            if (
+                previous is not Select.NULL
+                and previous != _TYPE_A_VALUE
+                and previous not in counts
+            ):
+                options.append((f"{previous}  (typed)", previous))
+            options.append(("Type a value...", _TYPE_A_VALUE))
             self._suppress_filter_events = True
             try:
                 select.set_options(options)
-                if previous is not Select.NULL and previous in counts:
+                if previous is not Select.NULL and previous != _TYPE_A_VALUE:
                     select.value = previous
             finally:
                 self._suppress_filter_events = False
+
+    _VALUE_PROMPTS = {
+        "ct_select_event_name": ("event name", "e.g. TerminateInstances"),
+        "ct_select_username": ("user", "an IAM user name or an instance ID"),
+        "ct_select_resource_type": ("resource type", "e.g. AWS::EC2::Instance"),
+    }
+
+    def _prompt_for_value(self, widget_id: str) -> None:
+        """Ask for a value, then search the window for it."""
+        label, example = self._VALUE_PROMPTS.get(widget_id, ("value", ""))
+        select = self.query_one(f"#{widget_id}", Select)
+
+        def _apply(value: Optional[str]) -> None:
+            self._suppress_filter_events = True
+            try:
+                if not value:
+                    select.value = Select.NULL
+                    return
+                options = [
+                    (str(text), val)
+                    for text, val in select._options
+                    if val is not Select.NULL and val != _TYPE_A_VALUE
+                ]
+                if value not in [val for _, val in options]:
+                    options.append((f"{value}  (typed)", value))
+                options.append(("Type a value...", _TYPE_A_VALUE))
+                select.set_options(options)
+                select.value = value
+            finally:
+                self._suppress_filter_events = False
+            if value:
+                # A typed value is usually absent from the loaded events, so
+                # narrowing locally would just empty the table; ask the API.
+                self.action_fetch()
+
+        self.app.push_screen(FilterValueModal(label, example), _apply)
 
     def _apply_filters(self) -> None:
         """Narrow the loaded events to the current selections.
@@ -261,6 +368,9 @@ class CloudTrailBrowserScreen(Screen):
             return
         if event.select.id not in {widget_id for widget_id, _ in _FILTER_FIELDS}:
             return
+        if event.value == _TYPE_A_VALUE:
+            self._prompt_for_value(event.select.id)
+            return
         self._current_page = 0
         self._apply_filters()
         self._populate_table()
@@ -280,19 +390,26 @@ class CloudTrailBrowserScreen(Screen):
             summary = f"{shown} of {loaded} loaded events"
         else:
             summary = f"{loaded} events"
-        if summary and self._cap_reached:
+        if self._loading_more:
+            summary += " - loading more..." if summary else "loading more..."
+        elif self._next_token:
+            summary += " - more in this window, press Next"
+        elif summary and self._cap_reached:
             summary += " (cap reached - narrow the range or filters, then Fetch)"
 
+        # Next also reads the next page when one exists, so it stays live on
+        # the last page of what is loaded.
+        more_available = bool(self._next_token) and not self._loading_more
         if total <= 1:
             page_info.update(f"[dim]{summary}[/dim]" if summary else "")
             prev_btn.disabled = True
-            next_btn.disabled = True
+            next_btn.disabled = not more_available
         else:
             page_info.update(
                 f"Page {self._current_page + 1} of {total}   [dim]{summary}[/dim]"
             )
             prev_btn.disabled = self._current_page == 0
-            next_btn.disabled = self._current_page >= total - 1
+            next_btn.disabled = self._current_page >= total - 1 and not more_available
 
     def _populate_table(self) -> None:
         table = self.query_one("#cloudtrail_table", DataTable)
@@ -322,6 +439,55 @@ class CloudTrailBrowserScreen(Screen):
             self._current_page += 1
             self._populate_table()
             self._update_pager()
+        elif self._next_token and not self._loading_more:
+            # Past the end with more in the window: read the next page rather
+            # than making the reader wait for the whole window up front.
+            self._loading_more = True
+            self._update_pager()
+            self.run_worker(self._load_more(), name="cloudtrail_more",
+                            group="fetch", exclusive=True)
+
+    async def _load_more(self) -> None:
+        """Append the next page of events and keep the reader's place."""
+        args = dict(self._fetch_args or {})
+        token = self._next_token
+        if not args or not token:
+            self._loading_more = False
+            self._update_pager()
+            return
+        try:
+            page = await self.app.cloudtrail_service.lookup_page(
+                resume_from=token, **args,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced to the operator
+            self._loading_more = False
+            self._update_pager()
+            self.app.notify(
+                f"Could not load more CloudTrail events: {exc}",
+                severity="error", markup=False,
+            )
+            return
+
+        before = len(self._events)
+        self._events = self._events + page.events
+        self._events.sort(
+            key=lambda e: e.get("event_time") or datetime.min, reverse=True,
+        )
+        self._next_token = page.next_token
+        self._cap_reached = False
+        self._fleet_names_cache = None
+        self._refresh_filter_options()
+        self._apply_filters()
+        self._loading_more = False
+        if self._current_page < self._total_pages - 1:
+            self._current_page += 1
+        self._populate_table()
+        self._update_pager()
+        added = len(self._events) - before
+        self.app.notify(
+            f"Loaded {added} more events ({len(self._events)} total)."
+            if added else "No further events in this window."
+        )
 
     def action_prev_page(self) -> None:
         if self._current_page > 0:
@@ -535,21 +701,24 @@ class CloudTrailBrowserScreen(Screen):
             # busy account can hold thousands of events per hour.
             config = self.app.config_manager.get()
             max_events = int(getattr(config, "cloudtrail_max_events", 0) or 0)
-            events = await self.app.cloudtrail_service.lookup_events(
-                region=region,
-                start_time=start_time,
-                end_time=end_time,
-                event_name=event_name,
-                username=username,
-                resource_type=resource_type,
-                max_results=max_events,
-            )
+            self._fetch_args = {
+                "region": region,
+                "start_time": start_time,
+                "end_time": end_time,
+                "event_name": event_name,
+                "username": username,
+                "resource_type": resource_type,
+                "max_results": max_events,
+            }
+            page = await self.app.cloudtrail_service.lookup_page(**self._fetch_args)
+            events = page.events
         except Exception as exc:
             self.app.notify(f"CloudTrail fetch failed: {exc}", severity="error")
             self.query_one("#ct_btn_fetch", Button).disabled = False
             return
 
         self._events = events
+        self._next_token = page.next_token
         self._fleet_names_cache = None
         self._cap_reached = bool(max_events) and len(events) >= max_events
         self._refresh_filter_options()

--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
@@ -11,7 +12,7 @@ from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 
 from servonaut.widgets.sidebar import Sidebar
 from textual.screen import Screen
-from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Select, Static
+from textual.widgets import Button, DataTable, Footer, Header, Label, Select, Static
 
 from servonaut.screens._binding_guard import check_action_passthrough
 import re
@@ -54,6 +55,12 @@ _TIME_RANGE_OPTIONS = [
     ("Last 90 days", 129600),
 ]
 
+# Picker id -> the parsed-event field it narrows.
+_FILTER_FIELDS = (
+    ("ct_select_event_name", "event_name"),
+    ("ct_select_username", "username"),
+    ("ct_select_resource_type", "resource_type"),
+)
 _PAGE_SIZE = 100
 
 
@@ -71,22 +78,26 @@ class CloudTrailBrowserScreen(Screen):
     def __init__(self) -> None:
         super().__init__()
         self._events: List[Dict[str, Any]] = []
+        self._visible: List[Dict[str, Any]] = []
         self._selected_row: Optional[int] = None
         self._current_page: int = 0
+        self._cap_reached: bool = False
+        # set_options() resets a Select and fires Changed; ignore those.
+        self._suppress_filter_events: bool = False
 
     def check_action(self, action: str, parameters: tuple) -> bool | None:
         return check_action_passthrough(self, action)
 
     @property
     def _total_pages(self) -> int:
-        if not self._events:
+        if not self._visible:
             return 0
-        return (len(self._events) + _PAGE_SIZE - 1) // _PAGE_SIZE
+        return (len(self._visible) + _PAGE_SIZE - 1) // _PAGE_SIZE
 
     @property
     def _page_events(self) -> List[Dict[str, Any]]:
         start = self._current_page * _PAGE_SIZE
-        return self._events[start : start + _PAGE_SIZE]
+        return self._visible[start : start + _PAGE_SIZE]
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -119,26 +130,32 @@ class CloudTrailBrowserScreen(Screen):
                     id="ct_filter_time_range",
                 ),
                 Vertical(
-                    Label("Event Name"),
-                    Input(
-                        placeholder="e.g. RunInstances",
-                        id="ct_input_event_name",
+                    Label("Event"),
+                    Select(
+                        [],
+                        prompt="All events",
+                        id="ct_select_event_name",
+                        allow_blank=True,
                     ),
                     id="ct_filter_event_name",
                 ),
                 Vertical(
-                    Label("Username"),
-                    Input(
-                        placeholder="IAM username",
-                        id="ct_input_username",
+                    Label("User"),
+                    Select(
+                        [],
+                        prompt="All users",
+                        id="ct_select_username",
+                        allow_blank=True,
                     ),
                     id="ct_filter_username",
                 ),
                 Vertical(
                     Label("Resource Type"),
-                    Input(
-                        placeholder="e.g. AWS::EC2::Instance",
-                        id="ct_input_resource_type",
+                    Select(
+                        [],
+                        prompt="All types",
+                        id="ct_select_resource_type",
+                        allow_blank=True,
                     ),
                     id="ct_filter_resource_type",
                 ),
@@ -180,22 +197,97 @@ class CloudTrailBrowserScreen(Screen):
     # Pagination
     # ------------------------------------------------------------------
 
+    def _filter_values(self) -> Dict[str, str]:
+        """Current picker selections, keyed by the event field they filter."""
+        values: Dict[str, str] = {}
+        for widget_id, field in _FILTER_FIELDS:
+            try:
+                value = self.query_one(f"#{widget_id}", Select).value
+            except Exception:  # noqa: BLE001 - screen may not be composed yet
+                value = Select.NULL
+            values[field] = "" if value is Select.NULL else str(value)
+        return values
+
+    def _refresh_filter_options(self) -> None:
+        """Offer exactly the values present in the loaded events, with counts.
+
+        Typing a filter meant guessing an exact, case-sensitive value that
+        might not occur at all. Usernames are redacted for display only; the
+        value behind the option stays real so the lookup still works.
+        """
+        for widget_id, field in _FILTER_FIELDS:
+            counts = Counter(str(ev.get(field) or "") for ev in self._events)
+            counts.pop("", None)
+            select = self.query_one(f"#{widget_id}", Select)
+            previous = select.value
+            options = [
+                (
+                    f"{self._u(value) if field == 'username' else value}  ({count})",
+                    value,
+                )
+                for value, count in sorted(
+                    counts.items(), key=lambda item: (-item[1], item[0])
+                )
+            ]
+            self._suppress_filter_events = True
+            try:
+                select.set_options(options)
+                if previous is not Select.NULL and previous in counts:
+                    select.value = previous
+            finally:
+                self._suppress_filter_events = False
+
+    def _apply_filters(self) -> None:
+        """Narrow the loaded events to the current selections.
+
+        Combining selections is a local pass, which the API cannot do: it
+        honours one lookup attribute per call.
+        """
+        active = {f: v for f, v in self._filter_values().items() if v}
+        if not active:
+            self._visible = list(self._events)
+            return
+        self._visible = [
+            ev
+            for ev in self._events
+            if all(str(ev.get(f) or "") == v for f, v in active.items())
+        ]
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Narrow the loaded events as soon as a picker changes."""
+        if self._suppress_filter_events:
+            return
+        if event.select.id not in {widget_id for widget_id, _ in _FILTER_FIELDS}:
+            return
+        self._current_page = 0
+        self._apply_filters()
+        self._populate_table()
+        self._update_pager()
+
     def _update_pager(self) -> None:
         total = self._total_pages
         page_info = self.query_one("#ct_page_info", Static)
         prev_btn = self.query_one("#ct_btn_prev", Button)
         next_btn = self.query_one("#ct_btn_next", Button)
 
+        loaded = len(self._events)
+        shown = len(self._visible)
+        if not loaded:
+            summary = ""
+        elif shown != loaded:
+            summary = f"{shown} of {loaded} loaded events"
+        else:
+            summary = f"{loaded} events"
+        if summary and self._cap_reached:
+            summary += " (cap reached - Fetch searches the whole window)"
+
         if total <= 1:
-            page_info.update(
-                f"[dim]{len(self._events)} events total[/dim]" if self._events else ""
-            )
+            page_info.update(f"[dim]{summary}[/dim]" if summary else "")
             prev_btn.disabled = True
             next_btn.disabled = True
         else:
             page_info.update(
-                f"Page {self._current_page + 1} of {total}  "
-                f"[dim]({len(self._events)} events total)[/dim]"
+                f"Page {self._current_page + 1} of {total}  [dim]({summary})[/dim]"
             )
             prev_btn.disabled = self._current_page == 0
             next_btn.disabled = self._current_page >= total - 1
@@ -362,14 +454,16 @@ class CloudTrailBrowserScreen(Screen):
         time_select = self.query_one("#ct_select_time_range", Select)
         minutes = int(time_select.value) if time_select.value is not Select.NULL else 1440
 
-        event_name = self.query_one("#ct_input_event_name", Input).value.strip()
-        username = self.query_one("#ct_input_username", Input).value.strip()
-        resource_type = self.query_one("#ct_input_resource_type", Input).value.strip()
+        selections = self._filter_values()
+        event_name = selections["event_name"]
+        username = selections["username"]
+        resource_type = selections["resource_type"]
 
         self.query_one("#ct_btn_fetch", Button).disabled = True
         self.query_one("#event_detail_text", Static).update("Loading...")
         self.query_one("#cloudtrail_table", DataTable).clear()
         self._events = []
+        self._visible = []
         self._current_page = 0
         self._update_pager()
 
@@ -411,6 +505,9 @@ class CloudTrailBrowserScreen(Screen):
             return
 
         self._events = events
+        self._cap_reached = bool(max_events) and len(events) >= max_events
+        self._refresh_filter_options()
+        self._apply_filters()
         self._current_page = 0
         self._populate_table()
         self._update_pager()

--- a/src/servonaut/screens/help.py
+++ b/src/servonaut/screens/help.py
@@ -237,7 +237,7 @@ Config file: `~/.servonaut/config.json`
 | `log_viewer_tail_lines` | `100` | Initial tail lines for log viewer |
 | `log_viewer_max_lines` | `10000` | Max lines before clearing log viewer |
 | `cloudtrail_default_lookback_hours` | `24` | Default CloudTrail time range |
-| `cloudtrail_max_events` | `100` | Max CloudTrail events per query |
+| `cloudtrail_max_events` | `500` | Max CloudTrail events per fetch (the browser pages 100 at a time) |
 | `ip_ban_configs` | `[]` | IP ban method configurations |
 | `ai_provider` | OpenAI defaults | AI provider settings (provider, api_key, model, etc.) |
 | `mcp.guard_level` | `standard` | MCP server guard level |

--- a/src/servonaut/screens/settings/panels/cloudtrail.py
+++ b/src/servonaut/screens/settings/panels/cloudtrail.py
@@ -40,7 +40,7 @@ class CloudtrailPanel(SettingsPanel):
         )
         yield Horizontal(
             Static("Max events", classes="label"),
-            Input(placeholder="100", id="cloudtrail_max_events"),
+            Input(placeholder="500", id="cloudtrail_max_events"),
             classes="setting_row",
         )
         yield Horizontal(

--- a/src/servonaut/services/cloudtrail_service.py
+++ b/src/servonaut/services/cloudtrail_service.py
@@ -5,12 +5,26 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timedelta
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from servonaut.services.interfaces import CloudTrailServiceInterface
 
 # CloudTrail returns at most 50 events per page.
 _API_PAGE_SIZE = 50
+
+
+@dataclass(frozen=True)
+class LookupPage:
+    """One page of events, and where to resume for the next one.
+
+    ``next_token`` maps a region to its continuation token and is ``None``
+    once every region queried is exhausted, so a caller can offer "more"
+    only when there really is more.
+    """
+
+    events: List[dict] = field(default_factory=list)
+    next_token: Optional[Dict[str, str]] = None
 # How far to read when criteria are applied locally: a multiple of the
 # caller's cap, never fewer than a few pages, never past the ceiling.
 _POST_FILTER_SCAN_MULTIPLIER = 20
@@ -38,6 +52,32 @@ class CloudTrailService(CloudTrailServiceInterface):
 
         Queries one region when specified, or all available regions when empty.
         Results are sorted by event_time descending.
+        """
+        page = await self.lookup_page(
+            region=region, start_time=start_time, end_time=end_time,
+            event_name=event_name, username=username,
+            resource_type=resource_type, max_results=max_results,
+        )
+        limit = max_results if max_results > 0 else len(page.events)
+        return page.events[:limit]
+
+    async def lookup_page(
+        self,
+        region: str = "",
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        event_name: str = "",
+        username: str = "",
+        resource_type: str = "",
+        max_results: int = 100,
+        resume_from: Optional[Dict[str, str]] = None,
+    ) -> "LookupPage":
+        """Fetch one page of events and the token to continue from.
+
+        ``resume_from`` is a previous page's ``next_token``. Reading on is
+        how the browser pages through a long window without waiting for the
+        whole of it up front: a day of events can be tens of thousands, and
+        the API is throttled to a couple of calls a second.
         """
         config = self._config_manager.get()
         target_region = region or config.cloudtrail_default_region
@@ -75,44 +115,64 @@ class CloudTrailService(CloudTrailServiceInterface):
                 _POST_FILTER_SCAN_CEILING,
             )
 
-        def _fetch() -> List[dict]:
+        def _fetch() -> "LookupPage":
             import boto3
 
-            regions_to_query = [target_region] if target_region else self._get_regions_sync()
+            regions_to_query = (
+                [target_region] if target_region else self._get_regions_sync()
+            )
+            if resume_from is not None:
+                # Only regions that still have a page left are worth calling.
+                regions_to_query = [r for r in regions_to_query if r in resume_from]
+            # One page is ``hard_limit`` events in total, shared out across the
+            # regions being read, so continuing does not multiply by region
+            # count and no region starves.
+            per_region = (
+                hard_limit
+                if len(regions_to_query) <= 1
+                else max(_API_PAGE_SIZE, hard_limit // max(1, len(regions_to_query)))
+            )
+            per_region_scan = max(per_region, scan_limit // max(1, len(regions_to_query)))
+
             all_events: List[dict] = []
+            resume_tokens: Dict[str, str] = {}
 
             for r in regions_to_query:
                 client = boto3.client("cloudtrail", region_name=r)
                 kwargs: dict = {
                     "StartTime": start_time,
                     "EndTime": end_time,
-                    "MaxResults": min(scan_limit, _API_PAGE_SIZE),
+                    "MaxResults": min(per_region_scan, _API_PAGE_SIZE),
                 }
                 if server_attr:
                     kwargs["LookupAttributes"] = [server_attr]
+                if resume_from is not None:
+                    kwargs["NextToken"] = resume_from[r]
 
                 events: List[dict] = []
                 scanned = 0
-                while len(events) < hard_limit and scanned < scan_limit:
+                carry: Optional[str] = None
+                while len(events) < per_region and scanned < per_region_scan:
                     response = client.lookup_events(**kwargs)
                     batch = response.get("Events", [])
                     scanned += len(batch)
+                    # Whole batches only: stopping mid-batch would leave events
+                    # behind that the resume token has already moved past.
                     for event in batch:
-                        if not self._matches_attributes(event, post_filters):
-                            continue
-                        events.append(self._parse_event(event, r))
-                        if len(events) >= hard_limit:
-                            break
+                        if self._matches_attributes(event, post_filters):
+                            events.append(self._parse_event(event, r))
 
-                    next_token = response.get("NextToken")
-                    if not next_token or len(events) >= hard_limit:
+                    carry = response.get("NextToken")
+                    if not carry:
                         break
-                    kwargs["NextToken"] = next_token
+                    kwargs["NextToken"] = carry
 
+                if carry:
+                    resume_tokens[r] = carry
                 all_events.extend(events)
 
             all_events.sort(key=lambda e: e["event_time"] or datetime.min, reverse=True)
-            return all_events[:hard_limit]
+            return LookupPage(events=all_events, next_token=resume_tokens or None)
 
         return await loop.run_in_executor(None, _fetch)
 

--- a/src/servonaut/services/cloudtrail_service.py
+++ b/src/servonaut/services/cloudtrail_service.py
@@ -9,6 +9,14 @@ from typing import List, Optional
 
 from servonaut.services.interfaces import CloudTrailServiceInterface
 
+# CloudTrail returns at most 50 events per page.
+_API_PAGE_SIZE = 50
+# How far to read when criteria are applied locally: a multiple of the
+# caller's cap, never fewer than a few pages, never past the ceiling.
+_POST_FILTER_SCAN_MULTIPLIER = 20
+_POST_FILTER_SCAN_MINIMUM = 500
+_POST_FILTER_SCAN_CEILING = 5000
+
 
 class CloudTrailService(CloudTrailServiceInterface):
     """Fetches and parses CloudTrail events via boto3."""
@@ -48,10 +56,24 @@ class CloudTrailService(CloudTrailServiceInterface):
         if resource_type:
             lookup_attrs.append({"AttributeKey": "ResourceType", "AttributeValue": resource_type})
 
+        # CloudTrail honours only the FIRST lookup attribute and silently
+        # ignores the rest, so two filters used to return results matching
+        # just one of them. Send one to the API and apply the others here.
+        server_attr = lookup_attrs[0] if lookup_attrs else None
+        post_filters = lookup_attrs[1:]
+
         loop = asyncio.get_event_loop()
 
         # max_results=0 means fetch all (capped at 10000)
         hard_limit = max_results if max_results > 0 else 10000
+        # Criteria applied locally need a wider read: a page can be mostly
+        # discarded. Bounded so a narrow filter cannot page forever.
+        scan_limit = hard_limit
+        if post_filters:
+            scan_limit = min(
+                max(hard_limit * _POST_FILTER_SCAN_MULTIPLIER, _POST_FILTER_SCAN_MINIMUM),
+                _POST_FILTER_SCAN_CEILING,
+            )
 
         def _fetch() -> List[dict]:
             import boto3
@@ -64,16 +86,23 @@ class CloudTrailService(CloudTrailServiceInterface):
                 kwargs: dict = {
                     "StartTime": start_time,
                     "EndTime": end_time,
-                    "MaxResults": min(hard_limit, 50),
+                    "MaxResults": min(scan_limit, _API_PAGE_SIZE),
                 }
-                if lookup_attrs:
-                    kwargs["LookupAttributes"] = lookup_attrs
+                if server_attr:
+                    kwargs["LookupAttributes"] = [server_attr]
 
                 events: List[dict] = []
-                while len(events) < hard_limit:
+                scanned = 0
+                while len(events) < hard_limit and scanned < scan_limit:
                     response = client.lookup_events(**kwargs)
-                    for event in response.get("Events", []):
+                    batch = response.get("Events", [])
+                    scanned += len(batch)
+                    for event in batch:
+                        if not self._matches_attributes(event, post_filters):
+                            continue
                         events.append(self._parse_event(event, r))
+                        if len(events) >= hard_limit:
+                            break
 
                     next_token = response.get("NextToken")
                     if not next_token or len(events) >= hard_limit:
@@ -86,6 +115,31 @@ class CloudTrailService(CloudTrailServiceInterface):
             return all_events[:hard_limit]
 
         return await loop.run_in_executor(None, _fetch)
+
+    @staticmethod
+    def _matches_attributes(event: dict, attributes: List[dict]) -> bool:
+        """Apply lookup attributes the API would not, against a raw event.
+
+        Mirrors CloudTrail's own semantics: exact, case-sensitive matches,
+        and ``ResourceType`` matches when ANY resource on the event has it.
+        """
+        for attribute in attributes:
+            key = attribute.get("AttributeKey")
+            value = attribute.get("AttributeValue")
+            if key == "ResourceType":
+                resources = event.get("Resources") or []
+                if not any(
+                    isinstance(res, dict) and res.get("ResourceType") == value
+                    for res in resources
+                ):
+                    return False
+            elif key == "EventName":
+                if (event.get("EventName") or "") != value:
+                    return False
+            elif key == "Username":
+                if (event.get("Username") or "") != value:
+                    return False
+        return True
 
     def _parse_event(self, event: dict, region: str) -> dict:
         """Parse a raw boto3 CloudTrail event dict into our normalized format."""

--- a/src/servonaut/styles/screens/cloudtrail.tcss
+++ b/src/servonaut/styles/screens/cloudtrail.tcss
@@ -77,3 +77,34 @@
     overflow-y: auto;
 }
 
+
+/* Typed filter value — reachable when a value sits further back in the
+   window than the loaded events. */
+#ct_value_modal {
+    width: 64;
+    height: auto;
+    padding: 1 2;
+    background: $surface;
+    border: round $primary;
+}
+
+#ct_value_modal_title {
+    margin-bottom: 1;
+}
+
+#ct_value_modal_hint {
+    margin-bottom: 1;
+}
+
+#ct_value_input {
+    margin-bottom: 1;
+}
+
+#ct_value_modal_buttons {
+    height: auto;
+    align-horizontal: right;
+}
+
+#btn_ct_value_ok, #btn_ct_value_cancel {
+    margin-left: 1;
+}

--- a/src/servonaut/styles/screens/cloudtrail.tcss
+++ b/src/servonaut/styles/screens/cloudtrail.tcss
@@ -34,6 +34,13 @@
     height: 3;
 }
 
+/* Event names run long ("UpdateInstanceInformation"); let the open list
+   size to its content instead of wrapping inside a narrow column. */
+#cloudtrail_filters Select SelectOverlay {
+    width: auto;
+    max-width: 46;
+}
+
 #cloudtrail_filters Button {
     margin: 1 0 0 1;
 }

--- a/tests/test_cloudtrail_browser_cap.py
+++ b/tests/test_cloudtrail_browser_cap.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from servonaut.config.schema import AppConfig
 from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+from servonaut.services.cloudtrail_service import LookupPage
 
 
 def _run(coro):
@@ -19,7 +20,7 @@ def _app(max_events: int):
     cfg = AppConfig()
     cfg.cloudtrail_max_events = max_events
     app.config_manager.get.return_value = cfg
-    app.cloudtrail_service.lookup_events = AsyncMock(return_value=[])
+    app.cloudtrail_service.lookup_page = AsyncMock(return_value=LookupPage(events=[], next_token=None))
     return app
 
 
@@ -32,7 +33,7 @@ def test_fetch_passes_the_configured_cap():
          patch.object(screen, "_update_pager"):
         _run(screen._fetch_events("eu-west-2", 60, "", "", ""))
 
-    kwargs = app.cloudtrail_service.lookup_events.await_args.kwargs
+    kwargs = app.cloudtrail_service.lookup_page.await_args.kwargs
     assert kwargs["max_results"] == 100
     assert kwargs["region"] == "eu-west-2"
 
@@ -46,4 +47,4 @@ def test_zero_cap_means_everything_in_the_window():
          patch.object(screen, "_update_pager"):
         _run(screen._fetch_events("eu-west-2", 60, "", "", ""))
 
-    assert app.cloudtrail_service.lookup_events.await_args.kwargs["max_results"] == 0
+    assert app.cloudtrail_service.lookup_page.await_args.kwargs["max_results"] == 0

--- a/tests/test_cloudtrail_filter_pickers.py
+++ b/tests/test_cloudtrail_filter_pickers.py
@@ -1,0 +1,163 @@
+"""CloudTrail filters are pickers over the values actually present.
+
+Typing a filter meant guessing an exact, case-sensitive value, and the API
+honours only one lookup attribute per call, so combining two used to return
+rows matching just one of them. The pickers offer what is really there and
+combine locally.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Select
+
+from servonaut.config.schema import AppConfig
+from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+from servonaut.services.redaction_service import RedactionService
+
+EVENTS = [
+    {"event_time": "2026-01-01 00:00:03", "event_name": "AssumeRole", "username": "",
+     "source_ip": "192.0.2.1", "resource_name": "", "resource_type": "AWS::IAM::Role",
+     "region": "eu-west-2", "error_code": ""},
+    {"event_time": "2026-01-01 00:00:02", "event_name": "AssumeRole", "username": "deploy",
+     "source_ip": "192.0.2.2", "resource_name": "", "resource_type": "AWS::IAM::Role",
+     "region": "eu-west-2", "error_code": ""},
+    {"event_time": "2026-01-01 00:00:01", "event_name": "RunInstances", "username": "deploy",
+     "source_ip": "192.0.2.3", "resource_name": "i-0abc12345678def01",
+     "resource_type": "AWS::EC2::Instance", "region": "eu-west-2", "error_code": ""},
+]
+
+
+def _harness(*, demo: bool = False, events=None):
+    config = AppConfig()
+    config.cloudtrail_max_events = 100
+    manager = MagicMock()
+    manager.get.return_value = config
+    service = MagicMock()
+    service.lookup_events = AsyncMock(return_value=list(events if events is not None else EVENTS))
+
+    class _Harness(App):
+        CSS_PATH = None
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.config_manager = manager
+            self.cloudtrail_service = service
+            self.demo_mode = demo
+            self.redaction_service = RedactionService() if demo else None
+
+        def compose(self) -> ComposeResult:
+            yield CloudTrailBrowserScreen()
+
+    app = _Harness()
+    app.lookup_mock = service.lookup_events  # type: ignore[attr-defined]
+    return app
+
+
+def _screen(app) -> CloudTrailBrowserScreen:
+    return app.query_one(CloudTrailBrowserScreen)
+
+
+def _choices(select: Select):
+    """The real options, without the leading blank ("All …") row."""
+    return [(str(label), value) for label, value in select._options if value is not Select.NULL]
+
+
+async def _load(pilot, screen) -> None:
+    screen.action_fetch()
+    await pilot.pause()
+    for _ in range(40):
+        if screen._events:
+            break
+        await pilot.pause(0.05)
+
+
+@pytest.mark.asyncio
+async def test_unselected_pickers_mean_no_filter() -> None:
+    """An untouched picker holds a sentinel, not a value: reading it as a
+    string would send a bogus filter to the API."""
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        assert screen._filter_values() == {"event_name": "", "username": "", "resource_type": ""}
+
+        await _load(pilot, screen)
+        assert pilot.app.lookup_mock.await_args.kwargs["event_name"] == ""
+        assert pilot.app.lookup_mock.await_args.kwargs["username"] == ""
+        assert pilot.app.lookup_mock.await_args.kwargs["resource_type"] == ""
+
+
+@pytest.mark.asyncio
+async def test_options_are_the_values_present_with_counts_most_common_first() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        choices = _choices(pilot.app.query_one("#ct_select_event_name", Select))
+        labels = [label for label, _ in choices]
+        values = [value for _, value in choices]
+        assert "AssumeRole" in values and "RunInstances" in values
+        assert any("AssumeRole" in label and "(2)" in label for label in labels)
+        # Most common first.
+        assert values.index("AssumeRole") < values.index("RunInstances")
+
+        types_ = _choices(pilot.app.query_one("#ct_select_resource_type", Select))
+        assert [v for _, v in types_] == ["AWS::IAM::Role", "AWS::EC2::Instance"]
+
+
+@pytest.mark.asyncio
+async def test_blank_usernames_are_not_offered() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        users = _choices(pilot.app.query_one("#ct_select_username", Select))
+        assert [v for _, v in users] == ["deploy"]
+
+
+@pytest.mark.asyncio
+async def test_picking_narrows_the_table_immediately_and_combines() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        assert len(screen._visible) == 3
+
+        pilot.app.query_one("#ct_select_username", Select).value = "deploy"
+        await pilot.pause()
+        assert len(screen._visible) == 2
+
+        # Combining two criteria is a local pass; the API cannot do it.
+        pilot.app.query_one("#ct_select_event_name", Select).value = "RunInstances"
+        await pilot.pause()
+        assert [e["event_name"] for e in screen._visible] == ["RunInstances"]
+        assert screen._current_page == 0
+
+        pilot.app.query_one("#ct_select_username", Select).value = Select.NULL
+        await pilot.pause()
+        assert len(screen._visible) == 1
+
+
+@pytest.mark.asyncio
+async def test_selection_survives_a_refetch_and_is_sent_to_the_api() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        pilot.app.query_one("#ct_select_event_name", Select).value = "AssumeRole"
+        await pilot.pause()
+        await _load(pilot, screen)
+
+        assert pilot.app.lookup_mock.await_args.kwargs["event_name"] == "AssumeRole"
+        assert pilot.app.query_one("#ct_select_event_name", Select).value == "AssumeRole"
+
+
+@pytest.mark.asyncio
+async def test_usernames_are_redacted_in_the_option_label_but_not_the_value() -> None:
+    async with _harness(demo=True).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        users = _choices(pilot.app.query_one("#ct_select_username", Select))
+        assert [v for _, v in users] == ["deploy"]
+        assert all("deploy" not in label for label, _ in users)

--- a/tests/test_cloudtrail_filter_pickers.py
+++ b/tests/test_cloudtrail_filter_pickers.py
@@ -14,7 +14,8 @@ from textual.app import App, ComposeResult
 from textual.widgets import Select
 
 from servonaut.config.schema import AppConfig
-from servonaut.screens.cloudtrail_browser import CloudTrailBrowserScreen
+from servonaut.screens.cloudtrail_browser import _TYPE_A_VALUE, CloudTrailBrowserScreen
+from servonaut.services.cloudtrail_service import LookupPage
 from servonaut.services.redaction_service import RedactionService
 
 EVENTS = [
@@ -36,7 +37,8 @@ def _harness(*, demo: bool = False, events=None):
     manager = MagicMock()
     manager.get.return_value = config
     service = MagicMock()
-    service.lookup_events = AsyncMock(return_value=list(events if events is not None else EVENTS))
+    rows = list(events if events is not None else EVENTS)
+    service.lookup_page = AsyncMock(return_value=LookupPage(events=rows, next_token=None))
 
     class _Harness(App):
         CSS_PATH = None
@@ -52,7 +54,7 @@ def _harness(*, demo: bool = False, events=None):
             yield CloudTrailBrowserScreen()
 
     app = _Harness()
-    app.lookup_mock = service.lookup_events  # type: ignore[attr-defined]
+    app.lookup_mock = service.lookup_page  # type: ignore[attr-defined]
     return app
 
 
@@ -61,8 +63,12 @@ def _screen(app) -> CloudTrailBrowserScreen:
 
 
 def _choices(select: Select):
-    """The real options, without the leading blank ("All …") row."""
-    return [(str(label), value) for label, value in select._options if value is not Select.NULL]
+    """The real values, without the blank ("All …") row or the type-a-value row."""
+    return [
+        (str(label), value)
+        for label, value in select._options
+        if value is not Select.NULL and value != _TYPE_A_VALUE
+    ]
 
 
 async def _load(pilot, screen) -> None:
@@ -235,3 +241,126 @@ async def test_the_resolved_name_is_redacted_in_demo_mode() -> None:
         assert any(label.startswith(expected) for label in labels)
         # The value behind the option is still the real id.
         assert "i-0abc12345678def01" in {value for _, value in users}
+
+
+# ---------------------------------------------------------------------------
+# Paging past the loaded events, and typing a value they do not contain
+# ---------------------------------------------------------------------------
+
+MORE = [
+    {"event_time": "2025-12-31 23:59:59", "event_name": "TerminateInstances",
+     "username": "jane.doe", "source_ip": "192.0.2.9", "resource_name": "",
+     "resource_type": "AWS::EC2::Instance", "region": "eu-west-2", "error_code": ""},
+]
+
+
+def _paged_harness(first_token):
+    """A service whose first page reports more, and whose next page ends."""
+    app = _harness()
+    pages = [
+        LookupPage(events=list(EVENTS), next_token=first_token),
+        LookupPage(events=list(MORE), next_token=None),
+    ]
+    app.cloudtrail_service.lookup_page = AsyncMock(side_effect=pages)
+    app.lookup_mock = app.cloudtrail_service.lookup_page
+    return app
+
+
+@pytest.mark.asyncio
+async def test_next_reads_the_following_page_when_one_exists() -> None:
+    """A day of events is tens of thousands, so the reader pages into the
+    window instead of waiting for all of it."""
+    async with _paged_harness({"eu-west-2": "page-2"}).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        assert len(screen._events) == len(EVENTS)
+        assert screen._next_token == {"eu-west-2": "page-2"}
+
+        screen.action_next_page()
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if len(screen._events) > len(EVENTS):
+                break
+
+        assert len(screen._events) == len(EVENTS) + len(MORE)
+        assert screen._next_token is None
+        # The continuation carries the same query, resumed from the token.
+        resumed = pilot.app.lookup_mock.await_args
+        assert resumed.kwargs["resume_from"] == {"eu-west-2": "page-2"}
+        assert resumed.kwargs["region"] == ""
+        # Newly loaded values join the pickers.
+        events_seen = {v for _, v in _choices(pilot.app.query_one("#ct_select_event_name", Select))}
+        assert "TerminateInstances" in events_seen
+
+
+@pytest.mark.asyncio
+async def test_next_stays_available_on_the_last_page_when_more_exists() -> None:
+    from textual.widgets import Button
+
+    async with _paged_harness({"eu-west-2": "page-2"}).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        assert pilot.app.query_one("#ct_btn_next", Button).disabled is False
+
+
+@pytest.mark.asyncio
+async def test_next_is_dead_once_the_window_is_exhausted() -> None:
+    from textual.widgets import Button
+
+    async with _paged_harness(None).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        assert screen._next_token is None
+        assert pilot.app.query_one("#ct_btn_next", Button).disabled is True
+
+
+@pytest.mark.asyncio
+async def test_every_picker_offers_to_type_a_value() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        for widget_id, _field in [("ct_select_event_name", 0), ("ct_select_username", 0),
+                                  ("ct_select_resource_type", 0)]:
+            select = pilot.app.query_one(f"#{widget_id}", Select)
+            assert _TYPE_A_VALUE in [v for _, v in select._options], widget_id
+
+
+@pytest.mark.asyncio
+async def test_a_typed_value_is_searched_for_across_the_window() -> None:
+    """The pickers can only offer what was fetched, so a typed value goes
+    to the API rather than narrowing the loaded rows to nothing."""
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        before = pilot.app.lookup_mock.await_count
+
+        screen._prompt_for_value("ct_select_event_name")
+        await pilot.pause()
+        pilot.app.screen.query_one("#ct_value_input").value = "TerminateInstances"
+        pilot.app.screen._submit()
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if pilot.app.lookup_mock.await_count > before:
+                break
+
+        assert pilot.app.lookup_mock.await_args.kwargs["event_name"] == "TerminateInstances"
+        select = pilot.app.query_one("#ct_select_event_name", Select)
+        assert select.value == "TerminateInstances"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_prompt_leaves_the_picker_unset() -> None:
+    async with _harness().run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+        before = pilot.app.lookup_mock.await_count
+
+        screen._prompt_for_value("ct_select_username")
+        await pilot.pause()
+        pilot.app.screen.dismiss(None)
+        await pilot.pause()
+
+        assert pilot.app.query_one("#ct_select_username", Select).value is Select.NULL
+        assert pilot.app.lookup_mock.await_count == before
+        assert screen._filter_values()["username"] == ""

--- a/tests/test_cloudtrail_filter_pickers.py
+++ b/tests/test_cloudtrail_filter_pickers.py
@@ -161,3 +161,77 @@ async def test_usernames_are_redacted_in_the_option_label_but_not_the_value() ->
         users = _choices(pilot.app.query_one("#ct_select_username", Select))
         assert [v for _, v in users] == ["deploy"]
         assert all("deploy" not in label for label, _ in users)
+
+
+# ---------------------------------------------------------------------------
+# Instance-role sessions are named after the machine, not its id
+# ---------------------------------------------------------------------------
+
+FLEET = [
+    {"id": "i-0abc12345678def01", "name": "moon-prod-bidding-3"},
+    {"id": "i-0fedcba987654321f", "name": "bastion"},
+]
+
+MACHINE_EVENTS = [
+    {"event_time": "2026-01-01 00:00:02", "event_name": "UpdateInstanceInformation",
+     "username": "i-0abc12345678def01", "source_ip": "192.0.2.1", "resource_name": "",
+     "resource_type": "AWS::SSM::ManagedInstance", "region": "eu-west-2", "error_code": ""},
+    {"event_time": "2026-01-01 00:00:01", "event_name": "ConsoleLogin", "username": "jane.doe",
+     "source_ip": "192.0.2.2", "resource_name": "", "resource_type": "",
+     "region": "eu-west-2", "error_code": ""},
+]
+
+
+def _fleet_harness(*, demo: bool):
+    app = _harness(demo=demo, events=MACHINE_EVENTS)
+    app.instances = list(FLEET)
+    app._instances_pristine = list(FLEET)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_instance_role_sessions_show_the_machine_name() -> None:
+    """CloudTrail names those sessions after the instance id, which reads as
+    noise; the fleet already knows what that id is called."""
+    async with _fleet_harness(demo=False).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        users = _choices(pilot.app.query_one("#ct_select_username", Select))
+        labels = {label for label, _ in users}
+        values = {value for _, value in users}
+        # The label reads as the machine; the value still filters by the id.
+        assert any(label.startswith("moon-prod-bidding-3") for label in labels)
+        assert "i-0abc12345678def01" in values
+        # A human username is untouched.
+        assert any(label.startswith("jane.doe") for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_unknown_ids_keep_their_id() -> None:
+    app = _harness(events=MACHINE_EVENTS)
+    app.instances = []
+    app._instances_pristine = []
+    async with app.run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        labels = {label for label, _ in _choices(pilot.app.query_one("#ct_select_username", Select))}
+        assert any(label.startswith("i-0abc12345678def01") for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_the_resolved_name_is_redacted_in_demo_mode() -> None:
+    """The lookup keys off the real id from the pre-redaction snapshot, and
+    the name it produces is redacted like any other fleet name."""
+    async with _fleet_harness(demo=True).run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        users = _choices(pilot.app.query_one("#ct_select_username", Select))
+        labels = {label for label, _ in users}
+        assert all("moon-prod-bidding-3" not in label for label in labels)
+        expected = pilot.app.redaction_service.redact_name("moon-prod-bidding-3")
+        assert any(label.startswith(expected) for label in labels)
+        # The value behind the option is still the real id.
+        assert "i-0abc12345678def01" in {value for _, value in users}

--- a/tests/test_cloudtrail_service.py
+++ b/tests/test_cloudtrail_service.py
@@ -223,3 +223,84 @@ def test_parse_event_tolerates_resources_without_type_or_name(service):
     result = service._parse_event(raw, "eu-west-2")
     assert result["resource_type"] == "AWS::IAM::Role"
     assert result["resource_name"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Combined filters — CloudTrail applies only the first lookup attribute
+# ---------------------------------------------------------------------------
+
+def test_only_one_attribute_is_sent_and_the_rest_applied_locally(service):
+    """CloudTrail silently ignores every lookup attribute after the first,
+    so two filters used to return rows matching just one of them."""
+    matches_both = _make_raw_event(event_name="AssumeRole", username="deploy")
+    matches_first_only = _make_raw_event(event_name="AssumeRole", username="someone-else")
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {"Events": [matches_both, matches_first_only]}
+
+    with patch("boto3.client", return_value=mock_client):
+        result = asyncio.run(
+            service.lookup_events(
+                region="us-east-1", event_name="AssumeRole", username="deploy",
+            )
+        )
+
+    sent = mock_client.lookup_events.call_args[1]["LookupAttributes"]
+    assert sent == [{"AttributeKey": "EventName", "AttributeValue": "AssumeRole"}]
+    assert [e["username"] for e in result] == ["deploy"]
+
+
+def test_resource_type_filter_matches_any_resource_on_the_event(service):
+    """The API matches ResourceType against every resource on an event, so
+    the local pass must too — not just the first entry."""
+    event = _make_raw_event(username="alice")
+    event["Resources"] = [
+        {"ResourceType": "AWS::IAM::Role", "ResourceName": "role-a"},
+        {"ResourceType": "AWS::EC2::Instance", "ResourceName": "i-0abc12345678def01"},
+    ]
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {"Events": [event]}
+
+    with patch("boto3.client", return_value=mock_client):
+        kept = asyncio.run(service.lookup_events(
+            region="us-east-1", username="alice", resource_type="AWS::EC2::Instance",
+        ))
+        dropped = asyncio.run(service.lookup_events(
+            region="us-east-1", username="alice", resource_type="AWS::S3::Bucket",
+        ))
+
+    assert len(kept) == 1
+    assert dropped == []
+
+
+def test_locally_filtered_lookup_reads_past_the_first_page(service):
+    """A page can be mostly discarded by the local pass, so paging must
+    continue until enough matches are collected."""
+    page_one = {
+        "Events": [_make_raw_event(event_name="AssumeRole", username="other")] * 50,
+        "NextToken": "more",
+    }
+    page_two = {"Events": [_make_raw_event(event_name="AssumeRole", username="deploy")] * 2}
+    mock_client = MagicMock()
+    mock_client.lookup_events.side_effect = [page_one, page_two]
+
+    with patch("boto3.client", return_value=mock_client):
+        result = asyncio.run(service.lookup_events(
+            region="us-east-1", event_name="AssumeRole", username="deploy", max_results=2,
+        ))
+
+    assert mock_client.lookup_events.call_count == 2
+    assert len(result) == 2
+    assert {e["username"] for e in result} == {"deploy"}
+
+
+def test_single_filter_still_goes_straight_to_the_api(service):
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {"Events": [_make_raw_event(username="bob")]}
+
+    with patch("boto3.client", return_value=mock_client):
+        result = asyncio.run(service.lookup_events(region="us-east-1", username="bob"))
+
+    assert mock_client.lookup_events.call_args[1]["LookupAttributes"] == [
+        {"AttributeKey": "Username", "AttributeValue": "bob"}
+    ]
+    assert len(result) == 1

--- a/tests/test_cloudtrail_service.py
+++ b/tests/test_cloudtrail_service.py
@@ -304,3 +304,64 @@ def test_single_filter_still_goes_straight_to_the_api(service):
         {"AttributeKey": "Username", "AttributeValue": "bob"}
     ]
     assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Paging: a page carries the token to continue from
+# ---------------------------------------------------------------------------
+
+def test_lookup_page_reports_where_to_resume(service):
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {
+        "Events": [_make_raw_event() for _ in range(50)],
+        "NextToken": "page-2",
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        page = asyncio.run(service.lookup_page(region="us-east-1", max_results=50))
+
+    assert len(page.events) == 50
+    assert page.next_token == {"us-east-1": "page-2"}
+
+
+def test_lookup_page_has_no_token_once_a_region_is_exhausted(service):
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {"Events": [_make_raw_event()]}
+
+    with patch("boto3.client", return_value=mock_client):
+        page = asyncio.run(service.lookup_page(region="us-east-1", max_results=50))
+
+    assert page.next_token is None
+
+
+def test_resuming_sends_the_token_and_only_asks_regions_that_have_more(service):
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {"Events": [_make_raw_event()]}
+
+    with patch("boto3.client", return_value=mock_client) as boto:
+        page = asyncio.run(service.lookup_page(
+            region="us-east-1", max_results=50, resume_from={"us-east-1": "page-2"},
+        ))
+
+    assert mock_client.lookup_events.call_args[1]["NextToken"] == "page-2"
+    assert [c.kwargs["region_name"] for c in boto.call_args_list] == ["us-east-1"]
+    assert len(page.events) == 1
+
+
+def test_a_page_keeps_whole_batches_so_resuming_loses_nothing(service):
+    """Stopping mid-batch would skip events the token has already passed."""
+    mock_client = MagicMock()
+    mock_client.lookup_events.return_value = {
+        "Events": [_make_raw_event() for _ in range(50)],
+        "NextToken": "page-2",
+    }
+
+    with patch("boto3.client", return_value=mock_client):
+        page = asyncio.run(service.lookup_page(region="us-east-1", max_results=10))
+
+    # The batch is kept whole even though only 10 were asked for.
+    assert len(page.events) == 50
+    assert page.next_token == {"us-east-1": "page-2"}
+    # The compatibility wrapper still honours the caller's limit.
+    with patch("boto3.client", return_value=mock_client):
+        assert len(asyncio.run(service.lookup_events(region="us-east-1", max_results=10))) == 10

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -115,7 +115,7 @@ class TestMigrateToLatest:
         assert config.mcp.transfer_timeout_seconds == 300
 
     # ------------------------------------------------------------------
-    # Back-compat: v2, v3, v4, and no-version configs all land at v5
+    # Back-compat: v2, v3, v4, and no-version configs all land at the current version
     # with the new auto-scan fields available at their defaults.
     # ------------------------------------------------------------------
 
@@ -154,14 +154,14 @@ class TestMigrateToLatest:
             "auto_scan_stale_only should default True after migration"
         )
 
-    def test_no_version_config_lands_at_v5_with_new_fields(self):
-        """No-version dict (treated as v1) migrates cleanly to v5."""
+    def test_no_version_config_lands_at_the_current_version(self):
+        """No-version dict (treated as v1) migrates cleanly to the current version."""
         no_version = {'instance_keys': {}, 'default_key': ''}
         out = migrate_to_latest(no_version)
-        assert out['version'] == 5
+        assert out['version'] == CONFIG_VERSION
         self._assert_new_fields_at_defaults(out)
 
-    def test_v2_config_lands_at_v5_with_new_fields(self):
+    def test_v2_config_lands_at_the_current_version(self):
         """v2 on-disk config migrates to v5 preserving new field defaults."""
         v2 = {
             'version': 2,
@@ -169,20 +169,20 @@ class TestMigrateToLatest:
             'cache_ttl_seconds': 300,
         }
         out = migrate_to_latest(v2)
-        assert out['version'] == 5
+        assert out['version'] == CONFIG_VERSION
         self._assert_new_fields_at_defaults(out)
 
-    def test_v3_config_lands_at_v5_with_new_fields(self):
+    def test_v3_config_lands_at_the_current_version(self):
         """v3 on-disk config migrates to v5 preserving new field defaults."""
         v3 = {
             'version': 3,
             'ai_provider': {'provider': 'openai', 'api_key': ''},
         }
         out = migrate_to_latest(v3)
-        assert out['version'] == 5
+        assert out['version'] == CONFIG_VERSION
         self._assert_new_fields_at_defaults(out)
 
-    def test_v4_config_lands_at_v5_with_new_fields(self):
+    def test_v4_config_lands_at_the_current_version(self):
         """v4 on-disk config migrates to v5 preserving new field defaults."""
         v4 = {
             'version': 4,
@@ -195,7 +195,7 @@ class TestMigrateToLatest:
             },
         }
         out = migrate_to_latest(v4)
-        assert out['version'] == 5
+        assert out['version'] == CONFIG_VERSION
         self._assert_new_fields_at_defaults(out)
 
     def test_v4_config_with_existing_memory_block_preserves_fields(self):
@@ -210,7 +210,7 @@ class TestMigrateToLatest:
             },
         }
         out = migrate_to_latest(v4)
-        assert out['version'] == 5
+        assert out['version'] == CONFIG_VERSION
         # Memory fields we put in are still there after migration.
         assert out.get('memory', {}).get('enabled') is False
         assert out.get('memory', {}).get('disabled_modules') == ['containers']
@@ -232,3 +232,38 @@ class TestCreateBackup:
     def test_nonexistent_file(self, tmp_path):
         result = create_backup(tmp_path / 'nope.json')
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# v5 -> v6: the CloudTrail cap that could never turn a page
+# ---------------------------------------------------------------------------
+
+class TestMigrateV5ToV6:
+    """Every saved config carries ``cloudtrail_max_events``, so raising the
+    dataclass default alone reaches nobody who has ever saved settings."""
+
+    def test_the_old_default_is_raised(self):
+        out = migrate_to_latest({'version': 5, 'cloudtrail_max_events': 100})
+        assert out['version'] == CONFIG_VERSION
+        assert out['cloudtrail_max_events'] == 500
+
+    def test_a_deliberate_value_is_left_alone(self):
+        for chosen in (50, 250, 1000):
+            out = migrate_to_latest({'version': 5, 'cloudtrail_max_events': chosen})
+            assert out['cloudtrail_max_events'] == chosen, chosen
+            assert out['version'] == CONFIG_VERSION
+
+    def test_a_config_without_the_key_just_moves_version(self):
+        out = migrate_to_latest({'version': 5})
+        assert out['version'] == CONFIG_VERSION
+        assert 'cloudtrail_max_events' not in out
+
+    def test_running_it_again_changes_nothing(self):
+        once = migrate_to_latest({'version': 5, 'cloudtrail_max_events': 100})
+        twice = migrate_to_latest(dict(once))
+        assert twice == once
+
+    def test_an_old_config_picks_it_up_through_the_whole_chain(self):
+        out = migrate_to_latest({'version': 2, 'cloudtrail_max_events': 100})
+        assert out['version'] == CONFIG_VERSION
+        assert out['cloudtrail_max_events'] == 500

--- a/tests/test_css_id_coverage.py
+++ b/tests/test_css_id_coverage.py
@@ -398,11 +398,11 @@ ACCEPTABLE_UNSTYLED: frozenset[str] = frozenset(
         "ct_filter_resource_type",
         "ct_filter_time_range",
         "ct_filter_username",
-        "ct_input_event_name",    # Reason: Input; inherits global Input styling
-        "ct_input_resource_type",
-        "ct_input_username",
-        "ct_select_region",       # Reason: Select; inherits global Select styling
+        "ct_select_event_name",   # Reason: Select; inherits global Select styling
+        "ct_select_region",
+        "ct_select_resource_type",
         "ct_select_time_range",
+        "ct_select_username",
         "current_usage",          # Reason: Static usage label; inherits global Static
         # ---- CloudWatch filter inputs ----
         "cw_btn_back",

--- a/tests/test_demo_mode_coverage.py
+++ b/tests/test_demo_mode_coverage.py
@@ -918,6 +918,8 @@ class TestCloudTrailCopy:
             "raw_event": '{"account": "123456789012"}',
         }
         screen._events = [event]
+        # Paging reads the narrowed view; unfiltered it mirrors _events.
+        screen._visible = list(screen._events)
         screen._selected_row = 0
 
         copied: list = []
@@ -1272,6 +1274,8 @@ class TestCloudTrailEmailUsername:
                 "error_code": "",
             }
         ]
+        # Paging reads the narrowed view; unfiltered it mirrors _events.
+        screen._visible = list(screen._events)
         mock_app = _make_mock_app(demo=True)
 
         rows: list = []

--- a/tests/test_mcp_aws_security_tools.py
+++ b/tests/test_mcp_aws_security_tools.py
@@ -209,6 +209,40 @@ class TestCloudTrailLookupEvents:
         out = _run(tools.cloudtrail_lookup_events())
         assert "No CloudTrail events matched" in out
 
+    def test_combined_filters_reach_the_api_and_the_local_pass(self):
+        """End to end through the real service: CloudTrail honours only the
+        first lookup attribute, so an agent asking for two used to get rows
+        matching just one of them."""
+        from unittest.mock import patch
+
+        from servonaut.services.cloudtrail_service import CloudTrailService
+
+        matches_both = {
+            "EventTime": datetime(2026, 5, 21, 9, 0, 0), "EventName": "AssumeRole",
+            "Username": "deploy", "CloudTrailEvent": "{}",
+            "Resources": [{"ResourceType": "AWS::IAM::Role", "ResourceName": "r"}],
+        }
+        matches_first_only = dict(matches_both, Username="someone-else")
+        client = MagicMock()
+        client.lookup_events.return_value = {
+            "Events": [matches_both, matches_first_only],
+        }
+
+        config_manager = MagicMock()
+        config_manager.get.return_value = AppConfig()
+        service = CloudTrailService(config_manager)
+        tools = _make_tools(cloudtrail_service=service)
+
+        with patch("boto3.client", return_value=client):
+            out = _run(tools.cloudtrail_lookup_events(
+                region="us-east-1", event_name="AssumeRole", username="deploy",
+            ))
+
+        sent = client.lookup_events.call_args[1]["LookupAttributes"]
+        assert sent == [{"AttributeKey": "EventName", "AttributeValue": "AssumeRole"}]
+        assert "deploy" in out
+        assert "someone-else" not in out
+
 
 # ---------------------------------------------------------------------------
 # IP ban: list_configs / list_banned


### PR DESCRIPTION
## Summary

The CloudTrail filters were free-text boxes. CloudTrail matches them exactly and case-sensitively, so filtering meant guessing a value that might not occur at all, and there was no way to see what the account actually contained. They are now pickers built from the events you fetched, each option carrying its count.

Fixing the UI surfaced a correctness bug underneath it. CloudTrail's `LookupEvents` accepts a list of lookup attributes but honours only the **first** and silently ignores the rest, so filling two filters returned rows matching just one of them, with no error. Verified against a live account:

| Lookup sent | Result |
|---|---|
| Event name alone | matching events |
| Username alone | no events |
| Both, event name first | the event-name results, username ignored |
| Both, username first | the username result, event name ignored |

## Changes

- **Filters are pickers.** Event, user and resource type are populated from the loaded events, sorted by frequency, each option showing its count. Choosing one narrows the loaded rows immediately, with no round trip, and selections combine. Fetching again applies the selection to the whole time window, so you can still reach past the fetch cap.
- **Combining filters now tells the truth.** The service sends one attribute to the API and applies the remaining criteria itself, reading further when a local pass discards most of a page (bounded, so a narrow filter cannot page forever). `ResourceType` matches any resource on an event, as the API does. This fixes the agent tool as well, where the same silent behaviour applied.
- **The event cap is now 500, not 100.** The browser pages 100 events at a time, so the old cap gave exactly one page and dead Prev/Next buttons. Measured against a 24-hour window on a live account: 100 events took 0.4s, 500 took 2.1s, 1000 took 6.7s, and fetching that window uncapped took 103s — the last being what the browser did on every fetch before the cap was honoured at all. The pager says when the cap was reached and what to do about it, so a short result set is not mistaken for the whole window.
- **The open list sizes to its widest option** instead of wrapping inside a narrow column.
- **Instance-role sessions are named after the machine.** CloudTrail names them after the instance id, so the user column and the picker read as a column of hex. An id the fleet recognises now shows the instance's name, the picker still filters by the id behind the option, the event detail shows both, and an id the fleet does not know keeps its id.
- Demo mode redacts usernames and resolved machine names in the option labels; the value behind an option stays real so the lookup still works.
- **Next reads on into the window.** The fetch used to stop at the cap, so a day of events could not be read past the first few hundred. The service now returns the token to resume from, per region, keeping whole batches so nothing is skipped between pages; Next reads the following page when one exists instead of going dead on the last page, and the pickers and local narrowing grow with what is loaded. Reading a whole day up front would be roughly a hundred seconds against a throttle of about two calls a second, and would starve anything else calling CloudTrail; on demand it is about two seconds a page.
- **Each picker also offers to type a value**, for something further back in the window than the loaded events. A typed value goes to the API, which searches the whole range for it.
- **A config migration raises the old cap.** Every saved config carries `cloudtrail_max_events`, so changing the default alone reached only new installs. The migration raises exactly the old default of 100 to 500 and leaves any other number alone.
- Tests for the combined-filter behaviour, the picker flow, paging and resumption, and the typed-value path, including a mounted test pinning that an untouched picker means "no filter" rather than a stray sentinel value.
