### PR TITLE
Keep your place in CloudTrail when Next loads more events

### DIFF
--- a/src/servonaut/screens/cloudtrail_browser.py
+++ b/src/servonaut/screens/cloudtrail_browser.py
@@ -146,6 +146,9 @@ class CloudTrailBrowserScreen(Screen):
         self._fetch_args: Optional[Dict[str, Any]] = None
         # set_options() resets a Select and fires Changed; ignore those.
         self._suppress_filter_events: bool = False
+        # The selections the visible list was last narrowed by, so a repost
+        # of an unchanged selection can be told apart from a real one.
+        self._applied_filters: Dict[str, str] = {}
 
     def check_action(self, action: str, parameters: tuple) -> bool | None:
         return check_action_passthrough(self, action)
@@ -352,7 +355,9 @@ class CloudTrailBrowserScreen(Screen):
         Combining selections is a local pass, which the API cannot do: it
         honours one lookup attribute per call.
         """
-        active = {f: v for f, v in self._filter_values().items() if v}
+        values = self._filter_values()
+        self._applied_filters = values
+        active = {f: v for f, v in values.items() if v}
         if not active:
             self._visible = list(self._events)
             return
@@ -370,6 +375,12 @@ class CloudTrailBrowserScreen(Screen):
             return
         if event.value == _TYPE_A_VALUE:
             self._prompt_for_value(event.select.id)
+            return
+        if self._filter_values() == self._applied_filters:
+            # set_options() posts Changed asynchronously, so the suppression
+            # flag is already cleared by the time it lands. Nothing changed,
+            # so re-narrowing would only throw the reader back to page one of
+            # the list they were already paging through.
             return
         self._current_page = 0
         self._apply_filters()

--- a/tests/test_cloudtrail_filter_pickers.py
+++ b/tests/test_cloudtrail_filter_pickers.py
@@ -293,6 +293,68 @@ async def test_next_reads_the_following_page_when_one_exists() -> None:
         assert "TerminateInstances" in events_seen
 
 
+def _bulk(count: int, first_second: int):
+    """`count` AssumeRole events, timestamped so they sort stably."""
+    return [
+        {
+            "event_time": f"2026-01-01 00:{(first_second + i) // 60:02d}:{(first_second + i) % 60:02d}",
+            "event_name": "AssumeRole",
+            "username": "deploy",
+            "source_ip": "192.0.2.1",
+            "resource_name": "",
+            "resource_type": "AWS::IAM::Role",
+            "region": "eu-west-2",
+            "error_code": "",
+        }
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_next_keeps_the_readers_place_when_it_loads_more() -> None:
+    """Paging into the window is the whole point of Next, so landing back on
+    page one of what you just read would defeat it.
+
+    Loading more rebuilds the pickers, and set_options() posts Select.Changed
+    asynchronously — after the screen's suppression flag has been cleared. The
+    handler has to recognise its own repost rather than treat it as a new
+    selection.
+    """
+    app = _harness()
+    app.cloudtrail_service.lookup_page = AsyncMock(side_effect=[
+        LookupPage(events=_bulk(150, 0), next_token={"eu-west-2": "page-2"}),
+        LookupPage(events=_bulk(150, 150), next_token=None),
+    ])
+    app.lookup_mock = app.cloudtrail_service.lookup_page
+
+    async with app.run_test(headless=True) as pilot:
+        screen = _screen(pilot.app)
+        await _load(pilot, screen)
+
+        pilot.app.query_one("#ct_select_event_name", Select).value = "AssumeRole"
+        await pilot.pause()
+        assert len(screen._visible) == 150
+
+        # Read to the last page of what is loaded, then ask for more.
+        screen.action_next_page()
+        await pilot.pause()
+        assert screen._current_page == 1
+
+        screen.action_next_page()
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if len(screen._events) > 150 and not screen._loading_more:
+                break
+        # Let the pickers' deferred Changed messages land.
+        for _ in range(5):
+            await pilot.pause()
+
+        assert len(screen._events) == 300
+        assert screen._visible and len(screen._visible) == 300
+        assert pilot.app.query_one("#ct_select_event_name", Select).value == "AssumeRole"
+        assert screen._current_page == 2
+
+
 @pytest.mark.asyncio
 async def test_next_stays_available_on_the_last_page_when_more_exists() -> None:
     from textual.widgets import Button


### PR DESCRIPTION
Paging into a CloudTrail window is what `Next` is for, so being thrown back to page one at the moment it fetches more defeats it.

**What happened**

Reading to the end of the loaded events and pressing `Next` pulled the next page from the window, then reset the table to page one. Everything already read had to be paged through again to get back.

**Why**

Loading more rebuilds the filter pickers so values that only appear in the new page join them. `Select.set_options()` posts its `Changed` event asynchronously, so it arrives after the flag marking the rebuild as programmatic has been cleared. The screen then treated its own repost as a fresh selection and reset the page.

**The fix**

The screen records the selections the visible list was last narrowed by, and the change handler ignores an event whose selections are identical — a repost cannot change what is on screen, so it has no business moving the reader.

Covered by a regression test that pages to the end of a loaded window, loads more, drains the deferred events and asserts the reader advanced rather than restarted. It fails on the old code with `assert 0 == 2`.

Full suite: 7741 passed, 6 skipped.