### PR TITLE
Refuse a second release on the same day

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,49 @@ on:
     types: [published]
 
 jobs:
+  # Two releases in one day means every user is prompted to upgrade twice,
+  # and the update prompt has no snooze. Fixes ride a weekly train instead.
+  # To ship anyway (user-blocking damage only: data loss, corruption, crash
+  # on launch, broken upgrade path, security), set the repository variable
+  # ALLOW_SAME_DAY_RELEASE to "true" and re-run this workflow.
+  cadence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse a second release on the same day
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          THIS_TAG: ${{ github.event.release.tag_name }}
+          THIS_PUBLISHED: ${{ github.event.release.published_at }}
+          OVERRIDE: ${{ vars.ALLOW_SAME_DAY_RELEASE }}
+        run: |
+          set -euo pipefail
+          today="${THIS_PUBLISHED%%T*}"
+          echo "This release: $THIS_TAG published $THIS_PUBLISHED (day $today)"
+
+          if [ "${OVERRIDE:-}" = "true" ]; then
+            echo "::warning::ALLOW_SAME_DAY_RELEASE is set - skipping the cadence check."
+            exit 0
+          fi
+
+          # Drafts have no published_at; prereleases still prompt users, so
+          # they count. Compare dates in UTC, which is what the API returns.
+          clash=$(gh api --paginate "repos/$REPO/releases" \
+            --jq ".[] | select(.draft == false)
+                      | select(.tag_name != \"$THIS_TAG\")
+                      | select(.published_at != null)
+                      | select((.published_at | split(\"T\")[0]) == \"$today\")
+                      | .tag_name")
+
+          if [ -n "$clash" ]; then
+            echo "::error::A release already went out today ($today): $(echo "$clash" | tr '\n' ' ')."
+            echo "Nothing was published to PyPI. Delete this release and re-tag on the next"
+            echo "release train (Thursday), or set ALLOW_SAME_DAY_RELEASE=true for a genuine"
+            echo "user-blocking hotfix and re-run."
+            exit 1
+          fi
+          echo "No other release today - proceeding."
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +69,7 @@ jobs:
         run: pytest --tb=short -q
 
   publish:
-    needs: test
+    needs: [cadence, test]
     runs-on: ubuntu-latest
     environment: pypi
     steps:


### PR DESCRIPTION
Servonaut checks PyPI on every launch and, when anything is newer, shows an upgrade prompt and pins an update button in the sidebar. There is no snooze and no dismissal, so two releases in one day means every user is interrupted twice. Fixes are meant to ride a weekly train instead.

**What this adds**

A `cadence` job that runs before `publish` and fails if another (non-draft) release was already published on the same UTC day. `publish` and, transitively, `mcp-registry` depend on it, so a same-day release reaches neither PyPI nor the MCP registry — the GitHub release can simply be deleted and re-tagged on the next train.

**Escape hatch**

Setting the repository variable `ALLOW_SAME_DAY_RELEASE` to `true` skips the check and logs a warning, for a genuinely user-blocking fix — data loss, configuration or cache corruption, a crash on launch, a broken upgrade path, or security. Being a repository setting rather than a flag in the release makes it a deliberate act, and it leaves no trace in the release notes.

**Verified against real history**

Replaying the actual release list: `v2.26.1` detects `v2.26.0` on the same day and would have failed; `v2.25.4` finds no clash and passes.