### PR TITLE
Release only when something that ships has changed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,19 @@ jobs:
             exit 1
           fi
 
-          # Version bumps and merge commits are release bookkeeping, not
-          # user-visible change; a window holding only those has nothing to ship.
-          mapfile -t subjects < <(
-            git log --format='%s' "$last_tag..HEAD" \
-              | grep -vE '^(chore: bump version|Merge (pull request|branch))' || true
-          )
+          # Only what ships counts. A commit that touches nothing under src/
+          # or pyproject.toml — CI, tests, docs, fixtures, a version bump — is
+          # not a reason to interrupt every user with an upgrade prompt.
+          ships() {
+            git diff-tree --no-commit-id --name-only -r "$1" \
+              | grep -qE '^(src/|pyproject\.toml$)'
+          }
+          subjects=()
+          while IFS= read -r sha; do
+            subject="$(git log -1 --format='%s' "$sha")"
+            case "$subject" in "chore: bump version"*) continue ;; esac
+            ships "$sha" && subjects+=("$subject")
+          done < <(git rev-list --no-merges "$last_tag..HEAD")
           count="${#subjects[@]}"
           if [ "$count" -eq 0 ]; then
             echo "Nothing substantive since $last_tag — no release this time."


### PR DESCRIPTION
The first dry run of the release workflow on `master` (run 33966887660) proposed `v2.26.1 → v2.26.2` for two commits — the two workflow changes themselves. Nothing a user installs would have differed, yet every launch would have prompted them to upgrade. Left alone, that release would have gone out automatically on Thursday.

**The change**

A commit now counts towards a release only if it touches `src/` or `pyproject.toml` (checked per commit with `git diff-tree`; merge commits are skipped). Changes to CI, tests, docs and fixtures no longer raise a train on their own — they ship alongside the next real change.

**Verified by execution against real history**

- Current `master`: nothing to release (previously: a spurious patch).
- From `v2.26.0`: `v2.26.1`, patch — unchanged.
- From `v2.25.4`: `v2.26.0`, minor — unchanged, now 15 changes instead of 17 (the two dropped touched only tests).

A live `dry_run` of this revision can only be dispatched once it is on `master`, as before.